### PR TITLE
Enable access to AppId for Middlewares

### DIFF
--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -8,21 +8,42 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Primitives;
+using System.Security.Claims;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
     public class BotFrameworkAdapter : ActivityAdapterBase
     {
+        private const string AppIdRequestInfo = "AppId";
+
         private readonly ICredentialProvider _credentialProvider;
-        private readonly MicrosoftAppCredentials _credentials;
+
+        /// <summary>
+        /// App credentials map.
+        /// Why?
+        /// Tokens are stored in <see cref="MicrosoftAppCredentials"/>. If we init it everytime it will add token fetch to every single call. So
+        /// everytime we encounter a new appId we create <see cref="MicrosoftAppCredentials"/> object and store it here.
+        /// No lock?
+        /// It can happen that a flood of requests end up initializing the same <see cref="MicrosoftAppCredentials"/> multiple times. But this will
+        /// happen for a short duration so not worth using a ConcurrentDictionary which has it's own perf hit.
+        /// </summary>
+        private readonly IDictionary<string, MicrosoftAppCredentials> _appCredentialsMap = new Dictionary<string, MicrosoftAppCredentials>();
 
         public BotFrameworkAdapter(string appId, string appPassword) : base()
         {
-            _credentials = new MicrosoftAppCredentials(appId, appPassword);
             _credentialProvider = new StaticCredentialProvider(appId, appPassword);
         }
 
-        public async override Task Post(IList<IActivity> activities)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkAdapter"/> class.
+        /// </summary>
+        /// <param name="credentialProvider">The credential provider.</param>
+        public BotFrameworkAdapter(ICredentialProvider credentialProvider) :  base()
+        {
+            _credentialProvider = credentialProvider;
+        }
+
+        public async override Task Post(IList<IActivity> activities, IBotContext botContext)
         {
             BotAssert.ActivityListNotNull(activities);
 
@@ -37,33 +58,86 @@ namespace Microsoft.Bot.Builder.Adapters
                 }
                 else
                 {
-                    var connectorClient = new ConnectorClient(new Uri(activity.ServiceUrl), _credentials);
+                    MicrosoftAppCredentials microsoftAppCredentials = await this.GetAppCredentialsAsync(botContext);
+
+                    var connectorClient = new ConnectorClient(new Uri(activity.ServiceUrl), microsoftAppCredentials);
+
                     await connectorClient.Conversations.SendToConversationAsync(activity).ConfigureAwait(false);
                 }
             }
         }
 
-        public async Task Receive(IDictionary<string, StringValues> headers, Activity activity)
+        public async Task Receive(IDictionary<string, StringValues> requestInfo, Activity activity)
         {
-            if (headers == null)
-                throw new ArgumentNullException(nameof(headers));
+            if (requestInfo == null)
+                throw new ArgumentNullException(nameof(requestInfo));
 
             BotAssert.ActivityNotNull(activity);
 
             if (await _credentialProvider.IsAuthenticationDisabledAsync() == false)
             {
-                if (headers.TryGetValue("Authorization", out StringValues values))
+                if (requestInfo.TryGetValue("Authorization", out StringValues values))
                 {
-                    if (!await JwtTokenValidation.ValidateAuthHeader(values.SingleOrDefault(), _credentialProvider, activity.ServiceUrl))
+                    ClaimsIdentity claimsIdentity = await JwtTokenValidation.GetIdentityClaim(values.SingleOrDefault());
+
+                    if (!await JwtTokenValidation.ValidateAuthHeader(claimsIdentity, _credentialProvider, activity.ServiceUrl))
                         throw new UnauthorizedAccessException("Caller does not have a valid authentication header");
+
                     MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl);
+
+                    if (claimsIdentity != null)
+                    {
+                        requestInfo.Add(AppIdRequestInfo, claimsIdentity.GetAppIdFromClaims());
+                    }
                 }
                 else
                     throw new UnauthorizedAccessException("Caller does not have a valid authentication header");
             }
 
             if (this.OnReceive != null)
-                await this.OnReceive(activity).ConfigureAwait(false);
+                await this.OnReceive(activity, requestInfo).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the application credentials for sending responses.
+        /// </summary>
+        /// <param name="botContext">The bot context.</param>
+        /// <returns>Application credentials.</returns>
+        /// <exception cref="ArgumentException">Failed to get Credentials for post. Only StaticCredentialProvider is supported in unauthenticated scenarios.</exception>
+        private async Task<MicrosoftAppCredentials> GetAppCredentialsAsync(IBotContext botContext)
+        {
+            if (botContext?.RequestInfo == null)
+            {
+                throw new ArgumentNullException(nameof(botContext));
+            }
+
+            if (botContext.RequestInfo.TryGetValue(AppIdRequestInfo, out StringValues appId))
+            {
+                if (!this._appCredentialsMap.ContainsKey(appId.Single()))
+                {
+                    // Ideally we can just insert into the dictionary and then access it at next point. But this has a chance in which it can fail.
+                    // This can happen if you have multiple threads adding values to dictionary and 2 threads add different value (one for Bot1 second for Bot2).
+                    // In this case due to race, value can actually not get added. Hence just returing the object directly while trying to add it to dictionary.
+                    KeyValuePair<string, MicrosoftAppCredentials> appCreds = new KeyValuePair<string, MicrosoftAppCredentials>(appId.Single(), new MicrosoftAppCredentials(appId.Single(), await this._credentialProvider.GetAppPasswordAsync(appId.Single())));
+                    this._appCredentialsMap.Add(appCreds);
+
+                    return appCreds.Value;
+                }
+
+                return this._appCredentialsMap[appId.Single()];
+            }
+            else
+            {
+                // Unoptimzied pipeline for Unauthenticated scenarios as these are expected to be production.
+                if (this._credentialProvider as StaticCredentialProvider != null)
+                {
+                    StaticCredentialProvider staticCredentialProvider = this._credentialProvider as StaticCredentialProvider;
+
+                    return new MicrosoftAppCredentials(staticCredentialProvider.AppId, staticCredentialProvider.Password);
+                }
+
+                throw new ArgumentException("Failed to get Credentials for post. Only StaticCredentialProvider is supported in unauthenticated scenarios.");
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Adapters/ActivityAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ActivityAdapterBase.cs
@@ -4,17 +4,18 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
     public abstract class ActivityAdapterBase
     {
-        public delegate Task OnReceiveDelegate(IActivity activity);
+        public delegate Task OnReceiveDelegate(IActivity activity, IDictionary<string, StringValues> requestInfo);
 
         public ActivityAdapterBase() { }
 
         public OnReceiveDelegate OnReceive { get; set; }               
 
-        public abstract Task Post(IList<IActivity> activities);
+        public abstract Task Post(IList<IActivity> activities, IBotContext botContext);
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
         }
 
-        public async override Task Post(IList<IActivity> activities)
+        public async override Task Post(IList<IActivity> activities, IBotContext botContext)
         {
             foreach (IActivity activity in activities)
             {
@@ -71,7 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 };
 
                 if (this.OnReceive != null)
-                    await this.OnReceive(activity);
+                    await this.OnReceive(activity, new Dictionary<string, StringValues>());
             }
         }
     }    

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
@@ -69,10 +70,10 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <summary>
         /// Bot posting an activity back to the source
         /// </summary>
-        /// <param name="activities"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        public override async Task Post(IList<IActivity> activities)
+        /// <param name="activities">Activities to send back.</param>
+        /// <param name="botContext">Request context.</param>
+        /// <returns>Task tracking operation.</returns>
+        public override async Task Post(IList<IActivity> activities, IBotContext botContext)
         {
             foreach (var activity in activities)
             {
@@ -115,7 +116,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 activity.ServiceUrl = this.ConversationReference.ServiceUrl;
 
                 var id = activity.Id = (this._nextId++).ToString();
-                return this.OnReceive(activity);
+                return this.OnReceive(activity, new Dictionary<string, StringValues>());
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder
 {
@@ -64,11 +66,11 @@ namespace Microsoft.Bot.Builder
             System.Diagnostics.Trace.TraceInformation($"Middleware: Ending Pipeline for {context.ConversationReference.ActivityId}");
         }
 
-        public async Task RunPipeline(IActivity activity)
+        public async Task RunPipeline(IActivity activity, IDictionary<string, StringValues> requestInfo)
         {
             BotAssert.ActivityNotNull(activity);
 
-            var context = new BotContext(this, activity);
+            var context = new BotContext(this, activity, requestInfo);
 
             await RunPipeline(context).ConfigureAwait(false);
         }

--- a/libraries/Microsoft.Bot.Builder/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/IBotContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder
 {
@@ -18,6 +19,11 @@ namespace Microsoft.Bot.Builder
         /// Incoming request
         /// </summary>
         IActivity Request { get; }
+
+        /// <summary>
+        /// Gets the request additional information.
+        /// </summary>
+        IDictionary<string, StringValues> RequestInfo { get; }
 
         /// <summary>
         /// Respones
@@ -84,15 +90,17 @@ namespace Microsoft.Bot.Builder
     public class BotContext : FlexObject, IBotContext
     {
         private readonly Bot _bot;
-        private readonly IActivity _request;        
+        private readonly IActivity _request;
+        private readonly IDictionary<string, StringValues> _requestInfo;
         private readonly ConversationReference _conversationReference;
         private readonly BotState _state = new BotState();
         private IList<IActivity> _responses = new List<IActivity>();
 
-        public BotContext(Bot bot, IActivity request)
+        public BotContext(Bot bot, IActivity request, IDictionary<string, StringValues> requestInfo)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
-            _request = request ?? throw new ArgumentNullException(nameof(request)); 
+            _request = request ?? throw new ArgumentNullException(nameof(request));
+            _requestInfo = requestInfo ?? new Dictionary<string, StringValues>();
 
             _conversationReference = new ConversationReference()
             {
@@ -117,6 +125,8 @@ namespace Microsoft.Bot.Builder
         }
 
         public IActivity Request => _request;
+
+        public IDictionary<string, StringValues> RequestInfo => _requestInfo;
 
         public Bot Bot => _bot;
 

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -41,6 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <!--<PackageReference Include="Microsoft.Bot.Schema" Version="4.0.0" />

--- a/libraries/Microsoft.Bot.Builder/Middleware/PostToAdapterMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/PostToAdapterMiddleware.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Middleware
             BotAssert.ActivityListNotNull(activities);
 
             await next().ConfigureAwait(false); 
-            await _bot.Adapter.Post(activities).ConfigureAwait(false);            
+            await _bot.Adapter.Post(activities, context).ConfigureAwait(false);            
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Tests
             {
                 Type = ActivityTypes.Message
             };
-            BotContext bc = new BotContext(b, a);
+            BotContext bc = new BotContext(b, a, null);
 
             return bc;
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Tests
             Activity a = new Activity();
             if (typeof(T).IsAssignableFrom(typeof(IBotContext)))
             {
-                IBotContext bc = new BotContext(b, a);
+                IBotContext bc = new BotContext(b, a, null);
                 return (T)bc;
             }
             else


### PR DESCRIPTION
1) Enable Middlewares to create their own Connector Clients
2) Allow BFAdapter to accept ICredentialProvider object and hence use DI as well as support multiple bots.