### PR TITLE
Revert Microsoft.Rest.ClientRuntime.Azure.TestFramework to 1.6.0

### DIFF
--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="1.7.2" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="1.6.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
Fixes "Path too long" exception when running Connector's Tests