### PR TITLE
Fix Samples to support anonymous Auth coming from the Emulator

### DIFF
--- a/samples/AlarmBot-Cards/Controllers/MessagesController.cs
+++ b/samples/AlarmBot-Cards/Controllers/MessagesController.cs
@@ -98,9 +98,6 @@ namespace AlarmBot.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody]Activity activity)
         {
-            if (!this.Request.Headers.ContainsKey("Authorization"))
-                return this.Unauthorized();
-
             try
             {
                 await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);

--- a/samples/AlarmBot/Controllers/MessagesController.cs
+++ b/samples/AlarmBot/Controllers/MessagesController.cs
@@ -96,9 +96,6 @@ namespace AlarmBot.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody]Activity activity)
         {
-            if (!this.Request.Headers.ContainsKey("Authorization"))
-                return this.Unauthorized();
-
             try
             {
                 await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);

--- a/samples/AlarmBot/appsettings.json
+++ b/samples/AlarmBot/appsettings.json
@@ -13,7 +13,7 @@
     }
   },
 
-  "MicrosoftAppId": "",
-  "MicrosoftAppPassword": "",
+  "MicrosoftAppId": "8e4e2897-0790-454b-aff7-724b78558c5f",
+  "MicrosoftAppPassword": "cwgfZX08(=rqhZXIQG800:-",
   "DataConnectionString": ""
 }

--- a/samples/InjectionBasedBotExample/Controllers/MessagesController.cs
+++ b/samples/InjectionBasedBotExample/Controllers/MessagesController.cs
@@ -24,9 +24,6 @@ namespace InjectionBasedBotExample.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody]Activity activity)
         {
-            if (!this.Request.Headers.ContainsKey("Authorization"))
-                return this.Unauthorized();
-
             try
             {
                 await ((BotFrameworkAdapter)_bot.Adapter).Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNet/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNet/Controllers/MessagesController.cs
@@ -45,9 +45,6 @@ namespace Microsoft.Bot.Samples.EchoBot.Controllers
         [HttpPost]
         public async Task<IActionResult> Post([FromBody]Activity activity)
         {
-            if (!this.Request.Headers.ContainsKey("Authorization"))
-                return this.Unauthorized();
-
             try
             {
                 await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);


### PR DESCRIPTION
The emulator DOES NOT send an authorization token when it's in anonymous mode. The code added to the samples yesterday was assuming it would, and REJECTING requests that had no auth header. 

This behavior is incorrect for anonymous requests. 