### PR TITLE
Tomlm/fix activity init

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Bot.Schema
         {
             return new Activity(ActivityTypes.ConversationUpdate)
             {
-                MembersAdded = new List<ChannelAccount(),
-                MembersRemoved = new List<ChannelAccount(),
+                MembersAdded = new List<ChannelAccount>(),
+                MembersRemoved = new List<ChannelAccount>(),
             };
         }
 


### PR DESCRIPTION
we were over-initing properties in the ctor of activity. 
It is more appropriate to do this on activity centric methods