### PR TITLE
change ContextExtensionMethods namespace

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Bot.Schema;
 
-namespace Microsoft.Bot.Builder.ContextExtensions
+namespace Microsoft.Bot.Builder
 {
     public static class ContextExtensionMethods
     {


### PR DESCRIPTION
The `ContextExtensions` should be in `Microsoft.Bot.Builder` namespace; in order to use them, users need to see them. They don't see them if they have to import a completely separate namespace. In JS SDK, this hurdle doesn't exist; shouldn’t in .Net.