### PR TITLE
Renamed PostActivity to SendActivity throughout the BotBuilder layer.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/TranslationMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/TranslationMiddleware.cs
@@ -12,7 +12,7 @@ using Microsoft.Cognitive.LUIS;
 
 namespace Microsoft.Bot.Builder.Ai
 {
-    public class TranslationMiddleware : IReceiveActivity, IPostActivity
+    public class TranslationMiddleware : IReceiveActivity, ISendActivity
     {
         private LuisClient luisClient;
         private string[] nativeLanguages;
@@ -41,10 +41,12 @@ namespace Microsoft.Bot.Builder.Ai
                     // determine the language we are using for this conversation
                     var sourceLanguage = "en"; // context.Conversation.Data["Language"]?.ToString() ?? this.nativeLanguages.FirstOrDefault() ?? "en";
 
-                    var translationContext = new TranslationContext();
-                    translationContext.SourceText = message.Text;
-                    translationContext.SourceLanguage = sourceLanguage;
-                    translationContext.TargetLanguage = (this.nativeLanguages.Contains(sourceLanguage)) ? sourceLanguage : this.nativeLanguages.FirstOrDefault() ?? "en";
+                    var translationContext = new TranslationContext
+                    {
+                        SourceText = message.Text,
+                        SourceLanguage = sourceLanguage,
+                        TargetLanguage = (this.nativeLanguages.Contains(sourceLanguage)) ? sourceLanguage : this.nativeLanguages.FirstOrDefault() ?? "en"
+                    };
                     ((BotContext)context)["Translation"] = translationContext;
 
                     // translate to bots language
@@ -63,7 +65,7 @@ namespace Microsoft.Bot.Builder.Ai
         /// <param name="activities"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
         {
             foreach (var activity in activities)
             {

--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.BotFramework
             _credentialProvider = new SimpleCredentialProvider(appId, appPassword);
         }
 
-        public async override Task Post(IList<IActivity> activities)
+        public async override Task Send(IList<IActivity> activities)
         {
             BotAssert.ActivityListNotNull(activities);
 

--- a/libraries/Microsoft.Bot.Builder/Adapters/ActivityAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ActivityAdapterBase.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Bot.Builder.Adapters
 
         public OnReceiveDelegate OnReceive { get; set; }               
 
-        public abstract Task Post(IList<IActivity> activities);
+        public abstract Task Send(IList<IActivity> activities);
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
         }
 
-        public async override Task Post(IList<IActivity> activities)
+        public async override Task Send(IList<IActivity> activities)
         {
             foreach (IActivity activity in activities)
             {

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="activities"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public override async Task Post(IList<IActivity> activities)
+        public override async Task Send(IList<IActivity> activities)
         {
             foreach (var activity in activities)
             {

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Builder
             // through the Middleware Pipeline
             _adapter.OnReceive = this.RunPipeline;
 
-            this.Use(new Middleware.PostToAdapterMiddleware(this));
+            this.Use(new Middleware.SendToAdapterMiddleware(this));
             this.Use(new Middleware.TemplateManager());
         }
 
@@ -57,9 +57,9 @@ namespace Microsoft.Bot.Builder
             if (proactiveCallback != null)
                 await proactiveCallback(context).ConfigureAwait(false);
 
-            // Call any registered Middleware Components looking for PostActivity()
+            // Call any registered Middleware Components looking for SendActivity()
             if (context.Responses != null && context.Responses.Any())
-                await this.PostActivity(context, context.Responses).ConfigureAwait(false);
+                await this.SendActivity(context, context.Responses).ConfigureAwait(false);
 
             System.Diagnostics.Trace.TraceInformation($"Middleware: Ending Pipeline for {context.ConversationReference.ActivityId}");
         }

--- a/libraries/Microsoft.Bot.Builder/BotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/BotContext.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Bot.Builder
             _conversationReference = conversationReference ?? throw new ArgumentNullException(nameof(conversationReference));
         }
 
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities)
         {
-            await _bot.PostActivity(context, activities).ConfigureAwait(false);
+            await _bot.SendActivity(context, activities).ConfigureAwait(false);
         }
 
         public IActivity Request => _request;

--- a/libraries/Microsoft.Bot.Builder/BotStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder/BotStateManager.cs
@@ -30,17 +30,17 @@ namespace Microsoft.Bot.Builder
         {
             PersistConversationState = true;
             PersistUserState = true;
-            WriteBeforePost = true;
+            WriteBeforeSend = true;
             LastWriterWins = true;
         }
 
         public bool PersistUserState { get; set; }
         public bool PersistConversationState { get; set; }
-        public bool WriteBeforePost { get; set; }
+        public bool WriteBeforeSend { get; set; }
         public bool LastWriterWins { get; set; }
     }
 
-    public class BotStateManager : Middleware.IContextCreated, Middleware.IPostActivity
+    public class BotStateManager : Middleware.IContextCreated, Middleware.ISendActivity
     {
         private readonly BotStateManagerSettings _settings;
         private readonly IStorage _storage;
@@ -63,14 +63,14 @@ namespace Microsoft.Bot.Builder
             await next().ConfigureAwait(false); 
         }        
 
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
         {
-            if (_settings.WriteBeforePost)
+            if (_settings.WriteBeforeSend)
             {
                 await Write(context).ConfigureAwait(false);
             }
             await next().ConfigureAwait(false);
-            if (!_settings.WriteBeforePost)
+            if (!_settings.WriteBeforeSend)
             {
                 await Write(context).ConfigureAwait(false);
             }

--- a/libraries/Microsoft.Bot.Builder/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/IBotContext.cs
@@ -78,11 +78,11 @@ namespace Microsoft.Bot.Builder
 
     public static partial class BotContextExtension
     {
-        public static async Task Post(this BotContext context)
+        public static async Task Send(this BotContext context)
         {            
-            await context.PostActivity(context, new List<IActivity>()).ConfigureAwait(false);
-        }  
-        
+            await context.SendActivity(context, new List<IActivity>()).ConfigureAwait(false);
+        }
+
         public static BotContext ToBotContext(this IBotContext context)
         {
             return (BotContext)context; 

--- a/libraries/Microsoft.Bot.Builder/Middleware/IMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/IMiddleware.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Bot.Builder.Middleware
         Task ReceiveActivity(IBotContext context, NextDelegate next);
     }
 
-    public interface IPostActivity : IMiddleware
+    public interface ISendActivity : IMiddleware
     {
-        Task PostActivity(IBotContext context, IList<IActivity> activities, NextDelegate next);
+        Task SendActivity(IBotContext context, IList<IActivity> activities, NextDelegate next);
     }
 
     public class AnonymousReceiveMiddleware : IReceiveActivity
@@ -56,16 +56,16 @@ namespace Microsoft.Bot.Builder.Middleware
         }
     }
 
-    public class AnonymousPostActivityMiddleware : IPostActivity
+    public class AnonymousSendActivityMiddleware : ISendActivity
     {
         private readonly Func<IBotContext, IList<IActivity>, NextDelegate, Task> _toCall;
 
-        public AnonymousPostActivityMiddleware(Func<IBotContext, IList<IActivity>, NextDelegate, Task> anonymousMethod)
+        public AnonymousSendActivityMiddleware(Func<IBotContext, IList<IActivity>, NextDelegate, Task> anonymousMethod)
         {
             _toCall = anonymousMethod ?? throw new ArgumentNullException(nameof(anonymousMethod));
         }
 
-        public Task PostActivity(IBotContext context, IList<IActivity> activities, NextDelegate next)
+        public Task SendActivity(IBotContext context, IList<IActivity> activities, NextDelegate next)
         {
             return _toCall(context, activities, next);
         }

--- a/libraries/Microsoft.Bot.Builder/Middleware/PostToAdapterMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/PostToAdapterMiddleware.cs
@@ -8,22 +8,22 @@ using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Middleware
 {
-    public class PostToAdapterMiddleware : IPostActivity
+    public class SendToAdapterMiddleware : ISendActivity
     {
         private readonly Bot _bot;
 
-        public PostToAdapterMiddleware(Bot b)
+        public SendToAdapterMiddleware(Bot b)
         {
             _bot = b ?? throw new ArgumentNullException(nameof(Bot));
         }        
 
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities, Middleware.MiddlewareSet.NextDelegate next)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, Middleware.MiddlewareSet.NextDelegate next)
         {
             BotAssert.ContextNotNull(context);
             BotAssert.ActivityListNotNull(activities);
 
             await next().ConfigureAwait(false); 
-            await _bot.Adapter.Post(activities).ConfigureAwait(false);            
+            await _bot.Adapter.Send(activities).ConfigureAwait(false);            
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Middleware/TemplateManager.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/TemplateManager.cs
@@ -8,7 +8,7 @@ using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Middleware
 {
-    public class TemplateManager : IContextCreated, IPostActivity
+    public class TemplateManager : IContextCreated, ISendActivity
     {
         public const string TEMPLATE = "template";        
         private List<ITemplateRenderer> _templateRenderers = new List<ITemplateRenderer>();
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Middleware
             await next().ConfigureAwait(false);             
         }
 
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities, Middleware.MiddlewareSet.NextDelegate next)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, Middleware.MiddlewareSet.NextDelegate next)
         {
             BotAssert.ContextNotNull(context);
             BotAssert.ActivityListNotNull(activities);

--- a/samples/Microsoft.Bot.Samples.CustomMiddleware/Middleware/ExampleMiddleware.cs
+++ b/samples/Microsoft.Bot.Samples.CustomMiddleware/Middleware/ExampleMiddleware.cs
@@ -11,7 +11,7 @@ using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Samples.CustomMiddleware
 {
-    public class ExampleMiddleware : IContextCreated, IReceiveActivity, IPostActivity
+    public class ExampleMiddleware : IContextCreated, IReceiveActivity, ISendActivity
     {
         private string _name;
         private static object _syncRoot = new object();
@@ -35,11 +35,11 @@ namespace Microsoft.Bot.Samples.CustomMiddleware
             Write($"AFTER ReceiveActivity {PrettyPrint(context.Request)}");
         }
 
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
         {
-            Write($"BEFORE PostActivity {PrettyPrint(context.Responses)}");
+            Write($"BEFORE SendActivity {PrettyPrint(context.Responses)}");
             await next();
-            Write($"AFTER PostActivity {PrettyPrint(context.Responses)}");
+            Write($"AFTER SendActivity {PrettyPrint(context.Responses)}");
         }
 
         private void Write(string message)

--- a/tests/Microsoft.Bot.Builder.Tests/BotContext_Tests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotContext_Tests.cs
@@ -11,9 +11,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Bot.Builder.Tests
 {
 
-    public class AnnotateMiddleware : Middleware.IContextCreated, Middleware.IReceiveActivity, Middleware.IPostActivity
+    public class AnnotateMiddleware : IContextCreated, IReceiveActivity, ISendActivity
     {                
-        public async Task PostActivity(BotContext context, IList<Activity> activities) { ; }
+        public async Task SendActivity(BotContext context, IList<Activity> activities) { ; }
         public async Task ContextDone(BotContext context) { context.State["ContextDone"] = true; }
 
         public async Task ContextCreated(IBotContext context, MiddlewareSet.NextDelegate next)
@@ -27,9 +27,9 @@ namespace Microsoft.Bot.Builder.Tests
             context.Request.AsMessageActivity().Text += "ReceiveActivity";            
             await next();
         }
-        public async Task PostActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
         {
-            context.Responses[0].AsMessageActivity().Text += "PostActivity";
+            context.Responses[0].AsMessageActivity().Text += "SendActivity";
             await next();             
         }
     }
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.Tests
                     {
                         Assert.AreEqual(true, context.State["ContextCreated"]);
                         Assert.IsTrue(context.Request.AsMessageActivity().Text.Contains("ReceiveActivity"));
-                        Assert.IsFalse(context.Request.AsMessageActivity().Text.Contains("PostActivity"));
+                        Assert.IsFalse(context.Request.AsMessageActivity().Text.Contains("SendActivity"));
                         if (context.Request.AsMessageActivity().Text.StartsWith("proactive"))
                         {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Tests
                 {
                     Assert.IsTrue(activity.AsMessageActivity().Text.Contains("receive"));
                     Assert.IsTrue(activity.AsMessageActivity().Text.Contains("ReceiveActivity"));
-                    Assert.IsTrue(activity.AsMessageActivity().Text.Contains("PostActivity"));
+                    Assert.IsTrue(activity.AsMessageActivity().Text.Contains("SendActivity"));
                 }, "Assert response came through")
                 .StartTest();
         }
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Tests
                 {
                     Assert.IsTrue(activity.AsMessageActivity().Text.Contains("proactive"));
                     Assert.IsFalse(activity.AsMessageActivity().Text.Contains("ReceiveActivity"));
-                    Assert.IsTrue(activity.AsMessageActivity().Text.Contains("PostActivity"));
+                    Assert.IsTrue(activity.AsMessageActivity().Text.Contains("SendActivity"));
                 }, "Assert response came through")
                .StartTest();
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_ComposibilityTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_ComposibilityTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -18,14 +19,14 @@ namespace Microsoft.Bot.Builder.Tests
         {
             bool innerOnReceiveCalled = false;
 
-            Middleware.MiddlewareSet inner = new Middleware.MiddlewareSet();
+            MiddlewareSet inner = new MiddlewareSet();
             inner.OnReceive(async (context, next) =>
                {
                    innerOnReceiveCalled = true;
                    await next(); 
                });
 
-            Middleware.MiddlewareSet outer = new Middleware.MiddlewareSet();
+            MiddlewareSet outer = new MiddlewareSet();
             outer.Use(inner); 
 
             await outer.ReceiveActivity(null); 
@@ -38,14 +39,14 @@ namespace Microsoft.Bot.Builder.Tests
         {
             bool innerOnCreatedCalled = false;
 
-            Middleware.MiddlewareSet inner = new Middleware.MiddlewareSet();
+            MiddlewareSet inner = new MiddlewareSet();
             inner.OnContextCreated(async (context, next) =>
             {
                 innerOnCreatedCalled = true;
                 await next();
             });
 
-            Middleware.MiddlewareSet outer = new Middleware.MiddlewareSet();
+            MiddlewareSet outer = new MiddlewareSet();
             outer.Use(inner);
 
             await outer.ContextCreated(null);
@@ -56,39 +57,39 @@ namespace Microsoft.Bot.Builder.Tests
         [TestMethod]
         public async Task NestedSet_OnPostActivity()
         {
-            bool innerOnPostCalled = false;
+            bool innerOnSendCalled = false;
 
-            Middleware.MiddlewareSet inner = new Middleware.MiddlewareSet();
+            MiddlewareSet inner = new MiddlewareSet();
 
-            inner.OnPostActivity(async (context, activities, next) =>
+            inner.OnSendActivity(async (context, activities, next) =>
             {
-                innerOnPostCalled = true;
+                innerOnSendCalled = true;
                 await next();
             });
 
-            Middleware.MiddlewareSet outer = new Middleware.MiddlewareSet();
+            MiddlewareSet outer = new MiddlewareSet();
             outer.Use(inner);
 
-            await outer.PostActivity(null, new List<IActivity>());
+            await outer.SendActivity(null, new List<IActivity>());
 
-            Assert.IsTrue(innerOnPostCalled, "Inner Middleware PostActivity was not called.");
+            Assert.IsTrue(innerOnSendCalled, "Inner Middleware SendActivity was not called.");
         }
 
         [TestMethod]
         public async Task NestedSet_AllIsRun()
         {
-            bool innerOnPostCalled = false;
+            bool innerOnSendCalled = false;
             bool innerOnReceiveCalled = false;
             bool innerOnCreatedCalled = false;
             string replyMessage = Guid.NewGuid().ToString();
 
-            Middleware.MiddlewareSet inner = new Middleware.MiddlewareSet();
-            inner.OnPostActivity(async (context, activities, next) =>
+            MiddlewareSet inner = new MiddlewareSet();
+            inner.OnSendActivity(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 1, "incorrect activity count");
-                Assert.IsTrue(activities[0].AsMessageActivity().Text == replyMessage, "unexpected message"); 
+                Assert.IsTrue(activities[0].AsMessageActivity().Text == replyMessage, "unexpected message");
 
-                innerOnPostCalled = true;
+                innerOnSendCalled = true;
                 await next();
             });
 
@@ -111,11 +112,11 @@ namespace Microsoft.Bot.Builder.Tests
             IBotContext c = TestUtilities.CreateEmptyContext();
             await outer.ContextCreated(c);
             await outer.ReceiveActivity(c);
-            await outer.PostActivity(c, c.Responses);
+            await outer.SendActivity(c, c.Responses);
 
             Assert.IsTrue(innerOnReceiveCalled, "Inner Middleware Receive Activity was not called.");
             Assert.IsTrue(innerOnCreatedCalled, "Inner Middleware Create Context was not called.");
-            Assert.IsTrue(innerOnPostCalled, "Inner Middleware PostActivity was not called.");
+            Assert.IsTrue(innerOnSendCalled, "Inner Middleware SendActivity was not called.");
         }
     }
 }


### PR DESCRIPTION
Changed the IPostActivity Middleware name to ISendActivity. This change was then pulled through the BotBuilder layer in the SDK, including all Middlware and tests. 

The motivation is that nobody looks for "Post", instead everyone looks for Send.

The underlying protocol + swagger layers use "Send" rather than "Post". This more closely aligns the BotBuilder with the underlying protocol. 