### PR TITLE
Update MessagesController.cs

### DIFF
--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
@@ -1,4 +1,5 @@
-﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+
+// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -29,6 +30,10 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         {
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"))
+                
+                // LUIS with correct baseUri format example
+                //.Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx", "https://xxxxxx.api.cognitive.microsoft.com/luis/v2.0/apps"))
+                
                 .OnReceive(BotReceiveHandler);
 
             _adapter = (BotFrameworkAdapter)bot.Adapter;


### PR DESCRIPTION
Make it clear in the sample how to set a different data center for a published LUIS model as this is different from the v3 LuisDialog.

LuisRecognizerMiddleware overload BaseUri takes the full cognitive services api uri eg:
https://westeurope.api.cognitive.microsoft.com/luis/v2.0/apps
https://westus.api.cognitive.microsoft.com/luis/v2.0/apps

v3 LuisDialog accepts the domain only eg: 
westeurope.api.cognitive.microsoft.com
westus.api.cognitive.microsoft.com

LuisDialog v3 for reference
https://github.com/Microsoft/BotBuilder/blob/master/CSharp/Library/Microsoft.Bot.Builder/Luis/LuisModel.cs