### PR TITLE
Allowing Middlewares access to AppId and thus allow them to get their own tokens

### DIFF
--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -8,28 +8,44 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+using System.Security.Claims;
+using System.Linq;
 
 namespace Microsoft.Bot.Builder.BotFramework
 {
     public class BotFrameworkAdapter : ActivityAdapterBase
     {
-        private readonly SimpleCredentialProvider _credentialProvider;
-        private readonly MicrosoftAppCredentials _credentials;
+        private const string AppIdRequestInfo = "AppId";
 
-        public BotFrameworkAdapter(IConfiguration configuration) : base()
-        {
-            _credentialProvider = new ConfigurationCredentialProvider(configuration);
-            _credentials = new MicrosoftAppCredentials(this._credentialProvider.AppId, _credentialProvider.Password);                       
-        }
+        private readonly ICredentialProvider _credentialProvider;
+
+        /// <summary>
+        /// App credentials map.
+        /// Why?
+        /// Tokens are stored in <see cref="MicrosoftAppCredentials"/>. If we init it everytime it will add token fetch to every single call. So
+        /// everytime we encounter a new appId we create <see cref="MicrosoftAppCredentials"/> object and store it here.
+        /// No lock?
+        /// It can happen that a flood of requests end up initializing the same <see cref="MicrosoftAppCredentials"/> multiple times. But this will
+        /// happen for a short duration so not worth using a ConcurrentDictionary which has it's own perf hit.
+        /// </summary>
+        private readonly IDictionary<string, MicrosoftAppCredentials> _appCredentialsMap = new Dictionary<string, MicrosoftAppCredentials>();
 
         public BotFrameworkAdapter(string appId, string appPassword) : base()
         {
-            _credentials = new MicrosoftAppCredentials(appId, appPassword);
             _credentialProvider = new SimpleCredentialProvider(appId, appPassword);
         }
 
-        public async override Task Send(IList<IActivity> activities)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkAdapter"/> class.
+        /// </summary>
+        /// <param name="credentialProvider">The credential provider.</param>
+        public BotFrameworkAdapter(ICredentialProvider credentialProvider) :  base()
+        {
+            _credentialProvider = credentialProvider;
+        }
+
+        public async override Task Send(IList<IActivity> activities, IBotContext botContext)
         {
             BotAssert.ActivityListNotNull(activities);
 
@@ -44,20 +60,88 @@ namespace Microsoft.Bot.Builder.BotFramework
                 }
                 else
                 {
-                    var connectorClient = new ConnectorClient(new Uri(activity.ServiceUrl), _credentials);
+                    MicrosoftAppCredentials microsoftAppCredentials = await this.GetAppCredentialsAsync(botContext);
+
+                    var connectorClient = new ConnectorClient(new Uri(activity.ServiceUrl), microsoftAppCredentials);
+
                     await connectorClient.Conversations.SendToConversationAsync(activity).ConfigureAwait(false);
                 }
             }
         }
 
-        public async Task Receive(string authHeader, Activity activity)
+        public async Task Receive(IDictionary<string, StringValues> requestInfo, Activity activity)
         {
+            if (requestInfo == null)
+                throw new ArgumentNullException(nameof(requestInfo));
+
             BotAssert.ActivityNotNull(activity);
-            await JwtTokenValidation.AssertValidActivity(activity, authHeader, _credentialProvider);
+
+            if (await _credentialProvider.IsAuthenticationDisabledAsync() == false)
+            {
+                if (requestInfo.TryGetValue("Authorization", out StringValues values))
+                {
+                    ClaimsIdentity claimsIdentity = await JwtTokenValidation.AssertValidActivity(activity, values.SingleOrDefault(), _credentialProvider);
+
+                    MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl);
+
+                    if (claimsIdentity != null)
+                    {
+                        requestInfo.Add(AppIdRequestInfo, claimsIdentity.Claims.FirstOrDefault(c => c.Type == AuthenticationConstants.AudienceClaim).Value);
+                    }
+                    else if (_credentialProvider as SimpleCredentialProvider != null)
+                    {
+                        // Allowing single bot pipeline for unauthenticated requests as the only way to find bot's app Id is to
+                        // get it from Token. The condition below for now always stores null.
+                        requestInfo.Add(AppIdRequestInfo, (_credentialProvider as SimpleCredentialProvider).AppId);
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Only StaticCredentialProvider is supported in UnAuthenticated scenarios");
+                    }
+                }
+                else
+                    throw new UnauthorizedAccessException("Caller does not have a valid authentication header");
+            }
 
             if (this.OnReceive != null)
+                await this.OnReceive(activity, requestInfo).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the application credentials for sending responses.
+        /// </summary>
+        /// <param name="botContext">The bot context.</param>
+        /// <returns>Application credentials.</returns>
+        /// <exception cref="ArgumentException">Failed to get Credentials for post. Only StaticCredentialProvider is supported in unauthenticated scenarios.</exception>
+        private async Task<MicrosoftAppCredentials> GetAppCredentialsAsync(IBotContext botContext)
+        {
+            if (botContext?.RequestInfo == null)
             {
-                await this.OnReceive(activity).ConfigureAwait(false);
+                throw new ArgumentNullException(nameof(botContext));
+            }
+
+            if (botContext.RequestInfo.TryGetValue(AppIdRequestInfo, out StringValues appId))
+            {
+                string botAppId = StringValues.IsNullOrEmpty(appId) ? throw new ArgumentNullException("No valid AppId found", nameof(appId)) : appId.Single();
+
+                if (!this._appCredentialsMap.ContainsKey(botAppId))
+                {
+                    // Ideally we can just insert into the dictionary and then access it at next point. But this has a chance in which it can fail.
+                    // This can happen if you have multiple threads adding values to dictionary and 2 threads add different value (one for Bot1 second for Bot2).
+                    // In this case due to race, value can actually not get added. Hence just returing the object directly while trying to add it to dictionary.
+                    KeyValuePair<string, MicrosoftAppCredentials> appCreds = new KeyValuePair<string, MicrosoftAppCredentials>(
+                        botAppId, 
+                        new MicrosoftAppCredentials(botAppId, await this._credentialProvider.GetAppPasswordAsync(botAppId)));
+                    this._appCredentialsMap.Add(appCreds);
+
+                    return appCreds.Value;
+                }
+
+                return this._appCredentialsMap[botAppId];
+            }
+            else
+            {
+                throw new ArgumentNullException("AppId was not found in Request Info", nameof(botContext.RequestInfo));
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder/Adapters/ActivityAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ActivityAdapterBase.cs
@@ -4,17 +4,18 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
     public abstract class ActivityAdapterBase
     {
-        public delegate Task OnReceiveDelegate(IActivity activity);
+        public delegate Task OnReceiveDelegate(IActivity activity, IDictionary<string, StringValues> requestInfo);
 
         public ActivityAdapterBase() { }
 
         public OnReceiveDelegate OnReceive { get; set; }               
 
-        public abstract Task Send(IList<IActivity> activities);
+        public abstract Task Send(IList<IActivity> activities, IBotContext botContext);
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
         }
 
-        public async override Task Send(IList<IActivity> activities)
+        public async override Task Send(IList<IActivity> activities, IBotContext botContext)
         {
             foreach (IActivity activity in activities)
             {
@@ -71,7 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 };
 
                 if (this.OnReceive != null)
-                    await this.OnReceive(activity);
+                    await this.OnReceive(activity, new Dictionary<string, StringValues>());
             }
         }
     }    

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder.Adapters
 {
@@ -69,10 +70,10 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <summary>
         /// Bot posting an activity back to the source
         /// </summary>
-        /// <param name="activities"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        public override async Task Send(IList<IActivity> activities)
+        /// <param name="activities">Activities to send back.</param>
+        /// <param name="botContext">Request context.</param>
+        /// <returns>Task tracking operation.</returns>
+        public override async Task Send(IList<IActivity> activities, IBotContext botContext)
         {
             foreach (var activity in activities)
             {
@@ -115,7 +116,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 activity.ServiceUrl = this.ConversationReference.ServiceUrl;
 
                 var id = activity.Id = (this._nextId++).ToString();
-                return this.OnReceive(activity);
+                return this.OnReceive(activity, new Dictionary<string, StringValues>());
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder
 {
@@ -64,11 +66,11 @@ namespace Microsoft.Bot.Builder
             System.Diagnostics.Trace.TraceInformation($"Middleware: Ending Pipeline for {context.ConversationReference.ActivityId}");
         }
 
-        public async Task RunPipeline(IActivity activity)
+        public async Task RunPipeline(IActivity activity, IDictionary<string, StringValues> requestInfo)
         {
             BotAssert.ActivityNotNull(activity);
 
-            var context = new BotContext(this, activity);
+            var context = new BotContext(this, activity, requestInfo);
 
             await RunPipeline(context).ConfigureAwait(false);
         }

--- a/libraries/Microsoft.Bot.Builder/BotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/BotContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder
 {
@@ -14,14 +15,16 @@ namespace Microsoft.Bot.Builder
     {
         private readonly Bot _bot;
         private readonly IActivity _request;
+        private readonly IDictionary<string, StringValues> _requestInfo;
         private readonly ConversationReference _conversationReference;
         private readonly BotState _state = new BotState();
         private IList<IActivity> _responses = new List<IActivity>();
 
-        public BotContext(Bot bot, IActivity request)
+        public BotContext(Bot bot, IActivity request, IDictionary<string, StringValues> requestInfo)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
             _request = request ?? throw new ArgumentNullException(nameof(request));
+            _requestInfo = requestInfo ?? new Dictionary<string, StringValues>();
 
             _conversationReference = new ConversationReference()
             {
@@ -46,6 +49,8 @@ namespace Microsoft.Bot.Builder
         }
 
         public IActivity Request => _request;
+
+        public IDictionary<string, StringValues> RequestInfo => _requestInfo;
 
         public Bot Bot => _bot;
 
@@ -111,7 +116,7 @@ namespace Microsoft.Bot.Builder
             this.Responses.Add(activity);
             return this;
         }
-        
+
         public BotContext ReplyWith(string templateId, object data = null)
         {
             // queue template activity to be databound when sent

--- a/libraries/Microsoft.Bot.Builder/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/IBotContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Bot.Builder
 {
@@ -18,6 +19,11 @@ namespace Microsoft.Bot.Builder
         /// Incoming request
         /// </summary>
         IActivity Request { get; }
+
+        /// <summary>
+        /// Gets the request additional information.
+        /// </summary>
+        IDictionary<string, StringValues> RequestInfo { get; }
 
         /// <summary>
         /// Respones

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -46,6 +46,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />

--- a/libraries/Microsoft.Bot.Builder/Middleware/PostToAdapterMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/PostToAdapterMiddleware.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Middleware
             BotAssert.ActivityListNotNull(activities);
 
             await next().ConfigureAwait(false); 
-            await _bot.Adapter.Send(activities).ConfigureAwait(false);            
+            await _bot.Adapter.Send(activities, context).ConfigureAwait(false);            
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="activity">The incoming Activity from the Bot Framework or the Emulator</param>
         /// <param name="authHeader">The Bearer token included as part of the request</param>
         /// <param name="credentials">The set of valid credentials, such as the Bot Application ID</param>
-        /// <returns>Nothing</returns>
-        public static async Task AssertValidActivity(Activity activity, string authHeader, ICredentialProvider credentials)
+        /// <returns>Claims identity</returns>
+        public static async Task<ClaimsIdentity> AssertValidActivity(Activity activity, string authHeader, ICredentialProvider credentials)
         {
             if (string.IsNullOrWhiteSpace(authHeader))
             {
@@ -28,15 +28,17 @@ namespace Microsoft.Bot.Connector.Authentication
                 if (isAuthDisabled)
                 {
                     // We are on the anonymous code path. 
-                    return;
+                    return null;
                 }
             }
 
             // Go through the standard authentication path. 
-            await JwtTokenValidation.ValidateAuthHeader(authHeader, credentials, activity.ServiceUrl);
+            ClaimsIdentity claimsIdentity = await JwtTokenValidation.ValidateAuthHeader(authHeader, credentials, activity.ServiceUrl);
 
             // On the standard Auth path, we need to trust the URL that was incoming. 
             MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl);
+
+            return claimsIdentity;
         }
 
         public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials)

--- a/samples/AlarmBot-Cards/Controllers/MessagesController.cs
+++ b/samples/AlarmBot-Cards/Controllers/MessagesController.cs
@@ -99,7 +99,7 @@ namespace AlarmBot.Controllers
         {
             try
             {
-                await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await activityAdapter.Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/samples/AlarmBot/Controllers/MessagesController.cs
+++ b/samples/AlarmBot/Controllers/MessagesController.cs
@@ -99,7 +99,7 @@ namespace AlarmBot.Controllers
         {
             try
             {
-                await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await activityAdapter.Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/samples/InjectionBasedBotExample/Controllers/MessagesController.cs
+++ b/samples/InjectionBasedBotExample/Controllers/MessagesController.cs
@@ -26,7 +26,7 @@ namespace InjectionBasedBotExample.Controllers
         {
             try
             {
-                await ((BotFrameworkAdapter)_bot.Adapter).Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await ((BotFrameworkAdapter)_bot.Adapter).Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         /// </summary>        
         public MessagesController(IConfiguration configuration)
         {
-            var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
+            var bot = new Builder.Bot(new BotFrameworkAdapter(new ConfigurationCredentialProvider(configuration)))
                 .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"))
                 
                 // LUIS with correct baseUri format example
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         {
             try
             {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await _adapter.Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
                 SubscriptionKey = "xxxxxx",
                 KnowledgeBaseId = "xxxxxx"
             };
-            var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
+            var bot = new Builder.Bot(new BotFrameworkAdapter(new ConfigurationCredentialProvider(configuration)))
                 // add QnA middleware 
                 .Use(new QnAMaker(qnaOptions))
                 .OnReceive(BotReceiveHandler);
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
         {
             try
             {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await _adapter.Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Samples.CustomMiddleware
         /// </summary>        
         public MessagesController(IConfiguration configuration)
         {
-            var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
+            var bot = new Builder.Bot(new BotFrameworkAdapter(new ConfigurationCredentialProvider(configuration)))
                 .Use(new ExampleMiddleware("X"))
                 .Use(new ExampleMiddleware("\tY"))
                 .Use(new ExampleMiddleware("\t\tZ"))
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Samples.CustomMiddleware
         {
             try
             {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await _adapter.Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNet/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNet/Controllers/MessagesController.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Samples.EchoBot.Controllers
         /// </summary>        
         public MessagesController(IConfiguration configuration)
         {
-            var bot = new Builder.Bot(new BotFrameworkAdapter(configuration));
+            var bot = new Builder.Bot(new BotFrameworkAdapter(new ConfigurationCredentialProvider(configuration)));
             _adapter = (BotFrameworkAdapter)bot.Adapter;
             bot.OnReceive(BotReceiveHandler);
         }
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Samples.EchoBot.Controllers
         {
             try
             {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+                await _adapter.Receive(this.Request.Headers, activity);
                 return this.Ok();
             }
             catch (UnauthorizedAccessException)

--- a/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Tests
             {
                 Type = ActivityTypes.Message
             };
-            BotContext bc = new BotContext(b, a);
+            BotContext bc = new BotContext(b, a, null);
 
             return bc;
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Tests
             Activity a = new Activity();
             if (typeof(T).IsAssignableFrom(typeof(IBotContext)))
             {
-                IBotContext bc = new BotContext(b, a);
+                IBotContext bc = new BotContext(b, a, null);
                 return (T)bc;
             }
             else


### PR DESCRIPTION
Exposing AppId thru the layers (using IBotContext). This way Middlewares can use ICredentialProvider and AppId to get their own tokens. This allows developers to build extensions which utilize their owns tokens (e.g. Graph etc.) to enable enchanced scenarios.