### PR TITLE
QnAMaker Middleware bug: Assumes MessageActivity.Text will always have a value

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -89,9 +89,10 @@ namespace Microsoft.Bot.Builder.Ai
         {
             if (context.Request.Type == ActivityTypes.Message)
             {
-                if (!string.IsNullOrEmpty(context.Request.AsMessageActivity().Text))
+                var messageActivity = context.Request.AsMessageActivity();
+                if (!string.IsNullOrEmpty(messageActivity.Text))
                 {
-                    var results = await this.GetAnswers(context.Request.AsMessageActivity().Text.Trim()).ConfigureAwait(false);
+                    var results = await this.GetAnswers(messageActivity.Text.Trim()).ConfigureAwait(false);
                     if (results.Any())
                     {
                         context.Reply(results.First().Answer);

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -89,10 +89,13 @@ namespace Microsoft.Bot.Builder.Ai
         {
             if (context.Request.Type == ActivityTypes.Message)
             {
-                var results = await this.GetAnswers(context.Request.AsMessageActivity().Text.Trim()).ConfigureAwait(false);
-                if (results.Any())
+                if (!string.IsNullOrEmpty(context.Request.AsMessageActivity().Text))
                 {
-                    context.Reply(results.First().Answer);             
+                    var results = await this.GetAnswers(context.Request.AsMessageActivity().Text.Trim()).ConfigureAwait(false);
+                    if (results.Any())
+                    {
+                        context.Reply(results.First().Answer);
+                    }
                 }
             }
 


### PR DESCRIPTION
Issue with QnA Maker when there is no message text.

User can invoke bot without sending any text eg. by uploading an attachment.

To reproduce:

- Add QnAMaker Middleware
- Use emulator to invoke bot with an attachment (with no text)