### PR TITLE
Added Conversation Binding to outgoing messages, similar to JS

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Assertions.cs
+++ b/libraries/Microsoft.Bot.Builder/Assertions.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Bot.Builder
             if (context == null)
                 throw new ArgumentNullException(nameof(context)); 
         }
+        public static void ConversationReferenceNotNull(ConversationReference reference)
+        {
+            if (reference == null)
+                throw new ArgumentNullException(nameof(reference));
+        }
 
         public static void AdapterNotNull(ActivityAdapterBase adapter)
         {

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Bot.Builder
             // through the Middleware Pipeline
             _adapter.OnReceive = this.RunPipeline;
 
+            this.Use(new Middleware.BindOutoingResponsesMiddlware()); 
             this.Use(new Middleware.SendToAdapterMiddleware(this));
             this.Use(new Middleware.TemplateManager());
         }
@@ -84,6 +85,6 @@ namespace Microsoft.Bot.Builder
         {
             var context = new BotContext(this, reference);
             await RunPipeline(context, proactiveCallback).ConfigureAwait(false);
-        }
+        }    
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Middleware/BindOutgoingResponsesMiddlware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/BindOutgoingResponsesMiddlware.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Middleware
+{
+    /// <summary>
+    /// Binds outgoing activities to a particular conversation. 
+    /// As messages are sent during the Send pipeline, they must be
+    /// bound to the relvant ConversationReference object. This middleare
+    /// runs at the start of the Sending Pipeline and binds all outgoing
+    /// Activities to the ConversationRefernce on the Context. 
+    /// </summary>
+    /// <remarks>
+    /// This Middleware component is automatically added to the Send Pipeline
+    /// when constructing a bot. 
+    /// 
+    /// In terms of protocol level behavior, the binding of Actities to 
+    /// a ConversationReference is similar to how the Node SDK applies the same
+    /// set of rules on all outbound Activities.     
+    /// </remarks>
+    public class BindOutoingResponsesMiddlware : ISendActivity
+    {        
+        public BindOutoingResponsesMiddlware()
+        {            
+        }
+
+        public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
+        {
+            BotAssert.ContextNotNull(context);
+            BotAssert.ActivityListNotNull(activities);
+
+            foreach( var activity in activities)
+            {
+                if (string.IsNullOrWhiteSpace(activity.Type))
+                {
+                    activity.Type = ActivityTypes.Message;
+                }
+
+                ApplyConversationReference(activity, context.ConversationReference); 
+            }
+
+            await next().ConfigureAwait(false);            
+        }
+
+        /// <summary>
+        /// Applies all relevant Conversation related identifies to an activity. This effectivly
+        /// couples a blank Activity to a conversation. 
+        /// </summary>
+        /// <param name="activity">The activity to update. Existing values in the Activity will be overwritten.</param>
+        /// <param name="reference">The ConversationReference from which to pull the relevant conversation information</param>
+        /// <remarks>        
+        /// This method applies the following values from ConversationReference:
+        /// ChannelId
+        /// ServiceUrl
+        /// Conversation
+        /// Bot (assigned to the .From property on the Activity)
+        /// User (assigned to the .Recipient on the Activity)
+        /// ActivityId (assigned as the ReplyToId on the Activity)                
+        /// </remarks>
+        public static void ApplyConversationReference(IActivity activity, ConversationReference reference)
+        {
+            BotAssert.ActivityNotNull(activity);
+            BotAssert.ConversationReferenceNotNull(reference); 
+
+            activity.ChannelId = reference.ChannelId;
+            activity.ServiceUrl = reference.ServiceUrl;
+            activity.Conversation = reference.Conversation;
+            activity.From = reference.Bot;
+            activity.Recipient = reference.User;
+            activity.ReplyToId = reference.ActivityId;
+        }
+    }
+    
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_BindOutoingResponsesTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_BindOutoingResponsesTests.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    [TestClass]
+    [TestCategory("Middleware")]
+    [TestCategory("Functional Spec")]
+    public class Middleware_BindOutgoingResponsesTests
+    {
+        [TestMethod]
+        [TestCategory("Functional Spec")]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task ApplyConversationReference_NullActivity()
+        {
+            Activity activity = null;
+            ConversationReference reference = new ConversationReference();
+            BindOutoingResponsesMiddlware.ApplyConversationReference(activity, reference);
+
+            Assert.Fail("Actity was null. This should not run.");
+        }
+
+        [TestMethod]
+        [TestCategory("Functional Spec")]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task ApplyConversationReference_NullConversationReference()
+        {
+            Activity activity = new Activity();
+            BindOutoingResponsesMiddlware.ApplyConversationReference(activity, null);
+
+            Assert.Fail("ConversationReference was null. This should not run.");
+        }
+
+        [TestMethod]
+        [TestCategory("Functional Spec")]
+        public async Task FixupActivityType()
+        {
+            Activity activity = new Activity();
+            ConversationReference reference = CreateTestConversationReference();
+
+            // Should apply all relevent properties to the Activity
+            BindOutoingResponsesMiddlware.ApplyConversationReference(activity, reference);
+
+            Assert.IsTrue(activity.ChannelId == reference.ChannelId);
+            Assert.IsTrue(activity.ServiceUrl == reference.ServiceUrl);
+            Assert.IsTrue(activity.Conversation.Id == reference.Conversation.Id);
+            Assert.IsTrue(activity.Conversation.Name == reference.Conversation.Name);
+            Assert.IsTrue(activity.From.Id == reference.Bot.Id);
+            Assert.IsTrue(activity.From.Name == reference.Bot.Name);
+            Assert.IsTrue(activity.Recipient.Id == reference.User.Id);
+            Assert.IsTrue(activity.Recipient.Name == reference.User.Name);
+            Assert.IsTrue(activity.ReplyToId == reference.ActivityId);
+        }
+
+        public static ConversationReference CreateTestConversationReference()
+        {
+            ChannelAccount botAccount = new ChannelAccount("testBotId", "testBotName");
+            ChannelAccount userAccount = new ChannelAccount("testUserId", "testUserName");
+            ConversationAccount conversationAccount = new ConversationAccount(false, "testConversationAccount", "testConversationName");
+
+            ConversationReference reference = new ConversationReference()
+            {
+                ChannelId = "testChannelId",
+                ServiceUrl = $"https://testServiceUrl",
+                Conversation = conversationAccount,
+                Bot = botAccount,
+                User = userAccount,
+                ActivityId = "testActivityId"
+            };
+
+            return reference;
+        }
+
+
+        [TestMethod]
+        public async Task FixupMessageType()
+        {
+            IActivity a = new Activity();
+
+            TestAdapter adapter = new TestAdapter();
+            Bot b = new Bot(adapter);
+            b.OnReceive(async (context, next) =>
+               {
+                   Assert.IsTrue(string.IsNullOrEmpty(a.Type));
+                   context.Responses.Add(a);
+                   Assert.IsTrue(string.IsNullOrEmpty(a.Type)); 
+               });
+
+            await adapter
+               .Send("test")
+               .StartTest();
+
+            // The Message Binder Middleware should have detected an activiy
+            // with no message type and set it to be a "Message". 
+            Assert.IsTrue(a.Type == ActivityTypes.Message);
+        }
+    }
+}


### PR DESCRIPTION
This PR allows a developer to simple send a new Activity, with no set conversation fields, through the outgoing pipeline. 

The pipeline will correctly apply the ConversationReference fields to the outgoing activity. 

The primary motivatios here are:
1. Allows a developer to simply construct a new activity, set the .Text field, and send it. The framework will apply the remaining fields. 
2. Alignment with [Node SDK, which does this. ](https://github.com/Microsoft/botbuilder-js/blob/master/libraries/botbuilder/src/bot.ts#L154)

This addresses issue #96 
