### PR TITLE
Simplified Construction and Ordering of Bot/MiddlwareSet Interactions

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/BotContext.cs
@@ -40,10 +40,10 @@ namespace Microsoft.Bot.Builder
             _conversationReference = conversationReference ?? throw new ArgumentNullException(nameof(conversationReference));
         }
 
-        public async Task SendActivity(IBotContext context, IList<IActivity> activities)
-        {
-            await _bot.SendActivity(context, activities).ConfigureAwait(false);
-        }
+        //public async Task SendActivity(IBotContext context, IList<IActivity> activities)
+        //{
+        //    await _bot.SendActivity(context, activities).ConfigureAwait(false);
+        //}
 
         public IActivity Request => _request;
 

--- a/libraries/Microsoft.Bot.Builder/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder/IBotContext.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Bot.Builder
 
     public static partial class BotContextExtension
     {
-        public static async Task Send(this BotContext context)
-        {            
-            await context.SendActivity(context, new List<IActivity>()).ConfigureAwait(false);
-        }
+        //public static async Task Send(this BotContext context)
+        //{            
+        //    await context.SendActivity(context, new List<IActivity>()).ConfigureAwait(false);
+        //}
 
         public static BotContext ToBotContext(this IBotContext context)
         {

--- a/libraries/Microsoft.Bot.Builder/Middleware/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/MiddlewareSet.cs
@@ -21,29 +21,29 @@ namespace Microsoft.Bot.Builder.Middleware
             return this;
         }
 
-        public MiddlewareSet OnReceive(Func<IBotContext, NextDelegate, Task> anonymousMethod)
-        {
-            if (anonymousMethod == null)
-                throw new ArgumentNullException(nameof(anonymousMethod));
+        //public MiddlewareSet OnReceive(Func<IBotContext, NextDelegate, Task> anonymousMethod)
+        //{
+        //    if (anonymousMethod == null)
+        //        throw new ArgumentNullException(nameof(anonymousMethod));
 
-            return this.Use(new AnonymousReceiveMiddleware(anonymousMethod));
-        }
+        //    return this.Use(new AnonymousReceiveMiddleware(anonymousMethod));
+        //}
 
-        public MiddlewareSet OnContextCreated(Func<IBotContext, NextDelegate, Task> anonymousMethod)
-        {
-            if (anonymousMethod == null)
-                throw new ArgumentNullException(nameof(anonymousMethod));
+        //public MiddlewareSet OnContextCreated(Func<IBotContext, NextDelegate, Task> anonymousMethod)
+        //{
+        //    if (anonymousMethod == null)
+        //        throw new ArgumentNullException(nameof(anonymousMethod));
 
-            return this.Use(new AnonymousContextCreatedMiddleware(anonymousMethod));
-        }
+        //    return this.Use(new AnonymousContextCreatedMiddleware(anonymousMethod));
+        //}
 
-        public MiddlewareSet OnSendActivity(Func<IBotContext, IList<IActivity>, NextDelegate, Task> anonymousMethod)
-        {
-            if (anonymousMethod == null)
-                throw new ArgumentNullException(nameof(anonymousMethod));
+        //public MiddlewareSet OnSendActivity(Func<IBotContext, IList<IActivity>, NextDelegate, Task> anonymousMethod)
+        //{
+        //    if (anonymousMethod == null)
+        //        throw new ArgumentNullException(nameof(anonymousMethod));
 
-            return this.Use(new AnonymousSendActivityMiddleware(anonymousMethod));
-        }
+        //    return this.Use(new AnonymousSendActivityMiddleware(anonymousMethod));
+        //}
 
         public async Task ContextCreated(IBotContext context)
         {

--- a/samples/AlarmBot-Cards/Controllers/MessagesController.cs
+++ b/samples/AlarmBot-Cards/Controllers/MessagesController.cs
@@ -42,7 +42,7 @@ namespace AlarmBot.Controllers
                 //IStorage storage = new AzureTableStorage((System.Diagnostics.Debugger.IsAttached) ? "UseDevelopmentStorage=true;" : configuration.GetSection("DataConnectionString")?.Value, tableName: "AlarmBot");
 
                 // create bot hooked up to the activity adapater
-                bot = new Bot(activityAdapter)                                    
+                bot = new Bot(activityAdapter)
                     .Use(new BotStateManager(storage)) // --- add Bot State Manager to automatically persist and load the context.State.Conversation and context.State.User objects
                     .Use(new DefaultTopicView())
                     .Use(new ShowAlarmsTopicView())
@@ -55,12 +55,13 @@ namespace AlarmBot.Controllers
                         .AddIntent("help", new Regex("help(.*)", RegexOptions.IgnoreCase))
                         .AddIntent("cancel", new Regex("cancel(.*)", RegexOptions.IgnoreCase))
                         .AddIntent("confirmYes", new Regex("(yes|yep|yessir|^y$)", RegexOptions.IgnoreCase))
-                        .AddIntent("confirmNo", new Regex("(no|nope|^n$)", RegexOptions.IgnoreCase)))
-                    .OnReceive(BotReceiveHandler);
+                        .AddIntent("confirmNo", new Regex("(no|nope|^n$)", RegexOptions.IgnoreCase)));
+
+                bot.OnReceive(BotReceiveHandler);
             }
         }
 
-        private async Task BotReceiveHandler(IBotContext context, MiddlewareSet.NextDelegate next)
+        private async Task BotReceiveHandler(IBotContext context)
         {
             // --- Bot logic 
             bool handled = false;
@@ -90,8 +91,6 @@ namespace AlarmBot.Controllers
                 context.State.Conversation[ConversationProperties.ACTIVETOPIC] = activeTopic;
                 handled = await activeTopic.ResumeTopic(context);
             }
-
-            await next();
         }
 
         [HttpPost]

--- a/samples/AlarmBot/Controllers/MessagesController.cs
+++ b/samples/AlarmBot/Controllers/MessagesController.cs
@@ -55,12 +55,13 @@ namespace AlarmBot.Controllers
                         .AddIntent("help", new Regex("help(.*)", RegexOptions.IgnoreCase))
                         .AddIntent("cancel", new Regex("cancel(.*)", RegexOptions.IgnoreCase))
                         .AddIntent("confirmYes", new Regex("(yes|yep|yessir|^y$)", RegexOptions.IgnoreCase))
-                        .AddIntent("confirmNo", new Regex("(no|nope|^n$)", RegexOptions.IgnoreCase)))
-                    .OnReceive(BotReceiveHandler); 
+                        .AddIntent("confirmNo", new Regex("(no|nope|^n$)", RegexOptions.IgnoreCase)));
+                
+                bot.OnReceive(BotReceiveHandler); 
             }
         }
 
-        private async Task BotReceiveHandler(IBotContext context, MiddlewareSet.NextDelegate next)
+        private async Task BotReceiveHandler(IBotContext context)
         {
             // --- Bot logic 
             bool handled = false;
@@ -90,8 +91,6 @@ namespace AlarmBot.Controllers
                 context.State.Conversation[ConversationProperties.ACTIVETOPIC] = activeTopic;
                 handled = await activeTopic.ResumeTopic(context);
             }
-
-            await next();
         }
 
         [HttpPost]

--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
@@ -29,17 +29,17 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         public MessagesController(IConfiguration configuration)
         {
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
-                .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"))
-                
+                .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"));
+            
                 // LUIS with correct baseUri format example
                 //.Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx", "https://xxxxxx.api.cognitive.microsoft.com/luis/v2.0/apps"))
                 
-                .OnReceive(BotReceiveHandler);
+            bot.OnReceive(BotReceiveHandler);
 
             _adapter = (BotFrameworkAdapter)bot.Adapter;
         }
 
-        private Task BotReceiveHandler(IBotContext context, MiddlewareSet.NextDelegate next)
+        private Task BotReceiveHandler(IBotContext context)
         {
             if (context.Request.Type == ActivityTypes.Message)
             {

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
-                .Use(new QnAMaker(qnaOptions))
-                .OnReceive(BotReceiveHandler);
+                .Use(new QnAMaker(qnaOptions));
+            bot.OnReceive(BotReceiveHandler);
                
             _adapter = (BotFrameworkAdapter)bot.Adapter;
         }
 
-        private Task BotReceiveHandler(IBotContext context, MiddlewareSet.NextDelegate next)
+        private Task BotReceiveHandler(IBotContext context)
         {
             if (context.Request.Type == ActivityTypes.Message && context.Responses.Count == 0)
             {

--- a/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
@@ -29,13 +29,13 @@ namespace Microsoft.Bot.Samples.CustomMiddleware
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 .Use(new ExampleMiddleware("X"))
                 .Use(new ExampleMiddleware("\tY"))
-                .Use(new ExampleMiddleware("\t\tZ"))
-                .OnReceive(BotReceiveHandler);
+                .Use(new ExampleMiddleware("\t\tZ"));
+            bot.OnReceive(BotReceiveHandler);
 
             _adapter = (BotFrameworkAdapter)bot.Adapter;
         }
 
-        private Task BotReceiveHandler(IBotContext context, MiddlewareSet.NextDelegate next)
+        private Task BotReceiveHandler(IBotContext context)
         {
             if (context.Request.Type == ActivityTypes.Message)
             {

--- a/samples/Microsoft.Bot.Samples.EchoBot-Console/Program.cs
+++ b/samples/Microsoft.Bot.Samples.EchoBot-Console/Program.cs
@@ -18,14 +18,13 @@ namespace Microsoft.Bot.Samples.EchoBot
         static async Task MainAsync(string[] args)
         {
             var cc = new ConsoleAdapter();
-            Builder.Bot bot = new Builder.Bot(cc)
-                .OnReceive(async (context, next) =>
+            Builder.Bot bot = new Builder.Bot(cc);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.Request.Type == ActivityTypes.Message)
                     {
                         context.Reply($"echo: {context.Request.AsMessageActivity().Text}");
                     }
-                    await next();
                 });
 
             Console.WriteLine("Welcome to the EchoBot.");

--- a/samples/Microsoft.Bot.Samples.Simplified.Asp/BotController.cs
+++ b/samples/Microsoft.Bot.Samples.Simplified.Asp/BotController.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Samples.Simplified.Asp
             bot.OnReceive(BotReceiveHandler);
         }
 
-        private async Task BotReceiveHandler(IBotContext context, MiddlewareSet.NextDelegate next)
+        private async Task BotReceiveHandler(IBotContext context)
         {
             switch (context.Request.Type)
             {

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/LuisRecognizerTests.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Bot.Builder.Ai.Tests
             }
 
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)                                
-                .Use(new LuisRecognizerMiddleware(luisAppId, subscriptionKey))
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter)
+                .Use(new LuisRecognizerMiddleware(luisAppId, subscriptionKey));
+            bot.OnReceive((context) =>
                 {
                     context.Reply(context.TopIntent.Name);
-                    await next();
+                    return Task.CompletedTask;
                 });
             await adapter
                 .Send("I want ham and cheese sandwich!")

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
@@ -58,20 +58,21 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         {
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
-                {
-                    if (context.Request.AsMessageActivity().Text == "foo")
-                    {
-                        context.Reply(context.Request.AsMessageActivity().Text);                        
-                    }
-                    await next();
-                })
                 .Use(new QnAMaker(new QnAMakerOptions()
                 {
                     KnowledgeBaseId = knowlegeBaseId,
                     SubscriptionKey = subscriptionKey,
                     Top = 1
                 }));
+
+            bot.OnReceive((context) =>
+                {
+                    if (context.Request.AsMessageActivity().Text == "foo")
+                    {
+                        context.Reply(context.Request.AsMessageActivity().Text);
+                    }
+                    return Task.CompletedTask;
+                });               
 
             await adapter
                 .Send("foo")

--- a/tests/Microsoft.Bot.Builder.Tests/Adapter_TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapter_TestAdapterTests.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Bot.Builder.Tests
         private TestAdapter CreateAdapter()
         {
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .OnReceive(
-                    async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(
+                    async (context) =>
                     {
                         switch (context.Request.AsMessageActivity().Text)
                         {
@@ -31,8 +31,7 @@ namespace Microsoft.Bot.Builder.Tests
                             default:
                                 context.Reply($"echo:{context.Request.AsMessageActivity().Text}");
                                 break;
-                        }
-                        await next(); 
+                        }                        
                     }
                 );
             return adapter;

--- a/tests/Microsoft.Bot.Builder.Tests/BotContext_Tests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotContext_Tests.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Bot.Builder.Tests
 {
 
     public class AnnotateMiddleware : IContextCreated, IReceiveActivity, ISendActivity
-    {                
-        public async Task SendActivity(BotContext context, IList<Activity> activities) { ; }
+    {
+        public async Task SendActivity(BotContext context, IList<Activity> activities) {; }
         public async Task ContextDone(BotContext context) { context.State["ContextDone"] = true; }
 
         public async Task ContextCreated(IBotContext context, MiddlewareSet.NextDelegate next)
         {
             context.State["ContextCreated"] = true;
-            await next(); 
+            await next();
         }
 
         public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
         {
-            context.Request.AsMessageActivity().Text += "ReceiveActivity";            
+            context.Request.AsMessageActivity().Text += "ReceiveActivity";
             await next();
         }
         public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
         {
             context.Responses[0].AsMessageActivity().Text += "SendActivity";
-            await next();             
+            await next();
         }
     }
 
@@ -43,9 +43,10 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter);
             bot = bot
-                .Use(new AnnotateMiddleware())
-                .OnReceive(
-                    async (context, next) =>
+                .Use(new AnnotateMiddleware());
+
+            bot.OnReceive(
+                    async (context) =>
                     {
                         Assert.AreEqual(true, context.State["ContextCreated"]);
                         Assert.IsTrue(context.Request.AsMessageActivity().Text.Contains("ReceiveActivity"));
@@ -71,8 +72,6 @@ namespace Microsoft.Bot.Builder.Tests
                         {
                             context.Reply(context.Request.AsMessageActivity().Text);
                         }
-
-                        await next(); 
                     }
                 );
             return adapter;
@@ -111,14 +110,13 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task Context_ReplyTextOnly()
         {
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.Request.AsMessageActivity().Text == "hello")
                     {
                         context.Reply("world");
                     }
-                    await next();
                 });
 
             await adapter
@@ -134,14 +132,13 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             string ssml = @"<speak><p>hello</p></speak>";
 
-            Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.Request.AsMessageActivity().Text == "hello")
                     {
                         context.Reply("use ssml", ssml);
                     }
-                    await next();
                 });
 
             await adapter
@@ -151,7 +148,7 @@ namespace Microsoft.Bot.Builder.Tests
                         Assert.AreEqual("use ssml", activity.AsMessageActivity().Text);
                         Assert.AreEqual(ssml, activity.AsMessageActivity().Speak);
                     }
-                    , "send/reply with speak text works")                    
+                    , "send/reply with speak text works")
             .StartTest();
         }
 
@@ -160,8 +157,8 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task Context_ReplyActivity()
         {
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.Request.AsMessageActivity().Text == "hello")
                     {
@@ -169,7 +166,6 @@ namespace Microsoft.Bot.Builder.Tests
                         reply.AsMessageActivity().Text = "world";
                         context.Reply(reply);
                     }
-                    await next();
                 });
 
             await adapter

--- a/tests/Microsoft.Bot.Builder.Tests/ContextExtensionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ContextExtensionTests.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task ContextDelay()
         {
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.Request.AsMessageActivity().Text == "wait")
                     {
@@ -31,8 +31,7 @@ namespace Microsoft.Bot.Builder.Tests
                     else
                     {
                         context.Reply(context.Request.AsMessageActivity().Text);
-                    }
-                    await next(); 
+                    }                    
                 });
 
             DateTime start = DateTime.Now;
@@ -52,8 +51,8 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task ContextShowTyping()
         {
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.Request.AsMessageActivity().Text == "typing")
                     {
@@ -64,7 +63,6 @@ namespace Microsoft.Bot.Builder.Tests
                     {
                         context.Reply(context.Request.AsMessageActivity().Text);
                     }
-                    await next(); 
                 });
 
             await adapter

--- a/tests/Microsoft.Bot.Builder.Tests/Intent_RegExRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Intent_RegExRecognizerTests.cs
@@ -24,13 +24,12 @@ namespace Microsoft.Bot.Builder.Tests
                 .AddIntent("HelpIntent", new Regex("help", RegexOptions.IgnoreCase));
 
             Bot bot = new Bot(adapter)
-                .Use(helpRecognizer)
-                .OnReceive(async (context, next) =>
+                .Use(helpRecognizer);
+
+            bot.OnReceive(async (context) =>
                 {
                     if (context.IfIntent("HelpIntent"))
                         context.Reply("You selected HelpIntent");
-
-                    await next(); 
                 });
 
             await adapter.Test("help", "You selected HelpIntent")
@@ -86,15 +85,13 @@ namespace Microsoft.Bot.Builder.Tests
                 .AddIntent("bbbbb", new Regex("b", RegexOptions.IgnoreCase));
 
             Bot bot = new Bot(adapter)
-                .Use(recognizer)
-                .OnReceive(async (context, next) =>
+                .Use(recognizer);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.IfIntent(new Regex("a")))
                         context.Reply("aaaa Intent");
                     if (context.IfIntent(new Regex("b")))
                         context.Reply("bbbb Intent");
-
-                    await next();
                 });
 
             await adapter.Test("aaaaaaaaa", "aaaa Intent")
@@ -113,12 +110,11 @@ namespace Microsoft.Bot.Builder.Tests
                 .AddIntent("CancelIntent", new Regex("cancel", RegexOptions.IgnoreCase));
 
             Bot bot = new Bot(adapter)
-                .Use(helpRecognizer)
-                .OnReceive(async (context, next) =>
+                .Use(helpRecognizer);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.IfIntent("CancelIntent"))
-                        context.Reply("You selected CancelIntent");
-                    await next(); 
+                        context.Reply("You selected CancelIntent");                    
                 });
 
             await adapter.Test("cancel", "You selected CancelIntent")
@@ -136,15 +132,14 @@ namespace Microsoft.Bot.Builder.Tests
                 .AddIntent("CancelIntent", new Regex("cancel", RegexOptions.IgnoreCase));
 
             Bot bot = new Bot(adapter)
-                .Use(helpRecognizer)
-                .OnReceive(async (context, next) =>
+                .Use(helpRecognizer);
+
+            bot.OnReceive(async (context) =>
                 {
                     if (context.IfIntent("CancelIntent"))
                         context.Reply("You selected CancelIntent");
                     else
                         context.Reply("Bot received request of type message");
-
-                    await next(); 
                 });
 
             await adapter.Test("tacos", "Bot received request of type message")
@@ -164,8 +159,8 @@ namespace Microsoft.Bot.Builder.Tests
                 .AddIntent("TacoIntent", new Regex("taco", RegexOptions.IgnoreCase));
 
             Bot bot = new Bot(adapter)
-                .Use(helpRecognizer)
-                .OnReceive(async (context, next) =>
+                .Use(helpRecognizer);
+            bot.OnReceive(async (context) =>
                 {
                     if (context.IfIntent("HelpIntent"))
                         context.Reply("You selected HelpIntent");
@@ -173,8 +168,6 @@ namespace Microsoft.Bot.Builder.Tests
                         context.Reply("You selected CancelIntent");
                     else if (context.IfIntent("TacoIntent"))
                         context.Reply("You selected TacoIntent");
-
-                    await next(); 
                 });
 
             await adapter

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_BindOutoingResponsesTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_BindOutoingResponsesTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             TestAdapter adapter = new TestAdapter();
             Bot b = new Bot(adapter);
-            b.OnReceive(async (context, next) =>
+            b.OnReceive(async (context) =>
                {
                    Assert.IsTrue(string.IsNullOrEmpty(a.Type));
                    context.Responses.Add(a);

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_ComposibilityTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_ComposibilityTests.cs
@@ -20,18 +20,18 @@ namespace Microsoft.Bot.Builder.Tests
             bool innerOnReceiveCalled = false;
 
             MiddlewareSet inner = new MiddlewareSet();
-            inner.OnReceive(async (context, next) =>
-               {
-                   innerOnReceiveCalled = true;
-                   await next(); 
-               });
+            inner.Use(new AnonymousReceiveMiddleware(async (context, next) =>
+            {
+                innerOnReceiveCalled = true;
+                await next();
+            }));
 
             MiddlewareSet outer = new MiddlewareSet();
-            outer.Use(inner); 
+            outer.Use(inner);
 
-            await outer.ReceiveActivity(null); 
+            await outer.ReceiveActivity(null);
 
-            Assert.IsTrue(innerOnReceiveCalled, "Inner Middleware Receive was not called."); 
+            Assert.IsTrue(innerOnReceiveCalled, "Inner Middleware Receive was not called.");
         }
 
         [TestMethod]
@@ -40,11 +40,11 @@ namespace Microsoft.Bot.Builder.Tests
             bool innerOnCreatedCalled = false;
 
             MiddlewareSet inner = new MiddlewareSet();
-            inner.OnContextCreated(async (context, next) =>
+            inner.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 innerOnCreatedCalled = true;
                 await next();
-            });
+            }));
 
             MiddlewareSet outer = new MiddlewareSet();
             outer.Use(inner);
@@ -61,11 +61,11 @@ namespace Microsoft.Bot.Builder.Tests
 
             MiddlewareSet inner = new MiddlewareSet();
 
-            inner.OnSendActivity(async (context, activities, next) =>
-            {
-                innerOnSendCalled = true;
-                await next();
-            });
+            inner.Use(new AnonymousSendActivityMiddleware(async (context, activities, next) =>
+           {
+               innerOnSendCalled = true;
+               await next();
+           }));
 
             MiddlewareSet outer = new MiddlewareSet();
             outer.Use(inner);
@@ -84,27 +84,27 @@ namespace Microsoft.Bot.Builder.Tests
             string replyMessage = Guid.NewGuid().ToString();
 
             MiddlewareSet inner = new MiddlewareSet();
-            inner.OnSendActivity(async (context, activities, next) =>
+            inner.Use(new AnonymousSendActivityMiddleware( async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 1, "incorrect activity count");
                 Assert.IsTrue(activities[0].AsMessageActivity().Text == replyMessage, "unexpected message");
 
                 innerOnSendCalled = true;
                 await next();
-            });
+            }));
 
-            inner.OnReceive(async (context, next) =>
+            inner.Use( new AnonymousReceiveMiddleware(async (context, next) =>
             {
-                context.Responses.Add(MessageFactory.Text(replyMessage));                
+                context.Responses.Add(MessageFactory.Text(replyMessage));
                 innerOnReceiveCalled = true;
                 await next();
-            });
+            }));
 
-            inner.OnContextCreated(async (context, next) =>
+            inner.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 innerOnCreatedCalled = true;
                 await next();
-            });
+            }));
 
             Middleware.MiddlewareSet outer = new Middleware.MiddlewareSet();
             outer.Use(inner);

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_ContextCreatedTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_ContextCreatedTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Middleware;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Tests
@@ -44,10 +45,10 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task BubbleUncaughtException()
         {
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 throw new InvalidOperationException("test");
-            });
+            }));
 
             await m.ContextCreated(null);
             Assert.Fail("Should never have gotten here");
@@ -100,12 +101,12 @@ namespace Microsoft.Bot.Builder.Tests
         {
             bool didRun = false;
 
-            Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
-            m.OnContextCreated(async (context, next) =>
+            MiddlewareSet m = new MiddlewareSet();
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 didRun = true;
                 await next();
-            });
+            }));
 
             Assert.IsFalse(didRun);
             await m.ContextCreated(null);
@@ -119,16 +120,17 @@ namespace Microsoft.Bot.Builder.Tests
             bool didRun2 = false;
 
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 didRun1 = true;
                 await next();
-            });
-            m.OnContextCreated(async (context, next) =>
+            }));
+
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 didRun2 = true;
                 await next();
-            });
+            }));
 
             await m.ContextCreated(null);
             Assert.IsTrue(didRun1);
@@ -141,19 +143,19 @@ namespace Microsoft.Bot.Builder.Tests
             bool didRun1 = false;
             bool didRun2 = false;
 
-            Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
-            m.OnContextCreated(async (context, next) =>
+            MiddlewareSet m = new Middleware.MiddlewareSet();
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 Assert.IsFalse(didRun2, "Looks like the 2nd one has already run");
                 didRun1 = true;
                 await next();
-            });
-            m.OnContextCreated(async (context, next) =>
+            }));
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 Assert.IsTrue(didRun1, "Looks like the 1nd one has not yet run");
                 didRun2 = true;
                 await next();
-            });
+            }));
 
             await m.ContextCreated(null);
             Assert.IsTrue(didRun1);
@@ -168,12 +170,12 @@ namespace Microsoft.Bot.Builder.Tests
 
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
 
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 Assert.IsFalse(didRun2, "Looks like the 2nd one has already run");
                 didRun1 = true;
                 await next();
-            });
+            }));
 
             m.Use(
                 new CallMeMiddlware(() =>
@@ -202,12 +204,12 @@ namespace Microsoft.Bot.Builder.Tests
                     didRun1 = true;
                 }));
 
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 Assert.IsTrue(didRun1, "Looks like the 1st middleware has not been run");
                 didRun2 = true;
                 await next();
-            });
+            }));
 
             await m.ContextCreated(null);
             Assert.IsTrue(didRun1);
@@ -223,22 +225,22 @@ namespace Microsoft.Bot.Builder.Tests
 
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
 
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 Assert.IsFalse(didRun1, "Looks like the 1st middleware has already run");
                 didRun1 = true;
                 await next();
                 Assert.IsTrue(didRun1, "The 2nd middleware should have run now.");
                 codeafter2run = true;
-            });
+            }));
 
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 Assert.IsTrue(didRun1, "Looks like the 1st middleware has not been run");
                 Assert.IsFalse(codeafter2run, "The code that runs after middleware 2 is complete has already run.");
                 didRun2 = true;
                 await next();
-            });
+            }));
 
             await m.ContextCreated(null);
             Assert.IsTrue(didRun1);
@@ -252,7 +254,7 @@ namespace Microsoft.Bot.Builder.Tests
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
             bool caughtException = false;
 
-            m.OnContextCreated(async (context, next) =>
+            m.Use( new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 try
                 {
@@ -264,12 +266,12 @@ namespace Microsoft.Bot.Builder.Tests
                     Assert.IsTrue(ex.Message == "test");
                     caughtException = true;
                 }
-            });
+            }));
 
-            m.OnContextCreated(async (context, next) =>
+            m.Use(new AnonymousContextCreatedMiddleware(async (context, next) =>
             {
                 throw new Exception("test");
-            });
+            }));
 
             await m.ContextCreated(null);
             Assert.IsTrue(caughtException);

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_PostActivityTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_PostActivityTests.cs
@@ -35,11 +35,12 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task BubbleUncaughtException()
         {
             MiddlewareSet m = new MiddlewareSet();
-            m.OnSendActivity(async (context, activities, next) =>
+            m.Use(
+                new AnonymousSendActivityMiddleware(async (context, activities, next) =>
             {
                 throw new InvalidOperationException("test");
-            });
-
+            }));
+            
             await m.SendActivity(null, new List<IActivity>());
             Assert.Fail("Should never have gotten here");
         }
@@ -105,14 +106,14 @@ namespace Microsoft.Bot.Builder.Tests
             string message = Guid.NewGuid().ToString(); 
 
             MiddlewareSet m = new MiddlewareSet();
-            m.OnSendActivity(async (context, activities, next) =>
+            m.Use(new AnonymousSendActivityMiddleware(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 1);
                 Assert.IsTrue(activities[0].AsMessageActivity().Text == message); 
 
                 didRun = true;
                 await next();
-            });
+            }));
 
             Assert.IsFalse(didRun);
             await m.SendActivity(null, new List<IActivity> { MessageFactory.Text(message) });
@@ -131,7 +132,7 @@ namespace Microsoft.Bot.Builder.Tests
             string message3 = Guid.NewGuid().ToString();
 
             MiddlewareSet m = new MiddlewareSet();
-            m.OnSendActivity(async (context, activities, next) =>
+            m.Use(new AnonymousSendActivityMiddleware(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 1);
                 Assert.IsTrue(activities[0].AsMessageActivity().Text == message1);
@@ -145,8 +146,8 @@ namespace Microsoft.Bot.Builder.Tests
                 Assert.IsTrue(activities.Count == 2);
                 Assert.IsTrue(activities[0].AsMessageActivity().Text == message3);
                 Assert.IsTrue(activities[1].AsMessageActivity().Text == message2);
-            });
-            m.OnSendActivity(async (context, activities, next) =>
+            }));
+            m.Use(new AnonymousSendActivityMiddleware(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 2);
                 Assert.IsTrue(activities[0].AsMessageActivity().Text == message1);
@@ -163,9 +164,9 @@ namespace Microsoft.Bot.Builder.Tests
                 Assert.IsTrue(activities.Count == 2);
                 Assert.IsTrue(activities[0].AsMessageActivity().Text == message3);
                 Assert.IsTrue(activities[1].AsMessageActivity().Text == message2);
-            });
+            }));
 
-            m.OnSendActivity(async (context, activities, next) =>
+            m.Use(new AnonymousSendActivityMiddleware(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 2);
                 
@@ -174,7 +175,7 @@ namespace Microsoft.Bot.Builder.Tests
                 Assert.IsTrue(activities[1].AsMessageActivity().Text == message2);
                 didRun3 = true;
                 await next();
-            });
+            }));
 
             await m.SendActivity(null, new List<IActivity> { MessageFactory.Text(message1) });
             Assert.IsTrue(didRun1);

--- a/tests/Microsoft.Bot.Builder.Tests/State_BasicTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/State_BasicTests.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task State_DoNOTRememberContextState()
         {
             TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .OnReceive(async (context, next) =>
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) =>
                    {
                        Assert.IsNotNull(context.State, "context.state should exist");
                        switch (context.Request.AsMessageActivity().Text)
@@ -32,8 +32,7 @@ namespace Microsoft.Bot.Builder.Tests
                                string state = context.State["value"];
                                context.Reply(state);
                                break;
-                       }
-                       await next(); 
+                       }               
                    }
                 );
             await adapter.Test("set value", "value saved", "set value failed")
@@ -46,10 +45,10 @@ namespace Microsoft.Bot.Builder.Tests
         {
             TestAdapter adapter = new TestAdapter();
 
-            Bot bot = new Bot(adapter)                
-                .Use(new BotStateManager(new MemoryStorage()))
-                .OnReceive(
-                    async (context, next) =>
+            Bot bot = new Bot(adapter)
+                .Use(new BotStateManager(new MemoryStorage()));
+            bot.OnReceive(
+                    async (context) =>
                     {
                         Assert.IsNotNull(context.State.User, "state.user should exist");
                         switch (context.Request.AsMessageActivity().Text)
@@ -62,7 +61,6 @@ namespace Microsoft.Bot.Builder.Tests
                                 context.Reply(context.State.User["value"]);
                                 break;
                         }
-                        await next(); 
                     }
                 );
 
@@ -76,10 +74,10 @@ namespace Microsoft.Bot.Builder.Tests
         {
             TestAdapter adapter = new TestAdapter();
 
-            Bot bot = new Bot(adapter)                
-                .Use(new BotStateManager(new MemoryStorage()))
-                .OnReceive(
-                    async (context, next) =>
+            Bot bot = new Bot(adapter)
+                .Use(new BotStateManager(new MemoryStorage()));
+            bot.OnReceive(
+                    async (context) =>
                     {
                         Assert.IsNotNull(context.State.Conversation, "state.conversation should exist");
                         switch (context.Request.AsMessageActivity().Text)
@@ -92,7 +90,6 @@ namespace Microsoft.Bot.Builder.Tests
                                 context.Reply(context.State.Conversation["value"]);
                                 break;
                         }
-                        await next();
                     }
                 );
 
@@ -108,9 +105,8 @@ namespace Microsoft.Bot.Builder.Tests
             string testGuid = Guid.NewGuid().ToString();
 
             Bot bot = new Bot(adapter)
-                .Use(new CustomStateManager(new MemoryStorage()))
-                .OnReceive(
-                    async (context, next) =>
+                .Use(new CustomStateManager(new MemoryStorage()));
+            bot.OnReceive(async (context) =>
                     {
                         switch (context.Request.AsMessageActivity().Text)
                         {
@@ -140,10 +136,10 @@ namespace Microsoft.Bot.Builder.Tests
         {
             TestAdapter adapter = new TestAdapter();
 
-            Bot bot = new Bot(adapter)                
-                .Use(new BotStateManager(new MemoryStorage()))
-                .OnReceive(
-                    async (context, next) =>
+            Bot bot = new Bot(adapter)
+                .Use(new BotStateManager(new MemoryStorage()));
+            bot.OnReceive(
+                    async (context) =>
                     {
                         Assert.IsNotNull(context.State.Conversation, "state.conversation should exist");
                         switch (context.Request.AsMessageActivity().Text)
@@ -155,8 +151,7 @@ namespace Microsoft.Bot.Builder.Tests
                             case "get value":
                                 context.Reply(context.State.Conversation["value"].GetType().Name);
                                 break;
-                        }
-                        await next();
+                        }                        
                     }
                 );
 

--- a/tests/Microsoft.Bot.Builder.Tests/Templates_TemplateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Templates_TemplateManagerTests.cs
@@ -113,11 +113,10 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
                 .UseTemplates(templates1)
-                .UseTemplates(templates2)
-                .OnReceive(async (context, next) =>
+                .UseTemplates(templates2);
+            bot.OnReceive(async (context) =>
                 {
-                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });
-                    await next();
+                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });                    
                 });
 
             await adapter
@@ -132,12 +131,12 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
                 .UseTemplates(templates1)
-                .UseTemplates(templates2)
-                .OnReceive(async (context, next) =>
+                .UseTemplates(templates2);
+
+            bot.OnReceive(async (context) =>
                 {
                     context.Request.AsMessageActivity().Locale = "en"; // force to english
-                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });
-                    await next();
+                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });                    
                 });
 
             await adapter
@@ -152,12 +151,12 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
                 .UseTemplates(templates1)
-                .UseTemplates(templates2)
-                .OnReceive(async (context, next) =>
+                .UseTemplates(templates2);
+
+            bot.OnReceive(async (context) =>
                 {
                     context.Request.AsMessageActivity().Locale = "fr"; // force to french
                     context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });
-                    await next(); 
                 });
 
             await adapter
@@ -172,12 +171,12 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
                 .UseTemplates(templates1)
-                .UseTemplates(templates2)
-                .OnReceive(async (context, next) =>
+                .UseTemplates(templates2);
+
+            bot.OnReceive(async (context) =>
                 {
                     context.Request.AsMessageActivity().Locale = "fr"; // force to french
-                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });
-                    await next(); 
+                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });                    
                 });
 
             await adapter
@@ -192,11 +191,10 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
                 .UseTemplateRenderer(new DictionaryRenderer(templates1))
-                .UseTemplateRenderer(new DictionaryRenderer(templates2))
-                .OnReceive(async (context, next) =>
+                .UseTemplateRenderer(new DictionaryRenderer(templates2));
+            bot.OnReceive(async (context) =>
                 {
-                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });
-                    await next();
+                    context.ReplyWith(context.Request.AsMessageActivity().Text.Trim(), new { name = "joe" });                    
                 });
 
             await adapter


### PR DESCRIPTION
Addresses issue #114 

This change simplifies the use of OnReceive() as a pattern. The new usage aligns more with the "Expected" behavior, as observed during actual customer usage 

In the previous mechanism, each OnReceive was created as a new Anononymous Middleware component and added to the queue. This worked fine for test scenarios and simple bots, but did NOT have the correct semantics for ASP.Net usage. See issue #114 for more details. 

To fix this, the following has been done:
1. Removed the "Is A" relationship between Bot and MiddlewareSet. This had originally been envisioned by Steve & I as a mechanism by which composibility could be done, but turns out just to be confusing. The Bot is a Bot, and "has a" middleware set (composition instead of inheritance). This also simplifies the intellisense on Bot. 

2. Created a simple method on Bot called OnReceive, that takes a basic delegate handler. This method, if present, runs AT THE END of the Receive pipeline. There is no next() method to call, as by definition it runs at the end. If no such method is present (which is the default) then the Middleware pipeline is run as expected. If the method is replaced, then... it's replaced. Simple semantics. 

```
        public void OnReceive(Func<IBotContext, Task> anonymousMethod)
        {
            _onReceive = anonymousMethod;            
        }
```

Note in the code above the OnReceive is **NOT** returning Bot. This **prevents chaining**, as chaining semantics here seem incorrect. Current usage forces developers to use bot.OnReceive( (ctx)=>{});. 

Actual usage then looks like:

```
bot.OnReceive(async (context) =>
                {
                      // Do Something
                });
```

3. Doing this allowed the removal of the OnReceive / OnSend / OnContextCreated method on the Middleware Set, as they're no longer needed.

4. Updated all the tests, and verified they pass. 