### PR TITLE
Fixing show typing and delay

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -87,14 +88,19 @@ namespace Microsoft.Bot.Builder
             await RunPipeline(context).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Create proactive context around conversation reference
-        /// All middleware pipelines will be processed
-        /// </summary>
-        /// <param name="reference">reference to create context around</param>
-        /// <param name="proactiveCallback">callback where you can continue the conversation</param>
-        /// <returns>task when completed</returns>
-        public virtual async Task CreateContext(ConversationReference reference, Func<IBotContext, Task> proactiveCallback)
+        public async Task SendActivity(IBotContext context, List<IActivity> activities)
+        {
+            await _middlewareSet.SendActivity(context, activities);
+        }
+
+    /// <summary>
+    /// Create proactive context around conversation reference
+    /// All middleware pipelines will be processed
+    /// </summary>
+    /// <param name="reference">reference to create context around</param>
+    /// <param name="proactiveCallback">callback where you can continue the conversation</param>
+    /// <returns>task when completed</returns>
+    public virtual async Task CreateContext(ConversationReference reference, Func<IBotContext, Task> proactiveCallback)
         {
             var context = new BotContext(this, reference);
             await RunPipeline(context, proactiveCallback).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -85,6 +86,11 @@ namespace Microsoft.Bot.Builder
             var context = new BotContext(this, activity);
 
             await RunPipeline(context).ConfigureAwait(false);
+        }
+
+        public async Task SendActivity(IBotContext context, List<IActivity> activities)
+        {
+            await _middlewareSet.SendActivity(context, activities);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -86,11 +85,6 @@ namespace Microsoft.Bot.Builder
             var context = new BotContext(this, activity);
 
             await RunPipeline(context).ConfigureAwait(false);
-        }
-
-        public async Task SendActivity(IBotContext context, List<IActivity> activities)
-        {
-            await _middlewareSet.SendActivity(context, activities);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -2,27 +2,20 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Schema;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.ContextExtensions
 {
     public static class ContextExtensionMethods
     {
-        public static async Task<IBotContext> ShowTyping(this IBotContext context)
+        public static IBotContext ShowTyping(this IBotContext context)
         {
-            Activity activity = ((Activity)context.Request).CreateReply();
-            activity.Type = ActivityTypes.Typing;
-            await context.Bot.SendActivity(context, new List<IActivity>() { activity });
+            context.Responses.Add(new Activity { Type = ActivityTypes.Typing });
             return context;
         }
 
-        public static async Task<IBotContext> Delay(this IBotContext context, int duration)
+        public static IBotContext Delay(this IBotContext context, int duration)
         {
-            Activity activity = ((Activity)context.Request).CreateReply();
-            activity.Type = "delay";
-            activity.Value = duration;
-            await context.Bot.SendActivity(context, new List<IActivity>() { activity });
+            context.Responses.Add(new Activity { Type = "delay", Value = duration });
             return context;
         }
     }

--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -2,20 +2,27 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Schema;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.ContextExtensions
 {
     public static class ContextExtensionMethods
     {
-        public static IBotContext ShowTyping(this IBotContext context)
+        public static async Task<IBotContext> ShowTyping(this IBotContext context)
         {
-            context.Responses.Add(new Activity { Type = ActivityTypes.Typing });
+            Activity activity = ((Activity)context.Request).CreateReply();
+            activity.Type = ActivityTypes.Typing;
+            await context.Bot.SendActivity(context, new List<IActivity>() { activity });
             return context;
         }
 
-        public static IBotContext Delay(this IBotContext context, int duration)
+        public static async Task<IBotContext> Delay(this IBotContext context, int duration)
         {
-            context.Responses.Add(new Activity { Type = "delay", Value = duration });
+            Activity activity = ((Activity)context.Request).CreateReply();
+            activity.Type = "delay";
+            activity.Value = duration;
+            await context.Bot.SendActivity(context, new List<IActivity>() { activity });
             return context;
         }
     }

--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.ContextExtensions
         public static async Task<IBotContext> Delay(this IBotContext context, int duration)
         {
             Activity activity = ((Activity)context.Request).CreateReply();
-            activity.Type = ActivityTypes.Delay;
+            activity.Type = "delay";
             activity.Value = duration;
             await context.Bot.SendActivity(context, new List<IActivity>() { activity });
             return context;

--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.ContextExtensions
         public static async Task<IBotContext> Delay(this IBotContext context, int duration)
         {
             Activity activity = ((Activity)context.Request).CreateReply();
-            activity.Type = "delay";
+            activity.Type = ActivityTypes.Delay;
             activity.Value = duration;
             await context.Bot.SendActivity(context, new List<IActivity>() { activity });
             return context;

--- a/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Bot.Schema
         public const string ContactRelationUpdate = "contactRelationUpdate";
         public const string ConversationUpdate = "conversationUpdate";
         public const string Typing = "typing";
-        public const string Delay = "delay";
         public const string Ping = "ping";
         public const string EndOfConversation = "endOfConversation";
         public const string Event = "event";

--- a/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Bot.Schema
         public const string ContactRelationUpdate = "contactRelationUpdate";
         public const string ConversationUpdate = "conversationUpdate";
         public const string Typing = "typing";
+        public const string Delay = "delay";
         public const string Ping = "ping";
         public const string EndOfConversation = "endOfConversation";
         public const string Event = "event";

--- a/tests/Microsoft.Bot.Builder.Tests/ContextExtensionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ContextExtensionTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Bot.Builder.Tests
                 {
                     if (context.Request.AsMessageActivity().Text == "wait")
                     {
-                        context
+                        (await context
                             .Reply("before")
-                            .Delay(1000)
+                            .Delay(1000))
                             .Reply("after");
                     }
                     else


### PR DESCRIPTION
When the IActivitie's were being processed ServiceUrl and Conversation were not set. This was preventing the Typing from being sent.

I added the SendActivity method back because there is no flush method in order to force the Typing Activity to show in the chat client.