### PR TITLE
QnAMakerMiddleware with static HttpClient

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -39,12 +39,11 @@ namespace Microsoft.Bot.Builder.Ai
         public int Top { get; set; }
     }
 
-    public class QnAMaker : Middleware.IReceiveActivity, IDisposable
+    public class QnAMaker : Middleware.IReceiveActivity
     {
         public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
         private string answerUrl;
         private QnAMakerOptions options;
-        private HttpClient httpClient;
 
         public QnAMaker(QnAMakerOptions options)
         {
@@ -58,11 +57,6 @@ namespace Microsoft.Bot.Builder.Ai
 
         public async Task<QueryResult[]> GetAnswers(string question)
         {
-            lock (options)
-            {
-                if (httpClient == null)
-                    this.httpClient = new HttpClient();
-            }
             var request = new HttpRequestMessage(HttpMethod.Post, this.answerUrl);
 
             string jsonRequest = JsonConvert.SerializeObject(new
@@ -73,7 +67,7 @@ namespace Microsoft.Bot.Builder.Ai
 
             var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
             content.Headers.Add("Ocp-Apim-Subscription-Key", this.options.SubscriptionKey);
-            var response = await httpClient.PostAsync(this.answerUrl, content).ConfigureAwait(false);
+            var response = await Bot.GetHttpClientInstance().PostAsync(this.answerUrl, content).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -101,19 +95,6 @@ namespace Microsoft.Bot.Builder.Ai
             }
 
             await next().ConfigureAwait(false); 
-        }
-
-
-        public void Dispose()
-        {
-            lock (options)
-            {
-                if (httpClient != null)
-                {
-                    httpClient.Dispose();
-                    httpClient = null;
-                }
-            }
         }
 
     }

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Ai
         public int Top { get; set; }
     }
 
-    public class QnAMakerMiddleware : Middleware.IReceiveActivity, IDisposable
+    public class QnAMakerMiddleware : Middleware.IReceiveActivity
     {
         public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
         private string answerUrl;

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Bot.Builder.Ai
         public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
         private string answerUrl;
         private QnAMakerOptions options;
+        private readonly HttpClient httpClient;
 
-        public QnAMakerMiddleware(QnAMakerOptions options)
+        public QnAMakerMiddleware(QnAMakerOptions options, HttpClient httpClient)
         {
             this.answerUrl = $"{qnaMakerServiceEndpoint}{options.KnowledgeBaseId}/generateanswer";
             if (options.ScoreThreshold == 0)
@@ -53,6 +54,7 @@ namespace Microsoft.Bot.Builder.Ai
             if (options.Top == 0)
                 options.Top = 1;
             this.options = options;
+            this.httpClient = httpClient;
         }
 
         public async Task<QueryResult[]> GetAnswers(string question)
@@ -67,7 +69,7 @@ namespace Microsoft.Bot.Builder.Ai
 
             var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
             content.Headers.Add("Ocp-Apim-Subscription-Key", this.options.SubscriptionKey);
-            var response = await Bot.GetHttpClientInstance().PostAsync(this.answerUrl, content).ConfigureAwait(false);
+            var response = await this.httpClient.PostAsync(this.answerUrl, content).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
                 var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -103,6 +103,12 @@ namespace Microsoft.Bot.Builder
             await RunPipeline(context, proactiveCallback).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Method to get an HttpClient to promote reuse of the sharable client. This method should be preferred
+        /// over new'ing up a new HttpClient.
+        /// See https://docs.microsoft.com/en-us/azure/architecture/antipatterns/improper-instantiation/#considerations
+        /// </summary>
+        /// <returns>a shared instance of HttpClient</returns>
         public static HttpClient GetHttpClientInstance()
         {
             if (_httpClient == null)

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Bot.Builder
         private readonly Middleware.MiddlewareSet _middlewareSet = new Middleware.MiddlewareSet();
         Func<IBotContext, Task> _onReceive = null;
 
-        private static HttpClient _httpClient = new HttpClient();
-
         public void OnReceive(Func<IBotContext, Task> anonymousMethod)
         {
             _onReceive = anonymousMethod;            
@@ -101,17 +99,6 @@ namespace Microsoft.Bot.Builder
         {
             var context = new BotContext(this, reference);
             await RunPipeline(context, proactiveCallback).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Method to get an HttpClient to promote reuse of the sharable client. This method should be preferred
-        /// over new'ing up a new HttpClient.
-        /// See https://docs.microsoft.com/en-us/azure/architecture/antipatterns/improper-instantiation/#considerations
-        /// </summary>
-        /// <returns>a shared instance of HttpClient</returns>
-        public static HttpClient GetHttpClientInstance()
-        {
-            return _httpClient;
         }
 
     }

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder
         private readonly Middleware.MiddlewareSet _middlewareSet = new Middleware.MiddlewareSet();
         Func<IBotContext, Task> _onReceive = null;
 
-        private static HttpClient _httpClient;
+        private static HttpClient _httpClient = new HttpClient();
 
         public void OnReceive(Func<IBotContext, Task> anonymousMethod)
         {
@@ -111,11 +111,6 @@ namespace Microsoft.Bot.Builder
         /// <returns>a shared instance of HttpClient</returns>
         public static HttpClient GetHttpClientInstance()
         {
-            if (_httpClient == null)
-            {
-                _httpClient = new HttpClient();
-            }
-
             return _httpClient;
         }
 

--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
@@ -13,7 +14,9 @@ namespace Microsoft.Bot.Builder
     {
         private ActivityAdapterBase _adapter;
         private readonly Middleware.MiddlewareSet _middlewareSet = new Middleware.MiddlewareSet();
-        Func<IBotContext, Task> _onReceive = null; 
+        Func<IBotContext, Task> _onReceive = null;
+
+        private static HttpClient _httpClient;
 
         public void OnReceive(Func<IBotContext, Task> anonymousMethod)
         {
@@ -98,6 +101,17 @@ namespace Microsoft.Bot.Builder
         {
             var context = new BotContext(this, reference);
             await RunPipeline(context, proactiveCallback).ConfigureAwait(false);
-        }    
+        }
+
+        public static HttpClient GetHttpClientInstance()
+        {
+            if (_httpClient == null)
+            {
+                _httpClient = new HttpClient();
+            }
+
+            return _httpClient;
+        }
+
     }
 }

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
@@ -17,7 +18,16 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
     [Route("api/[controller]")]
     public class MessagesController : Controller
     {
+
+        private static readonly HttpClient HttpClient;
+
         BotFrameworkAdapter _adapter;
+
+        static MessagesController()
+        {
+            HttpClient = new HttpClient();
+        }
+
         public MessagesController(IConfiguration configuration)
         {
             var qnaOptions = new QnAMakerOptions
@@ -28,7 +38,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
-                .Use(new QnAMakerMiddleware(qnaOptions));
+                .Use(new QnAMakerMiddleware(qnaOptions, HttpClient));
             bot.OnReceive(BotReceiveHandler);
                
             _adapter = (BotFrameworkAdapter)bot.Adapter;

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Tests;
@@ -14,6 +15,13 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
         public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
 
+        private static readonly HttpClient HttpClient;
+
+        static QnaMakerTests()
+        {
+            HttpClient = new HttpClient();
+        }
+
         //[TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
@@ -24,7 +32,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
                 Top = 1
-            });
+            }, HttpClient);
 
             var results = await qna.GetAnswers("how do I clean the stove?");
             Assert.IsNotNull(results);
@@ -44,7 +52,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
                 SubscriptionKey = subscriptionKey,
                 Top = 1,
                 ScoreThreshold = 0.99F
-            });
+            }, HttpClient);
 
             var results = await qna.GetAnswers("how do I clean the stove?");
             Assert.IsNotNull(results);
@@ -63,7 +71,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
                     KnowledgeBaseId = knowlegeBaseId,
                     SubscriptionKey = subscriptionKey,
                     Top = 1
-                }));
+                }, HttpClient));
 
             bot.OnReceive((context) =>
                 {


### PR DESCRIPTION
Potential fix to #107. I have created a static instance of HttpClient in the Bot class as it is one of the most core classes of the BotBuilder.

According to the docs HttpClient is thread safe and is encouraged to be shared. 

https://docs.microsoft.com/en-us/azure/architecture/antipatterns/improper-instantiation/#considerations