### PR TITLE
Changing QnAMaker to QnAMakerMiddleware to be consistent for #120.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
@@ -39,14 +39,14 @@ namespace Microsoft.Bot.Builder.Ai
         public int Top { get; set; }
     }
 
-    public class QnAMaker : Middleware.IReceiveActivity, IDisposable
+    public class QnAMakerMiddleware : Middleware.IReceiveActivity, IDisposable
     {
         public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
         private string answerUrl;
         private QnAMakerOptions options;
         private HttpClient httpClient;
 
-        public QnAMaker(QnAMakerOptions options)
+        public QnAMakerMiddleware(QnAMakerOptions options)
         {
             this.answerUrl = $"{qnaMakerServiceEndpoint}{options.KnowledgeBaseId}/generateanswer";
             if (options.ScoreThreshold == 0)

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
-                .Use(new QnAMaker(qnaOptions));
+                .Use(new QnAMakerMiddleware(qnaOptions));
             bot.OnReceive(BotReceiveHandler);
                
             _adapter = (BotFrameworkAdapter)bot.Adapter;

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_ReturnsAnswer()
         {
-            var qna = new QnAMaker(new QnAMakerOptions()
+            var qna = new QnAMakerMiddleware(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         public async Task QnaMaker_TestThreshold()
         {
 
-            var qna = new QnAMaker(new QnAMakerOptions()
+            var qna = new QnAMakerMiddleware(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         {
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
-                .Use(new QnAMaker(new QnAMakerOptions()
+                .Use(new QnAMakerMiddleware(new QnAMakerOptions()
                 {
                     KnowledgeBaseId = knowlegeBaseId,
                     SubscriptionKey = subscriptionKey,


### PR DESCRIPTION
Changing QnAMaker to QnAMakerMiddleware to be consistent for #120.

Suffixing with Middleware seems to be consistent with how Microsoft is naming other common types: https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces