### PR TITLE
Make the HttpClient of QnA Maker static

### DIFF
--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
         public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
 
-        //[TestMethod]
+        [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_ReturnsAnswer()
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
             Assert.IsTrue(results[0].Answer.StartsWith("BaseCamp: You can use a damp rag to clean around the Power Pack"));
         }
 
-        //[TestMethod]
+        [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestThreshold()
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
             Assert.AreEqual(results.Length, 0, "should get zero result because threshold");
         }
 
-        //[TestMethod]
+        [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestMiddleware()


### PR DESCRIPTION
1. Made HTTPClient Static. This addresses #107 
2. Very minor code cleanup, extracting constants, readonly variables, and argument validation. 
3. Removed IDisposable and related code, as it's no longer needed. 
4. Re-Enabled tests, although I suspect this will break the build on the server, and I will shortly need to disable them before merging. 
