### PR TITLE
Reuse of HttpClient throughout the Stack.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/TranslationMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/TranslationMiddleware.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Middleware;
@@ -16,13 +17,13 @@ namespace Microsoft.Bot.Builder.Ai
     {
         private LuisClient luisClient;
         private string[] nativeLanguages;
-        private Translator translator;
+        private Translator translator;        
 
-        public TranslationMiddleware(string[] nativeLanguages, string translatorKey, string luisAppId, string luisAccessKey)
+        public TranslationMiddleware(HttpClient httpClient, string[] nativeLanguages, string translatorKey, string luisAppId, string luisAccessKey)
         {
             this.nativeLanguages = nativeLanguages;
             this.luisClient = new LuisClient(luisAppId, luisAccessKey);
-            this.translator = new Translator(translatorKey);
+            this.translator = new Translator(translatorKey, httpClient);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Connector;
@@ -16,15 +17,18 @@ namespace Microsoft.Bot.Builder.BotFramework
     {
         private readonly SimpleCredentialProvider _credentialProvider;
         private readonly MicrosoftAppCredentials _credentials;
+        private readonly HttpClient _httpClient; 
 
-        public BotFrameworkAdapter(IConfiguration configuration) : base()
+        public BotFrameworkAdapter(IConfiguration configuration, HttpClient httpClient = null) : base()
         {
+            _httpClient = httpClient ?? new HttpClient();
             _credentialProvider = new ConfigurationCredentialProvider(configuration);
-            _credentials = new MicrosoftAppCredentials(this._credentialProvider.AppId, _credentialProvider.Password);                       
+            _credentials = new MicrosoftAppCredentials(_credentialProvider.AppId, _credentialProvider.Password);                                   
         }
 
-        public BotFrameworkAdapter(string appId, string appPassword) : base()
+        public BotFrameworkAdapter(string appId, string appPassword, HttpClient httpClient = null) : base()
         {
+            _httpClient = httpClient ?? new HttpClient();
             _credentials = new MicrosoftAppCredentials(appId, appPassword);
             _credentialProvider = new SimpleCredentialProvider(appId, appPassword);
         }
@@ -53,11 +57,11 @@ namespace Microsoft.Bot.Builder.BotFramework
         public async Task Receive(string authHeader, Activity activity)
         {
             BotAssert.ActivityNotNull(activity);
-            await JwtTokenValidation.AssertValidActivity(activity, authHeader, _credentialProvider);
+            await JwtTokenValidation.AssertValidActivity(activity, authHeader, _credentialProvider, _httpClient);
 
             if (this.OnReceive != null)
             {
-                await this.OnReceive(activity).ConfigureAwait(false);
+                await OnReceive(activity).ConfigureAwait(false);
             }
         }
     }

--- a/libraries/Microsoft.Bot.Connector.AspNetCore/BotAuthenticationHandler.cs
+++ b/libraries/Microsoft.Bot.Connector.AspNetCore/BotAuthenticationHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading;
@@ -15,12 +16,13 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Bot.Connector
 {
-
     /// <summary>
     /// Bot authentication hanlder used by <see cref="BotAuthenticationMiddleware"/>.
     /// </summary>
     public class BotAuthenticationHandler : AuthenticationHandler<BotAuthenticationOptions>
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         public BotAuthenticationHandler(IOptionsMonitor<BotAuthenticationOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
             : base(options, logger, encoder, clock)
         {
@@ -53,7 +55,7 @@ namespace Microsoft.Bot.Connector
                 }
 
                 string authHeader = Request.Headers["Authorization"];
-                ClaimsIdentity claimsIdentity = await JwtTokenValidation.ValidateAuthHeader(authHeader, Options.CredentialProvider);
+                ClaimsIdentity claimsIdentity = await JwtTokenValidation.ValidateAuthHeader(authHeader, Options.CredentialProvider, _httpClient);
 
                 Logger.TokenValidationSucceeded();
 
@@ -73,7 +75,6 @@ namespace Microsoft.Bot.Connector
                 {
                     return tokenValidatedContext.Result;
                 }
-
 
                 tokenValidatedContext.Success();
                 return tokenValidatedContext.Result;

--- a/libraries/Microsoft.Bot.Connector/AttachmentsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/AttachmentsEx.cs
@@ -15,6 +15,18 @@ namespace Microsoft.Bot.Connector
     public partial class Attachments
     {
         /// <summary>
+        /// The attachment code uses this client. Ideally, this would be passed in or set via a DI system to 
+        /// allow developer control over behavior / headers / timesouts and such. Unfortunatly this is buried
+        /// pretty deep, the static solution used here is much cleaner. If this becomes an issue we could
+        /// consider circling back and exposing developer control over this HttpClient. 
+        /// </summary>
+        /// <remarks>
+        /// Relativly few bots use attachments, so rather than paying the startup cost, this is
+        /// a Lazy<> simply to avoid paying a static initialization penalty for every bot. 
+        /// </remarks>
+        private static Lazy<HttpClient> _httpClient = new Lazy<HttpClient>(); 
+
+        /// <summary>
         /// Get the URI of an attachment view
         /// </summary>
         /// <param name="attachmentId"></param>
@@ -43,10 +55,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>stream of attachment</returns>
         public Task<Stream> GetAttachmentStreamAsync(string attachmentId, string viewId = "original")
         {
-            using (HttpClient client = new HttpClient())
-            {
-                return client.GetStreamAsync(GetAttachmentUri(attachmentId, viewId));
-            }
+            return _httpClient.Value.GetStreamAsync(GetAttachmentUri(attachmentId, viewId));
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
@@ -98,15 +99,19 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]"</param>
         /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to 
+        /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <returns>
         /// A valid ClaimsIdentity. 
         /// </returns>
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
-        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials)
+        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient)
         {
             var tokenExtractor = new JwtTokenExtractor(
+                    httpClient,
                     ToBotFromEmulatorTokenValidationParameters,
                     AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
                     AuthenticationConstants.AllowedSigningAlgorithms, null);

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="httpClient">Validing an Activity requires validating the claimset on the security token. This 
         /// validation may require outbound calls for Endorsement validation and other checks. Those calls are made to
         /// TLS services, which are (latency wise) expensive resources. The httpClient passed in here, if shared by the layers
-        /// above from call to call, enables connetion reuse which is a signifant performance and resource improvement.</param>
+        /// above from call to call, enables connection reuse which is a signifant performance and resource improvement.</param>
         /// <returns>Nothing</returns>
         public static async Task AssertValidActivity(Activity activity, string authHeader, ICredentialProvider credentials, HttpClient httpClient)
         {

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -18,8 +19,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="activity">The incoming Activity from the Bot Framework or the Emulator</param>
         /// <param name="authHeader">The Bearer token included as part of the request</param>
         /// <param name="credentials">The set of valid credentials, such as the Bot Application ID</param>
+        /// <param name="httpClient">Validing an Activity requires validating the claimset on the security token. This 
+        /// validation may require outbound calls for Endorsement validation and other checks. Those calls are made to
+        /// TLS services, which are (latency wise) expensive resources. The httpClient passed in here, if shared by the layers
+        /// above from call to call, enables connetion reuse which is a signifant performance and resource improvement.</param>
         /// <returns>Nothing</returns>
-        public static async Task AssertValidActivity(Activity activity, string authHeader, ICredentialProvider credentials)
+        public static async Task AssertValidActivity(Activity activity, string authHeader, ICredentialProvider credentials, HttpClient httpClient)
         {
             if (string.IsNullOrWhiteSpace(authHeader))
             {
@@ -33,13 +38,13 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             // Go through the standard authentication path. 
-            await JwtTokenValidation.ValidateAuthHeader(authHeader, credentials, activity.ServiceUrl);
+            await JwtTokenValidation.ValidateAuthHeader(authHeader, credentials, activity.ServiceUrl, httpClient);
 
             // On the standard Auth path, we need to trust the URL that was incoming. 
             MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl);
         }
 
-        public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials)
+        public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, HttpClient httpClient)
         {
             if (string.IsNullOrWhiteSpace(authHeader))
             {
@@ -60,15 +65,15 @@ namespace Microsoft.Bot.Connector.Authentication
             bool usingEmulator = EmulatorValidation.IsTokenFromEmulator(authHeader);
             if (usingEmulator)
             {
-                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials);
+                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, httpClient);
             }
             else
             {
-                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials);
+                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, httpClient);
             }
         }
 
-        public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, string serviceUrl)
+        public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient)
         {
             if (string.IsNullOrWhiteSpace(authHeader))
             {
@@ -89,11 +94,11 @@ namespace Microsoft.Bot.Connector.Authentication
             bool usingEmulator = EmulatorValidation.IsTokenFromEmulator(authHeader);
             if (usingEmulator)
             {
-                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials);
+                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, httpClient);
             }
             else
             {
-                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl);
+                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient);
             }
         }             
     }

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Ai;
 using Microsoft.Bot.Builder.BotFramework;
-using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
@@ -19,14 +18,8 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
     public class MessagesController : Controller
     {
 
-        private static readonly HttpClient HttpClient;
-
+        private static readonly HttpClient _httpClient = new HttpClient(); 
         BotFrameworkAdapter _adapter;
-
-        static MessagesController()
-        {
-            HttpClient = new HttpClient();
-        }
 
         public MessagesController(IConfiguration configuration)
         {
@@ -38,7 +31,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
-                .Use(new QnAMakerMiddleware(qnaOptions, HttpClient));
+                .Use(new QnAMakerMiddleware(qnaOptions, _httpClient));
             bot.OnReceive(BotReceiveHandler);
                
             _adapter = (BotFrameworkAdapter)bot.Adapter;

--- a/samples/Microsoft.Bot.Samples.Simplified.Asp/appsettings.json
+++ b/samples/Microsoft.Bot.Samples.Simplified.Asp/appsettings.json
@@ -4,5 +4,8 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": ""
 }


### PR DESCRIPTION
Enabled reuse of HttpClient throughout the BotBuilder and Connector stack. 

This is needed to allow proper connection management + pooling, and also allows the developer at the very top of the stack to make any necessary changes (timeouts, etc) to the HttpClient used throughout the stack. 

Addresses #60, #106 