### PR TITLE
Make the BotFrameworkAdapter behave like a true receiver of the incoming HTTP request

### DIFF
--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.BotFramework
 {
@@ -19,13 +19,13 @@ namespace Microsoft.Bot.Builder.BotFramework
     {
         private readonly SimpleCredentialProvider _credentialProvider;
         private readonly MicrosoftAppCredentials _credentials;
-        private readonly HttpClient _httpClient; 
+        private readonly HttpClient _httpClient;
 
         public BotFrameworkAdapter(IConfiguration configuration, HttpClient httpClient = null) : base()
         {
             _httpClient = httpClient ?? new HttpClient();
             _credentialProvider = new ConfigurationCredentialProvider(configuration);
-            _credentials = new MicrosoftAppCredentials(_credentialProvider.AppId, _credentialProvider.Password);                                   
+            _credentials = new MicrosoftAppCredentials(_credentialProvider.AppId, _credentialProvider.Password);
         }
 
         public BotFrameworkAdapter(string appId, string appPassword, HttpClient httpClient = null) : base()
@@ -56,34 +56,32 @@ namespace Microsoft.Bot.Builder.BotFramework
             }
         }
 
-        public async Task Receive(AspNetCore.Http.HttpRequest httpRequest)
+        public Task<int> Receive(IEnumerable<KeyValuePair<string, Extensions.Primitives.StringValues>> headers, Activity activity) => Receive(headers.Select(i => new KeyValuePair<string, IEnumerable<string>>(i.Key, i.Value)), activity);
+
+        public async Task<int> Receive(IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers, Activity activity)
         {
-            var ser = new JsonSerializer();
-            using (var sr = new System.IO.StreamReader(httpRequest.Body))
-            using (var jtr = new JsonTextReader(sr))
+            BotAssert.ActivityNotNull(activity);
+
+            try
             {
-                // Should handle if incoming msg isn't an activity - throw some "malformed" error? 400 bad request?
-                var activity = ser.Deserialize<Activity>(jtr);
-                BotAssert.ActivityNotNull(activity);
+                var authHeader = headers.FirstOrDefault(i => i.Key.Equals(@"authorization", StringComparison.OrdinalIgnoreCase)).Value.FirstOrDefault();
+                await JwtTokenValidation.AssertValidActivity(activity, authHeader, _credentialProvider, _httpClient).ConfigureAwait(false);
 
-                try
+                if (this.OnReceive != null)
                 {
-                    var authHeader = httpRequest.Headers[@"Authorization"].FirstOrDefault();
-            await JwtTokenValidation.AssertValidActivity(activity, authHeader, _credentialProvider, _httpClient);
-
-                    if (this.OnReceive != null)
-                    {
-                await OnReceive(activity).ConfigureAwait(false);
-                    }
-
-                    httpRequest.HttpContext.Response.StatusCode = AspNetCore.Http.StatusCodes.Status200OK;
+                    await OnReceive(activity).ConfigureAwait(false);
                 }
-                catch (UnauthorizedAccessException)
-                {
-                    httpRequest.HttpContext.Response.StatusCode = AspNetCore.Http.StatusCodes.Status401Unauthorized;
-                }
+
+                return StatusCodes.Status200OK;
             }
-
+            catch (UnauthorizedAccessException)
+            {
+                return StatusCodes.Status401Unauthorized;
+            }
+            catch (InvalidOperationException)
+            {
+                return StatusCodes.Status404NotFound;
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.BotFramework/Microsoft.Bot.Builder.BotFramework.csproj
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/Microsoft.Bot.Builder.BotFramework.csproj
@@ -38,6 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />

--- a/samples/AlarmBot-Cards/Controllers/MessagesController.cs
+++ b/samples/AlarmBot-Cards/Controllers/MessagesController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AlarmBot.Models;
@@ -14,7 +12,6 @@ using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Builder.Storage;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
 namespace AlarmBot.Controllers
@@ -94,18 +91,7 @@ namespace AlarmBot.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Post([FromBody]Activity activity)
-        {
-            try
-            {
-                await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-                return this.Ok();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return this.Unauthorized();
-            }
-        }
+        public Task Post() => activityAdapter.Receive(this.Request);
     }
 
 }

--- a/samples/AlarmBot-Cards/Controllers/MessagesController.cs
+++ b/samples/AlarmBot-Cards/Controllers/MessagesController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using AlarmBot.Models;
 using AlarmBot.Topics;
 using AlarmBot.TopicViews;
@@ -13,6 +11,8 @@ using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Builder.Storage;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace AlarmBot.Controllers
 {
@@ -91,7 +91,7 @@ namespace AlarmBot.Controllers
         }
 
         [HttpPost]
-        public Task Post() => activityAdapter.Receive(this.Request);
+        public async Task Post([FromBody]Microsoft.Bot.Schema.Activity activity) => this.Response.StatusCode = await activityAdapter.Receive(this.Request.Headers, activity);
     }
 
 }

--- a/samples/AlarmBot/Controllers/MessagesController.cs
+++ b/samples/AlarmBot/Controllers/MessagesController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AlarmBot.Models;
@@ -14,7 +12,6 @@ using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Builder.Storage;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
 namespace AlarmBot.Controllers
@@ -56,8 +53,8 @@ namespace AlarmBot.Controllers
                         .AddIntent("cancel", new Regex("cancel(.*)", RegexOptions.IgnoreCase))
                         .AddIntent("confirmYes", new Regex("(yes|yep|yessir|^y$)", RegexOptions.IgnoreCase))
                         .AddIntent("confirmNo", new Regex("(no|nope|^n$)", RegexOptions.IgnoreCase)));
-                
-                bot.OnReceive(BotReceiveHandler); 
+
+                bot.OnReceive(BotReceiveHandler);
             }
         }
 
@@ -94,17 +91,17 @@ namespace AlarmBot.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Post([FromBody]Activity activity)
-        {
-            try
-            {
-                await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-                return this.Ok();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return this.Unauthorized();
-            }
-        }
+        public Task Post() => activityAdapter.Receive(this.Request);
+        //{
+        //    try
+        //    {
+        //        await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
+        //        return this.Ok();
+        //    }
+        //    catch (UnauthorizedAccessException)
+        //    {
+        //        return this.Unauthorized();
+        //    }
+        //}
     }
 }

--- a/samples/AlarmBot/Controllers/MessagesController.cs
+++ b/samples/AlarmBot/Controllers/MessagesController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using AlarmBot.Models;
 using AlarmBot.Topics;
 using AlarmBot.TopicViews;
@@ -13,6 +11,8 @@ using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Builder.Storage;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace AlarmBot.Controllers
 {
@@ -91,17 +91,6 @@ namespace AlarmBot.Controllers
         }
 
         [HttpPost]
-        public Task Post() => activityAdapter.Receive(this.Request);
-        //{
-        //    try
-        //    {
-        //        await activityAdapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-        //        return this.Ok();
-        //    }
-        //    catch (UnauthorizedAccessException)
-        //    {
-        //        return this.Unauthorized();
-        //    }
-        //}
+        public async Task Post([FromBody]Microsoft.Bot.Schema.Activity activity) => this.Response.StatusCode = await activityAdapter.Receive(this.Request.Headers, activity);
     }
 }

--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
@@ -2,13 +2,13 @@
 // Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Ai;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Samples.Ai.Luis
 {
@@ -51,6 +51,6 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         }
 
         [HttpPost]
-        public Task Post() => _adapter.Receive(this.Request);
+        public async Task Post([FromBody]Activity activity) => this.Response.StatusCode = await _adapter.Receive(this.Request.Headers, activity);
     }
 }

--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
@@ -2,14 +2,11 @@
 // Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Ai;
 using Microsoft.Bot.Builder.BotFramework;
-using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
@@ -30,10 +27,10 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         {
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"));
-            
-                // LUIS with correct baseUri format example
-                //.Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx", "https://xxxxxx.api.cognitive.microsoft.com/luis/v2.0/apps"))
-                
+
+            // LUIS with correct baseUri format example
+            //.Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx", "https://xxxxxx.api.cognitive.microsoft.com/luis/v2.0/apps"))
+
             bot.OnReceive(BotReceiveHandler);
 
             _adapter = (BotFrameworkAdapter)bot.Adapter;
@@ -54,17 +51,6 @@ namespace Microsoft.Bot.Samples.Ai.Luis
         }
 
         [HttpPost]
-        public async Task<IActionResult> Post([FromBody]Activity activity)
-        {
-            try
-            {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-                return this.Ok();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return this.Unauthorized();
-            }
-        }
+        public Task Post() => _adapter.Receive(this.Request);
     }
 }

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -34,7 +32,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
                 .Use(new QnAMakerMiddleware(qnaMiddlewareOptions, _httpClient));
 
             bot.OnReceive(BotReceiveHandler);
-               
+
             _adapter = (BotFrameworkAdapter)bot.Adapter;
         }
 
@@ -49,17 +47,6 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> Post([FromBody]Activity activity)
-        {
-            try
-            {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-                return this.Ok();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return this.Unauthorized();
-            }
-        }
+        public Task Post() => _adapter.Receive(this.Request);
     }
 }

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Ai;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
 {
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
     public class MessagesController : Controller
     {
 
-        private static readonly HttpClient _httpClient = new HttpClient(); 
+        private static readonly HttpClient _httpClient = new HttpClient();
         BotFrameworkAdapter _adapter;
 
         public MessagesController(IConfiguration configuration)
@@ -47,6 +47,6 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
         }
 
         [HttpPost]
-        public Task Post() => _adapter.Receive(this.Request);
+        public async Task Post([FromBody]Activity activity) => this.Response.StatusCode = await _adapter.Receive(this.Request.Headers, activity);
     }
 }

--- a/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
-using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 
@@ -45,17 +42,6 @@ namespace Microsoft.Bot.Samples.CustomMiddleware
         }
 
         [HttpPost]
-        public async Task<IActionResult> Post([FromBody]Activity activity)
-        {
-            try
-            {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-                return this.Ok();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return this.Unauthorized();
-            }
-        }
+        public Task Post() => _adapter.Receive(this.Request);
     }
 }

--- a/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.CustomMiddleware/Controllers/MessagesController.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Samples.CustomMiddleware
 {
@@ -42,6 +42,6 @@ namespace Microsoft.Bot.Samples.CustomMiddleware
         }
 
         [HttpPost]
-        public Task Post() => _adapter.Receive(this.Request);
+        public async Task Post([FromBody]Activity activity) => this.Response.StatusCode = await _adapter.Receive(this.Request.Headers, activity);
     }
 }

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNet461/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNet461/Controllers/MessagesController.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Schema;
-using System;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
@@ -56,21 +54,6 @@ namespace Microsoft.Bot.Samples.EchoBot_AspNet461
         /// POST: api/Messages
         /// Receive a message from a user and reply to it
         /// </summary>
-        public async Task<HttpResponseMessage> Post([FromBody]Activity activity)
-        {
-            try
-            {
-                await _adapter.Receive(this.Request.Headers.Authorization?.Parameter, activity);
-                return this.Request.CreateResponse(HttpStatusCode.OK);
-            }
-            catch (UnauthorizedAccessException e)
-            {
-                return this.Request.CreateErrorResponse(HttpStatusCode.Unauthorized, e.Message);
-            }
-            catch (InvalidOperationException e)
-            {
-                return this.Request.CreateErrorResponse(HttpStatusCode.NotFound, e.Message);
-            }
-        }
+        public async Task<HttpResponseMessage> Post([FromBody]Activity activity) => new HttpResponseMessage((System.Net.HttpStatusCode)(await _adapter.Receive(this.Request.Headers, activity)));
     }
 }

--- a/samples/Microsoft.Bot.Samples.Simplified.Asp/BotController.cs
+++ b/samples/Microsoft.Bot.Samples.Simplified.Asp/BotController.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Schema;
+using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Samples.Simplified.Asp
 {
@@ -82,6 +83,6 @@ namespace Microsoft.Bot.Samples.Simplified.Asp
         }
 
         [HttpPost]
-        public Task Post() => _adapter.Receive(this.Request);
+        public async Task Post([FromBody]Activity activity) => this.Response.StatusCode = await _adapter.Receive(this.Request.Headers, activity);
     }
 }

--- a/samples/Microsoft.Bot.Samples.Simplified.Asp/BotController.cs
+++ b/samples/Microsoft.Bot.Samples.Simplified.Asp/BotController.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
@@ -78,22 +76,12 @@ namespace Microsoft.Bot.Samples.Simplified.Asp
             return Task.CompletedTask;
         }
 
-        [HttpPost]
-        public async Task<IActionResult> Post([FromBody]Activity activity)
+        protected virtual Task ReceiveUnknown(IBotContext context)
         {
-            try
-            {
-                await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
-                return this.Ok();
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return this.Unauthorized();
-            }
-            catch (InvalidOperationException e)
-            {
-                return this.NotFound(e.Message);
-            }
+            return Task.CompletedTask;
         }
+
+        [HttpPost]
+        public Task Post() => _adapter.Receive(this.Request);
     }
 }


### PR DESCRIPTION
Looking at node, you can see we wire up the *adapter* as the listener for incoming HTTP POST messages. In .Net however, we (today) have this intermediary code in each controller:
```csharp
[HttpPost]
public async Task<IActionResult> Post([FromBody]Activity activity)
{
    try
    {
        await _adapter.Receive(this.Request.Headers["Authorization"].FirstOrDefault(), activity);
        return this.Ok();
    }
    catch (UnauthorizedAccessException)
    {
        return this.Unauthorized();
    }
}
```
This code brings up a few questions:
1. Why do I need the `Authorization` header?
1. What happens if I want to pass other headers to my adapter?
1. What happens if the `BotFrameworkAdapter` requires additional headers later? Or removes the need for `Authorization` ones?
1. Why does `UnauthorizedAccessException` get thrown?

To alleviate this, just make the adapter act like it does in node - as a true recipient of the incoming request:
```csharp
[HttpPost]
public Task Post() => _adapter.Receive(this.Request);
```
Now, `BotFrameworkAdapter` is free to change its usage/requirements under the hood and users don't need to care. It's also congruent with what developers in Node are doing by wiring up http listen to the adapter's receive method.

This PR accomplishes this ask & updates the samples accordingly.

cc @cleemullins @lynn-orrell 