### PR TITLE
DateTimeRecognizerExtension does not return dates without times

### DIFF
--- a/samples/AlarmBot-Cards/DateTimeRecognizerExtensions.cs
+++ b/samples/AlarmBot-Cards/DateTimeRecognizerExtensions.cs
@@ -29,7 +29,7 @@ namespace AlarmBot
                 return results.Where(result =>
                 {
                     var subType = result.TypeName.Split('.').Last();
-                    return subType.Contains("time") && !subType.Contains("range");
+                    return (subType.Contains("date") || subType.Contains("time")) && !subType.Contains("range");
                 })
                 .Select(result =>
                 {

--- a/samples/AlarmBot/DateTimeRecognizerExtensions.cs
+++ b/samples/AlarmBot/DateTimeRecognizerExtensions.cs
@@ -28,7 +28,7 @@ namespace AlarmBot
                 return results.Where(result =>
                 {
                     var subType = result.TypeName.Split('.').Last();
-                    return subType.Contains("time") && !subType.Contains("range");
+                    return (subType.Contains("date") || subType.Contains("time")) && !subType.Contains("range");
                 })
                 .Select(result =>
                 {


### PR DESCRIPTION
This change allows the extension method to return both date and datetime while still preventing ranges, which was indicated as desired behavior in the comments.