### PR TITLE
Tests no longer pass after PR #97. The ContextExtension name space ch…

### DIFF
--- a/tests/Microsoft.Bot.Builder.Tests/ContextExtensionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ContextExtensionTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Builder.ContextExtensions;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 


### PR DESCRIPTION
Tests no longer pass after PR #97. The ContextExtension name space changed and the changes were not reflected in the ContextExtensionTests class.