### PR TITLE
Pass exceptions on Faulted Tasks as inner Exceptions.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -273,7 +273,8 @@ namespace Microsoft.Bot.Builder.Adapters
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
                 if (task.IsFaulted)
-                    throw new Exception("failed");
+                    throw new Exception("Send failed. See InnerException for details", task.Exception);
+
                 return this._adapter.SendActivityToBot(userSays);
             }), this._adapter);
         }
@@ -291,7 +292,8 @@ namespace Microsoft.Bot.Builder.Adapters
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
                 if (task.IsFaulted)
-                    throw new Exception("failed");
+                    throw new Exception("Send failed. See InnerException for details", task.Exception);
+
                 return this._adapter.SendActivityToBot(userActivity);
             }), this._adapter);
         }
@@ -306,7 +308,8 @@ namespace Microsoft.Bot.Builder.Adapters
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
                 if (task.IsFaulted)
-                    throw new Exception("failed");
+                    throw new Exception("Delay failed. See InnerException for details", task.Exception);
+
                 return Task.Delay((int)ms);
             }), this._adapter);
         }
@@ -354,7 +357,8 @@ namespace Microsoft.Bot.Builder.Adapters
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
                 if (task.IsFaulted)
-                    throw new Exception("failed");
+                    throw new Exception($"Faulted Task in AssertReply on test '{description}'. See InnerException for details.", task.Exception);
+
                 var start = DateTime.UtcNow;
                 while (true)
                 {
@@ -362,7 +366,7 @@ namespace Microsoft.Bot.Builder.Adapters
 
                     if ((current - start).TotalMilliseconds > timeout)
                     {
-                        throw new TimeoutException($"{timeout}ms Timed out waiting for:${description}");
+                        throw new TimeoutException($"{timeout}ms Timed out waiting for:'{description}'");
                     }
 
                     IActivity replyActivity = this._adapter.GetNextReply();                    

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -274,7 +274,15 @@ namespace Microsoft.Bot.Builder.Adapters
             {
                 // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
                 // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
-                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                // The following StackOverflow answer provides some more details on why you want to do this: 
+                // https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                //
+                // From the Docs:
+                //  https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/exception-handling-task-parallel-library
+                //  Exceptions are propagated when you use one of the static or instance Task.Wait or Wait 
+                //  methods, and you handle them by enclosing the call in a try/catch statement. If a task is the 
+                //  parent of attached child tasks, or if you are waiting on multiple tasks, multiple exceptions 
+                //  could be thrown.
                 task.Wait();
 
                 return this._adapter.SendActivityToBot(userSays);
@@ -293,9 +301,7 @@ namespace Microsoft.Bot.Builder.Adapters
 
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
-                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
-                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                // NOTE: See details code in above method. 
                 task.Wait();
 
                 return this._adapter.SendActivityToBot(userActivity);
@@ -311,9 +317,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
-                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
-                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                // NOTE: See details code in above method. 
                 task.Wait();
 
                 return Task.Delay((int)ms);
@@ -362,9 +366,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
-                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
-                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                // NOTE: See details code in above method. 
                 task.Wait();
 
                 var start = DateTime.UtcNow;

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -272,11 +272,13 @@ namespace Microsoft.Bot.Builder.Adapters
 
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                if (task.IsFaulted)
-                    throw new Exception("Send failed. See InnerException for details", task.Exception);
+                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
+                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
+                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                task.Wait();
 
                 return this._adapter.SendActivityToBot(userSays);
-            }), this._adapter);
+            }).Unwrap(), this._adapter);
         }
 
         /// <summary>
@@ -291,11 +293,13 @@ namespace Microsoft.Bot.Builder.Adapters
 
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                if (task.IsFaulted)
-                    throw new Exception("Send failed. See InnerException for details", task.Exception);
+                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
+                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
+                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                task.Wait();
 
                 return this._adapter.SendActivityToBot(userActivity);
-            }), this._adapter);
+            }).Unwrap(), this._adapter);
         }
 
         /// <summary>
@@ -307,11 +311,13 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                if (task.IsFaulted)
-                    throw new Exception("Delay failed. See InnerException for details", task.Exception);
+                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
+                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
+                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                task.Wait();
 
                 return Task.Delay((int)ms);
-            }), this._adapter);
+            }).Unwrap(), this._adapter);
         }
 
         /// <summary>
@@ -356,8 +362,10 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             return new TestFlow(this.testTask.ContinueWith((task) =>
             {
-                if (task.IsFaulted)
-                    throw new Exception($"Faulted Task in AssertReply on test '{description}'. See InnerException for details.", task.Exception);
+                // NOTE: we need to .Wait() on the original Task to properly observe any exceptions that might have occurred
+                // and to have them propagate correctly up through the chain to whomever is waiting on the parent task
+                // The following StackOverflow answer provides some more details on why you want to do this: https://stackoverflow.com/questions/11904821/proper-way-to-use-continuewith-for-tasks/11906865#11906865
+                task.Wait();
 
                 var start = DateTime.UtcNow;
                 while (true)

--- a/tests/Microsoft.Bot.Builder.Tests/Adapter_TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapter_TestAdapterTests.cs
@@ -62,6 +62,28 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
+        public async Task TestAdapter_ExceptionInBotOnReceive()
+        {
+            string uniqueExceptionId = Guid.NewGuid().ToString();
+            TestAdapter adapter = new TestAdapter();
+            Bot bot = new Bot(adapter);
+            bot.OnReceive(async (context) => { throw new Exception(uniqueExceptionId); });
+
+            try
+            {
+                await adapter
+                    .Test("test", activity => Assert.IsNull(null), "uh oh!")
+                    .StartTest();
+
+                Assert.Fail("An Exception should have been thrown");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsTrue(ex.InnerException.Message == uniqueExceptionId, "Incorrect Exception Text");
+            }
+        }
+
+        [TestMethod]
         public async Task TestAdapter_ExceptionTypesOnAssertReply()
         {
             string uniqueExceptionId = Guid.NewGuid().ToString();

--- a/tests/Microsoft.Bot.Builder.Tests/Adapter_TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapter_TestAdapterTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Bot.Builder.Tests
             return adapter;
         }
 
-
         [TestMethod]
         public async Task TestAdapter_ExceptionTypesOnTest()
         {


### PR DESCRIPTION
Addresses #135.

Note that while I added tests, I couldn't get a test that **actually** exercised the new behavior. 

The behavior in this new code is clearly better, but how to get these tests to fault while using the standard semantics is complicated. 

I would be very interested in seeing a solution to how to test this. 