### PR TITLE
OnReceive is only run if all relevant Middleware Complete

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Ai
+{
+    public class QnAMaker
+    {
+        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
+        public const string APIManagementHeader = "Ocp-Apim-Subscription-Key";
+        public const string JsonMimeType = "application/json";
+
+        private readonly HttpClient _httpClient;
+        private readonly QnAMakerOptions _options;
+        private readonly string _answerUrl;
+
+        public QnAMaker(QnAMakerOptions options, HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrEmpty(options.KnowledgeBaseId))
+            {
+                throw new ArgumentException(nameof(options.KnowledgeBaseId));
+            }
+
+            _answerUrl = $"{qnaMakerServiceEndpoint}{options.KnowledgeBaseId}/generateanswer";
+
+            if (_options.ScoreThreshold == 0)
+            {
+                _options.ScoreThreshold = 0.3F;
+            }
+
+            if (_options.Top == 0)
+            {
+                _options.Top = 1;
+            }
+        }
+
+        public async Task<QueryResult[]> GetAnswers(string question)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, _answerUrl);
+
+            string jsonRequest = JsonConvert.SerializeObject(new
+            {
+                question,
+                top = _options.Top
+            }, Formatting.None);
+
+            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, JsonMimeType);
+            content.Headers.Add(APIManagementHeader, _options.SubscriptionKey);
+
+            var response = await _httpClient.PostAsync(_answerUrl, content).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var results = JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
+                foreach (var answer in results.Answers)
+                {
+                    answer.Score = answer.Score / 100;
+                }
+
+                return results.Answers.Where(answer => answer.Score > _options.ScoreThreshold).ToArray();
+            }
+            return null;
+        }
+    }
+
+    public class QnAMakerOptions
+    {
+        public string SubscriptionKey { get; set; }
+        public string KnowledgeBaseId { get; set; }
+        public float ScoreThreshold { get; set; }
+        public int Top { get; set; }
+    }
+
+    public class QueryResult
+    {
+        [JsonProperty("questions")]
+        public string[] Questions { get; set; }
+
+        [JsonProperty("answer")]
+        public string Answer { get; set; }
+
+        [JsonProperty("score")]
+        public float Score { get; set; }
+    }
+
+    public class QueryResults
+    {
+        [JsonProperty("answers")]
+        public QueryResult[] Answers { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Bot.Builder.Ai
 {
     public class QnAMaker
     {
-        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
+        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v3.0/knowledgebases/";
         public const string APIManagementHeader = "Ocp-Apim-Subscription-Key";
         public const string JsonMimeType = "application/json";
 
@@ -39,6 +39,16 @@ namespace Microsoft.Bot.Builder.Ai
             {
                 _options.Top = 1;
             }
+
+            if (_options.StrictFilters == null)
+            {
+                _options.StrictFilters = new Metadata[] {};
+            }
+
+            if (_options.MetadataBoost == null)
+            {
+                _options.MetadataBoost = new Metadata[] { };
+            }
         }
 
         public async Task<QueryResult[]> GetAnswers(string question)
@@ -48,7 +58,9 @@ namespace Microsoft.Bot.Builder.Ai
             string jsonRequest = JsonConvert.SerializeObject(new
             {
                 question,
-                top = _options.Top
+                top = _options.Top,
+                strictFilters = _options.StrictFilters,
+                metadataBoost = _options.MetadataBoost
             }, Formatting.None);
 
             var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, JsonMimeType);
@@ -76,6 +88,18 @@ namespace Microsoft.Bot.Builder.Ai
         public string KnowledgeBaseId { get; set; }
         public float ScoreThreshold { get; set; }
         public int Top { get; set; }
+        public Metadata[] StrictFilters { get; set; }
+        public Metadata[] MetadataBoost { get; set; }
+    }
+
+    [Serializable]
+    public class Metadata
+    {
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
     }
 
     public class QueryResult
@@ -88,6 +112,15 @@ namespace Microsoft.Bot.Builder.Ai
 
         [JsonProperty("score")]
         public float Score { get; set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata[] Metadata { get; set; }
+
+        [JsonProperty(PropertyName = "source")]
+        public string Source { get; set; }
+
+        [JsonProperty(PropertyName = "qnaId")]
+        public int QnaId { get; set; }
     }
 
     public class QueryResults

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
@@ -1,104 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Ai
 {
-
-    public class QueryResult
-    {
-        [JsonProperty("questions")]
-        public string[] Questions { get; set; }
-
-        [JsonProperty("answer")]
-        public string Answer { get; set; }
-
-        [JsonProperty("score")]
-        public float Score { get; set; }
-    }
-
-    public class QueryResults
-    {
-        [JsonProperty("answers")]
-        public QueryResult[] Answers { get; set; }
-    }
-
-
-    public class QnAMakerOptions
-    {
-        public string SubscriptionKey { get; set; }
-        public string KnowledgeBaseId { get; set; }
-        public float ScoreThreshold { get; set; }
-        public int Top { get; set; }
-    }
-
     public class QnAMakerMiddleware : Middleware.IReceiveActivity
     {
-        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
-        private readonly string _answerUrl;
-        private readonly QnAMakerOptions _options;
-        private readonly HttpClient _httpClient;
-
-        public const string APIManagementHeader = "Ocp-Apim-Subscription-Key";
-        public const string JsonMimeType = "application/json"; 
+        private readonly QnAMaker _qnaMaker;
 
         public QnAMakerMiddleware(QnAMakerOptions options, HttpClient httpClient)
         {
-
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-            this._httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-
-            if (string.IsNullOrEmpty(options.KnowledgeBaseId))
-            {
-                throw new ArgumentException(nameof(options.KnowledgeBaseId));
-            }
-
-            this._answerUrl = $"{qnaMakerServiceEndpoint}{options.KnowledgeBaseId}/generateanswer";
-
-            if (_options.ScoreThreshold == 0)
-            {
-                _options.ScoreThreshold = 0.3F;
-            }
-
-            if (_options.Top == 0)
-            {
-                _options.Top = 1;
-            }                        
-        }
-
-        public async Task<QueryResult[]> GetAnswers(string question)
-        {
-            var request = new HttpRequestMessage(HttpMethod.Post, this._answerUrl);
-            
-            string jsonRequest = JsonConvert.SerializeObject(new
-            {
-                question,
-                top = this._options.Top
-            }, Formatting.None);
-
-            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, JsonMimeType);
-            content.Headers.Add(APIManagementHeader, this._options.SubscriptionKey);
-
-            var response = await this._httpClient.PostAsync(this._answerUrl, content).ConfigureAwait(false);
-            if (response.IsSuccessStatusCode)
-            {
-                var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var results = JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
-                foreach (var answer in results.Answers)
-                {
-                    answer.Score = answer.Score / 100;
-                }
-
-                return results.Answers.Where(answer => answer.Score > this._options.ScoreThreshold).ToArray();
-            }
-            return null;
+            _qnaMaker = new QnAMaker(options, httpClient);
         }
 
         public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
@@ -108,7 +25,7 @@ namespace Microsoft.Bot.Builder.Ai
                 var messageActivity = context.Request.AsMessageActivity();
                 if (!string.IsNullOrEmpty(messageActivity.Text))
                 {
-                    var results = await this.GetAnswers(messageActivity.Text.Trim()).ConfigureAwait(false);
+                    var results = await _qnaMaker.GetAnswers(messageActivity.Text.Trim()).ConfigureAwait(false);
                     if (results.Any())
                     {
                         context.Reply(results.First().Answer);
@@ -116,7 +33,7 @@ namespace Microsoft.Bot.Builder.Ai
                 }
             }
 
-            await next().ConfigureAwait(false); 
+            await next().ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Middleware/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/MiddlewareSet.cs
@@ -52,30 +52,37 @@ namespace Microsoft.Bot.Builder.Middleware
 
         public async Task ReceiveActivity(IBotContext context)
         {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), null).ConfigureAwait(false);
-        }
-
-        public async Task ReceiveActivity(IBotContext context, Action runAtEnd)
-        {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), runAtEnd).ConfigureAwait(false);
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
         }
 
         public async Task ReceiveActivity(IBotContext context, NextDelegate next)
         {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), null).ConfigureAwait(false);
-            await next().ConfigureAwait(false);
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
+            await next().ConfigureAwait(false); 
         }
 
-        private async Task ReceiveActivityInternal(IBotContext context, IReceiveActivity[] middleware, Action runAtEnd)
+        /// <summary>
+        /// Intended to be called from Bot, this method performs exactly the same as the
+        /// standard ReceiveActivity, except that it returns TRUE if all Middlware in the receive
+        /// pipeline was run, and FALSE if a middlware failed to run next.         
+        /// </summary>
+        /// <returns>True, if all executed middleware in the pipeline called Next(). 
+        /// False, if one of the middleware instances did not call Next(). 
+        /// </returns>
+        public async Task<bool> ReceiveActivityWithStatus(IBotContext context)
+        {
+            return await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
+        }        
+
+        private async Task<bool> ReceiveActivityInternal(IBotContext context, IReceiveActivity[] middleware)
         {
             BotAssert.MiddlewareNotNull(middleware);
+            bool didAllRun = false;
 
             if (middleware.Length == 0) // No middleware to run.
             {
-                // If all the Middlware ran, then execute the specificied 
-                // runAtEndDelegate. 
-                runAtEnd?.Invoke();
-                return;
+                // If all the Middlware ran, let the caller know. 
+                return true;
             }
 
             // Default to "No more Middleware after this"
@@ -84,11 +91,12 @@ namespace Microsoft.Bot.Builder.Middleware
                 // Remove the first item from the list of middleware to call,
                 // so that the next call just has the remaining items to worry about. 
                 IReceiveActivity[] remainingMiddleware = middleware.Skip(1).ToArray();
-                await ReceiveActivityInternal(context, remainingMiddleware, runAtEnd).ConfigureAwait(false);
+                didAllRun |= await ReceiveActivityInternal(context, remainingMiddleware).ConfigureAwait(false);
             }
 
             // Grab the current middleware, which is the 1st element in the array, and execute it            
             await middleware[0].ReceiveActivity(context, next).ConfigureAwait(false);
+            return didAllRun;
         }
 
         public async Task SendActivity(IBotContext context, IList<IActivity> activities)

--- a/libraries/Microsoft.Bot.Builder/Middleware/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/MiddlewareSet.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Middleware
     public class MiddlewareSet : IMiddleware, IReceiveActivity, ISendActivity, IContextCreated
     {
         public delegate Task NextDelegate();
-        private readonly IList<IMiddleware> _middleware = new List<IMiddleware>();        
+        private readonly IList<IMiddleware> _middleware = new List<IMiddleware>();
 
         public MiddlewareSet Use(IMiddleware middleware)
         {
@@ -20,30 +20,6 @@ namespace Microsoft.Bot.Builder.Middleware
             _middleware.Add(middleware);
             return this;
         }
-
-        //public MiddlewareSet OnReceive(Func<IBotContext, NextDelegate, Task> anonymousMethod)
-        //{
-        //    if (anonymousMethod == null)
-        //        throw new ArgumentNullException(nameof(anonymousMethod));
-
-        //    return this.Use(new AnonymousReceiveMiddleware(anonymousMethod));
-        //}
-
-        //public MiddlewareSet OnContextCreated(Func<IBotContext, NextDelegate, Task> anonymousMethod)
-        //{
-        //    if (anonymousMethod == null)
-        //        throw new ArgumentNullException(nameof(anonymousMethod));
-
-        //    return this.Use(new AnonymousContextCreatedMiddleware(anonymousMethod));
-        //}
-
-        //public MiddlewareSet OnSendActivity(Func<IBotContext, IList<IActivity>, NextDelegate, Task> anonymousMethod)
-        //{
-        //    if (anonymousMethod == null)
-        //        throw new ArgumentNullException(nameof(anonymousMethod));
-
-        //    return this.Use(new AnonymousSendActivityMiddleware(anonymousMethod));
-        //}
 
         public async Task ContextCreated(IBotContext context)
         {
@@ -76,21 +52,31 @@ namespace Microsoft.Bot.Builder.Middleware
 
         public async Task ReceiveActivity(IBotContext context)
         {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);            
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), null).ConfigureAwait(false);
+        }
+
+        public async Task ReceiveActivity(IBotContext context, Action runAtEnd)
+        {
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), runAtEnd).ConfigureAwait(false);
         }
 
         public async Task ReceiveActivity(IBotContext context, NextDelegate next)
         {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), null).ConfigureAwait(false);
             await next().ConfigureAwait(false);
         }
 
-        private async Task ReceiveActivityInternal(IBotContext context, IReceiveActivity[] middleware)
+        private async Task ReceiveActivityInternal(IBotContext context, IReceiveActivity[] middleware, Action runAtEnd)
         {
             BotAssert.MiddlewareNotNull(middleware);
 
             if (middleware.Length == 0) // No middleware to run.
+            {
+                // If all the Middlware ran, then execute the specificied 
+                // runAtEndDelegate. 
+                runAtEnd?.Invoke();
                 return;
+            }
 
             // Default to "No more Middleware after this"
             async Task next()
@@ -98,7 +84,7 @@ namespace Microsoft.Bot.Builder.Middleware
                 // Remove the first item from the list of middleware to call,
                 // so that the next call just has the remaining items to worry about. 
                 IReceiveActivity[] remainingMiddleware = middleware.Skip(1).ToArray();
-                await ReceiveActivityInternal(context, remainingMiddleware).ConfigureAwait(false);
+                await ReceiveActivityInternal(context, remainingMiddleware, runAtEnd).ConfigureAwait(false);
             }
 
             // Grab the current middleware, which is the 1st element in the array, and execute it            
@@ -119,7 +105,7 @@ namespace Microsoft.Bot.Builder.Middleware
         private async Task SendActivityInternal(IBotContext context, IList<IActivity> activities, ISendActivity[] middleware)
         {
             BotAssert.MiddlewareNotNull(middleware);
-            BotAssert.ActivityListNotNull(activities); 
+            BotAssert.ActivityListNotNull(activities);
 
             if (middleware.Length == 0) // No middleware to run.
                 return;
@@ -134,6 +120,6 @@ namespace Microsoft.Bot.Builder.Middleware
 
             // Grab the current middleware, which is the 1st element in the array, and execute it            
             await middleware[0].SendActivity(context, activities, next).ConfigureAwait(false);
-        }       
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
@@ -8,9 +8,6 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public static class AuthenticationConstants
     {
-
-        public const string BotFrameworkTokenIssuer = "https://api.botframework.com";
-
         /// <summary>
         /// TO CHANNEL FROM BOT: Login URL
         /// </summary>
@@ -20,6 +17,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// TO CHANNEL FROM BOT: OAuth scope to request
         /// </summary>
         public const string ToChannelFromBotOAuthScope = "https://api.botframework.com/.default";
+
+        /// <summary>
+        /// TO BOT FROM CHANNEL: Token issuer
+        /// </summary>
+        public const string ToBotFromChannelTokenIssuer = "https://api.botframework.com";
 
         /// <summary>
         /// TO BOT FROM CHANNEL: OpenID metadata document for tokens coming from MSA
@@ -46,24 +48,24 @@ namespace Microsoft.Bot.Connector.Authentication
         public const string AuthorizedParty = "azp";
 
         /// <summary>
-        /// Audiance Claim. From RFC 7519. 
+        /// Audience Claim. From RFC 7519. 
         ///     https://tools.ietf.org/html/rfc7519#section-4.1.3
         /// The "aud" (audience) claim identifies the recipients that the JWT is
-        /// intended for.  Each principal intended to process the JWT MUST
-        /// identify itself with a value in the audience claim.If the principal
+        /// intended for. Each principal intended to process the JWT MUST
+        /// identify itself with a value in the audience claim. If the principal
         /// processing the claim does not identify itself with a value in the
         /// "aud" claim when this claim is present, then the JWT MUST be
-        /// rejected.In the general case, the "aud" value is an array of case-
-        /// sensitive strings, each containing a StringOrURI value.In the
+        /// rejected. In the general case, the "aud" value is an array of case-
+        /// sensitive strings, each containing a StringOrURI value. In the
         /// special case when the JWT has one audience, the "aud" value MAY be a
-        /// single case-sensitive string containing a StringOrURI value.The
+        /// single case-sensitive string containing a StringOrURI value. The
         /// interpretation of audience values is generally application specific.
         /// Use of this claim is OPTIONAL.
         /// </summary>
         public const string AudienceClaim = "aud";
 
         /// <summary>
-        /// From RFC 7517
+        /// From RFC 7515
         ///     https://tools.ietf.org/html/rfc7515#section-4.1.4
         /// The "kid" (key ID) Header Parameter is a hint indicating which key
         /// was used to secure the JWS. This parameter allows originators to
@@ -73,6 +75,21 @@ namespace Microsoft.Bot.Connector.Authentication
         /// When used with a JWK, the "kid" value is used to match a JWK "kid"
         /// parameter value.
         /// </summary>
-        public const string KeyIdHeader = "kid";               
+        public const string KeyIdHeader = "kid";
+
+        /// <summary>
+        /// Token version claim name. As used in Microsoft AAD tokens.
+        /// </summary>
+        public const string VersionClaim = "ver";
+
+        /// <summary>
+        /// App ID claim name. As used in Microsoft AAD 1.0 tokens.
+        /// </summary>
+        public const string AppIdClaim = "appid";
+
+        /// <summary>
+        /// Service URL claim name. As used in Microsoft Bot Framework v3.1 auth.
+        /// </summary>
+        public const string ServiceUrlClaim = "serviceurl";
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -16,10 +16,6 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public static class EmulatorValidation
     {
-        // The AppId Claim is only used during emulator token validation. 
-        private const string AppIdClaim = "appid";
-        private const string VersionClaim = "ver";
-
         /// <summary>
         /// TO BOT FROM EMULATOR: Token validation parameters when connecting to a channel.
         /// </summary>
@@ -133,7 +129,7 @@ namespace Microsoft.Bot.Connector.Authentication
             // what we're looking for. Note that in a multi-tenant bot, this value
             // comes from developer code that may be reaching out to a service, hence the 
             // Async validation. 
-            Claim versionClaim = identity.Claims.FirstOrDefault(c => c.Type == VersionClaim);
+            Claim versionClaim = identity.Claims.FirstOrDefault(c => c.Type == AuthenticationConstants.VersionClaim);
             if (versionClaim == null)
             {
                 throw new UnauthorizedAccessException("'ver' claim is required on Emulator Tokens.");
@@ -148,7 +144,7 @@ namespace Microsoft.Bot.Connector.Authentication
             {
                 // either no Version or a version of "1.0" means we should look for 
                 // the claim in the "appid" claim. 
-                Claim appIdClaim = identity.Claims.FirstOrDefault(c => c.Type == AppIdClaim);
+                Claim appIdClaim = identity.Claims.FirstOrDefault(c => c.Type == AuthenticationConstants.AppIdClaim);
                 if (appIdClaim == null)
                 {
                     // No claim around AppID. Not Authorized.
@@ -168,23 +164,6 @@ namespace Microsoft.Bot.Connector.Authentication
                 }
 
                 appID = appZClaim.Value;
-            }
-            else if (tokenVersion == "3.0")
-            {
-                // The v3.0 Token types have been disallowed. Not Authorized. 
-                throw new UnauthorizedAccessException("Emulator token version '3.0' is depricated.");
-            }
-            else if (tokenVersion == "3.1" || tokenVersion == "3.2")
-            {
-                // The emulator for token versions "3.1" & "3.2" puts the AppId in the "Audiance" claim. 
-                Claim audianceClaim = identity.Claims.FirstOrDefault(c => c.Type == AuthenticationConstants.AudienceClaim);
-                if (audianceClaim == null)
-                {
-                    // No claim around AppID. Not Authorized.
-                    throw new UnauthorizedAccessException("'aud' claim is required on Emulator Token version '3.x'.");
-                }
-
-                appID = audianceClaim.Value;
             }
             else
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
@@ -4,13 +4,13 @@ namespace Microsoft.Bot.Connector.Authentication
 {
     /// <summary>
     /// CredentialProvider interface. This interface allows Bots to provide their own
-    /// implemention of what is, and what is not, a valid appId and password. This is 
+    /// implementation of what is, and what is not, a valid appId and password. This is 
     /// useful in the case of multi-tenant bots, where the bot may need to call
     /// out to a service to determine if a particular appid/password pair
     /// is valid. 
     /// 
     /// For Single Tenant bots (the vast majority) the simple static providers 
-    /// are sufficent. 
+    /// are sufficient. 
     /// </summary>
     public interface ICredentialProvider
     {

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// The endorsements validator delegate.
         /// </summary>
-        /// <param name="endorsements"> The endorsements used for validation.</param>
+        /// <param name="endorsements">The endorsements used for validation.</param>
         /// <returns>true if validation passes; false otherwise.</returns>
         public delegate bool EndorsementsValidator(string[] endorsements);
 
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// Extracts relevant data from JWT Tokens
         /// </summary>
         /// <param name="httpClient">As part of validating JWT Tokens, endorsements need to be feteched from
-        /// sources specificed by the relevant security URLs. This HttpClient is used to allow for resource
+        /// sources specified by the relevant security URLs. This HttpClient is used to allow for resource
         /// pooling around those retrievals. As those resources require TLS sharing the HttpClient is 
         /// important to overall perfomance.</param>
         /// <param name="tokenValidationParameters"></param>

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="activity">The incoming Activity from the Bot Framework or the Emulator</param>
         /// <param name="authHeader">The Bearer token included as part of the request</param>
         /// <param name="credentials">The set of valid credentials, such as the Bot Application ID</param>
-        /// <param name="httpClient">Validing an Activity requires validating the claimset on the security token. This 
+        /// <param name="httpClient">Validating an Activity requires validating the claimset on the security token. This 
         /// validation may require outbound calls for Endorsement validation and other checks. Those calls are made to
         /// TLS services, which are (latency wise) expensive resources. The httpClient passed in here, if shared by the layers
-        /// above from call to call, enables connection reuse which is a signifant performance and resource improvement.</param>
+        /// above from call to call, enables connection reuse which is a significant performance and resource improvement.</param>
         /// <returns>Nothing</returns>
         public static async Task AssertValidActivity(Activity activity, string authHeader, ICredentialProvider credentials, HttpClient httpClient)
         {

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         /// <summary>
         /// The token refresh code uses this client. Ideally, this would be passed in or set via a DI system to 
-        /// allow developer control over behavior / headers / timesouts and such. Unfortunatly this is buried
+        /// allow developer control over behavior / headers / timeouts and such. Unfortunately this is buried
         /// pretty deep, the static solution used here is much cleaner. If this becomes an issue we could
         /// consider circling back and exposing developer control over this HttpClient. 
         /// </summary>

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerMiddlewareTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Ai.Tests
+{
+    [TestClass]
+    public class QnaMakerMiddlewareTests
+    {
+        public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
+        public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
+
+        //[TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_TestMiddleware()
+        {
+            TestAdapter adapter = new TestAdapter();
+            Bot bot = new Bot(adapter)
+                .Use(new QnAMakerMiddleware(new QnAMakerOptions()
+                {
+                    KnowledgeBaseId = knowlegeBaseId,
+                    SubscriptionKey = subscriptionKey,
+                    Top = 1
+                }, new HttpClient()));
+
+            bot.OnReceive((context) =>
+                {
+                    if (context.Request.AsMessageActivity().Text == "foo")
+                    {
+                        context.Reply(context.Request.AsMessageActivity().Text);
+                    }
+                    return Task.CompletedTask;
+                });               
+
+            await adapter
+                .Send("foo")
+                    .AssertReply("foo", "passthrough")
+                .Send("how do I clean the stove?")
+                    .AssertReply("BaseCamp: You can use a damp rag to clean around the Power Pack. Do not attempt to detach it from the stove body. As with any electronic device, never pour water on it directly. CampStove 2 &amp; CookStove: Power module: Remove the plastic power module from the fuel chamber and wipe it down with a damp cloth with soap and water. DO NOT submerge the power module in water or get it excessively wet. Fuel chamber: Wipe out with a nylon brush as needed. The pot stand at the top of the fuel chamber can be wiped off with a damp cloth and dried well. The fuel chamber can also be washed in a dishwasher. Dry very thoroughly.")
+                .StartTest();
+        }
+
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Ai.Tests
 {
     [TestClass]
-    public class QnaMakerTests
+    public class QnAMakerTests
     {
         public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
         public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
@@ -20,7 +19,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_ReturnsAnswer()
         {
-            var qna = new QnAMakerMiddleware(new QnAMakerOptions()
+            var qna = new QnAMaker(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
@@ -39,7 +38,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         public async Task QnaMaker_TestThreshold()
         {
 
-            var qna = new QnAMakerMiddleware(new QnAMakerOptions()
+            var qna = new QnAMaker(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
@@ -51,37 +50,5 @@ namespace Microsoft.Bot.Builder.Ai.Tests
             Assert.IsNotNull(results);
             Assert.AreEqual(results.Length, 0, "should get zero result because threshold");
         }
-
-        //[TestMethod]
-        [TestCategory("AI")]
-        [TestCategory("QnAMaker")]
-        public async Task QnaMaker_TestMiddleware()
-        {
-            TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .Use(new QnAMakerMiddleware(new QnAMakerOptions()
-                {
-                    KnowledgeBaseId = knowlegeBaseId,
-                    SubscriptionKey = subscriptionKey,
-                    Top = 1
-                }, new HttpClient()));
-
-            bot.OnReceive((context) =>
-                {
-                    if (context.Request.AsMessageActivity().Text == "foo")
-                    {
-                        context.Reply(context.Request.AsMessageActivity().Text);
-                    }
-                    return Task.CompletedTask;
-                });               
-
-            await adapter
-                .Send("foo")
-                    .AssertReply("foo", "passthrough")
-                .Send("how do I clean the stove?")
-                    .AssertReply("BaseCamp: You can use a damp rag to clean around the Power Pack. Do not attempt to detach it from the stove body. As with any electronic device, never pour water on it directly. CampStove 2 &amp; CookStove: Power module: Remove the plastic power module from the fuel chamber and wipe it down with a damp cloth with soap and water. DO NOT submerge the power module in water or get it excessively wet. Fuel chamber: Wipe out with a nylon brush as needed. The pot stand at the top of the fuel chamber can be wiped off with a damp cloth and dried well. The fuel chamber can also be washed in a dishwasher. Dry very thoroughly.")
-                .StartTest();
-        }
-
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_EchoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_EchoTests.cs
@@ -29,13 +29,10 @@ namespace Microsoft.Bot.Builder.Tests
         }       
     }
 
-    public class EchoMiddleWare : Middleware.IReceiveActivity
+    public class EchoMiddleWare : IReceiveActivity
     {
-        private readonly bool handled; 
-
-        public EchoMiddleWare(bool handled = true)
+        public EchoMiddleWare()
         {
-            this.handled = handled;
         }        
 
         public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)


### PR DESCRIPTION
#130 

This alters the behavior of the Bot, so that OnReceive is ONLY called if all relevant Middleware completes. If any middleware fails to call next, or throws, the the OnReceive handler will not be called. Based on consenus in #130, this is the desired behavior. 

The only "edge" case is a Pipeline with no relevant Middleware. I've defined this as "Run OnReceive if there is no Middleware". This seems the correct behavior. 

Relevant tests around this have been added testing the various conditions. 