### PR TITLE
Extracted QnAMaker logic from corresponding middleware

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Ai
+{
+    public class QnAMaker
+    {
+        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
+        public const string APIManagementHeader = "Ocp-Apim-Subscription-Key";
+        public const string JsonMimeType = "application/json";
+
+        private readonly HttpClient _httpClient;
+        private readonly QnAMakerOptions _options;
+        private readonly string _answerUrl;
+
+        public QnAMaker(QnAMakerOptions options, HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrEmpty(options.KnowledgeBaseId))
+            {
+                throw new ArgumentException(nameof(options.KnowledgeBaseId));
+            }
+
+            _answerUrl = $"{qnaMakerServiceEndpoint}{options.KnowledgeBaseId}/generateanswer";
+
+            if (_options.ScoreThreshold == 0)
+            {
+                _options.ScoreThreshold = 0.3F;
+            }
+
+            if (_options.Top == 0)
+            {
+                _options.Top = 1;
+            }
+        }
+
+        public async Task<QueryResult[]> GetAnswers(string question)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, _answerUrl);
+
+            string jsonRequest = JsonConvert.SerializeObject(new
+            {
+                question,
+                top = _options.Top
+            }, Formatting.None);
+
+            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, JsonMimeType);
+            content.Headers.Add(APIManagementHeader, _options.SubscriptionKey);
+
+            var response = await _httpClient.PostAsync(_answerUrl, content).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var results = JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
+                foreach (var answer in results.Answers)
+                {
+                    answer.Score = answer.Score / 100;
+                }
+
+                return results.Answers.Where(answer => answer.Score > _options.ScoreThreshold).ToArray();
+            }
+            return null;
+        }
+    }
+
+    public class QnAMakerOptions
+    {
+        public string SubscriptionKey { get; set; }
+        public string KnowledgeBaseId { get; set; }
+        public float ScoreThreshold { get; set; }
+        public int Top { get; set; }
+    }
+
+    public class QueryResult
+    {
+        [JsonProperty("questions")]
+        public string[] Questions { get; set; }
+
+        [JsonProperty("answer")]
+        public string Answer { get; set; }
+
+        [JsonProperty("score")]
+        public float Score { get; set; }
+    }
+
+    public class QueryResults
+    {
+        [JsonProperty("answers")]
+        public QueryResult[] Answers { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
@@ -1,104 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Ai
 {
-
-    public class QueryResult
-    {
-        [JsonProperty("questions")]
-        public string[] Questions { get; set; }
-
-        [JsonProperty("answer")]
-        public string Answer { get; set; }
-
-        [JsonProperty("score")]
-        public float Score { get; set; }
-    }
-
-    public class QueryResults
-    {
-        [JsonProperty("answers")]
-        public QueryResult[] Answers { get; set; }
-    }
-
-
-    public class QnAMakerOptions
-    {
-        public string SubscriptionKey { get; set; }
-        public string KnowledgeBaseId { get; set; }
-        public float ScoreThreshold { get; set; }
-        public int Top { get; set; }
-    }
-
     public class QnAMakerMiddleware : Middleware.IReceiveActivity
     {
-        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
-        private readonly string _answerUrl;
-        private readonly QnAMakerOptions _options;
-        private readonly HttpClient _httpClient;
-
-        public const string APIManagementHeader = "Ocp-Apim-Subscription-Key";
-        public const string JsonMimeType = "application/json"; 
+        private readonly QnAMaker _qnaMaker;
 
         public QnAMakerMiddleware(QnAMakerOptions options, HttpClient httpClient)
         {
-
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-            this._httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-
-            if (string.IsNullOrEmpty(options.KnowledgeBaseId))
-            {
-                throw new ArgumentException(nameof(options.KnowledgeBaseId));
-            }
-
-            this._answerUrl = $"{qnaMakerServiceEndpoint}{options.KnowledgeBaseId}/generateanswer";
-
-            if (_options.ScoreThreshold == 0)
-            {
-                _options.ScoreThreshold = 0.3F;
-            }
-
-            if (_options.Top == 0)
-            {
-                _options.Top = 1;
-            }                        
-        }
-
-        public async Task<QueryResult[]> GetAnswers(string question)
-        {
-            var request = new HttpRequestMessage(HttpMethod.Post, this._answerUrl);
-            
-            string jsonRequest = JsonConvert.SerializeObject(new
-            {
-                question,
-                top = this._options.Top
-            }, Formatting.None);
-
-            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, JsonMimeType);
-            content.Headers.Add(APIManagementHeader, this._options.SubscriptionKey);
-
-            var response = await this._httpClient.PostAsync(this._answerUrl, content).ConfigureAwait(false);
-            if (response.IsSuccessStatusCode)
-            {
-                var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var results = JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
-                foreach (var answer in results.Answers)
-                {
-                    answer.Score = answer.Score / 100;
-                }
-
-                return results.Answers.Where(answer => answer.Score > this._options.ScoreThreshold).ToArray();
-            }
-            return null;
+            _qnaMaker = new QnAMaker(options, httpClient);
         }
 
         public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
@@ -108,7 +25,7 @@ namespace Microsoft.Bot.Builder.Ai
                 var messageActivity = context.Request.AsMessageActivity();
                 if (!string.IsNullOrEmpty(messageActivity.Text))
                 {
-                    var results = await this.GetAnswers(messageActivity.Text.Trim()).ConfigureAwait(false);
+                    var results = await _qnaMaker.GetAnswers(messageActivity.Text.Trim()).ConfigureAwait(false);
                     if (results.Any())
                     {
                         context.Reply(results.First().Answer);
@@ -116,7 +33,7 @@ namespace Microsoft.Bot.Builder.Ai
                 }
             }
 
-            await next().ConfigureAwait(false); 
+            await next().ConfigureAwait(false);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerMiddlewareTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Ai.Tests
+{
+    [TestClass]
+    public class QnaMakerMiddlewareTests
+    {
+        public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
+        public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
+
+        //[TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_TestMiddleware()
+        {
+            TestAdapter adapter = new TestAdapter();
+            Bot bot = new Bot(adapter)
+                .Use(new QnAMakerMiddleware(new QnAMakerOptions()
+                {
+                    KnowledgeBaseId = knowlegeBaseId,
+                    SubscriptionKey = subscriptionKey,
+                    Top = 1
+                }, new HttpClient()));
+
+            bot.OnReceive((context) =>
+                {
+                    if (context.Request.AsMessageActivity().Text == "foo")
+                    {
+                        context.Reply(context.Request.AsMessageActivity().Text);
+                    }
+                    return Task.CompletedTask;
+                });               
+
+            await adapter
+                .Send("foo")
+                    .AssertReply("foo", "passthrough")
+                .Send("how do I clean the stove?")
+                    .AssertReply("BaseCamp: You can use a damp rag to clean around the Power Pack. Do not attempt to detach it from the stove body. As with any electronic device, never pour water on it directly. CampStove 2 &amp; CookStove: Power module: Remove the plastic power module from the fuel chamber and wipe it down with a damp cloth with soap and water. DO NOT submerge the power module in water or get it excessively wet. Fuel chamber: Wipe out with a nylon brush as needed. The pot stand at the top of the fuel chamber can be wiped off with a damp cloth and dried well. The fuel chamber can also be washed in a dishwasher. Dry very thoroughly.")
+                .StartTest();
+        }
+
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Ai.Tests
 {
     [TestClass]
-    public class QnaMakerTests
+    public class QnAMakerTests
     {
         public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
         public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
@@ -20,7 +19,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_ReturnsAnswer()
         {
-            var qna = new QnAMakerMiddleware(new QnAMakerOptions()
+            var qna = new QnAMaker(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
@@ -39,7 +38,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         public async Task QnaMaker_TestThreshold()
         {
 
-            var qna = new QnAMakerMiddleware(new QnAMakerOptions()
+            var qna = new QnAMaker(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
                 SubscriptionKey = subscriptionKey,
@@ -51,37 +50,5 @@ namespace Microsoft.Bot.Builder.Ai.Tests
             Assert.IsNotNull(results);
             Assert.AreEqual(results.Length, 0, "should get zero result because threshold");
         }
-
-        //[TestMethod]
-        [TestCategory("AI")]
-        [TestCategory("QnAMaker")]
-        public async Task QnaMaker_TestMiddleware()
-        {
-            TestAdapter adapter = new TestAdapter();
-            Bot bot = new Bot(adapter)
-                .Use(new QnAMakerMiddleware(new QnAMakerOptions()
-                {
-                    KnowledgeBaseId = knowlegeBaseId,
-                    SubscriptionKey = subscriptionKey,
-                    Top = 1
-                }, new HttpClient()));
-
-            bot.OnReceive((context) =>
-                {
-                    if (context.Request.AsMessageActivity().Text == "foo")
-                    {
-                        context.Reply(context.Request.AsMessageActivity().Text);
-                    }
-                    return Task.CompletedTask;
-                });               
-
-            await adapter
-                .Send("foo")
-                    .AssertReply("foo", "passthrough")
-                .Send("how do I clean the stove?")
-                    .AssertReply("BaseCamp: You can use a damp rag to clean around the Power Pack. Do not attempt to detach it from the stove body. As with any electronic device, never pour water on it directly. CampStove 2 &amp; CookStove: Power module: Remove the plastic power module from the fuel chamber and wipe it down with a damp cloth with soap and water. DO NOT submerge the power module in water or get it excessively wet. Fuel chamber: Wipe out with a nylon brush as needed. The pot stand at the top of the fuel chamber can be wiped off with a damp cloth and dried well. The fuel chamber can also be washed in a dishwasher. Dry very thoroughly.")
-                .StartTest();
-        }
-
     }
 }


### PR DESCRIPTION
Moved `GetAnswers` logic to separate class that is used in middleware and can be reused without it. There are test for QnA but they are commented and i don`t know how to run them.

@drub0y @daltskin

Closes #124 and i believe #137 as well.