### PR TITLE
Updated QnAMaker to use v3 API

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMaker.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Bot.Builder.Ai
 {
     public class QnAMaker
     {
-        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v2.0/knowledgebases/";
+        public const string qnaMakerServiceEndpoint = "https://westus.api.cognitive.microsoft.com/qnamaker/v3.0/knowledgebases/";
         public const string APIManagementHeader = "Ocp-Apim-Subscription-Key";
         public const string JsonMimeType = "application/json";
 
@@ -39,6 +39,16 @@ namespace Microsoft.Bot.Builder.Ai
             {
                 _options.Top = 1;
             }
+
+            if (_options.StrictFilters == null)
+            {
+                _options.StrictFilters = new Metadata[] {};
+            }
+
+            if (_options.MetadataBoost == null)
+            {
+                _options.MetadataBoost = new Metadata[] { };
+            }
         }
 
         public async Task<QueryResult[]> GetAnswers(string question)
@@ -48,7 +58,9 @@ namespace Microsoft.Bot.Builder.Ai
             string jsonRequest = JsonConvert.SerializeObject(new
             {
                 question,
-                top = _options.Top
+                top = _options.Top,
+                strictFilters = _options.StrictFilters,
+                metadataBoost = _options.MetadataBoost
             }, Formatting.None);
 
             var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, JsonMimeType);
@@ -76,6 +88,18 @@ namespace Microsoft.Bot.Builder.Ai
         public string KnowledgeBaseId { get; set; }
         public float ScoreThreshold { get; set; }
         public int Top { get; set; }
+        public Metadata[] StrictFilters { get; set; }
+        public Metadata[] MetadataBoost { get; set; }
+    }
+
+    [Serializable]
+    public class Metadata
+    {
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
     }
 
     public class QueryResult
@@ -88,6 +112,15 @@ namespace Microsoft.Bot.Builder.Ai
 
         [JsonProperty("score")]
         public float Score { get; set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public Metadata[] Metadata { get; set; }
+
+        [JsonProperty(PropertyName = "source")]
+        public string Source { get; set; }
+
+        [JsonProperty(PropertyName = "qnaId")]
+        public int QnaId { get; set; }
     }
 
     public class QueryResults


### PR DESCRIPTION
Updated QnAMaker to use v3 API (http://bit.ly/2EA7syR) which brings optional support for metadata to filter / boost answers returned. I can't see any downsides to implementing v3, given that it works exactly like v2, but with optional metadata properties on the request and in the response. If the user does not specify any metadata on the QnAMakerOptions.

@cleemullins As mentioned on the previous pull request to split out the QnAMaker from the middleware, I tried running the QnAMaker tests, but they are commented out at the moment.  I have however ran the QnA sample against my own QnA service (which has metadata against some of the items in the KB) and all seems to be working well.

@daltskin 