### PR TITLE
Added Delay to ActivityTypes to prevent need to use magic string

### DIFF
--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.BotFramework
 
             foreach (Activity activity in activities)
             {
-                if (activity.Type == "delay")
+                if (activity.Type == ActivityTypes.Delay)
                 {
                     // The Activity Schema doesn't have a delay type build in, so it's simulated
                     // here in the Bot. This matches the behavior in the Node connector. 

--- a/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.BotFramework/BotFrameworkAdapter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.BotFramework
 
             foreach (Activity activity in activities)
             {
-                if (activity.Type == ActivityTypes.Delay)
+                if (activity.Type == ActivityTypesEx.Delay)
                 {
                     // The Activity Schema doesn't have a delay type build in, so it's simulated
                     // here in the Bot. This matches the behavior in the Node connector. 

--- a/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Adapters
                             }
                         }
                         break;
-                    case "delay":
+                    case ActivityTypes.Delay:
                         {                            
                             // The Activity Schema doesn't have a delay type build in, so it's simulated
                             // here in the Bot. This matches the behavior in the Node connector. 

--- a/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/ConsoleAdapter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Adapters
                             }
                         }
                         break;
-                    case ActivityTypes.Delay:
+                    case ActivityTypesEx.Delay:
                         {                            
                             // The Activity Schema doesn't have a delay type build in, so it's simulated
                             // here in the Bot. This matches the behavior in the Node connector. 

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             foreach (var activity in activities)
             {
-                if (activity.Type == "delay")
+                if (activity.Type == ActivityTypes.Delay)
                 {
                     // The BotFrameworkAdapter and Console adapter implement this
                     // hack directly in the POST method. Replicating that here

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             foreach (var activity in activities)
             {
-                if (activity.Type == ActivityTypes.Delay)
+                if (activity.Type == ActivityTypesEx.Delay)
                 {
                     // The BotFrameworkAdapter and Console adapter implement this
                     // hack directly in the POST method. Replicating that here

--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder
         public static async Task<IBotContext> Delay(this IBotContext context, int duration)
         {
             Activity activity = ((Activity)context.Request).CreateReply();
-            activity.Type = "delay";
+            activity.Type = ActivityTypes.Delay;
             activity.Value = duration;
             await context.Bot.SendActivity(context, new List<IActivity>() { activity });
             return context;

--- a/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
+++ b/libraries/Microsoft.Bot.Builder/ContextExtensions/ContextExtensionMethods.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder
         public static async Task<IBotContext> Delay(this IBotContext context, int duration)
         {
             Activity activity = ((Activity)context.Request).CreateReply();
-            activity.Type = ActivityTypes.Delay;
+            activity.Type = ActivityTypesEx.Delay;
             activity.Value = duration;
             await context.Bot.SendActivity(context, new List<IActivity>() { activity });
             return context;

--- a/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
@@ -30,5 +30,6 @@ namespace Microsoft.Bot.Schema
         public const string InstallationUpdate = "installationUpdate";
         public const string MessageReaction = "messageReaction";
         public const string Suggestion = "suggestion";
+        public const string Delay = "delay";
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityTypes.cs
@@ -30,6 +30,5 @@ namespace Microsoft.Bot.Schema
         public const string InstallationUpdate = "installationUpdate";
         public const string MessageReaction = "messageReaction";
         public const string Suggestion = "suggestion";
-        public const string Delay = "delay";
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ActivityTypesEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityTypesEx.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Additional values for ActivityTypes beyond the auto-generated ActivityTypes class.
+    /// </summary>
+    public static class ActivityTypesEx
+    {
+        public const string Delay = "delay";
+    }
+}


### PR DESCRIPTION
We have an context extension method which was using an activity type of "delay".  Given that this is part of the core SDK, I have brought this in line with other activity types and added it to the ActivityTypes class to prevent the need to use a magic string for comparison and hopefully avoid typo mistakes.