### PR TITLE
Always run the SendPipeline, even if there's nothing to send.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Bot.cs
+++ b/libraries/Microsoft.Bot.Builder/Bot.cs
@@ -79,11 +79,14 @@ namespace Microsoft.Bot.Builder
                 await proactiveCallback(context).ConfigureAwait(false);
             }
 
-            // Call any registered Middleware Components looking for SendActivity()
-            if (context.Responses != null && context.Responses.Any())
-            {
-                await _middlewareSet.SendActivity(context, context.Responses).ConfigureAwait(false);
-            }
+            // Call any registered Middleware Components looking for SendActivity()               
+
+            // Don't pass in null. By default this won't happen, but it's possible that
+            // somone reset the context.Responses object to null. An empty list is much
+            // easier to deal with. 
+            await _middlewareSet.SendActivity(context, 
+                context.Responses ?? new List<IActivity>()).ConfigureAwait(false);
+            
 
             System.Diagnostics.Trace.TraceInformation($"Middleware: Ending Pipeline for {context.ConversationReference.ActivityId}");
         }

--- a/tests/Microsoft.Bot.Builder.Tests/BotContext_Tests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotContext_Tests.cs
@@ -29,7 +29,10 @@ namespace Microsoft.Bot.Builder.Tests
         }
         public async Task SendActivity(IBotContext context, IList<IActivity> activities, MiddlewareSet.NextDelegate next)
         {
-            context.Responses[0].AsMessageActivity().Text += "SendActivity";
+            if (context.Responses.Count > 0)
+            {
+                context.Responses[0].AsMessageActivity().Text += "SendActivity";
+            }
             await next();
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/Bot_FunctionalTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Bot_FunctionalTests.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Bot.Builder.Middleware.MiddlewareSet;
 
 namespace Microsoft.Bot.Builder.Tests
 {
@@ -27,10 +31,78 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter);
 
+
             ActivityAdapterBase retrievedAdapter = bot.Adapter;
 
             // Verify the Bot a property to allow retrieving the Adapter. 
             Assert.AreSame(adapter, retrievedAdapter);
+        }
+
+        [TestMethod]
+        public async Task RunSendPiplineWith0Response()
+        {
+            TestAdapter adapter = new TestAdapter();
+            Bot bot = new Bot(adapter);
+            WasThisMiddlwareCalled testMiddleware = new WasThisMiddlwareCalled();
+            bot.Use(testMiddleware)
+                .OnReceive(async (context) => { });
+
+            await adapter
+                .Send("foo")
+                .StartTest();
+
+            // Test that even though the bot didn't reply with anything, that all 3 pipelines
+            // were called. This allows (for example) bot state managment to run even if the 
+            // bot doesn't return anything. 
+            Assert.IsTrue(testMiddleware.WasContextCreatedCalled, "Context Created was not called");
+            Assert.IsTrue(testMiddleware.WasRecevieActivityCalled, "Receive was not called");
+            Assert.IsTrue(testMiddleware.WasSendActivityCalled, "Send was not called");
+        }
+
+        [TestMethod]
+        public async Task RunSendPiplineWith1Response()
+        {
+            TestAdapter adapter = new TestAdapter();
+            Bot bot = new Bot(adapter);
+            WasThisMiddlwareCalled testMiddleware = new WasThisMiddlwareCalled();
+            bot.Use(testMiddleware)
+                .OnReceive(async (context) => { context.Reply("one"); });
+
+            await adapter
+                .Send("foo").AssertReply("one")
+                .StartTest();
+
+            Assert.IsTrue(testMiddleware.WasContextCreatedCalled, "Context Created was not called");
+            Assert.IsTrue(testMiddleware.WasRecevieActivityCalled, "Receive was not called");
+            Assert.IsTrue(testMiddleware.WasSendActivityCalled, "Send was not called");
+        }        
+
+        public class WasThisMiddlwareCalled : IContextCreated, ISendActivity, IReceiveActivity
+        {
+            public bool WasContextCreatedCalled { get; set; } = false;
+            public bool WasRecevieActivityCalled { get; set; } = false;
+            public bool WasSendActivityCalled { get; set; } = false;
+
+
+            public WasThisMiddlwareCalled() { }
+
+            public async Task ContextCreated(IBotContext context, NextDelegate next)
+            {
+                WasContextCreatedCalled = true;
+                await next();
+            }
+
+            public async Task SendActivity(IBotContext context, IList<IActivity> activities, NextDelegate next)
+            {
+                WasSendActivityCalled = true;
+                await next();
+            }
+
+            public async Task ReceiveActivity(IBotContext context, NextDelegate next)
+            {
+                WasRecevieActivityCalled = true;
+                await next(); ;
+            }
         }
     }
 }


### PR DESCRIPTION
The SendPipeline needs to run even when there is nothing in the queue to send. This allows any registered "Cleanup" or "Post Processing" middleware to run. BotState.Save being a good example. 

We should (discussed in various issues) at least Rename this pipeline to more accurately reflect that it's a post-processing step. 

**The Node SDK already works this way. **

@RyanDawkins