### PR TITLE
QnAMakerMiddleware options

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddleware.cs
@@ -18,18 +18,7 @@ namespace Microsoft.Bot.Builder.Ai
         public QnAMakerMiddleware(QnAMakerMiddlewareOptions options, HttpClient httpClient)
         {
             _options = options ?? throw new ArgumentNullException(nameof(options));
-
-            var qnaMakerOptions = new QnAMakerOptions()
-            {
-                KnowledgeBaseId = _options.KnowledgeBaseId,
-                SubscriptionKey = _options.SubscriptionKey,
-                ScoreThreshold = _options.ScoreThreshold,
-                Top = _options.Top,
-                MetadataBoost = _options.MetadataBoost,
-                StrictFilters = _options.StrictFilters
-            };
-
-            _qnaMaker = new QnAMaker(qnaMakerOptions, httpClient);
+            _qnaMaker = new QnAMaker(options, httpClient);
         }
 
         public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
@@ -48,6 +37,7 @@ namespace Microsoft.Bot.Builder.Ai
                         context.Reply(results.First().Answer);
 
                         if (_options.EndActivityRoutingOnAnswer)
+                            //Question is answered, don't keep routing
                             return;
                     }
                 }

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddlewareOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddlewareOptions.cs
@@ -1,0 +1,24 @@
+﻿namespace Microsoft.Bot.Builder.Ai
+{
+    /// <summary>
+    /// Options to alter the default behaviour of the QnA Maker Middleware
+    /// </summary>
+    public class QnAMakerMiddlewareOptions
+    {
+        /// <summary>
+        /// If true then routing of the activity will be stopped when an answer is successfully returned by the QnA Maker Middleware
+        /// </summary>
+        public bool EndActivityRoutingOnAnswer { get; set; }
+
+        /// <summary>
+        /// If set this message will be output before the top answer returned from the service. e.g. "I think this answer might help you..."
+        /// </summary>
+        public string DefaultAnswerPrefixMessage { get; set; } 
+
+        public QnAMakerMiddlewareOptions(bool endActivityRoutingOnAnswer = false, string defaultAnswerPrefixMessage = null)
+        {
+            EndActivityRoutingOnAnswer = endActivityRoutingOnAnswer;
+            DefaultAnswerPrefixMessage = defaultAnswerPrefixMessage;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddlewareOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/QnAMakerMiddlewareOptions.cs
@@ -2,23 +2,26 @@
 {
     /// <summary>
     /// Options to alter the default behaviour of the QnA Maker Middleware
+    /// extending the QnAMakerOptions used on the QnAMaker client
     /// </summary>
-    public class QnAMakerMiddlewareOptions
+    public class QnAMakerMiddlewareOptions : QnAMakerOptions
     {
         /// <summary>
-        /// If true then routing of the activity will be stopped when an answer is successfully returned by the QnA Maker Middleware
+        /// If true then routing of the activity will be stopped when an answer is 
+        /// successfully returned by the QnA Maker Middleware
         /// </summary>
         public bool EndActivityRoutingOnAnswer { get; set; }
 
         /// <summary>
-        /// If set this message will be output before the top answer returned from the service. e.g. "I think this answer might help you..."
+        /// If set this message will be output before the top answer returned from 
+        /// the service. e.g. "I think this answer might help you..."
         /// </summary>
-        public string DefaultAnswerPrefixMessage { get; set; } 
+        public string DefaultAnswerPrefixMessage { get; set; }
 
-        public QnAMakerMiddlewareOptions(bool endActivityRoutingOnAnswer = false, string defaultAnswerPrefixMessage = null)
+        public QnAMakerMiddlewareOptions()
         {
-            EndActivityRoutingOnAnswer = endActivityRoutingOnAnswer;
-            DefaultAnswerPrefixMessage = defaultAnswerPrefixMessage;
+            // By default the middleware will continue routing of the activity
+            EndActivityRoutingOnAnswer = false;
         }
     }
 }

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -31,8 +31,14 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
-                .Use(new QnAMakerMiddleware(qnaOptions, _httpClient, new QnAMakerMiddlewareOptions(true, "See this answer....")))
                 .Use(new QnAMakerMiddleware(qnaOptions, _httpClient));
+
+            // You can use the QnAMakerMiddlewareOptions class to allow you to have the middleware 
+            // stop routing (e.g. to additional middleware) if an answer is successfully returned. 
+            // You can also specify a message to be output before an answer is sent back to the user.
+            // The line below shows how you can achieve this.
+            //.Use(new QnAMakerMiddleware(qnaOptions, _httpClient, new QnAMakerMiddlewareOptions(true, "Here is an answer that might help...")))
+
             bot.OnReceive(BotReceiveHandler);
                
             _adapter = (BotFrameworkAdapter)bot.Adapter;

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -26,11 +26,12 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             var qnaOptions = new QnAMakerOptions
             {
                 // add subscription key and knowledge base id
-                SubscriptionKey = "xxxxxx",
-                KnowledgeBaseId = "xxxxxx"
+                SubscriptionKey = "8f833e867b25443b95d8c23cd367f7ce",
+                KnowledgeBaseId = "ed3318af-4498-4a36-a485-a73f2d95220d"
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
+                .Use(new QnAMakerMiddleware(qnaOptions, _httpClient, new QnAMakerMiddlewareOptions(true, "See this answer....")))
                 .Use(new QnAMakerMiddleware(qnaOptions, _httpClient));
             bot.OnReceive(BotReceiveHandler);
                

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
 
         public MessagesController(IConfiguration configuration)
         {
-            var qnaOptions = new QnAMakerOptions
+            var qnaMiddlewareOptions = new QnAMakerMiddlewareOptions
             {
                 // add subscription key and knowledge base id
                 SubscriptionKey = "xxxxxx",
@@ -31,13 +31,7 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 
-                .Use(new QnAMakerMiddleware(qnaOptions, _httpClient));
-
-            // You can use the QnAMakerMiddlewareOptions class to allow you to have the middleware 
-            // stop routing (e.g. to additional middleware) if an answer is successfully returned. 
-            // You can also specify a message to be output before an answer is sent back to the user.
-            // The line below shows how you can achieve this.
-            //.Use(new QnAMakerMiddleware(qnaOptions, _httpClient, new QnAMakerMiddlewareOptions(true, "Here is an answer that might help...")))
+                .Use(new QnAMakerMiddleware(qnaMiddlewareOptions, _httpClient));
 
             bot.OnReceive(BotReceiveHandler);
                

--- a/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.QnA/Controllers/MessagesController.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Bot.Samples.Ai.QnA.Controllers
             var qnaOptions = new QnAMakerOptions
             {
                 // add subscription key and knowledge base id
-                SubscriptionKey = "8f833e867b25443b95d8c23cd367f7ce",
-                KnowledgeBaseId = "ed3318af-4498-4a36-a485-a73f2d95220d"
+                SubscriptionKey = "xxxxxx",
+                KnowledgeBaseId = "xxxxxx"
             };
             var bot = new Builder.Bot(new BotFrameworkAdapter(configuration))
                 // add QnA middleware 

--- a/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Tests/QnAMakerMiddlewareTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Ai.Tests
         {
             TestAdapter adapter = new TestAdapter();
             Bot bot = new Bot(adapter)
-                .Use(new QnAMakerMiddleware(new QnAMakerOptions()
+                .Use(new QnAMakerMiddleware(new QnAMakerMiddlewareOptions()
                 {
                     KnowledgeBaseId = knowlegeBaseId,
                     SubscriptionKey = subscriptionKey,


### PR DESCRIPTION
@cleemullins Included a new QnAMakerMiddlewareOptions class which can be passed to the QnAMakerMiddleware constructor.  This allows the user to specify that the routing should be short circuited on a successful answer.  This seems like a sensible option to provide in the case that the middleware is being used in a chain.
Another option is available to define a default message to be output before a top answer is returned. e.g. "I found this answer that might help...".

I have updated the sample to include comments to show how this can be used.  **I am not sure how to update the wiki to include this information, but if you tell me how then I am happy to do this.**

If the PR looks good then I am happy to implement something similar for the LUIS Middleware (certainly the option the short circuit would make sense I think).