### PR TITLE
ConversationVersion Middleware for #37

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Middleware/ConversationVersionMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/ConversationVersionMiddleware.cs
@@ -76,7 +76,20 @@ namespace Microsoft.Bot.Builder.Middleware
         /// <returns>a task upon completion</returns>
         public async Task ReceiveActivity(IBotContext context, NextDelegate next)
         {
-            throw new NotImplementedException();
+            int? conversationVersion = (int?) context.State.Conversation[CONVERSATION_VERSION];
+            if(!conversationVersion.HasValue)
+            {
+                context.State.Conversation[CONVERSATION_VERSION] = _majorVersion;
+            }
+            else if(conversationVersion.Value != _majorVersion)
+            {
+                await _handler.Invoke(context, conversationVersion.Value, () => {
+                    context.State.Conversation[CONVERSATION_VERSION] = _majorVersion;
+                    return next();
+                });
+            }
+
+            await next();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Middleware/ConversationVersionMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Middleware/ConversationVersionMiddleware.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using static Microsoft.Bot.Builder.Middleware.MiddlewareSet;
+
+namespace Microsoft.Bot.Builder.Middleware
+{
+    /// <summary>
+    /// Deploying new versions of your bot more often then not should have little
+    /// to no impact on the current conversations you're having with a user. Sometimes, however, a change 
+    /// to your bots conversation logic can result in the user getting into a stuck state that can only be
+    /// fixed by their conversation state being deleted.
+    ///
+    /// This middleware lets you track a version number for the conversations your bot is having so that
+    /// you can automatically delete the conversation state anytime a major version number difference is
+    /// detected.Example:
+    ///
+    ///
+    /// bot.Use(new ConversationVersionMiddleware(Assembly.GetAssembly(typeof(MessagesController)), (context, version, next) =>
+    /// {
+    ///     context.Reply("I'm sorry, my service was upgraded let's start over.");
+    ///     context.State.Conversation = new ConversationState();
+    ///     return Task.CompletedTask;
+    ///  }));
+    /// </summary>
+    public class ConversationVersionMiddleware : IReceiveActivity
+    {
+
+        public const string CONVERSATION_VERSION = "$CONVERSATION_VERSION";
+
+        private readonly int _majorVersion;
+        private readonly Func<IBotContext, int, NextDelegate, Task> _handler;
+
+        /// <summary>
+        /// This constructor will get the Entry Assembly and set the major version from that.
+        /// </summary>
+        /// <param name="handler">handler on what to do if an error comes in</param>
+        public ConversationVersionMiddleware(Func<IBotContext, int, NextDelegate, Task> handler)
+        {
+            _majorVersion = Assembly.GetEntryAssembly().GetName().Version.Major;
+            _handler = handler;
+        }
+
+        /// <summary>
+        /// This constructor will set the major version given as an integer.
+        /// </summary>
+        /// <param name="majorVersion">major version to compare against</param>
+        /// <param name="handler">handler on what to do if an error comes in</param>
+        public ConversationVersionMiddleware(int majorVersion, Func<IBotContext, int, NextDelegate, Task> handler)
+        {
+            _majorVersion = majorVersion;
+            _handler = handler;
+        }
+
+        /// <summary>
+        /// Allows an assembly to pull the major version
+        /// </summary>
+        /// <param name="assembly">assembly to get the major version from</param>
+        /// <param name="handler">handler on what to do if an error comes in</param>
+        public ConversationVersionMiddleware(Assembly assembly, Func<IBotContext, int, NextDelegate, Task> handler)
+        {
+            FileVersionInfo fileVersionInfo = FileVersionInfo.GetVersionInfo(assembly.Location);
+            _majorVersion = fileVersionInfo.FileMajorPart;
+            _handler = handler;
+        }
+
+        /// <summary>
+        /// This method will check if the major version has been set and if it has compare to make sure the current version is not greater. 
+        /// If it is it will call the handler set in the constructor.
+        /// </summary>
+        /// <param name="context">bot context</param>
+        /// <param name="next">next delegate of middleware</param>
+        /// <returns>a task upon completion</returns>
+        public async Task ReceiveActivity(IBotContext context, NextDelegate next)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_VersionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_VersionTests.cs
@@ -1,0 +1,230 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using Microsoft.Bot.Builder.Middleware;
+using System.Reflection;
+using static Microsoft.Bot.Builder.Middleware.MiddlewareSet;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    [TestClass]
+    public class Middleware_VersionTests
+    {
+        
+        [TestMethod]
+        public async Task MiddlewareVersion_Assembly_Exception()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+            int assemblyMajorVersionNumber = assembly.GetName().Version.Major;
+            int expectedVersion = assemblyMajorVersionNumber - 1;
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState((assemblyMajorVersionNumber - 1)));
+
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.AreEqual(assemblyMajorVersionNumber - 1, version);
+                return Task.CompletedTask;
+            };
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(assembly, handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_Assembly_NoPreExisting()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+            int assemblyMajorVersionNumber = assembly.GetName().Version.Major;
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState(null));
+
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(assembly, handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_Assembly()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+            int assemblyMajorVersionNumber = assembly.GetName().Version.Major;
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState((assemblyMajorVersionNumber)));
+
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(assembly, handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_String_Exception()
+        {
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState(13));
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.AreEqual(13, version);
+                return Task.CompletedTask;
+            };
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(14, handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_String_NoPreExisting()
+        {
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState(null));
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(14, handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_String()
+        {
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState(14));
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(14, handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_Empty_Exception()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+            int assemblyMajorVersionNumber = assembly.GetName().Version.Major;
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState((assemblyMajorVersionNumber - 1)));
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.AreEqual(assemblyMajorVersionNumber - 1, version);
+                return Task.CompletedTask;
+            };
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+
+        [TestMethod]
+        public async Task MiddlewareVersion_Empty_NoPreExisting()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+            int assemblyMajorVersionNumber = assembly.GetName().Version.Major;
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState(null));
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_Empty()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            contextMock.Setup(s => s.State).Returns(GetBotState(null));
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        [TestMethod]
+        public async Task MiddlewareVersion_NullState()
+        {
+            Assembly assembly = Assembly.GetAssembly(typeof(Middleware_VersionTests));
+
+            Mock<IBotContext> contextMock = new Mock<IBotContext>();
+            BotState botState = new BotState()
+            {
+                Conversation = new ConversationState()
+            };
+            contextMock.Setup(s => s.State).Returns(botState);
+
+            Mock<NextDelegate> nextDelegateMock = new Mock<NextDelegate>();
+
+            Func<IBotContext, int, NextDelegate, Task> handler = (context, version, next) =>
+            {
+                Assert.Fail();
+                return Task.CompletedTask;
+            };
+
+            ConversationVersionMiddleware versionMiddleware = new ConversationVersionMiddleware(handler);
+            await versionMiddleware.ReceiveActivity(contextMock.Object, nextDelegateMock.Object);
+        }
+
+        private BotState GetBotState(int? majorVersion)
+        {
+            ConversationState conversationState = new ConversationState();
+            conversationState[ConversationVersionMiddleware.CONVERSATION_VERSION] = majorVersion;
+
+            BotState botState = new BotState();
+            botState.Conversation = conversationState;
+
+            return botState;    
+        }
+
+    }
+}


### PR DESCRIPTION
ConversationVersion Middleware for #37 

This middleware will check if the ConversationState has a recorded major version. If the major version exists it will make sure the newly deployed **major version** is the same as what was stored. If it is not, it will call the handler function that was passed in.