### PR TITLE
Machine Translation Integration Into Bot Framework V4

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai/LocaleConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/LocaleConverter.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Recognizers.Text;
+using Microsoft.Recognizers.Text.DateTime;
+
+namespace Microsoft.Bot.Builder.Ai
+{
+
+    //Struct used to store date format and time format for different locales
+    internal struct DateAndTimeLocaleFormat
+    {
+        private string timeFormat;
+        private string dateFormat;
+        public string TimeFormat
+        {
+            get
+            {
+                return timeFormat;
+            }
+            set
+            {
+                timeFormat = value;
+            }
+        }
+        public string DateFormat
+        {
+            get
+            {
+                return dateFormat;
+            }
+            set
+            {
+                dateFormat = value;
+            }
+        }
+
+    }
+
+    //Struct to store  text and date time object from Microsoft Recognizer recognition result
+    internal struct TextAndDateTime
+    {
+        private string dateText;
+        private DateTime date;
+        public string Text
+        {
+            get
+            {
+                return dateText;
+            }
+            set
+            {
+                dateText = value;
+            }
+        }
+        public DateTime DateTimeObj
+        {
+            get
+            {
+                return date;
+            }
+            set
+            {
+                date = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Locale Converter Class used to convert between locales
+    /// in terms of date and time only
+    /// </summary>
+    public class LocaleConverter
+    { 
+        private Dictionary<string, DateAndTimeLocaleFormat> mapLocaleToFunction = new Dictionary<string, DateAndTimeLocaleFormat>();
+
+        public LocaleConverter()
+        {
+            initLocales();
+        }
+
+        //Init different locales format
+        //Supporting English ,French deutch and chinese locales
+        private void initLocales()
+        {
+            DateAndTimeLocaleFormat yearMonthDay = new DateAndTimeLocaleFormat
+            {
+                TimeFormat = "{0:hh:mm tt}",
+                DateFormat = "{0:yyyy-MM-dd}"
+            };
+            DateAndTimeLocaleFormat dayMonthYear = new DateAndTimeLocaleFormat
+            {
+                TimeFormat = "{0:hh:mm tt}",
+                DateFormat = "{0:dd/MM/yyyy}"
+            };
+            DateAndTimeLocaleFormat monthDayYEar = new DateAndTimeLocaleFormat
+            {
+                TimeFormat = "{0:hh:mm tt}",
+                DateFormat = "{0:MM/dd/yyyy}"
+            };
+            foreach (string locale in new string[] { "en-za", "en-ie", "en-gb", "en-ca", "fr-ca", "zh-cn", "zh-sg", "zh-hk", "zh-mo", "zh-tw" })
+            {
+                mapLocaleToFunction[locale] = yearMonthDay;
+            }
+            foreach (string locale in new string[] { "en-au", "fr-be", "fr-ch", "fr-fr", "fr-lu", "fr-mc", "de-at", "de-ch", "de-de", "de-lu", "de-li" })
+            {
+                mapLocaleToFunction[locale] = dayMonthYear;
+            }
+            mapLocaleToFunction["en-us"] = monthDayYEar;
+        }
+
+        //check if a specific locale is available
+        public bool IsLocaleAvailable(string locale)
+        {
+            return mapLocaleToFunction.ContainsKey(locale);
+        }
+
+        //extract date and time from a sentence using Microsoft Recognizer
+        private List<TextAndDateTime> extractDate(string message, string fromLocale)
+        {
+            List<TextAndDateTime> fndDates = new List<TextAndDateTime>();
+            var culture = Culture.English; 
+            if (fromLocale.StartsWith("fr"))
+            {
+                culture = Culture.French;
+            }
+            else if (fromLocale.StartsWith("de"))
+            {
+                culture = Culture.German;
+            }
+            else if (fromLocale.StartsWith("pt"))
+            {
+                culture = Culture.Portuguese;
+            }
+            else if (fromLocale.StartsWith("zh"))
+            {
+                culture = Culture.Chinese;
+            }
+            else if (fromLocale.StartsWith("es"))
+            {
+                culture = Culture.Spanish;
+            }
+            var model = DateTimeRecognizer.GetInstance().GetDateTimeModel(culture);
+            var results = model.Parse(message);
+            foreach (ModelResult result in results)
+            {
+                var resolutionValues = (IList<Dictionary<string, string>>)result.Resolution["values"];
+                string type = result.TypeName.Split('.').Last();
+                DateTime moment = new DateTime();
+                if (type.Contains("date") && !type.Contains("range"))
+                {
+                    moment = resolutionValues.Select(v => DateTime.Parse(v["value"])).FirstOrDefault();
+
+                }
+                else if (type.Contains("date") && type.Contains("range"))
+                {
+                    moment = DateTime.Parse(resolutionValues.First()["start"]);
+                }
+                else
+                    continue;
+                var curDateTimeText = new TextAndDateTime
+                {
+                    DateTimeObj = moment,
+                    Text = result.Text
+                };
+                fndDates.Add(curDateTimeText);
+            }
+            return fndDates;
+        }
+
+        //Convert a message from locale to another locale
+        public Task<string> Convert(string message, string fromLocale, string toLocale)
+        {
+            List<TextAndDateTime> dates = extractDate(message, fromLocale);
+            if (dates.Count == 0)
+                return Task.FromResult(message);
+            string processedMessage = message;
+            foreach (TextAndDateTime date in dates)
+            {
+                if (date.DateTimeObj.Date == DateTime.Now.Date)
+                {
+                    processedMessage = processedMessage.Replace(date.Text, String.Format(mapLocaleToFunction[toLocale].TimeFormat, date.DateTimeObj));
+                }
+                else
+                {
+                    processedMessage = processedMessage.Replace(date.Text, String.Format(mapLocaleToFunction[toLocale].DateFormat, date.DateTimeObj));
+                }
+            }
+            return Task.FromResult(processedMessage);
+        }
+
+        //Get all supported Locales
+        public string[] GetAvailableLocales()
+        {
+            return mapLocaleToFunction.Keys.ToArray();
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Ai/LocaleConverterMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai/LocaleConverterMiddleware.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Bot.Schema;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Ai
+{
+    /// <summary>
+    /// Middleware to convert messages between different locales specified
+    /// </summary>
+    public class LocaleConverterMiddleware : IReceiveActivity
+    {
+        private LocaleConverter localeConverter;
+        private string fromLocale;
+        private string toLocale;
+
+        public LocaleConverterMiddleware(string fromLocale, string toLocale)
+        {
+            localeConverter = new LocaleConverter();
+            this.fromLocale = fromLocale;
+            this.toLocale = toLocale;
+        }
+
+        public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
+        {
+            IMessageActivity message = context.Request.AsMessageActivity();
+            if (message != null)
+            {
+                if (!String.IsNullOrWhiteSpace(message.Text))
+                {
+                    await ConvertLocaleMessageAsync(message);
+                }
+            }
+            await next().ConfigureAwait(false);
+        }
+
+
+
+        private async Task ConvertLocaleMessageAsync(IMessageActivity message)
+        {
+            if (localeConverter.IsLocaleAvailable(fromLocale) && localeConverter.IsLocaleAvailable(toLocale) && fromLocale != toLocale)
+            {
+                message.Text = await localeConverter.Convert(message.Text, fromLocale, toLocale);
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Ai/Microsoft.Bot.Builder.Ai.csproj
+++ b/libraries/Microsoft.Bot.Builder.Ai/Microsoft.Bot.Builder.Ai.csproj
@@ -40,6 +40,8 @@
     <PackageReference Include="Microsoft.Cognitive.LUIS" Version="2.0.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
+    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.0.0.35" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
+++ b/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AdaptiveCards" Version="0.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.32" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.35" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/samples/AlarmBot/AlarmBot.csproj
+++ b/samples/AlarmBot/AlarmBot.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.32" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.35" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
- Translator Object Updated to support language detection from message 
- Fixed translation numeric error (restore number from original message e.g.: 20:30 translated to 10:30 the translator will output 20:30 along with the translated message)
- Added post processing internal class used to handle no translate templates for each language (e.g.: trouve moi (.*)   matched group 1 in the template file of French won’t be translated)

- Locale Converter Middleware Added 
- Supports conversion between locales in date and time using Microsoft.Text. Recognizer to recognize dates
- Now Supporting all English locales, French, Deutsch and Chinese

In progress : 
- Working on a sample showcasing machine translation Middleware and locale converter Middleware
- Will add template translate to translator object which will allow automatic translation of template of a specific language to other languages automatically
