### PR TITLE
Remove dependency on BotContext for IntentRecognizerMiddleware. Add fluent intent handers.

### DIFF
--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.Samples.EchoB
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Samples.EchoBot-Console", "samples\Microsoft.Bot.Samples.EchoBot-Console\Microsoft.Bot.Samples.EchoBot-Console.csproj", "{C8DF8AE3-0A4D-445D-993E-F7A1784BFDD4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Samples.Ai.Luis", "samples\Microsoft.Bot.Samples.Ai.Luis\Microsoft.Bot.Samples.Ai.Luis.csproj", "{1DB8478E-EAB2-4C9C-B6C8-0F5E23F2C4D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +107,10 @@ Global
 		{C8DF8AE3-0A4D-445D-993E-F7A1784BFDD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8DF8AE3-0A4D-445D-993E-F7A1784BFDD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8DF8AE3-0A4D-445D-993E-F7A1784BFDD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DB8478E-EAB2-4C9C-B6C8-0F5E23F2C4D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DB8478E-EAB2-4C9C-B6C8-0F5E23F2C4D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DB8478E-EAB2-4C9C-B6C8-0F5E23F2C4D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DB8478E-EAB2-4C9C-B6C8-0F5E23F2C4D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,6 +131,7 @@ Global
 		{C6485617-FBD0-4E7B-894A-214D11D2425F} = {3ADFB27A-95FA-4330-B211-1D66A29A17AB}
 		{AAC0F76C-4114-4D64-A99E-8BE4C43982F9} = {3ADFB27A-95FA-4330-B211-1D66A29A17AB}
 		{C8DF8AE3-0A4D-445D-993E-F7A1784BFDD4} = {3ADFB27A-95FA-4330-B211-1D66A29A17AB}
+		{1DB8478E-EAB2-4C9C-B6C8-0F5E23F2C4D7} = {3ADFB27A-95FA-4330-B211-1D66A29A17AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7173C9F3-A7F9-496E-9078-9156E35D6E16}

--- a/libraries/Microsoft.Bot.Builder.Core/Middleware/IntentRecognizerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Middleware/IntentRecognizerMiddleware.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Middleware
@@ -12,8 +11,9 @@ namespace Microsoft.Bot.Builder.Middleware
     {
         public string Name { get; set; }
         public double Score { get; set; }
-        public IList<Entity> Entities { get; } = new List<Entity>();
-    }
+
+        public IList<Entity> Entities { get; } = new List<Entity>();                       
+    }    
 
     public class IntentRecognizerMiddleware : IReceiveActivity
     {
@@ -28,6 +28,13 @@ namespace Microsoft.Bot.Builder.Middleware
         public delegate Task IntentHandler(IBotContext context, Intent intent);
 
         public Dictionary<string, IntentHandler> IntentHandlers;
+
+        public bool EndActivityRoutingOnIntentHandled { get; set; }
+
+        public IntentRecognizerMiddleware(bool endActivityRoutingOnIntentHandled = true)
+        {
+            EndActivityRoutingOnIntentHandled = endActivityRoutingOnIntentHandled;
+        }
 
         public IntentRecognizerMiddleware HandleIntent(string intentName, IntentHandler intentHandler)
         {
@@ -44,19 +51,22 @@ namespace Microsoft.Bot.Builder.Middleware
             BotAssert.ContextNotNull(context);
 
             var intents = await this.Recognize(context);
-
             if (intents.Count != 0)
             {
                 var topIntent = FindTopIntent(intents);
                 if (topIntent.Score > 0.0 && IntentHandlers.ContainsKey(topIntent.Name))
                 {
                     await IntentHandlers[topIntent.Name].Invoke(context, topIntent);
-                    return;
+
+                    if (EndActivityRoutingOnIntentHandled)
+                    {
+                        return;
+                    }
                 }
             }
-            await next().ConfigureAwait(false);
+            await next().ConfigureAwait(false); 
         }
-
+       
         public async Task<IList<Intent>> Recognize(IBotContext context)
         {
             BotAssert.ContextNotNull(context);
@@ -70,7 +80,7 @@ namespace Microsoft.Bot.Builder.Middleware
             }
             else
             {
-                return new List<Intent>();
+                return new List<Intent>(); 
             }
         }
 
@@ -91,7 +101,7 @@ namespace Microsoft.Bot.Builder.Middleware
         }
 
         private async Task<Boolean> IsRecognizerEnabled(IBotContext context)
-        {
+        {            
             foreach (var userCode in _intentDisablers)
             {
                 bool isEnabled = await userCode(context).ConfigureAwait(false);
@@ -101,7 +111,7 @@ namespace Microsoft.Bot.Builder.Middleware
                 }
             }
 
-            return true;
+            return true; 
         }
 
         private async Task RunFilters(IBotContext context, IList<Intent> intents)
@@ -123,8 +133,8 @@ namespace Microsoft.Bot.Builder.Middleware
         public IntentRecognizerMiddleware OnEnabled(IntentDisabler preCondition)
         {
             if (preCondition == null)
-                throw new ArgumentNullException(nameof(preCondition));
-
+                throw new ArgumentNullException(nameof(preCondition)); 
+            
             _intentDisablers.AddLast(preCondition);
 
             return this;
@@ -136,7 +146,7 @@ namespace Microsoft.Bot.Builder.Middleware
         public IntentRecognizerMiddleware OnRecognize(IntentRecognizer recognizer)
         {
             if (recognizer == null)
-                throw new ArgumentNullException(nameof(recognizer));
+                throw new ArgumentNullException(nameof(recognizer)); 
 
             _intentRecognizers.AddLast(recognizer);
 
@@ -149,7 +159,7 @@ namespace Microsoft.Bot.Builder.Middleware
         public IntentRecognizerMiddleware OnFilter(IntentResultMutator postCondition)
         {
             if (postCondition == null)
-                throw new ArgumentNullException(nameof(postCondition));
+                throw new ArgumentNullException(nameof(postCondition)); 
 
             _intentResultMutators.AddFirst(postCondition);
 
@@ -159,7 +169,7 @@ namespace Microsoft.Bot.Builder.Middleware
         public static Intent FindTopIntent(IList<Intent> intents)
         {
             if (intents == null)
-                throw new ArgumentNullException(nameof(intents));
+                throw new ArgumentNullException(nameof(intents)); 
 
             var enumerator = intents.GetEnumerator();
             if (!enumerator.MoveNext())
@@ -183,7 +193,7 @@ namespace Microsoft.Bot.Builder.Middleware
         public static string CleanString(string s)
         {
             return string.IsNullOrWhiteSpace(s) ? string.Empty : s.Trim();
-        }
+        }        
     }
 
 }

--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Controllers/MessagesController.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Ai;
-using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Builder.Middleware;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
@@ -31,25 +31,37 @@ namespace Microsoft.Bot.Samples.Ai.Luis
             if (adapter == null)
             {
                 adapter = new BotFrameworkAdapter(configuration)
-                    .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"));
+                    .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx")
+                        .HandleIntent("MyFirstIntent", HandleMyFirstIntent)
+                        .HandleIntent("MySecondIntent", HandleMySecondIntent));
+                
+                // becuase by default routing of an activity is terminated when an intent is handled 
+                // you can can use the LuisRecognizerMiddleware in a chain, to fallback to another 
+                // middleware such as the QnA Maker Middleware or another instance of the Luis Recognizer   
 
                 // LUIS with correct baseUri format example
                 //.Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx", "https://xxxxxx.api.cognitive.microsoft.com/luis/v2.0/apps"))
-
             }
+        }
+
+        private Task HandleMySecondIntent(IBotContext context, Intent intent)
+        {
+            context.Reply($"You hit the intent name 'MyFirstIntent' with a score of {intent.Score}");
+            return Task.CompletedTask;
+        }
+
+        private Task HandleMyFirstIntent(IBotContext context, Intent intent)
+        {
+            context.Reply($"You hit the intent name 'MySecondIntent' with a score of {intent.Score}");
+            return Task.CompletedTask;
         }
 
         private Task BotReceiveHandler(IBotContext context)
         {
-            if (context.Request.Type == ActivityTypes.Message)
-            {
-                context.Reply($"the top intent was: {context.TopIntent.Name}");
-
-                foreach (var entity in context.TopIntent.Entities)
-                {
-                    context.Reply($"entity: {entity.ValueAs<string>()}");
-                }
-            }
+            // No matching intents were returned, or no handler existed for it (e.g. the "None" intent was returned)
+            // so activity routing continued to this point. Alternatively we could have added a handler for the "None"
+            // intent. i.e..HandleIntent("None", HandleNoneIntent));
+            context.Reply("Sorry, not sure what you wanted.");
             return Task.CompletedTask;
         }
 

--- a/samples/Microsoft.Bot.Samples.Ai.Luis/Microsoft.Bot.Samples.Ai.Luis.csproj
+++ b/samples/Microsoft.Bot.Samples.Ai.Luis/Microsoft.Bot.Samples.Ai.Luis.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
 
@@ -15,10 +16,19 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Ai\Microsoft.Bot.Builder.Ai.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.BotFramework\Microsoft.Bot.Builder.BotFramework.csproj" />
+    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Core\Microsoft.Bot.Builder.Core.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.aspnetcore.mvc.viewfeatures\2.0.2\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.ViewFeatures.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@cleemullins Raised this PR as its the easiest way to get your thoughts. I have been thinking about how we could implement a useful generic middleware for Intent handling, with the comments you made around not having the TopIntent information on the BotContext. 

**More work to do, but,** I have updated IntentRecognizerMiddleware to support fluent style intent handlers, where the user can add the middleware using .Use() but then assign intent handlers using .HandleIntent(, similar to the below.  We could obviously add options to end / continue routing and more etc...

```cs
            if (adapter == null)
            {
                adapter = new BotFrameworkAdapter(configuration)
                    .Use(new LuisRecognizerMiddleware("xxxxxx", "xxxxxx"))
                    .HandleIntent("MyFirstIntent", HandleMyFirstIntent)
                    .HandleIntent("MySecondIntent", HandleMySecondIntent));
```

with an intent handler that looks something like....

```cs
        private Task HandleMyFirstIntent(IBotContext context, Intent intent)
        {
            context.Reply($"You triggered the intent {intent.Name} intent with a score of {intent.Score}");
            return Task.CompletedTask;
        }
```

I implemented a basic version of this and I really like it, especially as it keeps the whole thing very isolated and makes the understanding of what will happen when an intent is triggered really easy to understand (it actually maps very nicely to the way developers handle intents right now in v3 with a method decorated with the intent name).

Obviously, the best thing is the fact that we can remove the need to have anything to do with Intents on the BotContext at all.

Would be great to get your thoughts.
