### PR TITLE
Addresses Issue #184, which is that bracketing should work correctly

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -81,18 +81,7 @@ namespace Microsoft.Bot.Builder
             // Call any registered Middleware Components looking for ReceiveActivity()
             if (context.Request != null)
             {
-                bool didAllMiddlewareRun = await _middlewareSet.ReceiveActivityWithStatus(context).ConfigureAwait(false);
-                if (didAllMiddlewareRun && callback != null)
-                {
-                    await callback(context).ConfigureAwait(false);
-                }
-                else
-                {
-                    // One of the middleware instances did not call Next(). When this happens,
-                    // by design, we do NOT call the callback handler. This allows
-                    // Middleware interceptors to be written that activly prevent certain
-                    // Activites from being run. 
-                }
+                await _middlewareSet.ReceiveActivityWithStatus(context, callback).ConfigureAwait(false);                
             }
             else
             {

--- a/libraries/Microsoft.Bot.Builder.Core/Middleware/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Middleware/MiddlewareSet.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Bot.Builder.Middleware
 
         public async Task ReceiveActivity(IBotContext context)
         {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), null).ConfigureAwait(false);
         }
 
         public async Task ReceiveActivity(IBotContext context, NextDelegate next)
         {
-            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
-            await next().ConfigureAwait(false); 
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), null).ConfigureAwait(false);
+            await next().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -69,20 +69,30 @@ namespace Microsoft.Bot.Builder.Middleware
         /// <returns>True, if all executed middleware in the pipeline called Next(). 
         /// False, if one of the middleware instances did not call Next(). 
         /// </returns>
-        public async Task<bool> ReceiveActivityWithStatus(IBotContext context)
+        public async Task ReceiveActivityWithStatus(IBotContext context, Func<IBotContext, Task> callback)
         {
-            return await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray()).ConfigureAwait(false);
+            await ReceiveActivityInternal(context, this._middleware.OfType<IReceiveActivity>().ToArray(), callback).ConfigureAwait(false);
         }        
 
-        private async Task<bool> ReceiveActivityInternal(IBotContext context, IReceiveActivity[] middleware)
+        private async Task ReceiveActivityInternal(IBotContext context, IReceiveActivity[] middleware, Func<IBotContext, Task> callback)
         {
             BotAssert.MiddlewareNotNull(middleware);
-            bool didAllRun = false;
 
             if (middleware.Length == 0) // No middleware to run.
             {
-                // If all the Middlware ran, let the caller know. 
-                return true;
+                // If all the Middlware ran, the "leading edge" of the tree is now complete. 
+                // This means it's time to run any developer specified callback. 
+                // Once this callback is done, the "trailing edge" calls are then completed. This
+                // allows code that looks like:
+                //      console.print("before");
+                //      await next();
+                //      console.print("after"); 
+                // to run as expected. 
+
+                if (callback != null)
+                    await callback(context);
+
+                return;
             }
 
             // Default to "No more Middleware after this"
@@ -91,12 +101,11 @@ namespace Microsoft.Bot.Builder.Middleware
                 // Remove the first item from the list of middleware to call,
                 // so that the next call just has the remaining items to worry about. 
                 IReceiveActivity[] remainingMiddleware = middleware.Skip(1).ToArray();
-                didAllRun |= await ReceiveActivityInternal(context, remainingMiddleware).ConfigureAwait(false);
+                await ReceiveActivityInternal(context, remainingMiddleware, callback).ConfigureAwait(false);
             }
 
             // Grab the current middleware, which is the 1st element in the array, and execute it            
             await middleware[0].ReceiveActivity(context, next).ConfigureAwait(false);
-            return didAllRun;
         }
 
         public async Task SendActivity(IBotContext context, IList<IActivity> activities)

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_BracketingTest.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_BracketingTest.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Middleware;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    [TestClass]
+    [TestCategory("Middleware")]
+    public class Middleware_BracketingTest
+    {
+
+        /// <summary>
+        /// Developer authored Middleware that looks like this:
+        /// public async Task ReceiveActivity(IBotContext context, 
+        ///    MiddlewareSet.NextDelegate next)
+        /// {
+        ///    context.Reply("BEFORE");
+        ///    await next();   // User Says Hello
+        ///    context.Reply("AFTER");
+        ///  }
+        ///  Should result in an output that looks like:
+        ///    BEFORE
+        ///    ECHO:Hello
+        ///    AFTER        
+        /// </summary>       
+        [TestMethod]
+        public async Task Middlware_BracketingValidation()
+        {
+            TestAdapter adapter = new TestAdapter()
+                .Use(new BeforeAFterMiddlware());
+
+            async Task Echo(IBotContext ctx)
+            {
+                ctx.Reply("ECHO:" + ctx.Request.AsMessageActivity().Text);
+            }
+
+            await new TestFlow(adapter, Echo)
+                .Send("test")
+                .AssertReply("BEFORE")
+                .AssertReply("ECHO:test")
+                .AssertReply("AFTER")
+                .StartTest();
+        }
+
+        /// <summary>
+        /// Exceptions thrown during the processing of an Activity should
+        /// be catchable by Middleware that has wrapped the next() method. 
+        /// This tests verifies that, and makes sure the order of messages
+        /// coming back is correct. 
+        /// </summary>       
+        [TestMethod]
+        public async Task Middlware_ThrowException()
+        {
+            string uniqueId = Guid.NewGuid().ToString();
+
+            TestAdapter adapter = new TestAdapter()
+                .Use(new CatchExceptionMiddleware());
+
+            async Task EchoWithException(IBotContext ctx)
+            {
+                ctx.Reply("ECHO:" + ctx.Request.AsMessageActivity().Text);
+                throw new Exception(uniqueId);
+            }
+
+            await new TestFlow(adapter, EchoWithException)
+                .Send("test")
+                .AssertReply("BEFORE")
+                .AssertReply("ECHO:test")
+                .AssertReply("CAUGHT:" + uniqueId)
+                .AssertReply("AFTER")
+                .StartTest();
+        }
+
+        public class CatchExceptionMiddleware : IMiddleware, IReceiveActivity
+        {
+            public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
+            {
+                context.Reply("BEFORE");
+
+                try
+                {
+                    await next();
+                }
+                catch (Exception ex)
+                {
+                    context.Reply("CAUGHT:" + ex.Message);
+                }
+
+                context.Reply("AFTER");
+            }
+        }
+
+        public class BeforeAFterMiddlware : IMiddleware, IReceiveActivity
+        {
+            public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
+            {
+                context.Reply("BEFORE");
+                await next();
+                context.Reply("AFTER");
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Middleware_ReceiveActivityTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Middleware_ReceiveActivityTests.cs
@@ -102,7 +102,8 @@ namespace Microsoft.Bot.Builder.Tests
 
             // The middlware in this pipeline calls next(), so the resulting
             // status should be TRUE. 
-            bool didAllRun = await m.ReceiveActivityWithStatus(null);
+            bool didAllRun = false;
+            await m.ReceiveActivityWithStatus(null, async (ctx) => didAllRun = true);
 
             Assert.IsTrue(called1);
             Assert.IsTrue(didAllRun);
@@ -112,11 +113,13 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task Status_RunAtEndEmptyPipeline()
         {
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
+            bool didAllRun = false;
 
             // This middlware pipeline has no entries. This should result in
             // the status being TRUE. 
-            bool didAllRun = await m.ReceiveActivityWithStatus(null);
+            await m.ReceiveActivityWithStatus(null, async (ctx) => didAllRun = true); 
             Assert.IsTrue(didAllRun);
+
         }
 
         [TestMethod]
@@ -141,7 +144,8 @@ namespace Microsoft.Bot.Builder.Tests
             m.Use(one);
             m.Use(two);
 
-            bool didAllRun = await m.ReceiveActivityWithStatus(null);
+            bool didAllRun = false;
+            await m.ReceiveActivityWithStatus(null, async (ctx) => didAllRun = true);
             Assert.IsTrue(called1);
             Assert.IsTrue(called2);
 
@@ -159,9 +163,9 @@ namespace Microsoft.Bot.Builder.Tests
             Middleware.MiddlewareSet m = new Middleware.MiddlewareSet();
             m.Use(one);
 
-            // The middlware in this pipeline calls next(), so this must
-            // be called as the final activity. 
-            bool didAllRun = await m.ReceiveActivityWithStatus(null);
+            // The middlware in this pipeline DOES NOT call next(), so this must not be called 
+            bool didAllRun = false;
+            await m.ReceiveActivityWithStatus(null, async (ctx) => didAllRun = true);
 
             Assert.IsTrue(called1);
 
@@ -348,7 +352,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             await m.ReceiveActivity(null);
             Assert.IsTrue(caughtException);
-        }
+        }        
 
         public class WasCalledMiddlware : Middleware.IMiddleware, Middleware.IReceiveActivity
         {


### PR DESCRIPTION
#184 

Updated MiddlewearSet and relevant dependencies + tests to support the "Bracketed" Middleware. That issue says code like this should work:
```
    context.Reply("{"); // Leading Edge
    await next();
    context.Reply("}"); // Trailing Edge
```
I've included an explicit test for this, as well as one validating that Exceptions that are thrown can be properly handled. The new tests around this are very explicit in the ordering. For example:

```
 await new TestFlow(adapter, Echo)
                .Send("test")
                .AssertReply("BEFORE")
                .AssertReply("ECHO:test")
                .AssertReply("AFTER")
                .StartTest();
```

At a technical level, we want (per this example) the user supplied delegate to be run here:
1. All Leading edge middleware calls made.
2. Delegate called.
3. All trailing edge middleware code is run.  

All previous tests pass. 