### PR TITLE
Updated to latest Recognizer packages, which support NetStandard2.0

### DIFF
--- a/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
+++ b/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AdaptiveCards" Version="0.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.32" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.36" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/samples/AlarmBot/AlarmBot.csproj
+++ b/samples/AlarmBot/AlarmBot.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.32" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.0.36" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Addresses #127 

Updated to the latest recognizer-text package. This package supports .NetStandard2.0 which makes a number of build warnings go away. 