### PR TITLE
Fix BotFrameworkAdapter::GetAppCredentials assuming configured credentials

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -104,8 +104,12 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <returns>App credentials.</returns>
         protected virtual async Task<MicrosoftAppCredentials> GetAppCredentials(string appId)
         {
-            MicrosoftAppCredentials appCredentials;
-            if (!_appCredentialMap.TryGetValue(appId, out appCredentials))
+            if (appId == null)
+            {
+                return MicrosoftAppCredentials.Empty;
+            }
+
+            if (!_appCredentialMap.TryGetValue(appId, out var appCredentials))
             {
                 string appPassword = await _credentialProvider.GetAppPasswordAsync(appId);
                 appCredentials = new MicrosoftAppCredentials(appId, appPassword);

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Bot.Connector.Authentication
     public class MicrosoftAppCredentials : ServiceClientCredentials
     {
         /// <summary>
+        /// An empty set of credentials.
+        /// </summary>
+        public static readonly MicrosoftAppCredentials Empty = new MicrosoftAppCredentials(null, null);
+
+        /// <summary>
         /// The key for Microsoft app Id.
         /// </summary>
         public const string MicrosoftAppIdKey = "MicrosoftAppId";


### PR DESCRIPTION
Fixes #226 

 * Intro'd a static set of empty credentials on `MicrosoftAppCredentials` to minimize allocations/garbage being created for that scenario
 * Updated `BotFrameworkAdapter` to detect `null` application identity and use `Microsoft.AppCredentials.Empty` in that case