### PR TITLE
changed to allow pure POCO objects to be stored

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Azure
             if (_checkedTables.Add($"{storageAccount.TableStorageUri.PrimaryUri.Host}-{tableName}"))
                 this.Table.CreateIfNotExistsAsync().Wait();
         }
-                
+
         protected EntityKey GetEntityKey(string key)
         {
             return new EntityKey() { PartitionKey = SanitizeKey(key), RowKey = "0" };
@@ -58,9 +58,11 @@ namespace Microsoft.Bot.Builder.Azure
                 var result = await this.Table.ExecuteAsync(TableOperation.Retrieve<StoreItemEntity>(entityKey.PartitionKey, entityKey.RowKey)).ConfigureAwait(false);
                 if ((HttpStatusCode)result.HttpStatusCode == HttpStatusCode.OK)
                 {
-                    var storeItem = ((StoreItemEntity)result.Result).As<IStoreItem>();
-                    storeItem.eTag = result.Etag;
-                    storeItems[key] = storeItem;
+                    var value = ((StoreItemEntity)result.Result).AsObject();
+                    IStoreItem valueStoreItem = value as IStoreItem;
+                    if (valueStoreItem != null)
+                        valueStoreItem.eTag = result.Etag;
+                    storeItems[key] = value;
                 }
             }
             return storeItems;
@@ -72,8 +74,8 @@ namespace Microsoft.Bot.Builder.Azure
             foreach (var change in changes)
             {
                 var entityKey = GetEntityKey(change.Key);
-                var storeItem = (IStoreItem)change.Value;
-                StoreItemEntity entity = new StoreItemEntity(entityKey, storeItem);
+                var newValue = change.Value;
+                StoreItemEntity entity = new StoreItemEntity(entityKey, newValue);
                 if (entity.ETag == null || entity.ETag == "*")
                 {
                     var result = await this.Table.ExecuteAsync(TableOperation.InsertOrReplace(entity)).ConfigureAwait(false);
@@ -99,23 +101,26 @@ namespace Microsoft.Bot.Builder.Azure
 
             public StoreItemEntity() { }
 
-            public StoreItemEntity(EntityKey key, IStoreItem obj)
+            public StoreItemEntity(EntityKey key, object obj)
                 : this(key.PartitionKey, key.RowKey, obj)
             { }
 
-            public StoreItemEntity(string partitionKey, string rowKey, IStoreItem obj)
+            public StoreItemEntity(string partitionKey, string rowKey, object obj)
                 : base(partitionKey, rowKey)
             {
-                this.ETag = obj.eTag;
+                this.ETag = (obj as IStoreItem)?.eTag;
                 this.Json = JsonConvert.SerializeObject(obj, Formatting.None, serializationSettings);
             }
 
             public string Json { get; set; }
 
-            public T As<T>()
-                where T : IStoreItem
+            public object AsObject()
             {
-                return JsonConvert.DeserializeObject<T>(Json, serializationSettings);
+                var obj = JsonConvert.DeserializeObject(Json, serializationSettings);
+                IStoreItem storeItem = obj as IStoreItem;
+                if (storeItem != null)
+                    storeItem.eTag = this.ETag;
+                return obj;
             }
         }
 
@@ -153,6 +158,6 @@ namespace Microsoft.Bot.Builder.Azure
                     sb.Append(ch);
             }
             return sb.ToString();
-        }        
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Core/IStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/IStorage.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Bot.Builder
     }
 
     public class StoreItems<StoreItemT> : StoreItems
-        where StoreItemT : IStoreItem
     {
     }
 

--- a/libraries/Microsoft.Bot.Builder.Core/Storage/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Storage/MemoryStorage.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Storage
                     if (_memory.TryGetValue(key, out object value))
                     {
                         if (value != null)
-                            storeItems[key] = FlexObject.Clone<IStoreItem>(value);
+                            storeItems[key] = FlexObject.Clone(value);
                         else 
                             storeItems[key] = null;
                     }
@@ -59,18 +59,23 @@ namespace Microsoft.Bot.Builder.Storage
             {
                 foreach (var change in changes)
                 {
-                    IStoreItem newValue = change.Value as IStoreItem;
-                    IStoreItem oldValue = null;
+                    object newValue = change.Value;
+                    object oldValue = null;
 
                     if (_memory.TryGetValue(change.Key, out object x))
-                        oldValue = x as IStoreItem;
+                        oldValue = x;
+
+                    IStoreItem newStoreItem = newValue as IStoreItem;
+                    IStoreItem oldStoreItem = oldValue as IStoreItem;
                     if (oldValue == null ||
-                        newValue.eTag == "*" ||
-                        oldValue.eTag == newValue.eTag)
+                        newStoreItem?.eTag == "*" ||
+                        oldStoreItem?.eTag == newStoreItem?.eTag)
                     {
                         // clone and set etag
-                        newValue = FlexObject.Clone<IStoreItem>(newValue);
-                        newValue.eTag = (_eTag++).ToString();
+                        newValue = FlexObject.Clone(newValue);
+                        newStoreItem = newValue as IStoreItem;
+                        if (newStoreItem != null)
+                            newStoreItem.eTag = (_eTag++).ToString();
                         _memory[change.Key] = newValue;
                     }
                     else

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/TableStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/TableStorageTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
     [TestClass]
     [TestCategory("Storage")]
     [TestCategory("Storage - Azure Tables")]
-    public class TableStorageTests : Storage_BaseTests, IStorageTests
+    public class TableStorageTests : Storage_BaseTests 
     {
         private IStorage storage;
 
@@ -52,12 +52,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (hasStorageEmulator.Value)
             {
-                storage = new AzureTableStorage("UseDevelopmentStorage=true", TestContext.TestName + TestContext.GetHashCode().ToString("x"));
+                storage = new AzureTableStorage("UseDevelopmentStorage=true", TestContext.TestName.Replace("_","") + TestContext.GetHashCode().ToString("x"));
             }
         }
 
         [TestCleanup]
-        public async Task TestCleanUp()
+        public async Task TableStorage_TestCleanUp()
         {
             if (storage != null)
             {
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task CreateObjectTest()
+        public async Task TableStorage_CreateObjectTest()
         {
             if (CheckStorageEmulator())
                 await base._createObjectTest(storage);
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task ReadUnknownTest()
+        public async Task TableStorage_ReadUnknownTest()
         {
             if (CheckStorageEmulator())
                 await base._readUnknownTest(storage);
@@ -93,7 +93,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task UpdateObjectTest()
+        public async Task TableStorage_UpdateObjectTest()
         {
             if (CheckStorageEmulator())
                 await base._updateObjectTest(storage);
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task DeleteObjectTest()
+        public async Task TableStorage_DeleteObjectTest()
         {
             if (CheckStorageEmulator())
                 await base._deleteObjectTest(storage);
@@ -109,14 +109,14 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task HandleCrazyKeys()
+        public async Task TableStorage_HandleCrazyKeys()
         {
             if (CheckStorageEmulator())
                 await base._handleCrazyKeys(storage);
         }
 
         [TestMethod]
-        public async Task TypedSerialization()
+        public async Task TableStorage_TypedSerialization()
         {
             if (CheckStorageEmulator())
                 await base._typedSerialization(this.storage);

--- a/tests/Microsoft.Bot.Builder.Tests/Storage_FileTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Storage_FileTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Tests
     [TestClass]
     [TestCategory("Storage")]
     [TestCategory("Storage - File")]
-    public class Storage_FileTests : Storage_BaseTests, IStorageTests
+    public class Storage_FileTests : Storage_BaseTests
     {
         private IStorage storage;
         public Storage_FileTests() { }
@@ -29,37 +29,37 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        public async Task CreateObjectTest()
+        public async Task FileStorage_CreateObjectTest()
         {
             await base._createObjectTest(this.storage);
         }
 
         [TestMethod]
-        public async Task ReadUnknownTest()
+        public async Task FileStorage_ReadUnknownTest()
         {
             await base._readUnknownTest(this.storage);
         }
 
         [TestMethod]
-        public async Task UpdateObjectTest()
+        public async Task FileStorage_UpdateObjectTest()
         {
             await base._updateObjectTest(this.storage);
         }
 
         [TestMethod]
-        public async Task DeleteObjectTest()
+        public async Task FileStorage_DeleteObjectTest()
         {
             await base._deleteObjectTest(this.storage);
         }
 
         [TestMethod]
-        public async Task HandleCrazyKeys()
+        public async Task FileStorage_HandleCrazyKeys()
         {
             await base._handleCrazyKeys(this.storage);
         }
 
         [TestMethod]
-        public async Task TypedSerialization()
+        public async Task FileStorage_TypedSerialization()
         {
             await base._typedSerialization(this.storage);
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Storage_MemoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Storage_MemoryTests.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Bot.Builder.Tests
     [TestClass]
     [TestCategory("Storage")]
     [TestCategory("Storage - Memory")]
-    public class Storage_MemoryTests : Storage_BaseTests, IStorageTests
+    public class MemoryStorageTests : Storage_BaseTests
     {
         private IStorage storage;
 
-        public Storage_MemoryTests() { }
+        public MemoryStorageTests() { }
 
         [TestInitialize]
         public void initialize()
@@ -23,43 +23,50 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        public async Task CreateObjectTest()
+        public async Task MemoryStorage_CreateObjectTest()
         {
             await base._createObjectTest(storage);
         }
 
         [TestMethod]
-        public async Task ReadUnknownTest()
+        public async Task MemoryStorage_ReadUnknownTest()
         {
             await base._readUnknownTest(storage);
         }
 
         [TestMethod]
-        public async Task UpdateObjectTest()
+        public async Task MemoryStorage_UpdateObjectTest()
         {
             await base._updateObjectTest(storage);
         }
 
         [TestMethod]
-        public async Task DeleteObjectTest()
+        public async Task MemoryStorage_DeleteObjectTest()
         {
             await base._deleteObjectTest(storage);
         }
 
         [TestMethod]
-        public async Task HandleCrazyKeys()
+        public async Task MemoryStorage_HandleCrazyKeys()
         {
             await base._handleCrazyKeys(storage);
         }
 
         [TestMethod]
-        public async Task TypedSerialization()
+        public async Task MemoryStorage_TypedSerialization()
         {
             await base._typedSerialization(this.storage);
         }
     }
 
-    public class TestItem : IStoreItem
+    public class PocoItem
+    {
+        public string Id { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    public class PocoStoreItem : IStoreItem
     {
         public string eTag { get; set; }
 
@@ -68,16 +75,4 @@ namespace Microsoft.Bot.Builder.Tests
         public int Count { get; set; }
     }
 
-    public interface IStorageTests
-    {
-        Task ReadUnknownTest();
-
-        Task CreateObjectTest();
-
-        Task HandleCrazyKeys();
-
-        Task UpdateObjectTest();
-
-        Task DeleteObjectTest();
-    }
 }


### PR DESCRIPTION
If IStoreItem interface is implemented then eTag semantics will apply.  This allows truly POCO objects to be stored under a key in storage