### PR TITLE
Better handling of Content-Type header in .NET Core Framework

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
@@ -4,22 +4,13 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Adapters;
-using Microsoft.Bot.Schema;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using System;
-using System.IO;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 {
     public static class ApplicationBuilderExtensions
     {
-        private static readonly JsonSerializer ActivitySerializer = JsonSerializer.Create();
-
         public static IApplicationBuilder UseBotFramework(this IApplicationBuilder applicationBuilder)
         {
             var options = applicationBuilder.ApplicationServices.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
@@ -37,62 +28,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
             applicationBuilder.Map(
                 botActivitiesPath, 
-                botActivitiesAppBuilder => botActivitiesAppBuilder.Run(BotRequestHandler));
+                botActivitiesAppBuilder => botActivitiesAppBuilder.Run(new BotActivitiesHandler(botFrameworkAdapter).HandleAsync));
 
             return applicationBuilder;
 
-            async Task BotRequestHandler(HttpContext httpContext)
-            {
-                var request = httpContext.Request;
-                var response = httpContext.Response;
-
-                if(request.Method != HttpMethods.Post)
-                {
-                    response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
-
-                    return;
-                }
-
-                if(request.ContentType != "application/json")
-                {
-                    response.StatusCode = (int)HttpStatusCode.NotAcceptable;
-
-                    return;
-                }
-
-                if(request.ContentLength == 0)
-                {
-                    response.StatusCode = (int)HttpStatusCode.BadRequest;
-
-                    return;
-                }
-
-                var activity = default(Activity);
-
-                using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)))
-                {
-                    activity = ActivitySerializer.Deserialize<Activity>(bodyReader);
-                }
-
-                try
-                {
-                    await botFrameworkAdapter.ProcessActivity(
-                        request.Headers["Authorization"], 
-                        activity,
-                        botContext =>
-                        {
-                            var bot = httpContext.RequestServices.GetRequiredService<IBot>();
-
-                            return bot.OnReceiveActivity(botContext);
-                        });
-
-                    response.StatusCode = (int)HttpStatusCode.OK;
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    response.StatusCode = (int)HttpStatusCode.Forbidden;
-                }
-            }
+            
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotActivitiesHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotActivitiesHandler.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+{
+    internal class BotActivitiesHandler
+    {
+        private static readonly JsonSerializer ActivitySerializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Formatting = Newtonsoft.Json.Formatting.Indented,
+            NullValueHandling = NullValueHandling.Ignore,
+        });
+
+        private BotFrameworkAdapter _botFrameworkAdapter;
+
+        public BotActivitiesHandler(BotFrameworkAdapter botFrameworkAdapter)
+        {
+            _botFrameworkAdapter = botFrameworkAdapter;
+        }
+
+        public async Task HandleAsync(HttpContext httpContext)
+        {
+            var request = httpContext.Request;
+            var response = httpContext.Response;
+
+            if (request.Method != HttpMethods.Post)
+            {
+                response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
+
+                return;
+            }
+
+            if (request.ContentLength == 0)
+            {
+                response.StatusCode = (int)HttpStatusCode.BadRequest;
+
+                return;
+            }
+
+            if (!MediaTypeHeaderValue.TryParse(request.ContentType, out var mediaTypeHeaderValue)
+                    ||
+                mediaTypeHeaderValue.MediaType != "application/json")
+            {
+                response.StatusCode = (int)HttpStatusCode.NotAcceptable;
+
+                return;
+            }
+
+            var activity = default(Activity);
+
+            using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)))
+            {
+                activity = ActivitySerializer.Deserialize<Activity>(bodyReader);
+            }
+
+            try
+            {
+                await _botFrameworkAdapter.ProcessActivity(
+                    request.Headers["Authorization"],
+                    activity,
+                    botContext =>
+                    {
+                        var bot = httpContext.RequestServices.GetRequiredService<IBot>();
+
+                        return bot.OnReceiveActivity(botContext);
+                    });
+
+                response.StatusCode = (int)HttpStatusCode.OK;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                response.StatusCode = (int)HttpStatusCode.Forbidden;
+            }
+        }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -43,6 +43,7 @@
 		<PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 	</ItemGroup>
 


### PR DESCRIPTION
This PR fixes #246 by utilizing `MediaTypeHeaderValue::TryParse` which handles the many nuances of media type header values and then simply validation it's `application/json`  against that.

Additional work:
 * Breakes the handler out into its own class for better SRP (fixes
#240)
 * Explicitly aligns JSON.NET serializer settings with the NetFx version