### PR TITLE
Remove restriction of IStoreItem from StateT

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/IStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/IStorage.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Threading.Tasks;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder
 {
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder
         /// </summary>
         public string eTag { get; set; }
 
-        public T ToObject<T>()
+        public T ToObject<T>() where T : class
         {
             return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(this, serializationSettings), serializationSettings);
         }
@@ -57,15 +57,15 @@ namespace Microsoft.Bot.Builder
 
     public class StoreItems : FlexObject
     {
-        public T Get<T>(string name)
+        public T Get<T>(string name) where T : class
         {
-            if (this.TryGetValue(name, out dynamic value) && value != null)
-                return value.ToObject<T>();
-            return default(T);
+            this.TryGetValue(name, out object value);
+
+            return value as T;
         }
     }
 
-    public class StoreItems<StoreItemT> : StoreItems
+    public class StoreItems<StoreItemT> : StoreItems where StoreItemT : class
     {
     }
 
@@ -85,8 +85,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="storage"></param>
         /// <param name="keys"></param>
         /// <returns></returns>
-        public static async Task<StoreItems<StoreItemT>> Read<StoreItemT>(this IStorage storage, params string[] keys)
-            where StoreItemT : StoreItem
+        public static async Task<StoreItems<StoreItemT>> Read<StoreItemT>(this IStorage storage, params string[] keys) where StoreItemT : class
         {
             var storeItems = await storage.Read(keys).ConfigureAwait(false);
             var newResults = new StoreItems<StoreItemT>();

--- a/libraries/Microsoft.Bot.Builder.Core/Middleware/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Middleware/BotState.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Bot.Schema;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Middleware;
-using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Middleware
 {
@@ -21,7 +19,7 @@ namespace Microsoft.Bot.Builder.Middleware
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
     public abstract class BotState<StateT> : IContextCreated, ISendActivity
-        where StateT : IStoreItem, new()
+        where StateT : new()
     {
         private readonly StateSettings _settings;
         private readonly IStorage _storage;
@@ -102,7 +100,7 @@ namespace Microsoft.Bot.Builder.Middleware
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
     public class ConversationState<StateT> : BotState<StateT>
-        where StateT : IStoreItem, new()
+        where StateT : new()
     {
         public static string PropertyName = $"ConversationState:{typeof(ConversationState<StateT>).Namespace}.{typeof(ConversationState<StateT>).Name}";
 
@@ -126,7 +124,7 @@ namespace Microsoft.Bot.Builder.Middleware
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
     public class UserState<StateT> : BotState<StateT>
-        where StateT : IStoreItem, new()
+        where StateT : new()
     {
         public static readonly string PropertyName = $"UserState:{typeof(UserState<StateT>).Namespace}.{typeof(UserState<StateT>).Name}";
 
@@ -148,13 +146,13 @@ namespace Microsoft.Bot.Builder.Middleware
     public static class StateContextExtensions
     {
         public static T GetConversationState<T>(this IBotContext context)
-            where T : IStoreItem, new()
+            where T : new()
         {
             return ConversationState<T>.Get(context);
         }
 
         public static T GetUserState<T>(this IBotContext context)
-            where T : IStoreItem, new()
+            where T : new()
         {
             return UserState<T>.Get(context);
         }

--- a/libraries/Microsoft.Bot.Builder.Core/Middleware/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Middleware/BotState.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Middleware
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
     public abstract class BotState<StateT> : IContextCreated, ISendActivity
-        where StateT : new()
+        where StateT : class, new()
     {
         private readonly StateSettings _settings;
         private readonly IStorage _storage;
@@ -86,7 +86,10 @@ namespace Microsoft.Bot.Builder.Middleware
             {
                 foreach (var item in changes)
                 {
-                    ((StoreItem)changes[item.Key]).eTag = "*";
+                    if(item.Value is IStoreItem valueStoreItem)
+                    {
+                        valueStoreItem.eTag = "*";
+                    }
                 }
             }
 
@@ -100,7 +103,7 @@ namespace Microsoft.Bot.Builder.Middleware
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
     public class ConversationState<StateT> : BotState<StateT>
-        where StateT : new()
+        where StateT : class, new()
     {
         public static string PropertyName = $"ConversationState:{typeof(ConversationState<StateT>).Namespace}.{typeof(ConversationState<StateT>).Name}";
 
@@ -124,7 +127,7 @@ namespace Microsoft.Bot.Builder.Middleware
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
     public class UserState<StateT> : BotState<StateT>
-        where StateT : new()
+        where StateT : class, new()
     {
         public static readonly string PropertyName = $"UserState:{typeof(UserState<StateT>).Namespace}.{typeof(UserState<StateT>).Name}";
 
@@ -146,13 +149,13 @@ namespace Microsoft.Bot.Builder.Middleware
     public static class StateContextExtensions
     {
         public static T GetConversationState<T>(this IBotContext context)
-            where T : new()
+            where T : class, new()
         {
             return ConversationState<T>.Get(context);
         }
 
         public static T GetUserState<T>(this IBotContext context)
-            where T : new()
+            where T : class, new()
         {
             return UserState<T>.Get(context);
         }


### PR DESCRIPTION
Now that support was added to state management for POCOs they are no
longer _required_ `IStoreItem`, so we can/should remove the subtype
restriction on `StateT` from `BotState<StateT>` et. al.

This was raised as an issue in #248, though the discussion there spiraled 
into something broader.