### PR TITLE
Adding CatchExceptionMiddleware to provide basic exception handling

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/Middleware/CatchExceptionMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Middleware/CatchExceptionMiddleware.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Middleware;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Core.Middleware
+{
+    public class CatchExceptionMiddleware : IReceiveActivity, IContextCreated, ISendActivity
+    {
+        private readonly CatchExceptionHandler _handler;
+
+        public CatchExceptionMiddleware(CatchExceptionHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public async Task ReceiveActivity(IBotContext context, MiddlewareSet.NextDelegate next)
+        {
+            await CatchError(context, "receiveActivity", next);
+        }
+
+        public async Task ContextCreated(IBotContext context, MiddlewareSet.NextDelegate next)
+        {
+            await CatchError(context, "contextCreated", next);
+        }
+
+        public async Task SendActivity(IBotContext context, IList<Activity> activities, MiddlewareSet.NextDelegate next)
+        {
+            await CatchError(context, "sendActivity", next);
+        }
+
+        private async Task CatchError(IBotContext context, string phase, MiddlewareSet.NextDelegate next)
+        {
+            try
+            {
+                await next().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await _handler.Invoke(context, phase, ex);
+            }
+        }
+
+        public delegate Task CatchExceptionHandler(IBotContext context, string phase, Exception exception);
+    }
+}

--- a/samples/AlarmBot/Startup.cs
+++ b/samples/AlarmBot/Startup.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using AlarmBot.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -12,6 +13,8 @@ using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Core.Middleware;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 
 namespace AlarmBot
@@ -41,6 +44,7 @@ namespace AlarmBot
 
                 var middleware = options.Middleware;
 
+                middleware.Add(new CatchExceptionMiddleware(HandleException));
                 middleware.Add(new UserState<UserData>(new MemoryStorage()));
                 middleware.Add(new ConversationState<ConversationData>(new MemoryStorage()));
                 middleware.Add(new RegExpRecognizerMiddleware()
@@ -66,6 +70,14 @@ namespace AlarmBot
             app.UseDefaultFiles();
             app.UseStaticFiles();
             app.UseBotFramework();
+        }
+
+        // This handler is used by the CatchExceptionMiddleware to allow you to inform the user
+        // that something went wrong.
+        private Task HandleException(IBotContext context, string phase, Exception exception)
+        {
+            context.Reply("Sorry, but something went wrong.");
+            return Task.CompletedTask;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/CatchExceptionMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/CatchExceptionMiddlewareTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Core.Middleware;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    [TestClass]
+    public class CatchExceptionMiddlewareTests
+    {
+        [TestMethod]
+        [TestCategory("Middleware")]
+        public async Task CatchException_TestMiddleware()
+        {
+            TestAdapter adapter = new TestAdapter()
+                .Use(new CatchExceptionMiddleware((context, phase, exception) =>
+                    {
+                        context.Reply("Sorry, something went wrong");
+                        return Task.CompletedTask;
+                    }));
+
+
+            await new TestFlow(adapter, (context) =>
+            {
+                if (context.Request.AsMessageActivity().Text == "foo")
+                {
+                    context.Reply(context.Request.AsMessageActivity().Text);
+                }
+                if (context.Request.AsMessageActivity().Text == "error")
+                {
+                    throw new Exception();
+                }
+                return Task.CompletedTask;
+            })
+                .Send("foo")
+                    .AssertReply("foo", "passthrough")
+                .Send("error")
+                    .AssertReply("Sorry, something went wrong")
+                .StartTest();
+        }
+
+    }
+}


### PR DESCRIPTION
This is to address #35.  This mirrors the middleware that @Stevenic has created, with one exception.  The JS middleware will only handle one exception per conversation. However, in considering this, I think this is something that the user can choose to do in their handler if they wish. @Stevenic If I have misunderstood this functionality please let me know.

Added unit test to test for a message being sent / received with no error and then again where an exception is thrown.

Also added the middleware and a simple handler to the alarm bot to show how this is used.