### PR TITLE
Remove Batch processing from prompts and update tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/BotContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotContext.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Builder
             await SendActivity(newActivities.ToArray());
         }
 
-        public async Task SendActivity(params Activity[] activities)
+        public async Task SendActivity(params IActivity[] activities)
         {
             // Bind the relevant Conversation Reference properties, such as URLs and 
             // ChannelId's, to the activities we're about to send. 
@@ -99,7 +99,11 @@ namespace Microsoft.Bot.Builder
                 ApplyConversationReference(a, cr);
             }
 
-            List<Activity> activityList = new List<Activity>(activities);
+            // Convert the IActivities to Activies. 
+            Activity[] activityArray = Array.ConvertAll(activities, (input) => (Activity)input);            
+
+            // Create the list used by the recursive methods. 
+            List<Activity> activityList = new List<Activity>(activityArray);
 
             async Task ActuallySendStuff()
             {
@@ -107,7 +111,8 @@ namespace Microsoft.Bot.Builder
                 if (activities.Count() > 0)
                     anythingToSend = true;
 
-                await this.Adapter.SendActivity(this, activities);
+                // Send from the list, which may have been manipulated via the event handlers. 
+                await this.Adapter.SendActivity(this, activityList.ToArray());
 
                 // If we actually sent something, set the flag. 
                 if (anythingToSend)
@@ -121,14 +126,16 @@ namespace Microsoft.Bot.Builder
         /// Replaces an existing activity. 
         /// </summary>
         /// <param name="activity">New replacement activity. The activity should already have it's ID information populated</param>        
-        public async Task UpdateActivity(Activity activity)
+        public async Task UpdateActivity(IActivity activity)
         {
+            Activity a = (Activity)activity; 
+
             async Task ActuallyUpdateStuff()
             {
-                await this.Adapter.UpdateActivity(this, activity);
+                await this.Adapter.UpdateActivity(this, a);
             }
 
-            await UpdateActivityInternal(activity, _onUpdateActivity, ActuallyUpdateStuff);
+            await UpdateActivityInternal(a, _onUpdateActivity, ActuallyUpdateStuff);
         }
 
         public async Task DeleteActivity(string activityId)

--- a/libraries/Microsoft.Bot.Builder.Core/BotContextWrapper.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotContextWrapper.cs
@@ -25,9 +25,7 @@ namespace Microsoft.Bot.Builder
         public Activity Request => this._innerContext.Request;
 
         public bool Responded { get => _innerContext.Responded; set => _innerContext.Responded = value; }
-
         
-
         /// <summary>
         /// Get a value by a key.
         /// </summary>
@@ -42,12 +40,13 @@ namespace Microsoft.Bot.Builder
         {
             return _innerContext.SendActivity(textRepliesToSend);
         }
-        public Task SendActivity(params Activity[] activities)
+        
+        public Task SendActivity(params IActivity[] activities)
         {
             return _innerContext.SendActivity(activities); 
         }
 
-        public Task UpdateActivity(Activity activity)
+        public Task UpdateActivity(IActivity activity)
         {
             return _innerContext.UpdateActivity(activity);
         }

--- a/libraries/Microsoft.Bot.Builder.Core/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/IBotContext.cs
@@ -27,8 +27,9 @@ namespace Microsoft.Bot.Builder
         bool Responded { get; set; }
 
         Task SendActivity(params string[] textRepliesToSend);
-        Task SendActivity(params Activity[] activities);
-        Task UpdateActivity(Activity activity);
+        Task SendActivity(params IActivity[] activities);        
+
+        Task UpdateActivity(IActivity activity);
         Task DeleteActivity(string activityId);
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
@@ -74,9 +74,8 @@ namespace Microsoft.Bot.Builder.Prompts
         /// Creates a new Message Activity, and queues it for sending to the user. 
         /// </summary>
         public async Task Prompt(IBotContext context, IMessageActivity activity)
-        {
-            // Note: Cast can be removed once PR #284 is merged. Currently in CR. 
-            await context.SendActivity((Activity)activity);            
+        {            
+            await context.SendActivity(activity);            
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
@@ -73,9 +73,17 @@ namespace Microsoft.Bot.Builder.Prompts
         /// <summary>
         /// Creates a new Message Activity, and queues it for sending to the user. 
         /// </summary>
+<<<<<<< HEAD
         public async Task Prompt(IBotContext context, IMessageActivity activity)
         {            
             await context.SendActivity(activity);            
+=======
+        public Task Prompt(IBotContext context, IMessageActivity activity)
+        {
+            // Note: Cast can be removed once PR #284 is merged. Currently in CR. 
+            context.SendActivity((Activity)activity);
+            return Task.CompletedTask;
+>>>>>>> 4ed1d486ef152587cff3c2483cd2440075ac5123
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
@@ -73,11 +73,10 @@ namespace Microsoft.Bot.Builder.Prompts
         /// <summary>
         /// Creates a new Message Activity, and queues it for sending to the user. 
         /// </summary>
-        public Task Prompt(IBotContext context, IMessageActivity activity)
+        public async Task Prompt(IBotContext context, IMessageActivity activity)
         {
             // Note: Cast can be removed once PR #284 is merged. Currently in CR. 
-            context.SendActivity((Activity)activity);
-            return Task.CompletedTask;
+            await context.SendActivity((Activity)activity);            
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
@@ -73,17 +73,9 @@ namespace Microsoft.Bot.Builder.Prompts
         /// <summary>
         /// Creates a new Message Activity, and queues it for sending to the user. 
         /// </summary>
-<<<<<<< HEAD
         public async Task Prompt(IBotContext context, IMessageActivity activity)
         {            
             await context.SendActivity(activity);            
-=======
-        public Task Prompt(IBotContext context, IMessageActivity activity)
-        {
-            // Note: Cast can be removed once PR #284 is merged. Currently in CR. 
-            context.SendActivity((Activity)activity);
-            return Task.CompletedTask;
->>>>>>> 4ed1d486ef152587cff3c2483cd2440075ac5123
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Prompts/BasePrompt.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Bot.Builder.Core.Extensions;
-using Microsoft.Bot.Schema;
+﻿using Microsoft.Bot.Schema;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -76,7 +75,8 @@ namespace Microsoft.Bot.Builder.Prompts
         /// </summary>
         public Task Prompt(IBotContext context, IMessageActivity activity)
         {
-            context.Batch().Reply(activity);
+            // Note: Cast can be removed once PR #284 is merged. Currently in CR. 
+            context.SendActivity((Activity)activity);
             return Task.CompletedTask;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Prompts/Microsoft.Bot.Builder.Prompts.csproj
+++ b/libraries/Microsoft.Bot.Builder.Prompts/Microsoft.Bot.Builder.Prompts.csproj
@@ -49,7 +49,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Microsoft.Bot.Builder.Core.Extensions\Microsoft.Bot.Builder.Core.Extensions.csproj" />
 		<ProjectReference Include="..\Microsoft.Bot.Builder.Core\Microsoft.Bot.Builder.Core.csproj" />
 		<ProjectReference Include="..\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj" />
 	</ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Core.Tests/BotContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/BotContextTests.cs
@@ -128,6 +128,18 @@ namespace Microsoft.Bot.Builder.Core.Tests
         }
 
         [TestMethod]
+        public async Task SendAndSetRespondedUsingIMessageActivity()
+        {
+            SimpleAdapter a = new SimpleAdapter();
+            BotContext c = new BotContext(a, new Activity());
+            Assert.IsFalse(c.Responded);
+
+            IMessageActivity msg = TestMessage.Message().AsMessageActivity();
+            await c.SendActivity(msg);
+            Assert.IsTrue(c.Responded);
+        }
+
+        [TestMethod]
         public async Task SendOneActivityToAdapter()
         {
             bool foundActivity = false;

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/AgePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/AgePromptTests.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         public async Task AgePrompt_Test()
         {
             TestAdapter adapter = new TestAdapter()
-                .Use(new ConversationState<TestState>(new MemoryStorage()))
-                .Use(new BatchOutputMiddleware());
+                .Use(new ConversationState<TestState>(new MemoryStorage()));
                 
             await new TestFlow(adapter, async (context) =>
                 {
@@ -39,10 +38,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsNotNull(ageResult.Text);
                             Assert.IsNotNull(ageResult.Unit);
                             Assert.IsInstanceOfType(ageResult.Value, typeof(float));
-                            context.Batch().Reply($"{ageResult.Value} {ageResult.Unit}");
+                            await context.SendActivity($"{ageResult.Value} {ageResult.Unit}");
                         }
                         else
-                            context.Batch().Reply(ageResult.Status.ToString());
+                            await context.SendActivity(ageResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -59,8 +58,6 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-
-            adapter.Use(new BatchOutputMiddleware()); 
 
             await new TestFlow(adapter, async (context) =>
             {
@@ -79,9 +76,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 {
                     var numberResult = await numberPrompt.Recognize(context);
                     if (numberResult.Succeeded())
-                        context.Batch().Reply($"{numberResult.Value} {numberResult.Unit}");
+                        await context.SendActivity($"{numberResult.Value} {numberResult.Unit}");
                     else
-                        context.Batch().Reply(numberResult.Status.ToString());
+                        await context.SendActivity(numberResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/ConfirmPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/ConfirmPromptTests.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
 
             await new TestFlow(adapter, async (context) =>
                 {
@@ -37,10 +36,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                         if (confirmResult.Succeeded())
                         {
                             Assert.IsNotNull(confirmResult.Text);
-                            context.Batch().Reply($"{confirmResult.Confirmation}");
+                            await context.SendActivity($"{confirmResult.Confirmation}");
                         }
                         else
-                            context.Batch().Reply(confirmResult.Status.ToString());
+                            await context.SendActivity(confirmResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -59,7 +58,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -78,9 +77,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 {
                     var confirmResult = await confirmPrompt.Recognize(context);
                     if (confirmResult.Succeeded())
-                        context.Batch().Reply($"{confirmResult.Confirmation}");
+                        await context.SendActivity($"{confirmResult.Confirmation}");
                     else
-                        context.Batch().Reply(confirmResult.Status.ToString());
+                        await context.SendActivity(confirmResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/CurrencyPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/CurrencyPromptTests.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
 
             await new TestFlow(adapter, async (context) =>
                 {
@@ -40,10 +39,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsNotNull(currencyResult.Text);
                             Assert.IsNotNull(currencyResult.Unit);
                             Assert.IsInstanceOfType(currencyResult.Value, typeof(float));
-                            context.Batch().Reply($"{currencyResult.Value} {currencyResult.Unit}");
+                            await context.SendActivity($"{currencyResult.Value} {currencyResult.Unit}");
                         }
                         else
-                            context.Batch().Reply(currencyResult.Status.ToString());
+                            await context.SendActivity(currencyResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -60,7 +59,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -79,9 +78,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 {
                     var currencyPrompt = await numberPrompt.Recognize(context);
                     if (currencyPrompt.Succeeded())
-                        context.Batch().Reply($"{currencyPrompt.Value} {currencyPrompt.Unit}");
+                        await context.SendActivity($"{currencyPrompt.Value} {currencyPrompt.Unit}");
                     else
-                        context.Batch().Reply(currencyPrompt.Status.ToString());
+                        await context.SendActivity(currencyPrompt.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/DimensionPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/DimensionPromptTests.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware()); 
 
             await new TestFlow(adapter, async (context) =>
                 {
@@ -40,10 +39,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsNotNull(dimensionResult.Text);
                             Assert.IsNotNull(dimensionResult.Unit);
                             Assert.IsInstanceOfType(dimensionResult.Value, typeof(float));
-                            context.Batch().Reply($"{dimensionResult.Value} {dimensionResult.Unit}");
+                            await context.SendActivity($"{dimensionResult.Value} {dimensionResult.Unit}");
                         }
                         else
-                            context.Batch().Reply(dimensionResult.Status.ToString());
+                            await context.SendActivity(dimensionResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -62,7 +61,6 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware()); 
 
             await new TestFlow(adapter, async (context) =>
                 {
@@ -81,9 +79,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                     {
                         var dimensionResult = await numberPrompt.Recognize(context);
                         if (dimensionResult.Succeeded())
-                            context.Batch().Reply($"{dimensionResult.Value} {dimensionResult.Unit}");
+                            await context.SendActivity($"{dimensionResult.Value} {dimensionResult.Unit}");
                         else
-                            context.Batch().Reply(dimensionResult.Status.ToString());
+                            await context.SendActivity(dimensionResult.Status.ToString());
                     }
                 })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/NumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/NumberPromptTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
                 {
                     var state = ConversationState<TestState>.Get(context);
@@ -43,10 +43,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsTrue(numberResult.Value != float.NaN);
                             Assert.IsNotNull(numberResult.Text);
                             Assert.IsInstanceOfType(numberResult.Value, typeof(float));
-                            context.Batch().Reply(numberResult.Value.ToString());
+                            await context.SendActivity(numberResult.Value.ToString());
                         }
                         else
-                            context.Batch().Reply(numberResult.Status.ToString());
+                            await context.SendActivity(numberResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -82,10 +82,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                     {
                         Assert.IsInstanceOfType(numberResult.Value, typeof(int));
                         Assert.IsNotNull(numberResult.Text);
-                        context.Batch().Reply(numberResult.Value.ToString());
+                        await context.SendActivity(numberResult.Value.ToString());
                     }
                     else
-                        context.Batch().Reply(numberResult.Status.ToString());
+                        await context.SendActivity(numberResult.Status.ToString());
                 }
             })
                 .Send("hello")
@@ -104,7 +104,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -128,10 +128,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                         Assert.IsInstanceOfType(numberResult.Value, typeof(int));
                         Assert.IsTrue(numberResult.Value < 100);
                         Assert.IsNotNull(numberResult.Text);
-                        context.Batch().Reply(numberResult.Value.ToString());
+                        await context.SendActivity(numberResult.Value.ToString());
                     }
                     else
-                        context.Batch().Reply(numberResult.Status.ToString());
+                        await context.SendActivity(numberResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/OrdinalPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/OrdinalPromptTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
                 {
                     var state = ConversationState<TestState>.Get(context);
@@ -38,10 +38,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsTrue(ordinalResult.Value != float.NaN);
                             Assert.IsNotNull(ordinalResult.Text);
                             Assert.IsInstanceOfType(ordinalResult.Value, typeof(int));
-                            context.Batch().Reply(ordinalResult.Value.ToString());
+                            await context.SendActivity(ordinalResult.Value.ToString());
                         }
                         else
-                            context.Batch().Reply(ordinalResult.Status.ToString());
+                            await context.SendActivity(ordinalResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -80,10 +80,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                         Assert.IsInstanceOfType(ordinalResult.Value, typeof(int));
                         Assert.IsTrue(ordinalResult.Value < 100);
                         Assert.IsNotNull(ordinalResult.Text);
-                        context.Batch().Reply(ordinalResult.Value.ToString());
+                        await context.SendActivity(ordinalResult.Value.ToString());
                     }
                     else
-                        context.Batch().Reply(ordinalResult.Status.ToString());
+                        await context.SendActivity(ordinalResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/PercentagePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/PercentagePromptTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
                 {
                     var state = ConversationState<TestState>.Get(context);
@@ -38,10 +38,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsTrue(percentResult.Value != float.NaN);
                             Assert.IsNotNull(percentResult.Text);
                             Assert.IsInstanceOfType(percentResult.Value, typeof(float));
-                            context.Batch().Reply($"{percentResult.Value}");
+                            await context.SendActivity($"{percentResult.Value}");
                         }
                         else
-                            context.Batch().Reply(PromptStatus.NotRecognized.ToString());
+                            await context.SendActivity(PromptStatus.NotRecognized.ToString());
                     }
                 })
                 .Send("hello")
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -78,9 +78,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 {
                     var percentResult = await numberPrompt.Recognize(context);
                     if (percentResult.Succeeded())
-                        context.Batch().Reply($"{percentResult.Value}");
+                        await context.SendActivity($"{percentResult.Value}");
                     else
-                        context.Batch().Reply(percentResult.Status.ToString());
+                        await context.SendActivity(percentResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/PhoneNumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/PhoneNumberPromptTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
                 {
                     var state = ConversationState<TestState>.Get(context);
@@ -37,10 +37,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                         {
                             Assert.IsNotNull(phoneResult.Text);
                             Assert.IsNotNull(phoneResult.Value);
-                            context.Batch().Reply($"{phoneResult.Value}");
+                            await context.SendActivity($"{phoneResult.Value}");
                         }
                         else
-                            context.Batch().Reply(phoneResult.Status.ToString());
+                            await context.SendActivity(phoneResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -77,9 +77,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 {
                     var phoneResult = await numberPrompt.Recognize(context);
                     if (phoneResult.Succeeded())
-                        context.Batch().Reply($"{phoneResult.Value}");
+                        await context.SendActivity($"{phoneResult.Value}");
                     else
-                        context.Batch().Reply(phoneResult.Status.ToString());
+                        await context.SendActivity(phoneResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/RangePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/RangePromptTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
                 {
                     var state = ConversationState<TestState>.Get(context);
@@ -38,10 +38,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsTrue(rangeResult.Start > 0);
                             Assert.IsTrue(rangeResult.End > rangeResult.Start);
                             Assert.IsNotNull(rangeResult.Text);
-                            context.Batch().Reply($"{rangeResult.Start}-{rangeResult.End}");
+                            await context.SendActivity($"{rangeResult.Start}-{rangeResult.End}");
                         }
                         else
-                            context.Batch().Reply(rangeResult.Status.ToString());
+                            await context.SendActivity(rangeResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -82,10 +82,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                         Assert.IsTrue(rangeResult.Start > 0);
                         Assert.IsTrue(rangeResult.End > rangeResult.Start);
                         Assert.IsNotNull(rangeResult.Text);
-                        context.Batch().Reply($"{rangeResult.Start}-{rangeResult.End}");
+                        await context.SendActivity($"{rangeResult.Start}-{rangeResult.End}");
                     }
                     else
-                        context.Batch().Reply(rangeResult.Status.ToString());
+                        await context.SendActivity(rangeResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/TemperaturePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/TemperaturePromptTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
                 {
                     var state = ConversationState<TestState>.Get(context);
@@ -39,10 +39,10 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                             Assert.IsNotNull(tempResult.Text);
                             Assert.IsNotNull(tempResult.Unit);
                             Assert.IsInstanceOfType(tempResult.Value, typeof(float));
-                            context.Batch().Reply($"{tempResult.Value} {tempResult.Unit}");
+                            await context.SendActivity($"{tempResult.Value} {tempResult.Unit}");
                         }
                         else
-                            context.Batch().Reply(tempResult.Status.ToString());
+                            await context.SendActivity(tempResult.Status.ToString());
                     }
                 })
                 .Send("hello")
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<TestState>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, async (context) =>
             {
                 var state = ConversationState<TestState>.Get(context);
@@ -77,9 +77,9 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 {
                     var tempResult = await numberPrompt.Recognize(context);
                     if (tempResult.Succeeded())
-                        context.Batch().Reply($"{tempResult.Value} {tempResult.Unit}");
+                        await context.SendActivity($"{tempResult.Value} {tempResult.Unit}");
                     else
-                        context.Batch().Reply(tempResult.Status.ToString());
+                        await context.SendActivity(tempResult.Status.ToString());
                 }
             })
                 .Send("hello")

--- a/tests/Microsoft.Bot.Builder.Prompts.Tests/TextPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Prompts.Tests/TextPromptTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<StoreItem>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, MyTestPrompt)
                 .Send("hello")
                 .AssertReply("Your Name:")
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<StoreItem>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, LengthCheckPromptTest)
                 .Send("hello")
                 .AssertReply("Your Name:")
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
         {
             TestAdapter adapter = new TestAdapter()
                 .Use(new ConversationState<StoreItem>(new MemoryStorage()));
-            adapter.Use(new BatchOutputMiddleware());
+
             await new TestFlow(adapter, LengthCheckPromptTest)
                 .Send("hello")
                 .AssertReply("Your Name:")
@@ -70,11 +70,11 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 var textResult = await askForName.Recognize(context); 
                 if (textResult.Succeeded())
                 {
-                    context.Batch().Reply(textResult.Value);
+                    await context.SendActivity(textResult.Value);
                 }
                 else
                 {
-                    context.Batch().Reply(textResult.Status.ToString()); 
+                    await context.SendActivity(textResult.Status.ToString()); 
                 }
             }
         }
@@ -93,11 +93,11 @@ namespace Microsoft.Bot.Builder.Prompts.Tests
                 var textResult = await askForName.Recognize(context);
                 if (textResult.Succeeded())
                 {
-                    context.Batch().Reply(textResult.Value);
+                    await context.SendActivity(textResult.Value);
                 }
                 else
                 {
-                    context.Batch().Reply(textResult.Status.ToString());
+                    await context.SendActivity(textResult.Status.ToString());
                 }
             }
         }


### PR DESCRIPTION
Removes the batch processing from prompts. This also means the Core.Extensions assembly is no longer needed as a reference, and the BatchMiddleware is not needed in any way. 

Discussed yesterday with Tom & Steve, and Node will update to also removing batching. 

Also tracked in #293 