### PR TITLE
Wire ResourceResponses through from the Connector through the BotContext

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/ConnectorEx/BotToUser.cs
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/ConnectorEx/BotToUser.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Bot.Builder.Classic.Dialogs.Internals
         Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
         {
             // TODO, change this to context.SendActivity with M2 delta
-            return this.context.Adapter.SendActivity(this.context, (Activity)message);
+            return this.context.Adapter.SendActivity(this.context, new Activity[] { (Activity) message });
         }
     }
 

--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/ConnectorEx/BotToUser.cs
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/ConnectorEx/BotToUser.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Bot.Builder.Classic.Dialogs.Internals
         Task IBotToUser.PostAsync(IMessageActivity message, CancellationToken cancellationToken)
         {
             // TODO, change this to context.SendActivity with M2 delta
-            return this.context.Adapter.SendActivity(this.context, new Activity[] { (Activity) message });
+            return this.context.Adapter.SendActivities(this.context, new Activity[] { (Activity) message });
         }
     }
 

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BatchOutput.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BatchOutput.cs
@@ -111,13 +111,13 @@ namespace Microsoft.Bot.Builder.Core.Extensions
             return this;
         }
 
-        public async Task Flush(IBotContext context)
+        public async Task<ResourceResponse[]> Flush(IBotContext context)
         {
             // ToDo: addin the ResourceResponses when this is plumbed through
             Activity[] toSend = _activities.ToArray();
             _activities.Clear();
 
-            await context.SendActivity(toSend);            
+            return await context.SendActivities(toSend);            
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -45,14 +46,19 @@ namespace Microsoft.Bot.Builder.Adapters
             }
         }
 
-        public override async Task SendActivity(IBotContext context, params Activity[] activities)
+        public override async Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities)
         {
+            List<ResourceResponse> responses = new List<ResourceResponse>();
+
             foreach (var activity in activities)
             {
+                responses.Add(new ResourceResponse(activity.Id));
+
                 switch (activity.Type)
                 {
                     case ActivityTypes.Message:
-                        {
+                        {                            
+
                             IMessageActivity message = activity.AsMessageActivity();
                             if (message.Attachments != null && message.Attachments.Any())
                             {
@@ -78,6 +84,8 @@ namespace Microsoft.Bot.Builder.Adapters
                         break;
                 }
             }
+
+            return responses.ToArray();
         }
 
         public override Task<ResourceResponse> UpdateActivity(IBotContext context, Activity activity)

--- a/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Adapters
             }
         }
 
-        public override async Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities)
+        public override async Task<ResourceResponse[]> SendActivities(IBotContext context, Activity[] activities)
         {
             List<ResourceResponse> responses = new List<ResourceResponse>();
 

--- a/libraries/Microsoft.Bot.Builder.Core/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Adapters/TestAdapter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Adapters
         public ConversationReference ConversationReference { get; set; }
 
 
-        public async override Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities)
+        public async override Task<ResourceResponse[]> SendActivities(IBotContext context, Activity[] activities)
         {
             List<ResourceResponse> responses = new List<ResourceResponse>();
 

--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// implement send activities to the conversation
+        /// Implement send activities to the conversation
         /// </summary>        
         /// <param name="activities">Set of activities being sent</param>
         /// <returns>Array of ResourcesResponse containing the Ids of the sent activities. For
         /// most bots, these Ids are server-generated and enable Update and Delete to be 
         /// called against the remote resources.</returns>
-        public abstract Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities);
+        public abstract Task<ResourceResponse[]> SendActivities(IBotContext context, Activity[] activities);
 
         /// <summary>
         /// Implement updating an activity in the conversation

--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder
         /// </summary>        
         /// <param name="activities">Set of activities being sent</param>
         /// <returns></returns>
-        public abstract Task SendActivity(IBotContext context, params Activity[] activities);
+        public abstract Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities);
 
         /// <summary>
         /// Implement updating an activity in the conversation

--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Bot.Builder
         /// implement send activities to the conversation
         /// </summary>        
         /// <param name="activities">Set of activities being sent</param>
-        /// <returns></returns>
+        /// <returns>Array of ResourcesResponse containing the Ids of the sent activities. For
+        /// most bots, these Ids are server-generated and enable Update and Delete to be 
+        /// called against the remote resources.</returns>
         public abstract Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities);
 
         /// <summary>
@@ -41,6 +43,9 @@ namespace Microsoft.Bot.Builder
         /// </summary>        
         /// <param name="activity">New replacement activity. The activity should already have it's ID information populated. </param>
         /// <returns></returns>
+        /// <returns>ResourcesResponses containing the Id of the sent activity. For
+        /// most bots, this Id is server-generated and enables future Update and Delete calls
+        /// against the remote resources.</returns>
         public abstract Task<ResourceResponse> UpdateActivity(IBotContext context, Activity activity);
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Core/BotContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotContext.cs
@@ -74,22 +74,35 @@ namespace Microsoft.Bot.Builder
             }
         }
 
-        public async Task SendActivity(params string[] textRepliesToSend)
+        public async Task<ResourceResponse> SendActivity(string textReplyToSend)
         {
-            if (textRepliesToSend == null)
-                throw new ArgumentNullException(nameof(textRepliesToSend)); 
+            if (string.IsNullOrWhiteSpace(textReplyToSend))
+                throw new ArgumentNullException(nameof(textReplyToSend)); 
             
-            List<Activity> newActivities = new List<Activity>();
-            foreach (string s in textRepliesToSend)
-            {
-                if (!string.IsNullOrWhiteSpace(s))
-                    newActivities.Add(new Activity(ActivityTypes.Message) { Text = s });
-            }
+            var activityToSend = new Activity(ActivityTypes.Message) { Text = textReplyToSend };
 
-            await SendActivity(newActivities.ToArray());
+            return await SendActivity(activityToSend);
         }
 
-        public async Task SendActivity(params IActivity[] activities)
+        public async Task<ResourceResponse> SendActivity(IActivity activity)
+        {
+            if (activity == null)
+                throw new ArgumentNullException(nameof(activity));
+
+            ResourceResponse[] responses = await SendActivities(new IActivity[] { activity });
+            if (responses == null || responses.Length == 0)
+            {
+                // It's possible an interceptor prevented the activity from having been sent. 
+                // Just return an empty response in that case. 
+                return new ResourceResponse();
+            }
+            else
+            {
+                return responses[0];
+            }            
+        }
+
+        public async Task<ResourceResponse[]> SendActivities(IActivity[] activities)
         {
             // Bind the relevant Conversation Reference properties, such as URLs and 
             // ChannelId's, to the activities we're about to send. 
@@ -105,6 +118,9 @@ namespace Microsoft.Bot.Builder
             // Create the list used by the recursive methods. 
             List<Activity> activityList = new List<Activity>(activityArray);
 
+            // provide a variable to capture the set of responses returned from the adapter.
+            ResourceResponse[] responses = null; 
+
             async Task ActuallySendStuff()
             {
                 bool anythingToSend = false;
@@ -112,30 +128,37 @@ namespace Microsoft.Bot.Builder
                     anythingToSend = true;
 
                 // Send from the list, which may have been manipulated via the event handlers. 
-                await this.Adapter.SendActivity(this, activityList.ToArray());
+                // Note that 'responses' was captured from the root of the call, and will be
+                // returned to the original caller
+                responses = await this.Adapter.SendActivity(this, activityList.ToArray());
 
                 // If we actually sent something, set the flag. 
                 if (anythingToSend)
-                    this.Responded = true;
+                    this.Responded = true;                
             }
 
             await SendActivitiesInternal(activityList, _onSendActivities, ActuallySendStuff);
+
+            return responses;
         }
 
         /// <summary>
         /// Replaces an existing activity. 
         /// </summary>
         /// <param name="activity">New replacement activity. The activity should already have it's ID information populated</param>        
-        public async Task UpdateActivity(IActivity activity)
+        public async Task<ResourceResponse> UpdateActivity(IActivity activity)
         {
-            Activity a = (Activity)activity; 
+            Activity a = (Activity)activity;
+            ResourceResponse response = null;
 
             async Task ActuallyUpdateStuff()
             {
-                await this.Adapter.UpdateActivity(this, a);
+                response = await this.Adapter.UpdateActivity(this, a);
             }
 
             await UpdateActivityInternal(a, _onUpdateActivity, ActuallyUpdateStuff);
+
+            return response; 
         }
 
         public async Task DeleteActivity(string activityId)

--- a/libraries/Microsoft.Bot.Builder.Core/BotContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder
             _request = request ?? throw new ArgumentNullException(nameof(request));
         }
 
-        public IBotContext OnSendActivity(SendActivitiesHandler handler)
+        public IBotContext OnSendActivities(SendActivitiesHandler handler)
         {
             if (handler == null)
                 throw new ArgumentNullException(nameof(handler));
@@ -130,7 +130,7 @@ namespace Microsoft.Bot.Builder
                 // Send from the list, which may have been manipulated via the event handlers. 
                 // Note that 'responses' was captured from the root of the call, and will be
                 // returned to the original caller
-                responses = await this.Adapter.SendActivity(this, activityList.ToArray());
+                responses = await this.Adapter.SendActivities(this, activityList.ToArray());
 
                 // If we actually sent something, set the flag. 
                 if (anythingToSend)

--- a/libraries/Microsoft.Bot.Builder.Core/BotContextWrapper.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotContextWrapper.cs
@@ -60,19 +60,7 @@ namespace Microsoft.Bot.Builder
         {
             return _innerContext.DeleteActivity(activityId);
         }
-
-        //public IBotContext Reply(string text, string speak = null)
-        //{
-        //    this._innerContext.Reply(text, speak);
-        //    return this;
-        //}
-
-        //public IBotContext Reply(IActivity activity)
-        //{
-        //    this._innerContext.Reply(activity);
-        //    return this;
-        //}
-
+    
         /// <summary>
         /// Set the value associated with a key.
         /// </summary>
@@ -88,9 +76,9 @@ namespace Microsoft.Bot.Builder
             return this._innerContext.Has(key);
         }
 
-        public IBotContext OnSendActivity(SendActivitiesHandler handler)
+        public IBotContext OnSendActivities(SendActivitiesHandler handler)
         {
-            this._innerContext.OnSendActivity(handler);
+            this._innerContext.OnSendActivities(handler);
             return this;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Core/BotContextWrapper.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotContextWrapper.cs
@@ -36,17 +36,22 @@ namespace Microsoft.Bot.Builder
             return this._innerContext.Get(key);
         }
 
-        public Task SendActivity(params string[] textRepliesToSend)
+        public Task<ResourceResponse> SendActivity(string textRepliesToSend)
         {
             return _innerContext.SendActivity(textRepliesToSend);
         }
         
-        public Task SendActivity(params IActivity[] activities)
+        public Task<ResourceResponse> SendActivity(IActivity activity)
         {
-            return _innerContext.SendActivity(activities); 
+            return _innerContext.SendActivity(activity); 
         }
 
-        public Task UpdateActivity(IActivity activity)
+        public Task<ResourceResponse[]> SendActivities(params IActivity[] activities)
+        {
+            return _innerContext.SendActivities(activities);
+        }
+
+        public Task<ResourceResponse> UpdateActivity(IActivity activity)
         {
             return _innerContext.UpdateActivity(activity);
         }

--- a/libraries/Microsoft.Bot.Builder.Core/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/IBotContext.cs
@@ -26,10 +26,11 @@ namespace Microsoft.Bot.Builder
         /// </summary>
         bool Responded { get; set; }
 
-        Task SendActivity(params string[] textRepliesToSend);
-        Task SendActivity(params IActivity[] activities);        
+        Task<ResourceResponse> SendActivity(string textRepliesToSend);
+        Task<ResourceResponse> SendActivity(IActivity activity);
+        Task<ResourceResponse[]> SendActivities(IActivity[] activities);        
 
-        Task UpdateActivity(IActivity activity);
+        Task<ResourceResponse> UpdateActivity(IActivity activity);
         Task DeleteActivity(string activityId);
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Core/IBotContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/IBotContext.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="key">The key to lookup in the cache</param>
         bool Has(string key);
 
-        IBotContext OnSendActivity(SendActivitiesHandler handler);
+        IBotContext OnSendActivities(SendActivitiesHandler handler);
         IBotContext OnUpdateActivity(UpdateActivityHandler handler);
         IBotContext OnDeleteActivity(DeleteActivityHandler handler);
     }

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Adapters
             await base.RunPipeline(context, callback).ConfigureAwait(false);
         }
 
-        public override async Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities)
+        public override async Task<ResourceResponse[]> SendActivities(IBotContext context, Activity[] activities)
         {
             AssertBotFrameworkContext (context);
             List<ResourceResponse> responses = new List<ResourceResponse>(); 

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/BatchOutputTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/BatchOutputTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             BotContext c = new BotContext(new TestAdapter(), new Activity());
             BatchOutput bo = new BatchOutput();
             
-            c.OnSendActivity( async (context, activities, next) =>
+            c.OnSendActivities( async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 0, "Incorrect Item Count");
             });
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             BatchOutput bo = new BatchOutput();
             bo.Typing(); 
 
-            c.OnSendActivity(async (context, activities, next) =>
+            c.OnSendActivities(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 1, "Incorrect Activity Count");
                 Assert.IsTrue(activities[0].Type == ActivityTypes.Typing, "Incorrect Activity Type");
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             bo.Typing();
             bo.EndOfConversation();
            
-            c.OnSendActivity(async (context, activities, next) =>
+            c.OnSendActivities(async (context, activities, next) =>
             {
                 Assert.IsTrue(activities.Count == 2, "Incorrect Activity Count");
                 Assert.IsTrue(activities[0].Type == ActivityTypes.Typing, "Incorrect Activity Type in Slot 0");

--- a/tests/Microsoft.Bot.Builder.Core.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/BotAdapterTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Core.Tests
@@ -25,7 +26,26 @@ namespace Microsoft.Bot.Builder.Core.Tests
             SimpleAdapter a = new SimpleAdapter();
             a.Use(new CallCountingMiddleware()).Use(new CallCountingMiddleware());
             // Compiled. Test passed. 
-        }      
+        }
+
+        [TestMethod]
+        public async Task PassResourceResponsesThrough()
+        {
+            void ValidateResponses(Activity[] activities)
+            {
+                // no need to do anything. 
+            }
+
+            SimpleAdapter a = new SimpleAdapter(ValidateResponses);
+            BotContext c = new BotContext(a, new Activity());
+
+            string activityId = Guid.NewGuid().ToString();
+            var activity = TestMessage.Message();
+            activity.Id = activityId;
+
+            var resourceResponse = await c.SendActivity(activity);
+            Assert.IsTrue(resourceResponse.Id == activityId, "Incorrect response Id returned"); 
+        }
     }
 
     public class CallCountingMiddleware : IMiddleware

--- a/tests/Microsoft.Bot.Builder.Core.Tests/BotContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/BotContextTests.cs
@@ -122,9 +122,29 @@ namespace Microsoft.Bot.Builder.Core.Tests
         {
             SimpleAdapter a = new SimpleAdapter();
             BotContext c = new BotContext(a, new Activity());
+            Assert.IsFalse(c.Responded);            
+            var response = await c.SendActivity(TestMessage.Message("testtest"));
+
+            Assert.IsTrue(c.Responded);
+            Assert.IsTrue(response.Id == "testtest");
+        }
+
+        [TestMethod]
+        public async Task SendBatchOfActivities()
+        {
+            SimpleAdapter a = new SimpleAdapter();
+            BotContext c = new BotContext(a, new Activity());
             Assert.IsFalse(c.Responded);
-            await c.SendActivity(TestMessage.Message());
-            Assert.IsTrue(c.Responded);            
+
+            var message1 = TestMessage.Message("message1");
+            var message2 = TestMessage.Message("message2");
+
+            var response = await c.SendActivities(new IActivity[] { message1, message2 } );
+
+            Assert.IsTrue(c.Responded);
+            Assert.IsTrue(response.Length == 2);
+            Assert.IsTrue(response[0].Id == "message1");
+            Assert.IsTrue(response[1].Id == "message2");
         }
 
         [TestMethod]
@@ -241,14 +261,18 @@ namespace Microsoft.Bot.Builder.Core.Tests
             void ValidateUpdate(Activity activity)
             {
                 Assert.IsNotNull(activity);
-                Assert.IsTrue(activity.Id == "1234");
+                Assert.IsTrue(activity.Id == "test");
                 foundActivity = true;
             }
 
             SimpleAdapter a = new SimpleAdapter(ValidateUpdate);
             BotContext c = new BotContext(a, new Activity());
-            await c.UpdateActivity(TestMessage.Message());
+            
+            var message = TestMessage.Message("test");            
+            var updateResult = await c.UpdateActivity(message);
+
             Assert.IsTrue(foundActivity);
+            Assert.IsTrue(updateResult.Id == "test");
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.Core.Tests/BotContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/BotContextTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Bot.Builder.Core.Tests
             BotContext c = new BotContext(a, new Activity());
 
             int count = 0;
-            c.OnSendActivity(async (context, activities, next) =>
+            c.OnSendActivities(async (context, activities, next) =>
             {               
                Assert.IsNotNull(activities, "Null Array passed in");
                count = activities.Count();
@@ -210,7 +210,7 @@ namespace Microsoft.Bot.Builder.Core.Tests
             BotContext c = new BotContext(a, new Activity());
           
             int count = 0;
-            c.OnSendActivity(async (context, activities, next) =>
+            c.OnSendActivities(async (context, activities, next) =>
             {
                 Assert.IsNotNull(activities, "Null Array passed in");
                 count = activities.Count();
@@ -238,7 +238,7 @@ namespace Microsoft.Bot.Builder.Core.Tests
             SimpleAdapter a = new SimpleAdapter(ValidateResponses);
             BotContext c = new BotContext(a, new Activity());
             
-            c.OnSendActivity(async (context, activities, next) =>
+            c.OnSendActivities(async (context, activities, next) =>
             {
                 Assert.IsNotNull(activities, "Null Array passed in");
                 Assert.IsTrue(activities.Count() == 1);
@@ -430,7 +430,7 @@ namespace Microsoft.Bot.Builder.Core.Tests
             SimpleAdapter a = new SimpleAdapter();
             BotContext c = new BotContext(a, new Activity());
             
-            c.OnSendActivity(async (context, activities, next) =>
+            c.OnSendActivities(async (context, activities, next) =>
             {
                 throw new Exception("test");                 
             });

--- a/tests/Microsoft.Bot.Builder.Core.Tests/SimpleAdapter.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/SimpleAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -23,19 +24,26 @@ namespace Microsoft.Bot.Builder.Core.Tests
             _callOnDelete?.Invoke(reference);
         }
 
-        public async override Task SendActivity(IBotContext context, params Activity[] activities)
+        public async override Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities)
         {
             Assert.IsNotNull(activities, "SimpleAdapter.deleteActivity: missing reference");
             Assert.IsTrue(activities.Count() > 0, "SimpleAdapter.sendActivities: empty activities array.");
 
             _callOnSend?.Invoke(activities);
+            List<ResourceResponse> responses = new List<ResourceResponse>();
+            foreach(var activity in activities)
+            {
+                responses.Add(new ResourceResponse(activity.Id));
+            }
+
+            return responses.ToArray();
         }
 
         public async override Task<ResourceResponse> UpdateActivity(IBotContext context, Activity activity)
         {
             Assert.IsNotNull(activity, "SimpleAdapter.updateActivity: missing activity");
             _callOnUpdate?.Invoke(activity);
-            return new ResourceResponse("testId");
+            return new ResourceResponse(activity.Id); // echo back the Id
         }
 
         public async Task ProcessRequest(Activity activty, Func<IBotContext, Task> callback)

--- a/tests/Microsoft.Bot.Builder.Core.Tests/SimpleAdapter.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/SimpleAdapter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder.Core.Tests
             _callOnDelete?.Invoke(reference);
         }
 
-        public async override Task<ResourceResponse[]> SendActivity(IBotContext context, Activity[] activities)
+        public async override Task<ResourceResponse[]> SendActivities(IBotContext context, Activity[] activities)
         {
             Assert.IsNotNull(activities, "SimpleAdapter.deleteActivity: missing reference");
             Assert.IsTrue(activities.Count() > 0, "SimpleAdapter.sendActivities: empty activities array.");

--- a/tests/Microsoft.Bot.Builder.Core.Tests/TestMessage.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/TestMessage.cs
@@ -4,12 +4,12 @@ namespace Microsoft.Bot.Builder.Core.Tests
 {
     public static class TestMessage
     {
-        public static Activity Message()
+        public static Activity Message(string id = "1234")
         {
             Activity a = new Activity
             {
                 Type = ActivityTypes.Message,
-                Id = "1234",
+                Id = id,
                 Text = "test",
                 From = new ChannelAccount()
                 {

--- a/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
         }
 
         [TestMethod]
-        public async Task TemplateManager_Registration()
+        public void TemplateManager_Registration()
         {
             var templateManager = new TemplateManager();
             Assert.AreEqual(templateManager.List().Count, 0, "nothing registered yet");
@@ -69,7 +69,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
         }
 
         [TestMethod]
-        public async Task TemplateManager_MultiTemplate()
+        public void TemplateManager_MultiTemplate()
         {
             var templateManager = new TemplateManager();
             Assert.AreEqual(templateManager.List().Count, 0, "nothing registered yet");


### PR DESCRIPTION
When activities are sent, a server-generated ID is returned. In some cases the developer needs this Id in order to later Update or Delete an activity. 

The plumbing of the Resource Response from the Connector up through the BotContext on all the relevant Send/Update methods is needed to enable this scenario. 

While in here, I've also refactored the SendActivity() method to only take a single activity. Created a new SendActivities( Activity[] ) method to accept a batch of activities. This aligns with discussions with Tom and Steve for how this should be - optimized for the simple case ("Send 1 Activity") while still keeping the ability to send multiple. 