### PR TITLE
Add CatchException and ShowTyping middleware to Alarm bot sample

### DIFF
--- a/samples/AlarmBot-Cards/Startup.cs
+++ b/samples/AlarmBot-Cards/Startup.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Text.RegularExpressions;
 using AlarmBot.Models;
 using Microsoft.AspNetCore.Builder;
@@ -37,6 +38,14 @@ namespace AlarmBot
 
                 var middleware = options.Middleware;
 
+                // Add middleware to send an appropriate message to the user if an exception occurs
+                middleware.Add(new CatchExceptionMiddleware<Exception>(async (context, exception) =>
+                {
+                    await context.SendActivity("Sorry, it looks like something went wrong!");
+                }));
+                // Add middleware to send periodic typing activities until the bot responds. The initial
+                // delay before sending a typing activity and the frequency of additional activities can also be specified
+                middleware.Add(new ShowTypingMiddleware());
                 middleware.Add(new UserState<UserData>(new MemoryStorage()));
                 middleware.Add(new ConversationState<ConversationData>(new MemoryStorage()));                
                 middleware.Add(new RegExpRecognizerMiddleware()

--- a/samples/AlarmBot/Startup.cs
+++ b/samples/AlarmBot/Startup.cs
@@ -42,7 +42,8 @@ namespace AlarmBot
                     {
                         await context.SendActivity("Sorry, it looks like something went wrong!");
                     }));
-                // Add middleware to send periodic typing activities until the bot responds
+                // Add middleware to send periodic typing activities until the bot responds. The initial
+                // delay before sending a typing activity and the frequency of additional activities can also be specified
                 middleware.Add(new ShowTypingMiddleware());
                 middleware.Add(new UserState<UserData>(new MemoryStorage()));
                 middleware.Add(new ConversationState<ConversationData>(new MemoryStorage()));


### PR DESCRIPTION
Added CatchException and ShowTyping middleare to Alarm Bot example to demonstrate usage with an appropriate comment for each. cc/ @cleemullins 