### PR TITLE
Update BotState to allow it to be used on its own as well as middleware

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions
     /// Abstract Base class which manages details of auto loading/saving of BotState
     /// </summary>
     /// <typeparam name="StateT"></typeparam>
-    public abstract class BotState<StateT> : IMiddleware
+    public class BotState<StateT> : IMiddleware
         where StateT : class, new()
     {
         private readonly StateSettings _settings;
@@ -42,12 +42,12 @@ namespace Microsoft.Bot.Builder.Core.Extensions
 
         public async Task OnProcessRequest(ITurnContext context, MiddlewareSet.NextDelegate next)
         {
-            await Read(context).ConfigureAwait(false);
+            await ReadToContextService(context).ConfigureAwait(false);
             await next().ConfigureAwait(false);
-            await Write(context).ConfigureAwait(false);
+            await WriteFromContextService(context).ConfigureAwait(false);
         }
 
-        protected virtual async Task<StoreItems> Read(ITurnContext context)
+        protected virtual async Task ReadToContextService(ITurnContext context)
         {
             var key = this._keyDelegate(context);
             var keys = new List<String> { key };
@@ -56,14 +56,29 @@ namespace Microsoft.Bot.Builder.Core.Extensions
             if (state == null)
                 state = new StateT();
             context.Services.Add(this._propertyName, state);
-            return items;
         }
 
-        protected virtual async Task Write(ITurnContext context)
+        protected virtual async Task WriteFromContextService(ITurnContext context)
+        {
+            var state = context.Services.Get<StateT>(this._propertyName);
+            await Write(context, state);
+        }
+
+        public virtual async Task<StateT> Read(ITurnContext context)
+        {
+            var key = this._keyDelegate(context);
+            var keys = new List<String> { key };
+            var items = await _storage.Read(keys.ToArray());
+            var state = items.Get<StateT>(key);
+            if (state == null)
+                state = new StateT();
+            return state;
+        }
+
+        public virtual async Task Write(ITurnContext context, StateT state)
         {
             StoreItems changes = new StoreItems();
 
-            var state = context.Services.Get<StateT>(this._propertyName);
             if (state == null)
                 state = new StateT();
             var key = _keyDelegate(context);
@@ -73,7 +88,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions
             {
                 foreach (var item in changes)
                 {
-                    if(item.Value is IStoreItem valueStoreItem)
+                    if (item.Value is IStoreItem valueStoreItem)
                     {
                         valueStoreItem.eTag = "*";
                     }

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/BotStateTests.cs
@@ -208,6 +208,39 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                 .StartTest();
         }
 
+        [TestMethod]
+        public async Task State_UseBotStateDirectly()
+        {
+            var adapter = new TestAdapter();
+
+            await new TestFlow(adapter,
+                    async (context) =>
+                    {
+                        var botStateManager = new BotState<CustomState>(new MemoryStorage(),
+                            $"BotState:{typeof(BotState<CustomState>).Namespace}.{typeof(BotState<CustomState>).Name}",
+                            (ctx) => $"botstate/{ctx.Activity.ChannelId}/{ctx.Activity.Conversation.Id}/{typeof(BotState<CustomState>).Namespace}.{typeof(BotState<CustomState>).Name}");
+
+                        // read initial state object
+                        var customState = await botStateManager.Read(context);
+
+                        // this should be a 'new CustomState' as nothing is currently stored in storage
+                        Assert.Equals(customState, new CustomState());
+
+                        // amend property and write to storage
+                        customState.CustomString = "test";
+                        await botStateManager.Write(context, customState);
+
+                        // set customState to null before reading from storage
+                        customState = null;
+                        customState = await botStateManager.Read(context);
+
+                        // check object read from value has the correct value for CustomString
+                        Assert.Equals(customState.CustomString, "test");
+                    }
+                )
+                .StartTest();
+        }
+
         public class CustomState : StoreItem
         {
             public string CustomString { get; set; }


### PR DESCRIPTION
The full background to this discussion and it's intention can be found in #341. 

This PR is intended to make a small amend to how BotState works within the C# SDK to bring it in line with the JS SDK and allow it to be used independently, as well as from within middleware.  This is likely to eventually be superseded by more significant changes to state management, but this change will unblock the ability for middleware to maintain it's own state if required.

This change maintains the existing model for ConversationState and UserState.

Example use....

**Middleware constructor**

```cs
_state = new BotState<MiddlewareState>(new MemoryStorage(),
                $"BotState:{typeof(BotState<MiddlewareState>).Namespace}.{typeof(BotState<MiddlewareState>).Name}",
                (context) => $"botstate/{context.Activity.ChannelId}/{context.Activity.Conversation.Id}/{typeof(BotState<MiddlewareState>).Namespace}.{typeof(BotState<MiddlewareState>).Name}");
```

**Middleware process request**

```cs
var currentState = await _state.Read(context);
// do something with your state
await _state.Write(context, currentState);
```

cc'ing @billba @drub0y due to discussion in existing issue.