### PR TITLE
Fix for #351

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
@@ -43,6 +43,16 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         public async Task OnProcessRequest(ITurnContext context, MiddlewareSet.NextDelegate next)
         {
             await Read(context).ConfigureAwait(false);
+            if (_settings.WriteBeforeSend)
+            {
+                context.OnSendActivities(WriteOnSend);
+            }
+            await next().ConfigureAwait(false);
+            await Write(context).ConfigureAwait(false);
+        }
+
+        private async Task WriteOnSend(ITurnContext context, List<Activity> activities, Func<Task> next)
+        {
             await next().ConfigureAwait(false);
             await Write(context).ConfigureAwait(false);
         }

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Bot.Builder.Core.Extensions
 {
     public class StateSettings
     {
-        public bool WriteBeforeSend { get; set; } = true;
         public bool LastWriterWins { get; set; } = true;
     }
 
@@ -43,16 +42,6 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         public async Task OnProcessRequest(ITurnContext context, MiddlewareSet.NextDelegate next)
         {
             await Read(context).ConfigureAwait(false);
-            if (_settings.WriteBeforeSend)
-            {
-                context.OnSendActivities(WriteOnSend);
-            }
-            await next().ConfigureAwait(false);
-            await Write(context).ConfigureAwait(false);
-        }
-
-        private async Task WriteOnSend(ITurnContext context, List<Activity> activities, Func<Task> next)
-        {
             await next().ConfigureAwait(false);
             await Write(context).ConfigureAwait(false);
         }


### PR DESCRIPTION
Note, the name of the `WriteBeforeSend` flag is a bit ambiguous. On first reading, I assumed that this indicates state should also be written on any SendActivity threads generated, which is how this fix is written.