### PR TITLE
Added overload to context.DeleteActivity to accept a reference

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/ITurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/ITurnContext.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Bot.Builder
         Task<ResourceResponse[]> SendActivities(IActivity[] activities);        
 
         Task<ResourceResponse> UpdateActivity(IActivity activity);
+
         Task DeleteActivity(string activityId);
+        Task DeleteActivity(ConversationReference conversationReference);
 
         ITurnContext OnSendActivities(SendActivitiesHandler handler);
         ITurnContext OnUpdateActivity(UpdateActivityHandler handler);

--- a/libraries/Microsoft.Bot.Builder.Core/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/TurnContext.cs
@@ -180,6 +180,19 @@ namespace Microsoft.Bot.Builder
             await DeleteActivityInternal(cr, _onDeleteActivity, ActuallyDeleteStuff);
         }
 
+        public async Task DeleteActivity(ConversationReference conversationReference)
+        {
+            if (conversationReference == null)
+                throw new ArgumentNullException(nameof(conversationReference));
+            
+            async Task ActuallyDeleteStuff()
+            {
+                await this.Adapter.DeleteActivity(this, conversationReference);
+            }
+
+            await DeleteActivityInternal(conversationReference, _onDeleteActivity, ActuallyDeleteStuff);
+        }
+
         private async Task SendActivitiesInternal(
             List<Activity> activities,
             IEnumerable<SendActivitiesHandler> sendHandlers,

--- a/libraries/Microsoft.Bot.Builder.Core/TurnContextWrapper.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/TurnContextWrapper.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Bot.Builder
             return _innerContext.DeleteActivity(activityId);
         }
 
+        public Task DeleteActivity(ConversationReference conversationReference)
+        {
+            return _innerContext.DeleteActivity(conversationReference);
+        }
+
         public ITurnContext OnSendActivities(SendActivitiesHandler handler)
         {
             this._innerContext.OnSendActivities(handler);

--- a/tests/Microsoft.Bot.Builder.Core.Tests/TurnContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/TurnContextTests.cs
@@ -369,6 +369,27 @@ namespace Microsoft.Bot.Builder.Core.Tests
         }
 
         [TestMethod]
+        public async Task DeleteConversationReferenceToAdapter()
+        {
+            bool deleteCalled = false;
+
+            void ValidateDelete(ConversationReference r)
+            {
+                Assert.IsNotNull(r);
+                Assert.IsTrue(r.ActivityId == "12345");
+                deleteCalled = true;
+            }
+
+            SimpleAdapter a = new SimpleAdapter(ValidateDelete);
+            TurnContext c = new TurnContext(a, TestMessage.Message());
+
+            var reference = new ConversationReference("12345");
+
+            await c.DeleteActivity(reference);
+            Assert.IsTrue(deleteCalled);
+        }
+
+        [TestMethod]
         public async Task InterceptOnDelete()
         {
             bool adapterCalled = false;


### PR DESCRIPTION
As per comments from @Stevenic in #361 I have added the ability to pass a conversation reference to context.DeleteActivity, bringing this SDK in line with JS.