### PR TITLE
Add doc XML to BotFrameworkAdapter

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -67,6 +67,7 @@ namespace Microsoft.Bot.Builder
         /// <remarks>If the activities are successfully sent, the task result contains
         /// an array of <see cref="ResourceResponse"/> objects containing the IDs that 
         /// the receiving channel assigned to the activities.</remarks>
+        /// <seealso cref="ITurnContext.OnSendActivities(SendActivitiesHandler)"/>
         public abstract Task<ResourceResponse[]> SendActivities(ITurnContext context, Activity[] activities);
 
         /// <summary>
@@ -81,6 +82,7 @@ namespace Microsoft.Bot.Builder
         /// channel assigned to the activity.
         /// <para>Before calling this, set the ID of the replacement activity to the ID
         /// of the activity to replace.</para></remarks>
+        /// <seealso cref="ITurnContext.OnUpdateActivity(UpdateActivityHandler)"/>
         public abstract Task<ResourceResponse> UpdateActivity(ITurnContext context, Activity activity);
 
         /// <summary>
@@ -92,6 +94,7 @@ namespace Microsoft.Bot.Builder
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>The <see cref="ConversationReference.ActivityId"/> of the conversation
         /// reference identifies the activity to delete.</remarks>
+        /// <seealso cref="ITurnContext.OnDeleteActivity(DeleteActivityHandler)"/>
         public abstract Task DeleteActivity(ITurnContext context, ConversationReference reference);
 
 
@@ -139,7 +142,7 @@ namespace Microsoft.Bot.Builder
 
 
         /// <summary>
-        /// Requests a channel to begin a new conversation for the bot.
+        /// Creates a conversation on the specified channel.
         /// </summary>
         /// <param name="channelId">The ID of the channel.</param>
         /// <param name="callback">A method to call when the new conversation is available.</param>
@@ -152,7 +155,7 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// Send a proactive message to a conversation.
+        /// Sends a proactive message to a conversation.
         /// </summary>
         /// <param name="reference">A reference to the conversation to continue.</param>
         /// <param name="callback">The method to call for the resulting bot turn.</param>

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -38,6 +38,10 @@
 		<AssemblyName>Microsoft.Bot.Builder</AssemblyName>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	  <DocumentationFile>bin\Debug\netstandard2.0\Microsoft.Bot.Builder.xml</DocumentationFile>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bot.Builder.Core" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Builder.Core" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />


### PR DESCRIPTION
- Update the Bot.Builder library to generate document file
- Tweak BotAdapter doc XML.

**Open question** re [BotFramewrokAdapter.CreateConversation](https://github.com/Microsoft/botbuilder-dotnet/blob/c46107cb25ba385446fc5c98ddab4f7440966b8e/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L274):
- Does this call always complete?
- Should any part of this be in a try-catch block?
- How should a bot developer check for success?