### PR TITLE
Make TurnContext IDisposable

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
@@ -41,8 +41,10 @@ namespace Microsoft.Bot.Builder.Adapters
                     Type = ActivityTypes.Message
                 };
 
-                var context = new TurnContext(this, activity);
-                await base.RunPipeline(context, callback);
+                using (var context = new TurnContext(this, activity))
+                {
+                    await base.RunPipeline(context, callback);
+                }
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Core/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Adapters/TestAdapter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Adapters
             return this;
         }
 
-        public Task ProcessActivity(Activity activity, Func<ITurnContext, Task> callback, CancellationTokenSource cancelToken = null)
+        public async Task ProcessActivity(Activity activity, Func<ITurnContext, Task> callback, CancellationTokenSource cancelToken = null)
         {
             lock (this.ConversationReference)
             {
@@ -60,8 +60,10 @@ namespace Microsoft.Bot.Builder.Adapters
                 var id = activity.Id = (this._nextId++).ToString();
             }
 
-            var context = new TurnContext(this, activity);
-            return base.RunPipeline(context, callback, cancelToken);
+            using (var context = new TurnContext(this, activity))
+            {
+                await base.RunPipeline(context, callback, cancelToken);
+            }
         }
 
         public ConversationReference ConversationReference { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Core/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/TurnContext.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder
     /// length of the turn.</remarks>
     /// <seealso cref="IBot"/>
     /// <seealso cref="IMiddleware"/>
-    public class TurnContext : ITurnContext
+    public class TurnContext : ITurnContext, IDisposable
     {
         private readonly BotAdapter _adapter;
         private readonly Activity _activity;
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder
         private readonly IList<UpdateActivityHandler> _onUpdateActivity = new List<UpdateActivityHandler>();
         private readonly IList<DeleteActivityHandler> _onDeleteActivity = new List<DeleteActivityHandler>();
 
-        private readonly TurnContextServiceCollection _services = new TurnContextServiceCollection();
+        private readonly TurnContextServiceCollection _turnServices;
 
         /// <summary>
         /// Creates a context object.
@@ -42,6 +42,8 @@ namespace Microsoft.Bot.Builder
         {
             _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
             _activity = activity ?? throw new ArgumentNullException(nameof(activity));
+
+            _turnServices = new TurnContextServiceCollection();
         }
 
         /// <summary>
@@ -110,7 +112,7 @@ namespace Microsoft.Bot.Builder
         /// <summary>
         /// Gets the services registered on this context object.
         /// </summary>
-        public ITurnContextServiceCollection Services => _services;
+        public ITurnContextServiceCollection Services => _turnServices;
 
         /// <summary>
         /// Gets the activity associated with this turn; or <c>null</c> when processing
@@ -479,6 +481,11 @@ namespace Microsoft.Bot.Builder
                     activity.ReplyToId = reference.ActivityId;
             }
             return activity;
+        }
+
+        public void Dispose()
+        {
+            _turnServices.Dispose();
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Core.Tests/SimpleAdapter.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Tests/SimpleAdapter.cs
@@ -48,8 +48,10 @@ namespace Microsoft.Bot.Builder.Core.Tests
 
         public async Task ProcessRequest(Activity activty, Func<ITurnContext, Task> callback)
         {
-            TurnContext ctx = new TurnContext(this, activty);
-            await this.RunPipeline(ctx, callback); 
+            using (TurnContext ctx = new TurnContext(this, activty))
+            {
+                await this.RunPipeline(ctx, callback);
+            }
         }
     }
 


### PR DESCRIPTION
 * Make the `TurnContext` class `IDisposable`
 * Make the `TurnContextServiceCollection` class `IDisposable`
 * `TurnContext`'s implementation of `Dispose` disposes of its
`TurnContextServiceCollection` which in turn disposes of any services
inside of it that implement `IDisposable`
 * All `XXXAdapter` classes updated to dispose of the `TurnContext`
instances they create