### PR TITLE
AzureTableStorage improvements 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/TableStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/TableStorageTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Core.Extensions;
 using Microsoft.Bot.Builder.Core.Extensions.Tests;
@@ -116,11 +117,173 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 await base._handleCrazyKeys(storage);
         }
 
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
         public async Task TableStorage_TypedSerialization()
         {
             if (CheckStorageEmulator())
                 await base._typedSerialization(this.storage);
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        // Save a larger than 64KB object into Table Storage
+        // </summary>
+        [TestMethod]
+        public async Task TableStorage_CreateLargerObjectTest()
+        {
+            if (CheckStorageEmulator())
+            {
+                var bigString = RandomString(74000);
+                var storeItems = new StoreItems();
+                storeItems.Add("BigObject", new
+                {
+                    Text = bigString
+                });
+
+                await storage.Write(storeItems);
+
+                var storedItems = await storage.Read("BigObject");
+                Assert.AreEqual(bigString, storedItems.Get<dynamic>("BigObject").Text);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        // Save a larger than 64KB object into Table Storage
+        // </summary>
+        [TestMethod]
+        public async Task TableStorage_UpdateLargeObjectWithEtagTest()
+        {
+            if (CheckStorageEmulator())
+            {
+                var bigString = RandomString(74000);
+                var storeItems = new StoreItems();
+                storeItems.Add("BigObjectWithEtag", new BigPocoItem
+                {
+                    Text = bigString
+                });
+
+                await storage.Write(storeItems);
+
+                // Read and Update
+                var storedItems = await storage.Read("BigObjectWithEtag");
+
+                var biggerString = RandomString(100000);
+                storedItems.Get<dynamic>("BigObjectWithEtag").Text = biggerString;
+                await storage.Write(storedItems);
+
+                // Assert updated correctly
+                storedItems = await storage.Read("BigObjectWithEtag");
+                Assert.AreEqual(biggerString, storedItems.Get<dynamic>("BigObjectWithEtag").Text);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        // Save a larger than 64KB object into Table Storage
+        // </summary>
+        [TestMethod]
+        public async Task TableStorage_DeleteLargerObjectTest()
+        {
+            if (CheckStorageEmulator())
+            {
+                var bigString = RandomString(74000);
+                var storeItems = new StoreItems();
+                storeItems.Add("BigObject", new BigPocoItem
+                {
+                    Text = bigString
+                });
+
+                await storage.Write(storeItems);
+
+                await storage.Delete("BigObject");
+
+                storeItems = await storage.Read("BigObject");
+                Assert.IsFalse(storeItems.ContainsKey("BigObject"));
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        // Save a larger than 64KB object into Table Storage, then a smaller one
+        // </summary>
+        [TestMethod]
+        public async Task TableStorage_UpdateLargeObjectWithSmaller()
+        {
+            if (CheckStorageEmulator())
+            {
+                var bigString = RandomString(74000);
+                var newString = "Hello World!";
+
+                var storeItems = new StoreItems();
+                storeItems.Add("BigToSmallObject", new BigPocoItem
+                {
+                    Text = bigString
+                });
+
+                await storage.Write(storeItems);
+                var storedItem = await storage.Read("BigToSmallObject");
+                storedItem["BigToSmallObject"].Text = newString;
+                await storage.Write(storedItem);
+
+                storedItem = await storage.Read("BigToSmallObject");
+
+                Assert.AreEqual(newString, storedItem.Get<dynamic>("BigToSmallObject").Text);
+            }
+        }
+
+        [TestMethod]
+        public void TableStorage_SplitBigItemIntoChunks()
+        {
+            var bigString = RandomString(74000);
+            var obj = new { Text = bigString };
+
+            var splitter = new AzureTableStorage.StoreItemContainer("test", obj);
+            var chunks = splitter.Split();
+
+            Assert.AreEqual(3, chunks.Count());
+        }
+
+        [TestMethod]
+        public void TableStorage_JoinChunksIntoBiggerItem()
+        {
+            var bigString = RandomString(74000);
+            var obj = new { Text = bigString };
+
+            var splitter = new AzureTableStorage.StoreItemContainer("test", obj);
+            var chunks = splitter.Split();
+
+            var joined = AzureTableStorage.StoreItemContainer.Join(chunks);
+
+            Assert.AreEqual(bigString, ((dynamic)joined.Object).Text);
+        }
+
+        [TestMethod]
+        public void TableStorage_JoinChunksPreservesOriginalKey()
+        {
+            string key = "!@#$%^&*()~/\\><,.?';\"`~";
+            var bigString = RandomString(74000);
+            var obj = new { Text = bigString };
+
+            var splitter = new AzureTableStorage.StoreItemContainer(key, obj);
+            var chunks = splitter.Split();
+
+            var joined = AzureTableStorage.StoreItemContainer.Join(chunks);
+
+            Assert.AreEqual(key, joined.Key);
+        }
+
+        private static string RandomString(int length)
+        {
+            var random = new Random();
+            const string pool = "abcdefghijklmnopqrstuvwxyz0123456789";
+            var chars = Enumerable.Range(0, length)
+                .Select(x => pool[random.Next(0, pool.Length)]);
+            return new string(chars.ToArray());
+        }
+
+        public class BigPocoItem : IStoreItem
+        {
+            public string eTag { get; set; }
+
+            public string Text { get; set; }
         }
     }
 }


### PR DESCRIPTION
- Support for storing objects bigger than 32kb serialized
  When storing unicode text, this is 32768 characters.
  The AzureTables Storage provider stores the state object item as JSON.
  The workaround is to store the object in chunks of 32768 characters, using the PartitionKey as the Key and RowKey as the chunk position.
   - On Write: serialize to JSON and split into chunks, then create TableEntity with an incrementing RowKey. Delete any RowKey > than last generated RowKey (e.g.: cleanup chunks from a previous bigger object)
   - On Read: Query the table for the specific PartitionKey, retrieving all Rows and ordering by RowKey
   - On Delete: Query the table for the specific PartitionKey to delete, iterate over rows and delete them.
- Validate parameters
- Docs update


@cleemullins 
The current approach is to split the object into multiple rows. @Stevenic suggests to split the object into multiple columns instead. Let us know if this is the preferred way and we'll update the code to use TableEntity.Flatten instead. (Relevant discussion @ https://github.com/Microsoft/botbuilder-js/pull/178#issuecomment-380509161)