### PR TITLE
Fix build warnings in BotBuilder solution

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.Translation/Microsoft.Bot.Builder.Ai.Translation.csproj
+++ b/libraries/Microsoft.Bot.Builder.Ai.Translation/Microsoft.Bot.Builder.Ai.Translation.csproj
@@ -44,8 +44,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.0.1.1" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.1.1" />
+    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.0.3" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic.csproj
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic.csproj
@@ -43,9 +43,8 @@
     <DocumentationFile>bin\Documentation\Microsoft.Bot.Builder.Classic.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
-      <HintPath>..\..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Autofac, Version=4.2.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Autofac.4.2.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Chronic">
       <HintPath>..\..\..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>

--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/packages.config
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net461" />
+  <package id="Autofac" version="4.2.0" targetFramework="net461" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.10" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />

--- a/libraries/Microsoft.Bot.Builder.Prompts/Microsoft.Bot.Builder.Prompts.csproj
+++ b/libraries/Microsoft.Bot.Builder.Prompts/Microsoft.Bot.Builder.Prompts.csproj
@@ -47,10 +47,10 @@
 		<PackageReference Include="Microsoft.Bot.Builder.Core" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-		<PackageReference Include="Microsoft.Recognizers.Text" Version="1.0.1.1" />
-		<PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.0.1.1" />
-		<PackageReference Include="Microsoft.Recognizers.Text.NumberWithUnit" Version="1.0.1.1" />
-		<PackageReference Include="Microsoft.Recognizers.Text.Sequence" Version="1.0.1.1" />
+		<PackageReference Include="Microsoft.Recognizers.Text" Version="1.0.3" />
+		<PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.0.3" />
+		<PackageReference Include="Microsoft.Recognizers.Text.NumberWithUnit" Version="1.0.3" />
+		<PackageReference Include="Microsoft.Recognizers.Text.Sequence" Version="1.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -52,7 +52,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.0" />
+		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.1" />
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />

--- a/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
+++ b/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AdaptiveCards" Version="0.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.1.1" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.3" />
 
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>

--- a/samples/AlarmBot/AlarmBot.csproj
+++ b/samples/AlarmBot/AlarmBot.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.1.1" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.3" />
 
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/Microsoft.Bot.Samples.EchoBot-AspNetWebApi.csproj
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/Microsoft.Bot.Samples.EchoBot-AspNetWebApi.csproj
@@ -72,8 +72,8 @@
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.1.5\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.2.1\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/Web.config
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/Web.config
@@ -285,7 +285,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.5.0" newVersion="5.1.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.1.0" newVersion="5.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/packages.config
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.10" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.5" targetFramework="net461" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.1" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.4.0" targetFramework="net461" />
   <package id="Unity" version="5.7.3" targetFramework="net461" />
   <package id="Unity.Abstractions" version="3.3.0" targetFramework="net461" />

--- a/tests/FormTest/FormTest.csproj
+++ b/tests/FormTest/FormTest.csproj
@@ -68,39 +68,15 @@
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.AppContext.4.0.0\lib\net46\System.AppContext.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.StackTrace.4.0.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IO.FileSystem.4.0.0\lib\net46\System.IO.FileSystem.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.0.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>

--- a/tests/FormTest/FormTest.csproj
+++ b/tests/FormTest/FormTest.csproj
@@ -54,12 +54,11 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.2.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.4.2.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.10\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.1\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>

--- a/tests/FormTest/packages.config
+++ b/tests/FormTest/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.6.2" targetFramework="net461" />
+  <package id="Autofac" version="4.2.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.Net.Compilers" version="1.2.1" targetFramework="net46" developmentDependency="true" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.2" targetFramework="net46" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.10" targetFramework="net461" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
 </packages>

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/Microsoft.Bot.Builder.Classic.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/Microsoft.Bot.Builder.Classic.Tests.csproj
@@ -19,10 +19,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Autofac" Version="3.5.2" />
+		<PackageReference Include="Autofac" Version="4.2.0" />
 		<PackageReference Include="Chronic.Signed" Version="0.3.2" />
-		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" targetFramework="net46" />
-		<PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" targetFramework="net46" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4" targetFramework="net46" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.4" targetFramework="net46" />
 		<PackageReference Include="Microsoft.IdentityModel.Logging" Version="5.2.1" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.2.1" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.1" />

--- a/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
@@ -18,7 +18,7 @@ namespace Connector.Tests
 
     public class BaseTest
     {
-        private const HttpRecorderMode mode = HttpRecorderMode.Playback;
+        private readonly HttpRecorderMode mode = HttpRecorderMode.Playback;
 
         protected const string clientId = "[MSAPP_ID]";
         protected const string clientSecret = "[MSAPP_PASSWORD]";


### PR DESCRIPTION
Fixed the build warnings fixing the following issues:
- Update Microsoft.Recognizers.* packages to latest version available
- Consolidate NuGet packages to the latest version available (Autofac to 4.2.0)
- Fix BotBuilder.Schema autorest-generated classes inheritance warning (Removed Type property from GeoCoordinates.cs, Mention.cs & Place.cs. Also removed them from swagger file)
 _Note: We reverted this change since we learned we cannot modify the swagger file. Since these classes are generated via autorest based on the swagger file, we won't manually fix them._
- Make HttpRecorderMode readonly instead of const (avoids unreachable code)
- Removed unnecessary references in Tests\FormTest project
 _Note: They were missing from the NuGet packages file but actually not being used within the code._