### PR TITLE
Make Transcript tests pass on a "First time run" scenario

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobTranscriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobTranscriptTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             var containerName = "BlobTranscriptTests".ToLower();
             var blobClient = CloudStorageAccount.DevelopmentStorageAccount.CreateCloudBlobClient();
             var container = blobClient.GetContainerReference(containerName);
-            container.DeleteAsync();
+            container.DeleteIfExistsAsync().Wait();
         }
 
         public BlobTranscriptTests() : base()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobTranscriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobTranscriptTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             return false;
         });
 
-        public bool CheckStorageEmulator()
+        public static bool CheckStorageEmulator()
         {
             if (!hasStorageEmulator.Value)
                 System.Diagnostics.Debug.WriteLine(noEmulatorMessage);
@@ -52,10 +52,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [ClassInitialize]
         public static void Initialize(TestContext context)
         {
-            var containerName = "BlobTranscriptTests".ToLower();
-            var blobClient = CloudStorageAccount.DevelopmentStorageAccount.CreateCloudBlobClient();
-            var container = blobClient.GetContainerReference(containerName);
-            container.DeleteIfExistsAsync().Wait();
+            if (CheckStorageEmulator())
+            {
+                var containerName = "BlobTranscriptTests".ToLower();
+                var blobClient = CloudStorageAccount.DevelopmentStorageAccount.CreateCloudBlobClient();
+                var container = blobClient.GetContainerReference(containerName);
+                container.DeleteIfExistsAsync().Wait();
+            }
         }
 
         public BlobTranscriptTests() : base()


### PR DESCRIPTION
The new transcript tests would fail on initialize if the container was not there. This meant anytime they're run on a new machine, they would fail. 

Switched to a DeleteIfExists, and also made the init wait for the delete to complete. 