### PR TITLE
Fix for authenitcation issue when using bot framework web api integration

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
             var activity = await request.Content.ReadAsAsync<Activity>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken);
 
             var invokeResponse = await botFrameworkAdapter.ProcessActivity(
-                request.Headers.Authorization?.Parameter,
+                request.Headers.Authorization?.ToString(),
                 activity,
                 botCallbackHandler);
 


### PR DESCRIPTION
This PR fixes an issue where bot framework authentication was not working with the ASP.NET Web API integration libraries. When calling processActivity on the BF activity, only the parameter for the auth header was being passed through, but the authenitcation libraries in the connector expect the whole header, i.e. scheme and param. cc @drub0y 
