### PR TITLE
Fail safe tests with missing credentials

### DIFF
--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Core.Extensions.Tests;
@@ -24,7 +23,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -38,7 +37,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         [TestMethod]
         public void LuisRecognizer_MiddlewareConstruction()
         {
+            if (!EnvironmentVariablesDefined())
+            {
+                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                return;
+            }
+
             var middleware = GetLuisRecognizerMiddleware();
             Assert.IsNotNull(middleware);
             Assert.ThrowsException<ArgumentNullException>(() => new LuisRecognizerMiddleware(null));

--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerTests.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,7 +30,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -59,7 +58,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -95,7 +94,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -120,7 +119,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -146,7 +145,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -174,7 +173,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -215,7 +214,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Luis Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -146,7 +146,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -174,7 +174,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 
@@ -215,7 +215,7 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Luis Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing Luis Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Core.Extensions.Tests;
@@ -22,7 +21,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
+                Assert.Inconclusive("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Core.Extensions.Tests;
@@ -19,6 +20,12 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestMiddleware()
         {
+            if (!EnvironmentVariablesDefined())
+            {
+                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                return;
+            }
+
             TestAdapter adapter = new TestAdapter()
                 .Use(new QnAMakerMiddleware(new QnAMakerMiddlewareOptions()
                 {
@@ -42,5 +49,9 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
                 .StartTest();
         }
 
+        private bool EnvironmentVariablesDefined()
+        {
+            return knowlegeBaseId != null && subscriptionKey != null;
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -23,7 +22,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
+                Assert.Inconclusive("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 
@@ -47,7 +46,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
+                Assert.Inconclusive("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 
@@ -71,7 +70,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
+                Assert.Inconclusive("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                Debug.WriteLine("Missing QnaMaker Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -12,14 +13,20 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
     [TestClass]
     public class QnAMakerTests
     {
-        public string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
-        public string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
+        public readonly string knowlegeBaseId = TestUtilities.GetKey("QNAKNOWLEDGEBASEID");
+        public readonly string subscriptionKey = TestUtilities.GetKey("QNASUBSCRIPTIONKEY");
 
         [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_ReturnsAnswer()
         {
+            if (!EnvironmentVariablesDefined())
+            {
+                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                return;
+            }
+
             var qna = new QnAMaker(new QnAMakerOptions()
             {
                 KnowledgeBaseId = knowlegeBaseId,
@@ -38,6 +45,11 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestThreshold()
         {
+            if (!EnvironmentVariablesDefined())
+            {
+                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                return;
+            }
 
             var qna = new QnAMaker(new QnAMakerOptions()
             {
@@ -57,7 +69,12 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestMiddleware()
         {
-            
+            if (!EnvironmentVariablesDefined())
+            {
+                Debug.WriteLine("Missing QnaMaker Environemnt variables - Skipping test");
+                return;
+            }
+
             TestAdapter adapter = new TestAdapter()
                 .Use(new QnAMakerMiddleware(new QnAMakerMiddlewareOptions()
                 {
@@ -77,5 +94,9 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
                 .StartTest();
         }
 
+        private bool EnvironmentVariablesDefined()
+        {
+            return knowlegeBaseId != null && subscriptionKey != null;
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
@@ -26,7 +26,11 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("Translator")]
         public async Task TranslatorMiddleware_DetectAndTranslateToEnglish()
         {
-            
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
+
             TestAdapter adapter = new TestAdapter() 
             .Use(new TranslationMiddleware(new string[] { "en-us" }, translatorKey));
 
@@ -50,6 +54,10 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("Translator")]
         public async Task TranslatorMiddleware_TranslateFrenchToEnglish()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             TestAdapter adapter = new TestAdapter()
                 .Use(new UserState<LanguageState>(new MemoryStorage()))
@@ -75,6 +83,10 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("Translator")]
         public async Task TranslatorMiddleware_TranslateFrenchToEnglishToUserLanguage()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             TestAdapter adapter = new TestAdapter()
                 .Use(new UserState<LanguageState>(new MemoryStorage()))

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Ai.Translation;
-using System.Diagnostics;
 
 namespace Microsoft.Bot.Builder.Ai.QnA.Tests
 {
@@ -29,7 +28,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -58,7 +57,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -88,7 +87,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Ai.Translation;
+using System.Diagnostics;
 
 namespace Microsoft.Bot.Builder.Ai.QnA.Tests
 {
@@ -26,8 +27,9 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("Translator")]
         public async Task TranslatorMiddleware_DetectAndTranslateToEnglish()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -54,8 +56,9 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("Translator")]
         public async Task TranslatorMiddleware_TranslateFrenchToEnglish()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -83,8 +86,9 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("Translator")]
         public async Task TranslatorMiddleware_TranslateFrenchToEnglishToUserLanguage()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -145,6 +149,11 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
             }
 
             return "en";
-        }   
+        }
+
+        private bool EnvironmentVariablesDefined()
+        {
+            return translatorKey != null;
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorTests.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_DetectAndTranslateToEnglish()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
+
             Translator translator = new Translator(translatorKey);
 
             var sentence = "salut";
@@ -36,6 +41,11 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_LiteralTagTest()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
+
             Translator translator = new Translator(translatorKey);
 
             var sentence = "salut <literal>Jean Bouchier mon ami</literal>";
@@ -50,6 +60,11 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_PatternsTest()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
+
             Translator translator = new Translator(translatorKey);
             translator.SetPostProcessorTemplate(new List<string> { "perr[oa]" });
             var sentence = "mi perro se llama Enzo";
@@ -70,6 +85,10 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateFrenchToEnglish()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             Translator translator = new Translator(translatorKey);
 
@@ -84,6 +103,10 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateFrenchToEnglishArray()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             Translator translator = new Translator(translatorKey);
 
@@ -100,6 +123,10 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateEnglishToFrench()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             Translator translator = new Translator(translatorKey);
 
@@ -114,6 +141,10 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateEnglishToFrenchArray()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             Translator translator = new Translator(translatorKey);
 
@@ -130,6 +161,10 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_InvalidSourceLanguage()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             Translator translator = new Translator(translatorKey);
 
@@ -143,6 +178,10 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_InvalidTargetLanguage()
         {
+            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            {
+                return;
+            }
 
             Translator translator = new Translator(translatorKey);
 

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Bot.Builder.Core.Extensions.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Ai.Translation.Tests
@@ -19,8 +20,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_DetectAndTranslateToEnglish()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -41,8 +43,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_LiteralTagTest()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -60,8 +63,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_PatternsTest()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -85,8 +89,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateFrenchToEnglish()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -103,8 +108,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateFrenchToEnglishArray()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -123,8 +129,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateEnglishToFrench()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -141,8 +148,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_TranslateEnglishToFrenchArray()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -161,8 +169,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_InvalidSourceLanguage()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -178,8 +187,9 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         [TestCategory("Translator")]
         public async Task Translator_InvalidTargetLanguage()
         {
-            if (!TestUtilities.CheckKeys(new string[] { "TRANSLATORKEY" }))
+            if (!EnvironmentVariablesDefined())
             {
+                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -188,6 +198,11 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
             var sentence = "Arrange an appointment for tomorrow";
             await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
                 await translator.Translate(sentence, "en", "na"));
+        }
+
+        private bool EnvironmentVariablesDefined()
+        {
+            return translatorKey != null;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorTests.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Builder.Core.Extensions.Tests; 
+using Microsoft.Bot.Builder.Core.Extensions.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Ai.Translation.Tests
@@ -22,7 +21,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -45,7 +44,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -65,7 +64,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -91,7 +90,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -110,7 +109,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -131,7 +130,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -150,7 +149,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -171,7 +170,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 
@@ -189,7 +188,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
         {
             if (!EnvironmentVariablesDefined())
             {
-                Debug.WriteLine("Missing Translator Environment variables - Skipping test");
+                Assert.Inconclusive("Missing Translator Environment variables - Skipping test");
                 return;
             }
 

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/TestUtilities.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             var invalidKeys = keys.Where(key => GetKey(key) == null);
             if (invalidKeys.Any())
             {
-                System.Diagnostics.Debug.WriteLine($"Missing Environemnt variables - Skipping test ({string.Join(", ", invalidKeys)})");
+                System.Diagnostics.Debug.WriteLine($"Missing Environment variables - Skipping test ({string.Join(", ", invalidKeys)})");
                 return false;
             }
 

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/TestUtilities.cs
@@ -63,6 +63,18 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                     value = null;
             }
             return value;
-        }   
+        }
+
+        public static bool CheckKeys(string[] keys)
+        {
+            var invalidKeys = keys.Where(key => GetKey(key) == null);
+            if (invalidKeys.Any())
+            {
+                System.Diagnostics.Debug.WriteLine($"Missing Environemnt variables - Skipping test ({string.Join(", ", invalidKeys)})");
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/TestUtilities.cs
@@ -64,17 +64,5 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             }
             return value;
         }
-
-        public static bool CheckKeys(string[] keys)
-        {
-            var invalidKeys = keys.Where(key => GetKey(key) == null);
-            if (invalidKeys.Any())
-            {
-                System.Diagnostics.Debug.WriteLine($"Missing Environment variables - Skipping test ({string.Join(", ", invalidKeys)})");
-                return false;
-            }
-
-            return true;
-        }
     }
 }


### PR DESCRIPTION
We use the same approach found in the [Luis Recognizer Middleware tests](https://github.com/Microsoft/botbuilder-dotnet/blob/master/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs#L33) for all the tests that need specifics keys (environment variables):
1.  Validate the required environment variables with an EnvironmentVariablesDefined() method.
2. If any variable is not defined, terminate the test as a valid test.

This pull-request fixes #429 