### PR TITLE
Update Autofac to version 4.7.1

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic.csproj
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic.csproj
@@ -43,9 +43,8 @@
     <DocumentationFile>bin\Documentation\Microsoft.Bot.Builder.Classic.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
-      <HintPath>..\..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Autofac, Version=4.7.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Autofac.4.7.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Chronic">
       <HintPath>..\..\..\packages\Chronic.Signed.0.3.2\lib\net40\Chronic.dll</HintPath>

--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/packages.config
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net461" />
+  <package id="Autofac" version="4.7.1" targetFramework="net461" />
   <package id="Chronic.Signed" version="0.3.2" targetFramework="net461" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.10" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />

--- a/tests/FormTest/FormTest.csproj
+++ b/tests/FormTest/FormTest.csproj
@@ -54,8 +54,8 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.6.2.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.4.6.2\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.7.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.4.7.1\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Rest.ClientRuntime.2.3.2\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>

--- a/tests/FormTest/packages.config
+++ b/tests/FormTest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.6.2" targetFramework="net461" />
+  <package id="Autofac" version="4.7.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
   <package id="Microsoft.Net.Compilers" version="1.2.1" targetFramework="net46" developmentDependency="true" />

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/ChainTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/ChainTests.cs
@@ -373,15 +373,11 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 .Catch<string, OperationCanceledException>((antecedent, error) => Chain.Return("world"))
                 .PostToUser();
 
-            using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var container = Build(Options.ResolveDialogFromContainer, test))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(test).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(test)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "hello",
                     "world"
                     );
@@ -403,14 +399,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 .PostToUser();
 
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(quiz).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(quiz)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "hello",
                     "how many questions?",
                     "3",
@@ -448,14 +440,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 .PostToUser();
 
             using (var container = Build(Options.ResolveDialogFromContainer | Options.Reflection))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(root).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(root)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "hello",
                     "question 0",
                     "A",
@@ -494,14 +482,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 .PostToUser();
 
             using (var container = Build(Options.ResolveDialogFromContainer | Options.Reflection))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(rootDialog).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(rootDialog)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "hello",
                     "hello back!",
                     "what is the subject?",
@@ -552,14 +536,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 Loop();
 
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(joke).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(joke)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "chicken",
                     "why did the chicken cross the road?",
                     "i don't know",
@@ -602,14 +582,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 }).PostToUser();
 
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(waterfall).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(waterfall)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "test",
                     "you said test",
                     "Which one you want to select?",

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/DialogModuleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/DialogModuleTests.cs
@@ -18,13 +18,9 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             var echo = Chain.PostToChain().Select(m => m.Text).PostToUser();
 
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var containerScope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(echo).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(echo)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
                 Func<ILifetimeScope, Task> Test = async (s) =>
                 {
                     await AssertScriptAsync(s,
@@ -34,26 +30,26 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                         "world");
                 };
 
-                using (var scope = container.BeginLifetimeScope())
+                using (var scope = containerScope.BeginLifetimeScope())
                 {
                     await Test(scope);
                     await Test(scope);
                 }
 
-                using (var scope = container.BeginLifetimeScope(b => { }))
+                using (var scope = containerScope.BeginLifetimeScope(b => { }))
                 {
                     await Test(scope);
                     await Test(scope);
                 }
 
-                using (var scope = container.BeginLifetimeScope())
+                using (var scope = containerScope.BeginLifetimeScope())
                 using (var inner = scope.BeginLifetimeScope(b => { }))
                 {
                     await Test(inner);
                     await Test(inner);
                 }
 
-                using (var scope = container.BeginLifetimeScope(b => { }))
+                using (var scope = containerScope.BeginLifetimeScope(b => { }))
                 using (var inner = scope.BeginLifetimeScope())
                 {
                     await Test(inner);

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/EndConversationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/EndConversationTests.cs
@@ -91,18 +91,12 @@ namespace Microsoft.Bot.Builder.Classic.Tests
         [TestMethod]
         public async Task EndConversation_Resets_Data()
         {
+            var dialog = new TestResetDialog();
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(dialog).As<IDialog<object>>()))
             {
-                var dialog =
-                    new TestResetDialog();
-
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(dialog)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container,
+                await AssertScriptAsync(scope,
                     "hello",
                     "echo hello 1 2 3",
                     "world",

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/ExceptionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/ExceptionTests.cs
@@ -31,17 +31,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using Autofac;
-using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Classic.Dialogs;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Classic.Tests
 {
@@ -62,12 +58,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
         public async Task Exception_DialogStack_NoResumeHandler()
         {
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterType<NoResumeHandlerDialog>().AsImplementedInterfaces()))
             {
-                var builder = new ContainerBuilder();
-                builder.RegisterType<NoResumeHandlerDialog>().AsImplementedInterfaces();
-                builder.Update(container);
-
-                await AssertScriptAsync(container, "hello");
+                await AssertScriptAsync(scope, "hello");
             }
         }
 
@@ -91,12 +85,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
         public async Task Exception_DialogStack_ResumeHandlerTwice()
         {
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterType<ResumeHandlerTwiceDialog>().AsImplementedInterfaces()))
             {
-                var builder = new ContainerBuilder();
-                builder.RegisterType<ResumeHandlerTwiceDialog>().AsImplementedInterfaces();
-                builder.Update(container);
-
-                await AssertScriptAsync(container, "hello");
+                await AssertScriptAsync(scope, "hello");
             }
         }
 
@@ -117,14 +109,12 @@ namespace Microsoft.Bot.Builder.Classic.Tests
         public async Task Exception_NonSerializableDialog()
         {
             using (var container = Build(Options.ResolveDialogFromContainer))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterType<NonSerializableDialog>().AsImplementedInterfaces()))
             {
-                var builder = new ContainerBuilder();
-                builder.RegisterType<NonSerializableDialog>().AsImplementedInterfaces();
-                builder.Update(container);
-
                 try
                 {
-                    await AssertScriptAsync(container, "hello");
+                    await AssertScriptAsync(scope, "hello");
                     Assert.Fail();
                 }
                 catch (SerializationException)

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/LuisTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/LuisTests.cs
@@ -279,25 +279,21 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
             using (new FiberTestBase.ResolveMoqAssembly(service1.Object, service2.Object))
             using (var container = Build(Options.ResolveDialogFromContainer, service1.Object, service2.Object))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(dialog).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(dialog)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
                 const string EntityOne = "one";
                 const string EntityTwo = "two";
 
                 SetupLuis<MultiServiceLuisDialog>(service1, d => d.ServiceOne(null, null), 1.0, new EntityRecommendation(type: EntityOne));
                 SetupLuis<MultiServiceLuisDialog>(service2, d => d.ServiceTwo(null, null), 0.0, new EntityRecommendation(type: EntityTwo));
 
-                await AssertScriptAsync(container, "hello", EntityOne);
+                await AssertScriptAsync(scope, "hello", EntityOne);
 
                 SetupLuis<MultiServiceLuisDialog>(service1, d => d.ServiceOne(null, null), 0.0, new EntityRecommendation(type: EntityOne));
                 SetupLuis<MultiServiceLuisDialog>(service2, d => d.ServiceTwo(null, null), 1.0, new EntityRecommendation(type: EntityTwo));
 
-                await AssertScriptAsync(container, "hello", EntityTwo);
+                await AssertScriptAsync(scope, "hello", EntityTwo);
             }
         }
 
@@ -326,14 +322,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
             using (new FiberTestBase.ResolveMoqAssembly(service.Object))
             using (var container = Build(Options.ResolveDialogFromContainer, service.Object))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(dialog).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(dialog)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container, null, "I see null");
+                await AssertScriptAsync(scope, null, "I see null");
             }
         }
 
@@ -444,14 +436,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             var dialog = new MultiServiceLuisDialog(service.Object);
             using (new FiberTestBase.ResolveMoqAssembly(service.Object))
             using (var container = Build(Options.ResolveDialogFromContainer, service.Object))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(dialog).As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(dialog)
-                    .As<IDialog<object>>();
-                builder.Update(container);
-
-                await AssertScriptAsync(container, "start", prompt, "EntityOne", action);
+                await AssertScriptAsync(scope, "start", prompt, "EntityOne", action);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/Microsoft.Bot.Builder.Classic.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/Microsoft.Bot.Builder.Classic.Tests.csproj
@@ -19,7 +19,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Autofac" Version="3.5.2" />
+		<PackageReference Include="Autofac" Version="4.7.1" />
 		<PackageReference Include="Chronic.Signed" Version="0.3.2" />
 		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" targetFramework="net46" />
 		<PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3" targetFramework="net46" />

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/Script.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/Script.cs
@@ -206,14 +206,10 @@ namespace Microsoft.Bot.Builder.Classic.Tests
         {
             using (var stream = new StreamWriter(filePath))
             using (var container = Build(Options.ResolveDialogFromContainer | Options.Reflection))
+            using (var scope = container.BeginLifetimeScope(
+                builder => builder.RegisterInstance(dialog).AsSelf().As<IDialog<object>>()))
             {
-                var builder = new ContainerBuilder();
-                builder
-                    .RegisterInstance(dialog)
-                    .AsSelf()
-                    .As<IDialog<object>>();
-                builder.Update(container);
-                await RecordScript(container, proactive, stream, null, inputs);
+                await RecordScript(scope, proactive, stream, null, inputs);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/Script.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/Script.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             var adapter = new TestAdapter();
             await adapter.ProcessActivity((Activity)toBot, async (ctx) =>
             {
-                using (var scope = DialogModule.BeginLifetimeScope(container, ctx))
+                using (var containerScope = DialogModule.BeginLifetimeScope(container, ctx))
                 {
-                    var task = scope.Resolve<IPostToBot>();
+                    var task = containerScope.Resolve<IPostToBot>();
                     var queue = adapter.ActiveQueue;
 
                     Action drain = () =>
@@ -49,14 +49,14 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                         }
                     };
                     string result = null;
-                    var root = scope.Resolve<IDialog<object>>().Do(async (context, value) =>
+                    var root = containerScope.Resolve<IDialog<object>>().Do(async (context, value) =>
                         result = JsonConvert.SerializeObject(await value));
                     if (proactive)
                     {
                         var loop = root.Loop();
-                        var data = scope.Resolve<IBotData>();
+                        var data = containerScope.Resolve<IBotData>();
                         await data.LoadAsync(CancellationToken.None);
-                        var stack = scope.Resolve<IDialogTask>();
+                        var stack = containerScope.Resolve<IDialogTask>();
                         stack.Call(loop, null);
                         await stack.PollAsync(CancellationToken.None);
                         drain();


### PR DESCRIPTION
This PR updates and consolidates the Autofac NuGet to version [4.7.1](https://www.nuget.org/packages/Autofac/)
Since version [4.2.1](https://github.com/autofac/Autofac/releases/tag/v4.2.1) [ContainerBuilder.Update Marked Obsolete](https://github.com/autofac/Autofac/issues/811)
The `ContainerBuilder.Update` method was used in the BotBuilder project in tests projects to replace dependencies with mock/stub version of services. All this references to `ContainerBuilder.Update` method resulted in build warnings.
In this PR, we replace those references with the a new ILifetimeScope and registered the new dependencies.