### PR TITLE
Console Adapter Echo Bot with State Counter

### DIFF
--- a/AspNetCore-EchoBot-With-State/AspNetCore-EchoBot-With-State.csproj
+++ b/AspNetCore-EchoBot-With-State/AspNetCore-EchoBot-With-State.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Bot.Builder.Core" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Core.Extensions" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.0-alpha-m3.1" />
+  </ItemGroup>
+
+</Project>

--- a/AspNetCore-EchoBot-With-State/EchoBot.cs
+++ b/AspNetCore-EchoBot-With-State/EchoBot.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Bot;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Core.Extensions;
+using Microsoft.Bot.Schema;
+
+namespace AspNetCore_EchoBot_With_State
+{
+    public class EchoBot : IBot
+    {
+        /// <summary>
+        /// Every Conversation turn for our EchoBot will call this method. In here
+        /// the bot checks the Activty type to verify it's a message, bumps the 
+        /// turn conversation 'Turn' count, and then echoes the users typing
+        /// back to them. 
+        /// </summary>
+        /// <param name="context">Turn scoped context containing all the data needed
+        /// for processing this conversation turn. </param>        
+        public async Task OnTurn(ITurnContext context)
+        {
+            // This bot is only handling Messages
+            if (context.Activity.Type == ActivityTypes.Message)
+            {
+                // Get the conversation state from the turn context
+                var state = context.GetConversationState<EchoState>();
+
+                // Bump the turn count. 
+                state.TurnCount++;
+
+                // Echo back to the user whatever they typed.
+                await context.SendActivity($"Turn {state.TurnCount}: You sent '{context.Activity.Text}'");
+            }
+        }
+    }    
+}

--- a/AspNetCore-EchoBot-With-State/EchoState.cs
+++ b/AspNetCore-EchoBot-With-State/EchoState.cs
@@ -1,0 +1,10 @@
+﻿namespace AspNetCore_EchoBot_With_State
+{
+    /// <summary>
+    /// Class for storing conversation state. 
+    /// </summary>
+    public class EchoState
+    {
+        public int TurnCount { get; set; } = 0;
+    }
+}

--- a/AspNetCore-EchoBot-With-State/Program.cs
+++ b/AspNetCore-EchoBot-With-State/Program.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace AspNetCore_EchoBot_With_State
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/AspNetCore-EchoBot-With-State/Startup.cs
+++ b/AspNetCore-EchoBot-With-State/Startup.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Core.Extensions;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCore_EchoBot_With_State
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddBot<EchoBot>(options =>
+            {
+                options.CredentialProvider = new ConfigurationCredentialProvider(Configuration);                
+                options.Middleware.Add(new CatchExceptionMiddleware<Exception>(async (context, exception) =>
+                {
+                    await context.TraceActivity("EchoBot Exception", exception);
+                    await context.SendActivity("Sorry, it looks like something went wrong!");
+                }));
+                options.Middleware.Add(new ConversationState<EchoState>(new MemoryStorage()));
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseDefaultFiles()
+                .UseStaticFiles()
+                .UseBotFramework();
+        }
+    }
+}

--- a/AspNetCore-EchoBot-With-State/Startup.cs
+++ b/AspNetCore-EchoBot-With-State/Startup.cs
@@ -32,7 +32,13 @@ namespace AspNetCore_EchoBot_With_State
         {
             services.AddBot<EchoBot>(options =>
             {
-                options.CredentialProvider = new ConfigurationCredentialProvider(Configuration);                
+                options.CredentialProvider = new ConfigurationCredentialProvider(Configuration);
+
+                // The CatchExceptionMiddleware provides a top-level exception handler for your bot. 
+                // Any exceptions thrown by other Middleware, or by your OnTurn method, will be 
+                // caught here. To facillitate debugging, the exception is sent out, via Trace, 
+                // to the emulator. Trace activities are NOT displayed to users, so in addition
+                // an "Ooops" message is sent. 
                 options.Middleware.Add(new CatchExceptionMiddleware<Exception>(async (context, exception) =>
                 {
                     await context.TraceActivity("EchoBot Exception", exception);
@@ -41,7 +47,6 @@ namespace AspNetCore_EchoBot_With_State
 
                 // The Memory Storage used here is for local bot debugging only. When the bot
                 // is restarted, anything stored in memory will be gone. 
-
                 IStorage dataStore = new MemoryStorage();
 
                 // The File data store, shown here, is suitable for bots that run on 

--- a/AspNetCore-EchoBot-With-State/Startup.cs
+++ b/AspNetCore-EchoBot-With-State/Startup.cs
@@ -38,7 +38,26 @@ namespace AspNetCore_EchoBot_With_State
                     await context.TraceActivity("EchoBot Exception", exception);
                     await context.SendActivity("Sorry, it looks like something went wrong!");
                 }));
-                options.Middleware.Add(new ConversationState<EchoState>(new MemoryStorage()));
+
+                // The Memory Storage used here is for local bot debugging only. When the bot
+                // is restarted, anything stored in memory will be gone. 
+
+                IStorage dataStore = new MemoryStorage();
+
+                // The File data store, shown here, is suitable for bots that run on 
+                // a single machine and need durable state across application restarts.                 
+                // IStorage dataStore = new FileStorage(System.IO.Path.GetTempPath());
+
+                // For production bots use the Azure Table Store, Azure Blob, or 
+                // Azure CosmosDB storage provides, as seen below. To include any of 
+                // the Azure based storage providers, add the Microsoft.Bot.Builder.Azure 
+                // Nuget package to your solution. That package is found at:
+                //      https://www.nuget.org/packages/Microsoft.Bot.Builder.Azure/
+
+                // IStorage dataStore = new Microsoft.Bot.Builder.Azure.AzureTableStorage("AzureTablesConnectionString", "TableName");
+                // IStorage dataStore = new Microsoft.Bot.Builder.Azure.AzureBlobStorage("AzureBlobConnectionString", "containerName");
+
+                options.Middleware.Add(new ConversationState<EchoState>(dataStore));
             });
         }
 

--- a/AspNetCore-EchoBot-With-State/appsettings.json
+++ b/AspNetCore-EchoBot-With-State/appsettings.json
@@ -1,0 +1,4 @@
+﻿{  
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": ""
+}

--- a/AspNetCore-EchoBot-With-State/readme.md
+++ b/AspNetCore-EchoBot-With-State/readme.md
@@ -1,0 +1,2 @@
+﻿# EchoBot hosted in ASP.NET Core
+This sample shows how to integrate a simple EchoBot bot with ASP.Net Core 2. 

--- a/AspNetCore-EchoBot-With-State/wwwroot/default.htm
+++ b/AspNetCore-EchoBot-With-State/wwwroot/default.htm
@@ -3,10 +3,19 @@
 <head>
     <title></title>
     <meta charset="utf-8" />
+    
 </head>
 <body style="font-family:'Segoe UI'">
     <h1>EchoBot sample using ASP.Net Core 2</h1>
     <p>Describe your bot here and your terms of use etc.</p>
-    <p>Visit <a href="https://www.botframework.com/">Bot Framework</a> to register your bot. When you register it, remember to set your bot's endpoint to <pre>https://<i>your_bots_hostname</i>/api/messages</pre></p>
+    <p>To debug you bot using the Bot Framework Emulator, paste this URL into the Emulator window: <span id="botBaseUrl"></span></p>
+    <p>Visit <a href="https://www.botframework.com/">Bot Framework</a> to register your bot. When you register, remember to set the endpoint to https://{your domain name}/api/messages</p>
+    <script>        
+        var urlSpan = document.getElementById("botBaseUrl");
+        var aTag = document.createElement('a');
+        aTag.setAttribute('href', location.protocol + "//" + location.host + "/api/messages");
+        aTag.innerHTML = location.protocol + "//" + location.host + "/api/messages";
+        urlSpan.appendChild(aTag);
+    </script>
 </body>
 </html>

--- a/AspNetCore-EchoBot-With-State/wwwroot/default.htm
+++ b/AspNetCore-EchoBot-With-State/wwwroot/default.htm
@@ -1,0 +1,12 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <meta charset="utf-8" />
+</head>
+<body style="font-family:'Segoe UI'">
+    <h1>EchoBot sample using ASP.Net Core 2</h1>
+    <p>Describe your bot here and your terms of use etc.</p>
+    <p>Visit <a href="https://www.botframework.com/">Bot Framework</a> to register your bot. When you register it, remember to set your bot's endpoint to <pre>https://<i>your_bots_hostname</i>/api/messages</pre></p>
+</body>
+</html>

--- a/AspNetCore-EchoBot-With-State/wwwroot/default.htm
+++ b/AspNetCore-EchoBot-With-State/wwwroot/default.htm
@@ -3,19 +3,23 @@
 <head>
     <title></title>
     <meta charset="utf-8" />
-    
+
 </head>
 <body style="font-family:'Segoe UI'">
     <h1>EchoBot sample using ASP.Net Core 2</h1>
     <p>Describe your bot here and your terms of use etc.</p>
-    <p>To debug you bot using the Bot Framework Emulator, paste this URL into the Emulator window: <span id="botBaseUrl"></span></p>
-    <p>Visit <a href="https://www.botframework.com/">Bot Framework</a> to register your bot. When you register, remember to set the endpoint to https://{your domain name}/api/messages</p>
-    <script>        
-        var urlSpan = document.getElementById("botBaseUrl");
+    <p>To debug you bot using the Bot Framework Emulator, paste this URL into the Emulator window:</p>
+    <div style="padding-left: 50px;" id="botBaseUrl"></div>
+    <p>Visit <a href="https://www.botframework.com/">Bot Framework</a> to register your bot. When you register, remember to set the endpoint to:</p>
+    <div style="padding-left: 50px;">
+        https://<strong>{your domain name}</strong>/api/messages
+    </div>
+    <script>
+        var urlDiv = document.getElementById("botBaseUrl");
         var aTag = document.createElement('a');
         aTag.setAttribute('href', location.protocol + "//" + location.host + "/api/messages");
         aTag.innerHTML = location.protocol + "//" + location.host + "/api/messages";
-        urlSpan.appendChild(aTag);
+        urlDiv.appendChild(aTag);
     </script>
 </body>
 </html>

--- a/Microsoft.Bot.Builder.Samples.sln
+++ b/Microsoft.Bot.Builder.Samples.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console-EchoBot-With-State", "samples-final\Console-EchoBot-With-State\Console-EchoBot-With-State.csproj", "{0549C776-A599-49B7-AF01-D0B9F46A2BCD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {68EA4F74-8BF2-4600-9588-AC42C2FED632}
+	EndGlobalSection
+EndGlobal

--- a/Microsoft.Bot.Builder.Samples.sln
+++ b/Microsoft.Bot.Builder.Samples.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console-EchoBot-With-State", "samples-final\Console-EchoBot-With-State\Console-EchoBot-With-State.csproj", "{0549C776-A599-49B7-AF01-D0B9F46A2BCD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore-EchoBot-With-State", "AspNetCore-EchoBot-With-State\AspNetCore-EchoBot-With-State.csproj", "{CD26C375-7253-4F42-8BE3-33C1176D3DEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0549C776-A599-49B7-AF01-D0B9F46A2BCD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD26C375-7253-4F42-8BE3-33C1176D3DEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD26C375-7253-4F42-8BE3-33C1176D3DEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD26C375-7253-4F42-8BE3-33C1176D3DEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD26C375-7253-4F42-8BE3-33C1176D3DEC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples-final/Console-EchoBot-With-State/Console-EchoBot-With-State.csproj
+++ b/samples-final/Console-EchoBot-With-State/Console-EchoBot-With-State.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bot.Builder.Core" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Core.Extensions" Version="4.0.0-alpha-m3.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples-final/Console-EchoBot-With-State/Program.cs
+++ b/samples-final/Console-EchoBot-With-State/Program.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Bot;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Core.Extensions;
+using Microsoft.Bot.Schema;
+
+namespace Console_EchoBot_With_State
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Welcome to the EchoBot. Type something to get started.");
+
+            // Create the Console Adapter, and add Conversation State 
+            // to the Bot. The Conversation State will be stored in memory. 
+            var adapter = new ConsoleAdapter()
+                .Use(new ConversationState<EchoState>(new MemoryStorage()));
+
+            // Create the instance of our Bot.
+            var echoBot = new EchoBot();
+
+            // Connect the Console Adapter to the Bot. 
+            adapter.ProcessActivity(
+                async (context) => await echoBot.OnTurn(context)).Wait();
+        }
+    }
+
+    public class EchoBot : IBot
+    {
+        /// <summary>
+        /// Every Conversation turn for our EchoBot will call this method. In here
+        /// the bot checks the Activty type to verify it's a message, bumps the 
+        /// turn conversation 'Turn' count, and then echoes the users typing
+        /// back to them. 
+        /// </summary>
+        /// <param name="context">Turn scoped context containing all the data needed
+        /// for processing this conversation turn. </param>        
+        public async Task OnTurn(ITurnContext context)
+        {
+            // This bot is only handling Messages
+            if (context.Activity.Type == ActivityTypes.Message)
+            {
+                // Get the conversation state from the turn context
+                var state = context.GetConversationState<EchoState>();
+
+                // Bump the turn count. 
+                state.TurnCount++;
+
+                // Echo back to the user whatever they typed.
+                await context.SendActivity($"Turn {state.TurnCount}: You sent '{context.Activity.Text}'");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Class for storing conversation state. 
+    /// </summary>
+    public class EchoState
+    {
+        public int TurnCount { get; set; } = 0;
+    }
+}


### PR DESCRIPTION
C# implementation of the Console Adapter Echo Bot with State Counter. 

Note: 
All code in a single file (Main + Bot + State) to make it easier to read / share / and so on. If we want to change this, we should decide on the standard(s) we want to use moving forward. 

For the console based bots, this seems a reasonable choice. For the ASP.Net Core (and WebAPI samples) following the standard patterns of those platforms will be the right choice. 