### PR TITLE
Fail safe tests - Add missing Environment Variables check

### DIFF
--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
@@ -67,6 +67,11 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestMiddleware_OneResult()
         {
+            if (!EnvironmentVariablesDefined())
+            {
+                Assert.Inconclusive("Missing QnaMaker Environment variables - Skipping test");
+                return;
+            }
             const string goodUtterance = @"how do I clean the stove?";
             const string botResponse = @"BaseCamp: You can use a damp rag to clean around the Power Pack. Do not attempt to detach it from the stove body. As with any electronic device, never pour water on it directly. CampStove 2 &amp; CookStove: Power module: Remove the plastic power module from the fuel chamber and wipe it down with a damp cloth with soap and water. DO NOT submerge the power module in water or get it excessively wet. Fuel chamber: Wipe out with a nylon brush as needed. The pot stand at the top of the fuel chamber can be wiped off with a damp cloth and dried well. The fuel chamber can also be washed in a dishwasher. Dry very thoroughly.";
             TestAdapter adapter = new TestAdapter()


### PR DESCRIPTION
We added missing environment variable check to QnaMaker_TestMiddleware_OneResult test.
