### PR TITLE
Fix NullReferenceException when calling BotFrameworkAdapter::ContinueConversation

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -166,8 +166,10 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="RunPipeline(ITurnContext, Func{ITurnContext, Task}, CancellationTokenSource)"/>
         public virtual Task ContinueConversation(ConversationReference reference, Func<ITurnContext, Task> callback)
         {
-            var context = new TurnContext(this, reference.GetPostToBotMessage());
-            return RunPipeline(context, callback);
+            using (var context = new TurnContext(this, reference.GetPostToBotMessage()))
+            {
+                return RunPipeline(context, callback);
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes #314 which is an issue that is constantly biting people who are attempting to do proactive conversations using the base overload of `BotAdapter::ContinueConversation(ConversationReference, Func<ITurnContext, Task>)`.

More details on the fix is available in the individual commit messages.