### PR TITLE
Removed incorrect overload.

### DIFF
--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{4269F3C3-6B42-419B-B64A-3E6DC0F1574A}"
 EndProject
@@ -406,7 +406,6 @@ Global
 		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Documentation|Any CPU.ActiveCfg = Debug|Any CPU
-		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Documentation|Any CPU.Build.0 = Debug|Any CPU 
 		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/BotAdapter.cs
@@ -157,6 +157,9 @@ namespace Microsoft.Bot.Builder
         /// <summary>
         /// Sends a proactive message to a conversation.
         /// </summary>
+        /// <param name="botAppId">The application ID of the bot. This paramter is ignored in 
+        /// single tenant the Adpters (Console, Test, etc) but is critical to the BotFrameworkAdapter
+        /// which is multi-tenant aware. </param>    
         /// <param name="reference">A reference to the conversation to continue.</param>
         /// <param name="callback">The method to call for the resulting bot turn.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
@@ -164,7 +167,7 @@ namespace Microsoft.Bot.Builder
         /// Most channels require a user to initaiate a conversation with a bot
         /// before the bot can send activities to the user.</remarks>
         /// <seealso cref="RunPipeline(ITurnContext, Func{ITurnContext, Task}, CancellationTokenSource)"/>
-        public virtual Task ContinueConversation(ConversationReference reference, Func<ITurnContext, Task> callback)
+        public virtual Task ContinueConversation(string botId, ConversationReference reference, Func<ITurnContext, Task> callback)
         {
             using (var context = new TurnContext(this, reference.GetPostToBotMessage()))
             {

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <summary>
         /// Sends a proactive message from the bot to a conversation.
         /// </summary>
-        /// <param name="botAppId">The application ID of the bot.</param>
+        /// <param name="botAppId">The application ID of the bot. This is the appId returned by Portal registration, and is
+        /// generally found in the "MicrosoftAppId" parameter in appSettings.json.</param>
         /// <param name="reference">A reference to the conversation to continue.</param>
         /// <param name="callback">The method to call for the resulting bot turn.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
@@ -85,10 +86,15 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <item><see cref="IIdentity"/> (key = "BotIdentity"), a claims identity for the bot.</item>
         /// <item><see cref="IConnectorClient"/>, the channel connector client to use this turn.</item>
         /// </list></para>
+        /// <para>
+        /// This overload differers from the Node implementation by requiring the BotId to be 
+        /// passed in. The .Net code allows multiple bots to be hosted in a single adapter which
+        /// isn't something supported by Node.
+        /// </para>
         /// </remarks>
         /// <seealso cref="ProcessActivity(string, Activity, Func{ITurnContext, Task})"/>
         /// <seealso cref="BotAdapter.RunPipeline(ITurnContext, Func{ITurnContext, Task}, System.Threading.CancellationTokenSource)"/>
-        public async Task ContinueConversation(string botAppId, ConversationReference reference, Func<ITurnContext, Task> callback)
+        public override async Task ContinueConversation(string botAppId, ConversationReference reference, Func<ITurnContext, Task> callback)
         {
             if (string.IsNullOrWhiteSpace(botAppId))
                 throw new ArgumentNullException(nameof(botAppId));
@@ -115,10 +121,6 @@ namespace Microsoft.Bot.Builder.Adapters
                 await RunPipeline(context, callback);
             }
         }
-
-        /// <inheritdoc />
-        public override Task ContinueConversation(ConversationReference reference, Func<ITurnContext, Task> callback) =>
-            ContinueConversation(reference.Bot.Id, reference, callback);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BotFrameworkAdapter"/> class,


### PR DESCRIPTION
#466 

The overload that was there is (was) using the incorrect bot id. That overload is now removed, forcing the developer to explicitly pass in the BotId. 

This is different than the Node SDK, as the BotFrameworkAdapter in .Net allows multiple Bots to be serviced by a single Adapter. This has been confirmed with @Stevenic 