### PR TITLE
Add new methods (GDPR Required++) to BF Adapter

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -314,6 +314,127 @@ namespace Microsoft.Bot.Builder.Adapters
         }
 
         /// <summary>
+        /// Deletes a member from the current conversation
+        /// </summary>
+        /// <param name="context">The context object for the turn.</param>
+        /// <param name="memberId">ID of the member to delete from the conversation</param>
+        /// <returns></returns>
+        public async Task DeleteConversationMember(ITurnContext context, string memberId)
+        {
+            if (context.Activity.Conversation == null)
+                throw new ArgumentNullException("BotFrameworkAdapter.deleteConversationMember(): missing conversation");
+
+            if (string.IsNullOrWhiteSpace(context.Activity.Conversation.Id))
+                throw new ArgumentNullException("BotFrameworkAdapter.deleteConversationMember(): missing conversation.id");
+
+            var connectorClient = context.Services.Get<IConnectorClient>();
+
+            string conversationId = context.Activity.Conversation.Id;
+
+            await connectorClient.Conversations.DeleteConversationMemberAsync(conversationId, memberId);
+        }
+
+        /// <summary>
+        /// Lists the members of a given activity.
+        /// </summary>
+        /// <param name="context">The context object for the turn.</param>
+        /// <param name="activityId">(Optional) Activity ID to enumerate. If not specified the current activities ID will be used.</param>
+        /// <returns>List of Members of the activity</returns>
+        public async Task<IList<ChannelAccount>> GetActivityMembers(ITurnContext context, string activityId = null)
+        {
+            // If no activity was passed in, use the current activity. 
+            if (activityId == null)
+                activityId = context.Activity.Id;
+
+            if (context.Activity.Conversation == null)
+                throw new ArgumentNullException("BotFrameworkAdapter.GetActivityMembers(): missing conversation");
+
+            if (string.IsNullOrWhiteSpace(context.Activity.Conversation.Id))
+                throw new ArgumentNullException("BotFrameworkAdapter.GetActivityMembers(): missing conversation.id");
+
+            var connectorClient = context.Services.Get<IConnectorClient>();
+            string conversationId = context.Activity.Conversation.Id;
+
+            IList<ChannelAccount> accounts = await connectorClient.Conversations.GetActivityMembersAsync(conversationId, activityId);
+
+            return accounts;
+        }
+
+        /// <summary>
+        /// Lists the members of the current conversation.
+        /// </summary>
+        /// <param name="context">The context object for the turn.</param>        
+        /// <returns>List of Members of the current conversation</returns>
+        public async Task<IList<ChannelAccount>> GetConversationMembers(ITurnContext context)
+        {
+            if (context.Activity.Conversation == null)
+                throw new ArgumentNullException("BotFrameworkAdapter.GetActivityMembers(): missing conversation");
+
+            if (string.IsNullOrWhiteSpace(context.Activity.Conversation.Id))
+                throw new ArgumentNullException("BotFrameworkAdapter.GetActivityMembers(): missing conversation.id");
+
+            var connectorClient = context.Services.Get<IConnectorClient>();
+            string conversationId = context.Activity.Conversation.Id;
+
+            IList<ChannelAccount> accounts = await connectorClient.Conversations.GetConversationMembersAsync(conversationId);
+
+            return accounts;
+        }
+
+        /// <summary>
+        /// Lists the Conversations in which this bot has participated for a given channel server. The 
+        /// channel server returns results in pages and each page will include a `continuationToken` 
+        /// that can be used to fetch the next page of results from the server.
+        /// </summary>
+        /// <param name="serviceUrl">The URL of the channel server to query.  This can be retrieved 
+        /// from `context.activity.serviceUrl`. </param>
+        /// <param name="credentials">The credentials needed for the Bot to connect to the services.</param>
+        /// <param name="continuationToken">(Optional) token used to fetch the next page of results 
+        /// from the channel server. This should be left as `null` to retrieve the first page 
+        /// of results.</param>
+        /// <returns>List of Members of the current conversation</returns>
+        /// <remarks>
+        /// This overload may be called from outside the context of a conversation, as only the 
+        /// Bot's ServiceUrl and credentials are required.         
+        /// </remarks>
+        public async Task<ConversationsResult> GetConversations(string serviceUrl, MicrosoftAppCredentials credentials, string continuationToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(serviceUrl))
+                throw new ArgumentNullException(nameof(serviceUrl));
+
+            if (credentials == null)
+                throw new ArgumentNullException(nameof(credentials)); 
+
+            var connectorClient = this.CreateConnectorClient(serviceUrl, credentials);            
+            ConversationsResult results = await connectorClient.Conversations.GetConversationsAsync(continuationToken);
+            return results;
+        }
+
+        /// <summary>
+        /// Lists the Conversations in which this bot has participated for a given channel server. The 
+        /// channel server returns results in pages and each page will include a `continuationToken` 
+        /// that can be used to fetch the next page of results from the server.
+        /// </summary>
+        /// <param name="context">The context object for the turn.</param>        
+        /// <param name="continuationToken">(Optional) token used to fetch the next page of results 
+        /// from the channel server. This should be left as `null` to retrieve the first page 
+        /// of results.</param>
+        /// <returns>List of Members of the current conversation</returns>
+        /// <remarks>
+        /// This overload may be called during standard Activity processing, at which point the Bot's 
+        /// service URL and credentials that are part of the current activity processing pipeline
+        /// will be used.         
+        /// </remarks>
+        public async Task<ConversationsResult> GetConversations(ITurnContext context, string continuationToken = null)
+        {
+            var connectorClient = context.Services.Get<IConnectorClient>();
+            ConversationsResult results = await connectorClient.Conversations.GetConversationsAsync(continuationToken);
+            return results;
+        }
+
+
+
+        /// <summary>
         /// Creates a conversation on the specified channel.
         /// </summary>
         /// <param name="channelId">The ID for the channel.</param>

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNetCore/EchoBot.cs
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNetCore/EchoBot.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Bot.Samples.Echo.AspNetCore
         {
             switch (context.Activity.Type)
             {
+                // Note: This Sample is soon to be deleted. I've added in some easy testing here
+                // for now, although we do need a better solution for testing the BotFrameworkConnector in the
+                // near future
+
                 case ActivityTypes.Message:
                     await context.SendActivity($"You sent '{context.Activity.Text}'");
                     if (context.Activity.Text.ToLower() == "getmembers")

--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNetCore/EchoBot.cs
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNetCore/EchoBot.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Samples.Echo.AspNetCore
@@ -14,6 +15,37 @@ namespace Microsoft.Bot.Samples.Echo.AspNetCore
             {
                 case ActivityTypes.Message:
                     await context.SendActivity($"You sent '{context.Activity.Text}'");
+                    if (context.Activity.Text.ToLower() == "getmembers")
+                    {
+                        BotFrameworkAdapter b = (BotFrameworkAdapter)context.Adapter;
+                        var members = await b.GetConversationMembers(context);
+                        await context.SendActivity($"Members Found: {members.Count} "); 
+                        foreach ( var m in members)
+                        {
+                            await context.SendActivity($"Member Id: {m.Id} Name: {m.Name} Role: {m.Role}");
+                        }
+                    }
+                    else if (context.Activity.Text.ToLower() == "getactivitymembers")
+                    {
+                        BotFrameworkAdapter b = (BotFrameworkAdapter)context.Adapter;
+                        var members = await b.GetActivityMembers(context);
+                        await context.SendActivity($"Members Found: {members.Count} ");
+                        foreach (var m in members)
+                        {
+                            await context.SendActivity($"Member Id: {m.Id} Name: {m.Name} Role: {m.Role}");
+                        }
+                    }
+                    else if (context.Activity.Text.ToLower() == "getconversations")
+                    {
+                        BotFrameworkAdapter b = (BotFrameworkAdapter)context.Adapter;
+                        var conversations = await b.GetConversations(context); 
+                        await context.SendActivity($"Conversations Found: {conversations.Conversations.Count} ");
+                        foreach (var m in conversations.Conversations)
+                        {
+                            await context.SendActivity($"Conversation Id: {m.Id} Member Count: {m.Members.Count}");                            
+                        }
+                    }
+
                     break;
                 case ActivityTypes.ConversationUpdate:
                     foreach (var newMember in context.Activity.MembersAdded)


### PR DESCRIPTION
Adds the recent protocol methods to the BF Adapter. 

1. DeleteConversationMember
2. GetActivityMembers
3. GetConversationMembers
4. GetConversations

#446 

Aligns with the Node side as well. 

Note: The GetConversations method DOES NOT WORK with the emulator at this time. It returns a "MethodNotAllowed" at the protocol level. This is un-related to the work checked in here (at the Adapter Level), as the adapter is just a pass-through to the lower layer connector. 
