### PR TITLE
Fix incorrect Header to show the protocol version

### DIFF
--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -31,7 +31,11 @@ namespace Microsoft.Bot.Connector
         protected static Lazy<HttpClient> g_httpClient = new Lazy<HttpClient>(() =>
         {
             var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Microsoft-BotFramework", "4.0"));
+            // The Schema version is 3.1, put into the Microsoft-BotFramework header
+            // https://github.com/Microsoft/botbuilder-dotnet/issues/471
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Microsoft-BotFramework", "3.1"));
+
+            // The client SDK version is coupled to the version number of the package. 
             httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue($"(BotBuilder .Net/{typeof(ConnectorClient).GetTypeInfo().Assembly.GetName().Version})"));
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
             return httpClient;


### PR DESCRIPTION
Tracked in #471 

The Headers now show the protocol version as 3.1. 

(Cut/Pasted from Emulator)
"headers": {
      "connection": "Keep-Alive",
      "content-length": "467",
      "content-type": "application/json; charset=utf-8",
      "host": "localhost:51427",
      "request-id": "|17c88eac-44c94c8f62bf8585.1.1.",
      **"user-agent": "Microsoft-BotFramework/3.1 (BotBuilder .Net/4.0.0.0)"**
    },