### PR TITLE
Removing unused WriteBeforeSend property from BotState

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
@@ -10,8 +10,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Bot.Builder.Core.Extensions
 {
     public class StateSettings
-    {
-        public bool WriteBeforeSend { get; set; } = true;
+    { 
         public bool LastWriterWins { get; set; } = true;
     }
 


### PR DESCRIPTION
Removing as per bug #374 raised by @cleemullins. Should also resolve #351 