### PR TITLE
Added message attribute to QnAMaker trace

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMakerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMakerMiddleware.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA
 
                     var traceInfo = new QnAMakerTraceInfo
                     {
+                        Message = messageActivity,
                         QueryResults = results,
                         KnowledgeBaseId = _options.KnowledgeBaseId,
                         // leave out _options.SubscriptionKey, it is not public

--- a/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMakerTraceInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMakerTraceInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Ai.QnA
@@ -11,6 +12,12 @@ namespace Microsoft.Bot.Builder.Ai.QnA
     /// </summary>
     public class QnAMakerTraceInfo
     {
+        /// <summary>
+        /// Message which instigated the query to QnAMaker
+        /// </summary>
+        [JsonProperty("message")]
+        public IMessageActivity Message { set; get; }
+
         /// <summary>
         /// Results that QnAMaker returned
         /// </summary>

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerMiddlewareTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
 
                     var qnaMakerTraceInfo = traceActivity.Value as QnAMakerTraceInfo;
                     Assert.IsNotNull(qnaMakerTraceInfo);
+                    Assert.IsNotNull(qnaMakerTraceInfo.Message);
                     Assert.IsNotNull(qnaMakerTraceInfo.QueryResults);
                     Assert.IsNotNull(qnaMakerTraceInfo.KnowledgeBaseId);
                     Assert.IsNotNull(qnaMakerTraceInfo.ScoreThreshold);
@@ -55,6 +56,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
                     Assert.IsNotNull(qnaMakerTraceInfo.StrictFilters);
                     Assert.IsNotNull(qnaMakerTraceInfo.MetadataBoost);
 
+                    Assert.AreEqual(qnaMakerTraceInfo.Message.Text, passUtterance);
                     Assert.AreEqual(qnaMakerTraceInfo.QueryResults.Length, 0);
                 }, "qnaMakerTraceInfo")
                 .Send(passUtterance)
@@ -98,6 +100,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
 
                     var qnaMakerTraceInfo = traceActivity.Value as QnAMakerTraceInfo;
                     Assert.IsNotNull(qnaMakerTraceInfo);
+                    Assert.IsNotNull(qnaMakerTraceInfo.Message);
                     Assert.IsNotNull(qnaMakerTraceInfo.QueryResults);
                     Assert.IsNotNull(qnaMakerTraceInfo.KnowledgeBaseId);
                     Assert.IsNotNull(qnaMakerTraceInfo.ScoreThreshold);
@@ -105,6 +108,7 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
                     Assert.IsNotNull(qnaMakerTraceInfo.StrictFilters);
                     Assert.IsNotNull(qnaMakerTraceInfo.MetadataBoost);
 
+                    Assert.AreEqual(qnaMakerTraceInfo.Message.Text, goodUtterance);
                     Assert.AreEqual(qnaMakerTraceInfo.QueryResults.Length, 1);
                     Assert.AreEqual(qnaMakerTraceInfo.QueryResults[0].Answer, botResponse);
                     Assert.AreEqual(qnaMakerTraceInfo.KnowledgeBaseId, knowlegeBaseId);


### PR DESCRIPTION
I need information regarding which message started the query to QnAMaker for the emulator's QnAMaker extension. Technically, I just need message's text, but the other attributes regarding the message should all be public, so no real harm in throwing the whole thing in, I believe.

I wasn't about to run the tests, as I was getting the error "Call to QnAMaker failed." This problem existed before I made my changes, so it's unrelated to my work. It's also not an issue with getting the credentials, I checked and I was getting those. So I'm not sure what the issue is, possible something wrong with the test's Knowledge Base.