### PR TITLE
QnAMaker V4 query results have property id, instead of qnaId

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMaker.cs
@@ -251,8 +251,15 @@ namespace Microsoft.Bot.Builder.Ai.QnA
         [JsonProperty(PropertyName = "source")]
         public string Source { get; set; }
 
+        /// <summary>
+        /// The index of the answer in the knowledge base. V3 uses
+        /// 'qnaId', V4 uses 'id'.
+        /// </summary>
         [JsonProperty(PropertyName = "qnaId")]
         public int QnaId { get; set; }
+
+        [JsonProperty(PropertyName = "id")]
+        private int Id { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
QnAMaker v4 has renamed the QueryResult attribute 'qnaId' to just 'id'.

If we want just one id property, we can use 
`public int QnaId { set { Id = value; } }`
to move any 'qnaId' value to 'id'.