### PR TITLE
Fix QnAMakerEndpoint regex to work with QnA v2.0 services

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.QnA/QnAMaker.cs
@@ -139,8 +139,8 @@ namespace Microsoft.Bot.Builder.Ai.QnA
     /// </summary>
     public class QnAMakerEndpoint
     {
-        private const string ENDPOINT_REGEXP = "/knowledgebases/(.*)/generateAnswer\\r\\nHost:\\s(.*)\\r\\n.* (?:EndpointKey|Ocp-Apim-Subscription-Key:)\\s(.*)\\r\\n";
-        private const string UNIX_ENDPOINT_REGEXP = "/knowledgebases/(.*)/generateAnswer\\nHost:\\s(.*)\\n.* (?:EndpointKey|Ocp-Apim-Subscription-Key:)\\s(.*)\\n";
+        private const string ENDPOINT_REGEXP = "/knowledgebases/(.*)/generateAnswer\\r\\nHost:\\s(.*)\\r\\n.*(?:EndpointKey|Ocp-Apim-Subscription-Key:)\\s(.*)\\r\\n";
+        private const string UNIX_ENDPOINT_REGEXP = "/knowledgebases/(.*)/generateAnswer\\nHost:\\s(.*)\\n.*(?:EndpointKey|Ocp-Apim-Subscription-Key:)\\s(.*)\\n";
 
         public QnAMakerEndpoint()
         {


### PR DESCRIPTION
Remove extra spaces in the regexes so that you can make a `QnAMakerEndpoint` using the QnA Maker 2.0 endpoints that have requests in this form:
```
POST /knowledgebases/<kb-id>/generateAnswer
Host: https://westus.api.cognitive.microsoft.com/qnamaker/v2.0
Ocp-Apim-Subscription-Key: <subscription-key>
```
The space wasn't working with the line containing Ocp-Apim-Subscription-Key