### PR TITLE
Troubleshooting AzureBlobStorage issues

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Bot.Builder.Azure
     /// </remarks>
     public class AzureBlobStorage : IStorage
     {
-        private readonly static JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
             // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
             TypeNameHandling = TypeNameHandling.All
-        };
-        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(JsonSerializerSettings);
+        });
+        
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -169,8 +169,14 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    var payload = JsonConvert.SerializeObject(newValue, JsonSerializerSettings);
-                    await blobReference.UploadTextAsync(payload, accessCondition,blobRequestOptions, operationContext);
+                    using (var memoryStream = new MemoryStream())
+                    using (var streamWriter = new StreamWriter(memoryStream))
+                    {
+                        JsonSerializer.Serialize(streamWriter, newValue);
+                        streamWriter.Flush();
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+                        await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext);
+                    }
                 }));
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
@@ -129,5 +129,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             if (HasStorage())
                 await base._handleCrazyKeys(storage);
         }
+
+        [TestMethod]
+        public async Task BlobStorage_BatchCreateObjectTest()
+        {
+            if (HasStorage())
+                await base._batchCreateObjectTest(storage);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -209,7 +209,10 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                 new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
             });
 
-            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            await Task.WhenAll(
+                storeItemsList.Select(storeItems =>
+                    Task.Run(async () => await storage.Write(storeItems))));
 
             var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
             Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -199,6 +199,23 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
         {
             await storage.Delete("unknown_key");
         }
+
+        protected async Task _batchCreateObjectTest(IStorage storage)
+        {
+            var storeItemsList = new List<Dictionary<string, object>>(new[]
+                {
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 0 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 1 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
+            });
+
+            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
+            Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));
+            var createPoco = readStoreItems["createPoco"] as PocoItem;
+            Assert.AreEqual(createPoco.Id, "1", "createPoco.id should be 1");
+        }
     }
 
     public class PocoItem


### PR DESCRIPTION
This PR included a new storage _batchCreateObjectTest() to create multiple instances of the same object (same key) in parallel (async).
This probes the current implementation of AzureBlobStorag.Write() has Blobk Blob concurrency issues when using ClocuBlockBlob.OpenWriteAsync() to serialize objects using JsonStreamWriter(). It is our assumption that this implementation has conflicts uploading different blocks of the same blob in parallel as it occurs during the initial ConversationUpdate between the first User and the Bot. (We spotted the issue using the AzureBlobStorage in the Echo Bot with State sample)

The AzureBlobStorage.Write() implementation in this PR uses CloudBlockBlob.UploadTextAsync() instead to workaround this issue.