### PR TITLE
[TO REVIEW] Leverage RecyclableMemoryStream for pooling resources

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Bot.Builder.Azure
     /// </remarks>
     public class AzureBlobStorage : IStorage
     {
-        private readonly static JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
             // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
             TypeNameHandling = TypeNameHandling.All
-        };
-        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(JsonSerializerSettings);
+        });
+        
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -169,8 +169,14 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    var payload = JsonConvert.SerializeObject(newValue, JsonSerializerSettings);
-                    await blobReference.UploadTextAsync(payload, accessCondition,blobRequestOptions, operationContext);
+                    using (var memoryStream = new MemoryStream())
+                    using (var streamWriter = new StreamWriter(memoryStream))
+                    {
+                        JsonSerializer.Serialize(streamWriter, newValue);
+                        streamWriter.Flush();
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+                        await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext);
+                    }
                 }));
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Azure
             // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
             TypeNameHandling = TypeNameHandling.All
         });
-        
+        private readonly static IO.RecyclableMemoryStreamManager MemoryManager = new IO.RecyclableMemoryStreamManager();
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;
@@ -169,7 +169,7 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    using (var memoryStream = new MemoryStream())
+                    using (var memoryStream = MemoryManager.GetStream(tag: $"{nameof(AzureBlobStorage.Write)}_{blobName}"))
                     using (var streamWriter = new StreamWriter(memoryStream))
                     {
                         JsonSerializer.Serialize(streamWriter, newValue);

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -50,6 +50,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
@@ -129,5 +129,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             if (HasStorage())
                 await base._handleCrazyKeys(storage);
         }
+
+        [TestMethod]
+        public async Task BlobStorage_BatchCreateObjectTest()
+        {
+            if (HasStorage())
+                await base._batchCreateObjectTest(storage);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -209,7 +209,10 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                 new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
             });
 
-            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            await Task.WhenAll(
+                storeItemsList.Select(storeItems =>
+                    Task.Run(async () => await storage.Write(storeItems))));
 
             var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
             Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -199,6 +199,23 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
         {
             await storage.Delete("unknown_key");
         }
+
+        protected async Task _batchCreateObjectTest(IStorage storage)
+        {
+            var storeItemsList = new List<Dictionary<string, object>>(new[]
+                {
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 0 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 1 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
+            });
+
+            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
+            Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));
+            var createPoco = readStoreItems["createPoco"] as PocoItem;
+            Assert.AreEqual(createPoco.Id, "1", "createPoco.id should be 1");
+        }
     }
 
     public class PocoItem


### PR DESCRIPTION
Based on the discussion around PR #547 (this PR is based on these changes), we created an alternative implementation leveraging [`RecyclableMemoryStream`](https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream) to improve GC caused by in-memory serializing objects to be written to Blob storage.
While this is the easiest replacement of `MemoryStream` it adds another external dependeny on [Microsoft.IO.RecyclableMemoryStream](https://www.nuget.org/packages/Microsoft.IO.RecyclableMemoryStream/) NuGet package.