### PR TITLE
Leverage Azure's MultiBufferMemoryStream and Blob client BufferManager for pooling resources

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Bot.Builder.Azure
     /// </remarks>
     public class AzureBlobStorage : IStorage
     {
-        private readonly static JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
             // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
             TypeNameHandling = TypeNameHandling.All
-        };
-        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(JsonSerializerSettings);
+        });
+        
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -169,8 +169,14 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    var payload = JsonConvert.SerializeObject(newValue, JsonSerializerSettings);
-                    await blobReference.UploadTextAsync(payload, accessCondition,blobRequestOptions, operationContext);
+                    using (var memoryStream = new MemoryStream())
+                    using (var streamWriter = new StreamWriter(memoryStream))
+                    {
+                        JsonSerializer.Serialize(streamWriter, newValue);
+                        streamWriter.Flush();
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+                        await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext);
+                    }
                 }));
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -11,6 +11,7 @@ using System.Web;
 using Microsoft.Bot.Builder.Core.Extensions;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Core;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Azure
@@ -169,7 +170,7 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    using (var memoryStream = new MemoryStream())
+                    using (var memoryStream = new MultiBufferMemoryStream(blobReference.ServiceClient.BufferManager))
                     using (var streamWriter = new StreamWriter(memoryStream))
                     {
                         JsonSerializer.Serialize(streamWriter, newValue);

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
@@ -129,5 +129,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             if (HasStorage())
                 await base._handleCrazyKeys(storage);
         }
+
+        [TestMethod]
+        public async Task BlobStorage_BatchCreateObjectTest()
+        {
+            if (HasStorage())
+                await base._batchCreateObjectTest(storage);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -209,7 +209,10 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                 new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
             });
 
-            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            await Task.WhenAll(
+                storeItemsList.Select(storeItems =>
+                    Task.Run(async () => await storage.Write(storeItems))));
 
             var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
             Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -199,6 +199,23 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
         {
             await storage.Delete("unknown_key");
         }
+
+        protected async Task _batchCreateObjectTest(IStorage storage)
+        {
+            var storeItemsList = new List<Dictionary<string, object>>(new[]
+                {
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 0 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 1 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
+            });
+
+            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
+            Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));
+            var createPoco = readStoreItems["createPoco"] as PocoItem;
+            Assert.AreEqual(createPoco.Id, "1", "createPoco.id should be 1");
+        }
     }
 
     public class PocoItem


### PR DESCRIPTION
Based on the discussion around PR #547 (this PR is based on these changes), we created another alternative implementation leveraging the [`MultiBufferMemoryStream`](https://github.com/Azure/azure-storage-net/blob/master/Lib/Common/Core/MultiBufferMemoryStream.cs) and the [`CloudBlobClient.BufferManager`](https://github.com/Azure/azure-storage-net/blob/3331c605fb2e07de5759da46b8f7086deb78a5a4/Lib/Common/Blob/CloudBlobClient.Common.cs#L90) for pooling resources improving GC caused by in-memory serializing object to be written to Blob storage.
We found this approach broadly used within the [Microsoft.WindowsAzure.Storage library](https://github.com/Azure/azure-storage-net/search?utf8=%E2%9C%93&q=%22new+MultiBufferMemoryStream%22)
Also, reusing the same `BufferManager` to perform requests to the same service seems the correct approach.
We'll close without merging PR #565 since this seems a better fit than leveraging `RecyclableMemoryStream`.