### PR TITLE
[DO NOT MERGE] Leverage Azure Blob Lease to Manage Storage Write Concurrency

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Bot.Builder.Azure
     /// </remarks>
     public class AzureBlobStorage : IStorage
     {
-        private readonly static JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(new JsonSerializerSettings
         {
             // we use All so that we get typed roundtrip out of storage, but we don't use validation because we don't know what types are valid
             TypeNameHandling = TypeNameHandling.All
-        };
-        private readonly static JsonSerializer JsonSerializer = JsonSerializer.Create(JsonSerializerSettings);
+        });
+        
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -169,8 +169,14 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    var payload = JsonConvert.SerializeObject(newValue, JsonSerializerSettings);
-                    await blobReference.UploadTextAsync(payload, accessCondition,blobRequestOptions, operationContext);
+                    using (var memoryStream = new MemoryStream())
+                    using (var streamWriter = new StreamWriter(memoryStream))
+                    {
+                        JsonSerializer.Serialize(streamWriter, newValue);
+                        streamWriter.Flush();
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+                        await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext);
+                    }
                 }));
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -11,6 +11,7 @@ using System.Web;
 using Microsoft.Bot.Builder.Core.Extensions;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.Core;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Azure
@@ -169,7 +170,7 @@ namespace Microsoft.Bot.Builder.Azure
                     var blobName = GetBlobName(keyValuePair.Key);
                     var blobReference = blobContainer.GetBlockBlobReference(blobName);
 
-                    using (var memoryStream = new MemoryStream())
+                    using (var memoryStream = new MultiBufferMemoryStream(blobReference.ServiceClient.BufferManager))
                     using (var streamWriter = new StreamWriter(memoryStream))
                     {
                         JsonSerializer.Serialize(streamWriter, newValue);

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
@@ -129,5 +129,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             if (HasStorage())
                 await base._handleCrazyKeys(storage);
         }
+
+        [TestMethod]
+        public async Task BlobStorage_BatchCreateObjectTest()
+        {
+            if (HasStorage())
+                await base._batchCreateObjectTest(storage);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobStorageTests.cs
@@ -130,11 +130,24 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 await base._handleCrazyKeys(storage);
         }
 
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task BlobStorage_BatchCreateObjectTest()
+        public async Task BlobStorage_BatchCreateObjectsTest()
         {
             if (HasStorage())
                 await base._batchCreateObjectTest(storage);
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE AZURE STORAGE EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task BlobStorage_BatchCreateLargeObjectsTest()
+        {
+            // The maximum size of a blob before it must be separated into blocks.
+            // https://docs.microsoft.com/en-us/dotnet/api/microsoft.windowsazure.storage.shared.protocol.constants.maxsingleuploadblobsize
+            var extraBytesToUploadBlobinBlocks = Microsoft.WindowsAzure.Storage.Shared.Protocol.Constants.MaxSingleUploadBlobSize;
+
+            if (HasStorage())
+                await base._batchCreateObjectTest(storage, extraBytesToUploadBlobinBlocks);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -209,7 +209,10 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                 new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
             });
 
-            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            await Task.WhenAll(
+                storeItemsList.Select(storeItems =>
+                    Task.Run(async () => await storage.Write(storeItems))));
 
             var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
             Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -71,7 +72,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             var originalPocoStoreItem = new PocoStoreItem() { Id = "1", Count = 1 };
 
             // first write should work
-            await storage.Write(new [] 
+            await storage.Write(new[]
             {
                 new KeyValuePair<string, object>("pocoItem", originalPocoItem),
                 new KeyValuePair<string, object>("pocoStoreItem", originalPocoStoreItem )
@@ -200,13 +201,25 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             await storage.Delete("unknown_key");
         }
 
-        protected async Task _batchCreateObjectTest(IStorage storage)
+        protected async Task _batchCreateObjectTest(IStorage storage, long minimumExtraBytes = 0)
         {
+            string[] stringArray = null;
+
+            if (minimumExtraBytes > 0)
+            {
+                // chunks of maximum string size to fill the extra bytes request
+                var extraStringCount = (int)(minimumExtraBytes / int.MaxValue);
+                stringArray = Enumerable.Range(0, extraStringCount).Select(i => new string('X', int.MaxValue / 2)).ToArray();
+
+                // Append the remaining string size
+                stringArray = stringArray.Append(new string('X', (int)(minimumExtraBytes % int.MaxValue) / 2)).ToArray();
+            }
+
             var storeItemsList = new List<Dictionary<string, object>>(new[]
                 {
-                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 0 }},
-                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 1 }},
-                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 0, ExtraBytes = stringArray }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 1, ExtraBytes = stringArray }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2, ExtraBytes = stringArray }}
             });
 
 
@@ -226,6 +239,8 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
         public string Id { get; set; }
 
         public int Count { get; set; }
+
+        public string[] ExtraBytes { get; set; }
     }
 
     public class PocoStoreItem : IStoreItem

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -199,6 +199,23 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
         {
             await storage.Delete("unknown_key");
         }
+
+        protected async Task _batchCreateObjectTest(IStorage storage)
+        {
+            var storeItemsList = new List<Dictionary<string, object>>(new[]
+                {
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 0 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 1 }},
+                new Dictionary<string, object> {["createPoco"] = new PocoItem() { Id = "1", Count = 2 }}
+            });
+
+            await Task.WhenAll(storeItemsList.Select(storeItems => storage.Write(storeItems)));
+
+            var readStoreItems = new Dictionary<string, object>(await storage.Read("createPoco"));
+            Assert.IsInstanceOfType(readStoreItems["createPoco"], typeof(PocoItem));
+            var createPoco = readStoreItems["createPoco"] as PocoItem;
+            Assert.AreEqual(createPoco.Id, "1", "createPoco.id should be 1");
+        }
     }
 
     public class PocoItem


### PR DESCRIPTION
Create a new unit test to write 3 large objects (larger than [`MaxSingleUploadBlobSize`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.windowsazure.storage.shared.protocol.constants.maxsingleuploadblobsize) to force `UploadFromStreamAsync` upload them in blocks.
This test failed with a `The specified block list is invalid` due to concurrency issues.
We fixed the test by ensuring the blob exists (creating an empty one if necessary) and then taking a lease on it to lock the resource while the writing operations takes place.
The main downside of this approach is that for any small object it takes up to 4 requests to write the content.
1. Create the blob (even if it exists the request is made)
2. Lease the blob
3. (internally) Put the content blocks
4. (internally) Put the block list