### PR TITLE
Fix logic typo for pluralization of "1"

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Core/Adapters/ConsoleAdapter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.Adapters
                             IMessageActivity message = activity.AsMessageActivity();
                             if (message.Attachments != null && message.Attachments.Any())
                             {
-                                var attachment = message.Attachments.Count == 1 ? "1 attachments" : $"{message.Attachments.Count()} attachments";
+                                var attachment = message.Attachments.Count == 1 ? "1 attachment" : $"{message.Attachments.Count()} attachments";
                                 Console.WriteLine($"{message.Text} with {attachment} ");
                             }
                             else


### PR DESCRIPTION
The logic is there to support pluralization, and adds a special case for one, but still adds the extraneous "s" at the end of the word "attachment"