### PR TITLE
Add Check for CosmosDB emulator actually running.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -202,9 +202,11 @@ namespace Microsoft.Bot.Builder.Azure
             async Task<CloudBlobContainer> EnsureBlobContainerExists()
             {
                 var blobClient = _storageAccount.CreateCloudBlobClient();
-                _container = blobClient.GetContainerReference(_containerName);
+                var container = blobClient.GetContainerReference(_containerName);
 
-                await _container.CreateIfNotExistsAsync().ConfigureAwait(false);
+                await container.CreateIfNotExistsAsync().ConfigureAwait(false);
+
+                _container = container;
 
                 return _container;
             }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
@@ -160,10 +160,13 @@ namespace Microsoft.Bot.Builder.Azure
 
             async Task<CloudTable> EnsureTableExists()
             {
-                _table = _storageAccount.CreateCloudTableClient().GetTableReference(_tableName);
+                var table = _storageAccount.CreateCloudTableClient().GetTableReference(_tableName);
 
                 // This call may not be thread-safe and multiple calls may be made, but Azure will handle it correctly and there is no destructive side effect.
-                await _table.CreateIfNotExistsAsync();
+                await table.CreateIfNotExistsAsync();
+
+                _table = table;
+
                 return _table;
             }
         }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -27,8 +27,19 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
         private static Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
         {
-            // return true if it's installed.  If it's installed not running you will get test errors
-            return File.Exists(_emulatorPath);
+            if (File.Exists(_emulatorPath))
+            { 
+                Process p = new Process();
+                p.StartInfo.UseShellExecute = true;
+                p.StartInfo.FileName = _emulatorPath;
+                p.StartInfo.Arguments = "/GetStatus";
+                p.Start();
+                p.WaitForExit();
+
+                return p.ExitCode == 2;
+            }
+
+            return false;
         });
 
         private IStorage _storage;


### PR DESCRIPTION
The Build has been failing on the CosmosDB tests, which should not be running on the build server(s). The check for the emulator was only looking for the existance of the Cosmosdb emulator file, which is apparently now present on the build servers. 

This PR brings back the "Is the emulator actually running?" code that @tomlm removed in pr #493 

I've verified on my local machine that this works correctly:
1. emulator not installed = Tests not run, reporting "Inconclusive".
2. Emulator installed but not running. Tests not run, reporting "Inconclusive".
3. Emulator running, tests run and passing. 