### PR TITLE
Remove InternalsVisibleTo from integration libs

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -68,11 +68,5 @@
 		<ProjectReference Include="..\..\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
 		<ProjectReference Include="..\..\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj" />
 	</ItemGroup>
-
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>Microsoft.Bot.Builder.Integration.AspNet.Core.Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
   
 </Project>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 {
     public sealed class BotMessageHandler : BotMessageHandlerBase
     {
-        internal static readonly string RouteName = "BotFramework - Message Handler";
+        public static readonly string RouteName = "BotFramework - Message Handler";
 
         public BotMessageHandler(BotFrameworkAdapter botFrameworkAdapter) : base(botFrameworkAdapter)
         {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotProactiveMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotProactiveMessageHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 {
     public sealed class BotProactiveMessageHandler : BotMessageHandlerBase
     {
-        internal static readonly string RouteName = "BotFramework - Proactive Message Handler";
+        public static readonly string RouteName = "BotFramework - Proactive Message Handler";
 
         public BotProactiveMessageHandler(BotFrameworkAdapter botFrameworkAdapter) : base(botFrameworkAdapter)
         {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
@@ -73,10 +73,4 @@
 	  <Reference Include="System.Web" />
 	</ItemGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
The build that signed the assemblies was broken due to the use of
`InternalsVisibleTo` for ASP.NET integration libs.

 * ASP.NET Core integration didn't actually need it right now, removed
from build
 * ASP.NET WebAPI integration only needed it for some `string` fields
which we made public instead and removed from build