### PR TITLE
Luis recognizer middleware shouldn't invoke the luis recognizer on null/empty utterances

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisRecognizerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisRecognizerMiddleware.cs
@@ -67,18 +67,22 @@ namespace Microsoft.Bot.Builder.Ai.LUIS
             if (context.Activity.Type == ActivityTypes.Message)
             {
                 var utterance = context.Activity.AsMessageActivity().Text;
-                var result = await _luisRecognizer.Recognize(utterance, CancellationToken.None).ConfigureAwait(false);
-                context.Services.Add(LuisRecognizerResultKey, result);
 
-                var traceInfo = new LuisTraceInfo
-                {
-                    RecognizerResult = result,
-                    LuisModel = RemoveSensitiveData(_luisModel),
-                    LuisOptions = _luisOptions,
-                    LuisResult = (LuisResult) result.Properties["luisResult"]
-                };
-                var traceActivity = Activity.CreateTraceActivity("LuisRecognizerMiddleware", LuisTraceType, traceInfo, LuisTraceLabel);
-                await context.SendActivity(traceActivity).ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(utterance))
+                { 
+                    var result = await _luisRecognizer.Recognize(utterance, CancellationToken.None).ConfigureAwait(false);
+                    context.Services.Add(LuisRecognizerResultKey, result);
+
+                    var traceInfo = new LuisTraceInfo
+                    {
+                        RecognizerResult = result,
+                        LuisModel = RemoveSensitiveData(_luisModel),
+                        LuisOptions = _luisOptions,
+                        LuisResult = (LuisResult) result.Properties["luisResult"]
+                    };
+                    var traceActivity = Activity.CreateTraceActivity("LuisRecognizerMiddleware", LuisTraceType, traceInfo, LuisTraceLabel);
+                    await context.SendActivity(traceActivity).ConfigureAwait(false);
+                }
             }
             await next().ConfigureAwait(false);
         }

--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerMiddlewareTests.cs
@@ -93,6 +93,35 @@ namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
 
         }
 
+        [TestMethod]
+        public async Task LuisRecognizer_MiddlewareNullUtterance()
+        {
+            await RunTest(null);
+            await RunTest(string.Empty);
+            await RunTest(" ");
+        }
+
+        private async Task RunTest(string utterance)
+        {
+            var adapter = new TestAdapter()
+                .Use(GetLuisRecognizerMiddleware(true));
+
+            var messageActivity = Activity.CreateMessageActivity();
+            messageActivity.Text = utterance;
+
+            const string botResponse = @"Hi";
+            await new TestFlow(adapter, async context =>
+                {
+                    if (context.Activity.Text == utterance)
+                    {
+                        await context.SendActivity(botResponse);
+                    }
+                })
+                .Send(messageActivity)
+                .AssertReply(botResponse, "passthrough")
+                .StartTest();
+        }
+
         private LuisRecognizerMiddleware GetLuisRecognizerMiddleware(bool verbose = false, ILuisOptions luisOptions = null)
         {
             var luisRecognizerOptions = new LuisRecognizerOptions { Verbose = verbose };


### PR DESCRIPTION
This fixes #572 