### PR TITLE
Move endpoint path config to BotFrameworkOptions

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
@@ -23,40 +23,17 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// </summary>
         /// <param name="appicationBuilder">The <see cref="IApplicationBuilder"/>.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <remarks>
-        ///     This maps the bot using a default set of endpoints. To control the exact paths you would
-        ///     prefer the bot's endpoints to be exposed at, use the <see cref="UseBotFramwork(IApplicationBuilder, Action{BotFrameworkPaths})"/> 
-        ///     overload instead.
-        /// </remarks>
-        public static IApplicationBuilder UseBotFramework(this IApplicationBuilder applicationBuilder) =>
-            applicationBuilder.UseBotFramework(paths => {});
-
-        /// <summary>
-        /// Maps various endpoint handlers for the <see cref="ServiceCollectionExtensions.AddBot{TBot}(IServiceCollection, Action{BotFrameworkOptions})">registered bot</see> into the request execution pipeline.
-        /// </summary>
-        /// <param name="appicationBuilder">The <see cref="IApplicationBuilder"/>.</param>
-        /// <param name="configurePaths">A callback to configure the paths that determine where the endpoints of the bot will be exposed.</param>
-        /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <seealso cref="ServiceCollectionExtensions.AddBot{TBot}(IServiceCollection, Action{BotFrameworkOptions})"/>
-        /// <seealso cref="BotFrameworkPaths"/>
-        public static IApplicationBuilder UseBotFramework(this IApplicationBuilder applicationBuilder, Action<BotFrameworkPaths> configurePaths)
+        public static IApplicationBuilder UseBotFramework(this IApplicationBuilder applicationBuilder)
         {
             if (applicationBuilder == null)
             {
                 throw new ArgumentNullException(nameof(applicationBuilder));
             }
 
-            if (configurePaths == null)
-            {
-                throw new ArgumentNullException(nameof(configurePaths));
-            }
-
-            var paths = new BotFrameworkPaths();
-
-            configurePaths(paths);
-
             var applicationServices = applicationBuilder.ApplicationServices;
             var options = applicationServices.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
+
+            var paths = options.Paths;
 
             if (options.EnableProactiveMessages)
             {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkOptions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkOptions.cs
@@ -16,25 +16,22 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// <seealso cref="ApplicationBuilderExtensions"/>
     public class BotFrameworkOptions
     {
-        private readonly List<IMiddleware> _middleware;
-
         /// <summary>
         /// Creates a <see cref="BotFrameworkOptions"/> object.
         /// </summary>
         public BotFrameworkOptions()
         {
-            _middleware = new List<IMiddleware>();
         }
 
         /// <summary>
         /// An <see cref="ICredentialProvider"/> that should be used to store and retrieve credentials used during authentication with the Bot Framework Service.
         /// </summary>
         public ICredentialProvider CredentialProvider { get; set; }
-        
+
         /// <summary>
         /// A list of <see cref="IMiddleware"/> that will be executed for each turn of the conversation.
         /// </summary>
-        public IList<IMiddleware> Middleware { get => _middleware; }
+        public IList<IMiddleware> Middleware { get; } = new List<IMiddleware>();
 
         /// <summary>
         /// Gets or sets whether a proactive messaging endpoint should be exposed for the bot.
@@ -53,5 +50,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// Gets or sets the <see cref="HttpClient"/> instance that should be used to make requests to the Bot Framework Service.
         /// </summary>
         public HttpClient HttpClient { get; set; }
+
+        /// <summary>
+        /// Gets or sets what paths should be used when exposing the various bot endpoints.
+        /// </summary>
+        /// <seealso cref="BotFrameworkPaths"/>
+        public BotFrameworkPaths Paths { get; set; } = new BotFrameworkPaths();
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
             services.PostConfigure<BotFrameworkOptions>(options => 
             {
-                if (options.CredentialProvider== null)
+                if (options.CredentialProvider == null)
                 {
                     options.CredentialProvider = new SimpleCredentialProvider();
                 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkOptions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkOptions.cs
@@ -11,13 +11,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
 {
     public class BotFrameworkOptions
     {
-        private readonly List<IMiddleware> _middleware;
-        private readonly BotFrameworkPaths _paths;
-
         public BotFrameworkOptions()
         {
-            _middleware = new List<IMiddleware>();
-            _paths = new BotFrameworkPaths();
         }
 
         /// <summary>
@@ -28,7 +23,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
         /// <summary>
         /// A list of <see cref="IMiddleware"/> that will be executed for each turn of the conversation.
         /// </summary>
-        public List<IMiddleware> Middleware { get => _middleware; }
+        public List<IMiddleware> Middleware { get; } = new List<IMiddleware>();
 
         /// <summary>
         /// Gets or sets whether a proactive messaging endpoint should be exposed for the bot.
@@ -42,13 +37,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
         /// Gets or sets what paths should be used when exposing the various bot endpoints.
         /// </summary>
         /// <seealso cref="BotFrameworkPaths" />
-        public BotFrameworkPaths Paths { get => _paths; }
+        public BotFrameworkPaths Paths { get; set; } = new BotFrameworkPaths();
 
         /// <summary>
         /// Gets or sets the retry policy to retry operations in case of errors from Bot Framework Service.
         /// </summary>
         public RetryPolicy ConnectorClientRetryPolicy { get; set; }
-
 
         /// <summary>
         /// Gets or sets the <see cref="HttpClient"/> instance that should be used to make requests to the Bot Framework Service.

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ApplicationBuilderExtensionsTests.cs
@@ -51,46 +51,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             }
 
             [Fact]
-            public void WithExplicitNullPathConfigurationCallback()
-            {
-                var applicationBuilderMock = new Mock<IApplicationBuilder>();
-
-                var action = new Action(() => applicationBuilderMock.Object.UseBotFramework(null));
-
-                action.Should().Throw<ArgumentNullException>();
-            }
-
-            [Fact]
-            public void WithPathConfigurationCallback()
-            {
-                var botFrameworkOptionsMock = new Mock<IOptions<BotFrameworkOptions>>();
-                botFrameworkOptionsMock.Setup(o => o.Value)
-                    .Returns(new BotFrameworkOptions());
-
-                var serviceProviderMock = new Mock<IServiceProvider>();
-                serviceProviderMock.Setup(sp => sp.GetService(typeof(IOptions<BotFrameworkOptions>)))
-                    .Returns(botFrameworkOptionsMock.Object);
-
-                var mappedApplicationBuilderMock = new Mock<IApplicationBuilder>();
-
-                var applicationBuilderMock = new Mock<IApplicationBuilder>();
-                applicationBuilderMock.Setup(ab => ab.ApplicationServices)
-                    .Returns(serviceProviderMock.Object);
-
-                applicationBuilderMock.Setup(ab => ab.New())
-                    .Returns(mappedApplicationBuilderMock.Object);
-
-                applicationBuilderMock.Object.UseBotFramework(paths =>
-                {
-                    paths.Should().NotBeNull();
-                });
-
-                applicationBuilderMock.Verify(ab => ab.New(), Times.Once());
-                mappedApplicationBuilderMock.Verify(mab => mab.Build(), Times.Once());
-                mappedApplicationBuilderMock.Verify(mab => mab.Use(It.IsAny<Func<RequestDelegate, RequestDelegate>>()), Times.Once());
-            }
-
-            [Fact]
             public void WhenEnableProactiveTrueShouldMapMultipleHandlers()
             {
                 var botFrameworkOptionsMock = new Mock<IOptions<BotFrameworkOptions>>();
@@ -118,10 +78,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 applicationBuilderMock.Setup(ab => ab.New())
                     .Returns(() => mappedApplicationBlocks[rootApplicationBuilderNewCallCount++].Object);
 
-                applicationBuilderMock.Object.UseBotFramework(paths =>
-                {
-                    paths.Should().NotBeNull();
-                });
+                applicationBuilderMock.Object.UseBotFramework();
 
                 applicationBuilderMock.Verify(ab => ab.New(), Times.Exactly(2));
 


### PR DESCRIPTION
Exposes the `BotFrameworkPaths` as a property `Paths`, of type
`BotFrameworkPaths`, to the `BotFrameworkOptions` class.

 * Makes it a subset of the options that can be configured (via
configuration APIs) in one fell swoop
 * Unifies the design between Core and WebAPI (because it was already
this way in WebAPI)
 * Makes it possible for runtime code to detect where the endpoints are
actually exposed via `IOptions<BotFrameworkOptions>` (helps with
discussion in #587)

**NOTE:** this also removes an overload from `UseBotFramework` which is
where it was previously configurable in Core (which, in retrospect, was
not a the proper design anyway)