### PR TITLE
Add BuildPackages.cmd 

### DIFF
--- a/BuildPackages.cmd
+++ b/BuildPackages.cmd
@@ -1,0 +1,1 @@
+msbuild Microsoft.Bot.Builder.sln /p:Configuration="Debug - Nuget Packages" /p:PackageOutputPath="%~dp0binaries\Debug\packages"


### PR DESCRIPTION
This builds .nupkg files locally, putting them in a single centralized folder.

Proposed resolution for Issue #391 https://github.com/Microsoft/botbuilder-dotnet/issues/391