### PR TITLE
Removing IEnumerable<KVP> code in favor of a dictionary

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// </summary>
         /// <param name="keys">An array of entity keys</param>
         /// <returns></returns>
-        public async Task<IEnumerable<KeyValuePair<string, object>>> Read(params string[] keys)
+        public async Task<IDictionary<string, object>> Read(params string[] keys)
         {
             if (keys == null) throw new ArgumentNullException(nameof(keys));
 
@@ -108,8 +108,18 @@ namespace Microsoft.Bot.Builder.Azure
 
             await Task.WhenAll(readTasks);
 
-            // Project back the entries that were read, filtering out any entries that were not found
-            return readTasks.Select(readTask => readTask.Result).Where(kvp => kvp.Key != null);
+            // Project back the entries that were read, filtering out any entries that were not found.
+            // This gives us a List<KeyValuePair<>>. 
+            var items = readTasks.Select(readTask => readTask.Result).Where(kvp => kvp.Key != null);
+
+            // Iterate over the KVPs and add them into a dictionary. 
+            IDictionary<string, object> values = new Dictionary<string, object>();
+            foreach(var i in items)
+            {
+                values.Add(i);
+            }
+
+            return values; 
 
             async Task<KeyValuePair<string, object>> ReadIndividualKey(string key)
             {
@@ -150,7 +160,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// </summary>
         /// <param name="changes"></param>
         /// <returns></returns>
-        public async Task Write(IEnumerable<KeyValuePair<string, object>> changes)
+        public async Task Write(IDictionary<string, object> changes)
         {
             if (changes == null) throw new ArgumentNullException(nameof(changes));
 

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -109,17 +109,12 @@ namespace Microsoft.Bot.Builder.Azure
             await Task.WhenAll(readTasks);
 
             // Project back the entries that were read, filtering out any entries that were not found.
-            // This gives us a List<KeyValuePair<>>. 
-            var items = readTasks.Select(readTask => readTask.Result).Where(kvp => kvp.Key != null);
-
-            // Iterate over the KVPs and add them into a dictionary. 
-            IDictionary<string, object> values = new Dictionary<string, object>();
-            foreach(var i in items)
-            {
-                values.Add(i);
-            }
-
-            return values; 
+            // This gives us a Dictionary(key, value) 
+            var items = readTasks.Select(readTask => readTask.Result)
+                .Where(kvp => kvp.Key != null)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+          
+            return items; 
 
             async Task<KeyValuePair<string, object>> ReadIndividualKey(string key)
             {

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// Loads store items from storage.
         /// </summary>
         /// <param name="keys">Array of item keys to read from the store.</param>
-        public async Task<IEnumerable<KeyValuePair<string, object>>> Read(params string[] keys)
+        public async Task<IDictionary<string, object>> Read(params string[] keys)
         {
             if (keys == null || keys.Length == 0)
             {
@@ -107,15 +107,22 @@ namespace Microsoft.Bot.Builder.Azure
                 return new KeyValuePair<string, object>();
             });
 
-            return (await Task.WhenAll(readTasks).ConfigureAwait(false))
-                .Where(kv => kv.Key != null);
+            var kvps = (await Task.WhenAll(readTasks).ConfigureAwait(false)).Where(kv => kv.Key != null);
+
+            IDictionary<string, object> items = new Dictionary<string, object>();
+            foreach(var kvp in kvps)
+            {
+                items.Add(kvp);
+            }
+
+            return items; 
         }
 
         /// <summary>
         /// Saves store items to storage.
         /// </summary>
         /// <param name="changes">Map of items to write to storage.</param>
-        public async Task Write(IEnumerable<KeyValuePair<string, object>> changes)
+        public async Task Write(IDictionary<string, object> changes)
         {
             if (changes == null) throw new ArgumentNullException(nameof(changes));
 

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureTableStorage.cs
@@ -107,15 +107,14 @@ namespace Microsoft.Bot.Builder.Azure
                 return new KeyValuePair<string, object>();
             });
 
-            var kvps = (await Task.WhenAll(readTasks).ConfigureAwait(false)).Where(kv => kv.Key != null);
+            // Wait for all the reads to complete
+            var completedTasks = await Task.WhenAll(readTasks).ConfigureAwait(false);
 
-            IDictionary<string, object> items = new Dictionary<string, object>();
-            foreach(var kvp in kvps)
-            {
-                items.Add(kvp);
-            }
+            // Filter out the Nulls and convert to a dictionary
+            var dict = completedTasks.Where(kv => kv.Key != null)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value); 
 
-            return items; 
+            return dict; 
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentException("Please provide at least one key to read from storage", nameof(keys));
             }
 
-            IDictionary<string, object> storeItems = new Dictionary<string, object>();
+            var storeItems = new Dictionary<string, object>(keys.Length);
 
             // Ensure collection exists
             var collectionLink = await GetCollectionLink();
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder.Azure
                     }
 
                     // doc.Id cannot be used since it is escaped, read it from RealId property instead
-                    storeItems.Add(new KeyValuePair<string, object>(doc.ReadlId, item));
+                    storeItems.Add(doc.ReadlId, item);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -106,14 +106,14 @@ namespace Microsoft.Bot.Builder.Azure
         /// Loads store items from storage.
         /// </summary>
         /// <param name="keys">Array of item keys to read from the store.</param>
-        public async Task<IEnumerable<KeyValuePair<string, object>>> Read(params string[] keys)
+        public async Task<IDictionary<string, object>> Read(params string[] keys)
         {
             if (keys.Length == 0)
             {
                 throw new ArgumentException("Please provide at least one key to read from storage", nameof(keys));
             }
 
-            var storeItems = new List<KeyValuePair<string, object>>();
+            IDictionary<string, object> storeItems = new Dictionary<string, object>();
 
             // Ensure collection exists
             var collectionLink = await GetCollectionLink();
@@ -149,7 +149,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// Saves store items to storage.
         /// </summary>
         /// <param name="changes">Map of items to write to storage.</param>
-        public async Task Write(IEnumerable<KeyValuePair<string, object>> changes)
+        public async Task Write(IDictionary<string, object> changes)
         {
             if (changes == null)
             {

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/BotState.cs
@@ -94,12 +94,13 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         /// <param name="state">The state object.</param>
         public virtual async Task Write(ITurnContext context, TState state)
         {
-            var changes = new List<KeyValuePair<string, object>>();
+            var changes = new Dictionary<string, object>();
 
             if (state == null)
                 state = new TState();
             var key = _keyDelegate(context);
-            changes.Add(new KeyValuePair<string, object>(key, state));
+
+            changes.Add(key, state);
 
             if (this._settings.LastWriterWins)
             {

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/FileStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/FileStorage.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Bot.Builder.Core.Extensions
 
         public async Task<IDictionary<string, object>> Read(string[] keys)
         {
-            IDictionary<string, object> storeItems = new Dictionary<string, object>(keys.Length);
+            var storeItems = new Dictionary<string, object>(keys.Length);
 
             foreach (var key in keys)
             {
                 var item = await ReadIStoreItem(key).ConfigureAwait(false);
                 if (item != null)
                 {
-                    storeItems.Add(new KeyValuePair<string, object>(key, item));
+                    storeItems.Add(key, item);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/FileStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/FileStorage.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Bot.Builder.Core.Extensions
             return Task.CompletedTask;
         }
 
-        public async Task<IEnumerable<KeyValuePair<string, object>>> Read(string[] keys)
+        public async Task<IDictionary<string, object>> Read(string[] keys)
         {
-            var storeItems = new List<KeyValuePair<string, object>>(keys.Length);
+            IDictionary<string, object> storeItems = new Dictionary<string, object>(keys.Length);
 
             foreach (var key in keys)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions
             }
         }
 
-        public async Task Write(IEnumerable<KeyValuePair<string, object>> changes)
+        public async Task Write(IDictionary<string, object> changes)
         {
             // Similar to the Read method, the funky threading in here is due to 
             // concurrency and async methods. 

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/IStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/IStorage.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         public static async Task<IDictionary<string, StoreItemT>> Read<StoreItemT>(this IStorage storage, params string[] keys) where StoreItemT : class
         {
             var storeItems = await storage.Read(keys).ConfigureAwait(false);
-            IDictionary<string, StoreItemT> values = new Dictionary<string, StoreItemT>();
+            var values = new Dictionary<string, StoreItemT>(keys.Length);
             foreach (var entry in storeItems)
             {
                 if (entry.Value is StoreItemT valueAsType)
                 {
-                    values.Add(new KeyValuePair<string, StoreItemT>(entry.Key, valueAsType));
+                    values.Add(entry.Key, valueAsType);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/IStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/IStorage.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         /// Read StoreItems from storage
         /// </summary>
         /// <param name="keys">keys of the storeItems to read</param>
-        /// <returns>StoreItem dictionary</returns>
-        Task<IEnumerable<KeyValuePair<string, object>>> Read(params string[] keys);
+        /// <returns>Dictionary of Key/Value pairs</returns>
+        Task<IDictionary<string, object>> Read(params string[] keys);
 
         /// <summary>
-        /// Write StoreItems to storage
+        /// Dictionary of Key/Value pairs to write
         /// </summary>
         /// <param name="changes"></param>
-        Task Write(IEnumerable<KeyValuePair<string, object>> changes);
+        Task Write(IDictionary<string, object> changes);
 
         /// <summary>
         /// Delete StoreItems from storage
@@ -48,22 +48,19 @@ namespace Microsoft.Bot.Builder.Core.Extensions
         /// <param name="storage"></param>
         /// <param name="keys"></param>
         /// <returns></returns>
-        public static async Task<IEnumerable<KeyValuePair<string, StoreItemT>>> Read<StoreItemT>(this IStorage storage, params string[] keys) where StoreItemT : class
+        public static async Task<IDictionary<string, StoreItemT>> Read<StoreItemT>(this IStorage storage, params string[] keys) where StoreItemT : class
         {
             var storeItems = await storage.Read(keys).ConfigureAwait(false);
-
-            return ReturnStoreItemsOfDesiredType();
-
-            IEnumerable<KeyValuePair<string, StoreItemT>> ReturnStoreItemsOfDesiredType()
+            IDictionary<string, StoreItemT> values = new Dictionary<string, StoreItemT>();
+            foreach (var entry in storeItems)
             {
-                foreach (var entry in storeItems)
+                if (entry.Value is StoreItemT valueAsType)
                 {
-                    if (entry.Value is StoreItemT valueAsType)
-                    {
-                        yield return new KeyValuePair<string, StoreItemT>(entry.Key, valueAsType);
-                    }
+                    values.Add(new KeyValuePair<string, StoreItemT>(entry.Key, valueAsType));
                 }
             }
+
+            return values;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/MemoryStorage.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Bot.Builder.Core.Extensions
             return Task.CompletedTask;
         }
 
-        public Task<IEnumerable<KeyValuePair<string, object>>> Read(string[] keys)
+        public Task<IDictionary<string, object>> Read(string[] keys)
         {
-            var storeItems = new List<KeyValuePair<string, object>>(keys.Length);
+            IDictionary<string, object> storeItems = new Dictionary<string, object>(keys.Length);
             lock (_syncroot)
             {
                 foreach (var key in keys)
@@ -54,11 +54,11 @@ namespace Microsoft.Bot.Builder.Core.Extensions
                 }
             }
 
-            return Task.FromResult<IEnumerable<KeyValuePair<string, object>>>(storeItems);
+            return Task.FromResult<IDictionary<string, object>>(storeItems);
         }
 
 
-        public Task Write(IEnumerable<KeyValuePair<string, object>> changes)
+        public Task Write(IDictionary<string, object> changes)
         {
             lock (_syncroot)
             {

--- a/libraries/Microsoft.Bot.Builder.Core.Extensions/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Core.Extensions/MemoryStorage.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions
 
         public Task<IDictionary<string, object>> Read(string[] keys)
         {
-            IDictionary<string, object> storeItems = new Dictionary<string, object>(keys.Length);
+            var storeItems = new Dictionary<string, object>(keys.Length);
             lock (_syncroot)
             {
                 foreach (var key in keys)
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Builder.Core.Extensions
                     {
                         if (state != null)
                         {
-                            storeItems.Add(new KeyValuePair<string, object>(key, state.ToObject<object>(StateJsonSerializer)));
+                            storeItems.Add(key, state.ToObject<object>(StateJsonSerializer));
                         }
                     }
                 }

--- a/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
+++ b/samples/AlarmBot-Cards/AlarmBot-Cards.csproj
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AdaptiveCards" Version="0.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.5.1" />
 
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>

--- a/samples/AlarmBot/AlarmBot.csproj
+++ b/samples/AlarmBot/AlarmBot.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.0.5.1" />
 
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Core.Extensions.Tests/StorageBaseTests.cs
@@ -50,7 +50,9 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             var key = "!@#$%^&*()~/\\><,.?';\"`~";
             var storeItem = new PocoStoreItem() { Id = "1" };
 
-            await storage.Write(new[] { new KeyValuePair<string, object>(key, storeItem) });
+            var dict = new Dictionary<string, object>() { { key, storeItem } };
+
+            await storage.Write(dict);
 
             var storeItems = await storage.Read(key);
 
@@ -71,11 +73,13 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             var originalPocoStoreItem = new PocoStoreItem() { Id = "1", Count = 1 };
 
             // first write should work
-            await storage.Write(new[]
+            var dict = new Dictionary<string, object>()
             {
-                new KeyValuePair<string, object>("pocoItem", originalPocoItem),
-                new KeyValuePair<string, object>("pocoStoreItem", originalPocoStoreItem )
-            });
+                { "pocoItem", originalPocoItem },
+                { "pocoStoreItem", originalPocoStoreItem }
+            };
+
+            await storage.Write(dict);
 
             var loadedStoreItems = new Dictionary<string, object>(await storage.Read("pocoItem", "pocoStoreItem"));
 
@@ -103,11 +107,10 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             try
             {
                 updatePocoItem.Count = 123;
-
-                await storage.Write(new[]
-                {
-                    new KeyValuePair<string, object>("pocoItem", updatePocoItem)
-                });
+                
+                await storage.Write(
+                    new Dictionary<string, object>() { { "pocoItem", updatePocoItem } }
+                );
             }
             catch
             {
@@ -118,11 +121,10 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             try
             {
                 updatePocoStoreItem.Count = 123;
-
-                await storage.Write(new[]
-                {
-                    new KeyValuePair<string, object>("pocoStoreItem", updatePocoStoreItem)
-                });
+                
+                await storage.Write(
+                    new Dictionary<string, object>() { { "pocoStoreItem", updatePocoStoreItem } }
+                );
 
                 Assert.Fail("Should have thrown exception on write with store item because of old etag");
             }
@@ -143,11 +145,12 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
             reloadedPocoStoreItem2.Count = 100;
             reloadedPocoStoreItem2.eTag = "*";
 
-            await storage.Write(new[]
-            {
-                new KeyValuePair<string, object>("pocoItem", reloadedPocoItem2),
-                new KeyValuePair<string, object>("pocoStoreItem", reloadedPocoStoreItem2)
-            });
+            var wildcardEtagedict = new Dictionary<string, object>() {
+                { "pocoItem", reloadedPocoItem2 },
+                { "pocoStoreItem", reloadedPocoStoreItem2 }                    
+            };
+
+            await storage.Write(wildcardEtagedict);
 
             var reloadedStoreItems3 = new Dictionary<string, object>(await storage.Read("pocoItem", "pocoStoreItem"));
 
@@ -160,10 +163,13 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
                 var reloadedStoreItem4 = (await storage.Read("pocoStoreItem")).OfType<PocoStoreItem>().First();
 
                 reloadedStoreItem4.eTag = "";
-                await storage.Write(new[]
-                {
-                    new KeyValuePair<string, object>("pocoStoreItem", reloadedStoreItem4)
-                });
+                var dict2 = new Dictionary<string, object>()
+                {                
+                    { "pocoStoreItem", reloadedStoreItem4 }
+                };
+
+
+                await storage.Write(dict2);
 
                 Assert.Fail("Should have thrown exception on write with storeitem because of empty etag");
             }
@@ -180,7 +186,12 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
         protected async Task _deleteObjectTest(IStorage storage)
         {
             //first write should work
-            await storage.Write(new[] { new KeyValuePair<string, object>("delete1", new PocoStoreItem() { Id = "1", Count = 1 }) });
+            var dict = new Dictionary<string, object>()
+                {
+                    { "delete1", new PocoStoreItem() { Id = "1", Count = 1 } }
+                };
+
+            await storage.Write(dict);
 
             var storeItems = await storage.Read("delete1");
             var storeItem = storeItems.First().Value as PocoStoreItem;


### PR DESCRIPTION
Closes #428 

IEnumerable<KeyValuePair<string,Object>

... becomes

IDictionary<string,Object>