### PR TITLE
Optimize Activity::IsActivity helper method

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -180,6 +180,15 @@ namespace Microsoft.Bot.Schema
         /// </summary>
         protected bool IsActivity(string activityType)
         {
+            /*
+             * NOTE: While it is possible to come up with a fancy looking "one-liner" to solve 
+             * this problem, this code is purposefully more verbose due to optimizations. 
+             * 
+             * This main goal of the optimizations was to make zero allocations because it is called 
+             * by all of the .AsXXXActivity methods which are used in a pattern heavily upstream to 
+             * "pseudo-cast" the activity based on its type.
+             */
+
             var type = this.Type;
 
             // If there's no type set then we can't tell if it's the type they're looking for

--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -178,7 +178,36 @@ namespace Microsoft.Bot.Schema
         /// <summary>
         /// True if the Activity is of the specified activity type
         /// </summary>
-        protected bool IsActivity(string activity) { return string.Compare(this.Type?.Split('/').First(), activity, true) == 0; }
+        protected bool IsActivity(string activityType)
+        {
+            var type = this.Type;
+
+            // If there's no type set then we can't tell if it's the type they're looking for
+            if (type == null)
+            {
+                return false;
+            }
+
+            // Check if the full type value starts with the type they're looking for
+            var result = type.StartsWith(activityType, StringComparison.OrdinalIgnoreCase);
+
+            // If the full type value starts with the type they're looking for, then we need to check a little further to check if it's definitely the right type
+            if (result)
+            {
+                // If the lengths are equal, then it's the exact type they're looking for
+                result = type.Length == activityType.Length;
+
+                if (!result)
+                {
+                    // Finally, if the type is longer than the type they're looking for then we need to check if there's a / separator right after the type they're looking for
+                    result = type.Length > activityType.Length
+                                    &&
+                            type[activityType.Length] == '/';
+                }
+            }
+
+            return result;
+        }
 
         /// <summary>
         /// Return an IMessageActivity mask if this is a message activity


### PR DESCRIPTION
This method is at the base of all of the `AsXXXActivity` conversion
methods which are called frequently. It was using a `string::Split`
100% of the time causing an unnecessary allocation. The focus was
removing that allocation which also came with a massive ~9x performance
boost as well.

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3101.0
  Job-HXPPJN : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3101.0

Jit=LegacyJit  Platform=X86  Runtime=Clr  

```
|                 Method |              Type |  activity |       Mean |     Error |     StdDev |     Median | Scaled |  Gen 0 | Allocated |
|----------------------- |------------------ |---------- |-----------:|----------:|-----------:|-----------:|-------:|-------:|----------:|
|    **IsActivity_ORIGINAL** |         **othertype** | **othertype** | **204.103 ns** | **4.0980 ns** |  **4.7192 ns** | **205.755 ns** |   **1.00** | **0.0188** |      **80 B** |
| IsActivity_OPTIMIZED |         othertype | othertype |   3.125 ns | 0.1242 ns |  0.3585 ns |   2.975 ns |   0.02 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** |         **othertype** |      **type** | **201.088 ns** | **4.4141 ns** |  **6.0421 ns** | **200.532 ns** |   **1.00** | **0.0188** |      **80 B** |
| IsActivity_OPTIMIZED |         othertype |      type |  36.111 ns | 0.7289 ns |  0.7159 ns |  35.987 ns |   0.18 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** | **othertype/subtype** | **othertype** | **298.578 ns** | **6.1381 ns** | **15.1719 ns** | **295.676 ns** |   **1.00** | **0.0415** |     **176 B** |
| IsActivity_OPTIMIZED | othertype/subtype | othertype |  38.245 ns | 1.0248 ns |  1.0065 ns |  38.109 ns |   0.13 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** | **othertype/subtype** |      **type** | **273.638 ns** | **6.0054 ns** |  **6.9159 ns** | **271.152 ns** |   **1.00** | **0.0415** |     **176 B** |
| IsActivity_OPTIMIZED | othertype/subtype |      type |  37.246 ns | 0.7742 ns |  0.7950 ns |  37.156 ns |   0.14 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** |              **type** | **othertype** | **192.496 ns** | **3.6844 ns** |  **3.6186 ns** | **193.298 ns** |   **1.00** | **0.0143** |      **60 B** |
| IsActivity_OPTIMIZED |              type | othertype |   3.949 ns | 0.0765 ns |  0.0715 ns |   3.987 ns |   0.02 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** |              **type** |      **type** | **201.699 ns** | **4.2483 ns** |  **6.3587 ns** | **199.729 ns** |   **1.00** | **0.0143** |      **60 B** |
| IsActivity_OPTIMIZED |              type |      type |   2.829 ns | 0.0911 ns |  0.0895 ns |   2.812 ns |   0.01 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** |      **type/subtype** | **othertype** | **255.071 ns** | **3.8012 ns** |  **3.5556 ns** | **253.991 ns** |   **1.00** | **0.0348** |     **148 B** |
| IsActivity_OPTIMIZED |      type/subtype | othertype |  33.824 ns | 0.7028 ns |  0.8094 ns |  33.689 ns |   0.13 |      - |       0 B |
|                        |                   |           |            |           |            |            |        |        |           |
|    **IsActivity_ORIGINAL** |      **type/subtype** |      **type** | **241.663 ns** | **4.8204 ns** |  **6.5982 ns** | **240.832 ns** |   **1.00** | **0.0348** |     **148 B** |
| IsActivity_OPTIMIZED |      type/subtype |      type |  34.729 ns | 0.7030 ns |  0.6905 ns |  34.917 ns |   0.14 |      - |       0 B |
