### PR TITLE
Update packit.cmd to use outputpackages folder

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/packit.cmd
+++ b/libraries/Microsoft.Bot.Builder.Classic/Microsoft.Bot.Builder.Classic/packit.cmd
@@ -1,4 +1,4 @@
 copy Microsoft.Bot.Builder.Classic.nuspec temp.nuspec
 ..\..\..\nuget\rep -find:$version$ -replace:%1 temp.nuspec
-NuGet.exe pack -symbols temp.nuspec -outputdirectory bin\release
+NuGet.exe pack -symbols temp.nuspec -outputdirectory ..\..\..\outputpackages
 erase temp.nuspec


### PR DESCRIPTION
This makes Bot.Builder.Classic consistent with the other projects that all write their .nupkg files (via Directory.Build.props) to the same folder.