### PR TITLE
first level of cleanup across prompts

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 {
     public class Choice
     {
+        public Choice(string s = null)
+        {
+            Value = s;
+        }
+
         ///<summary>
         /// Value to return when selected.
         ///</summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -11,23 +11,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 {
     public class ChoiceFactory
     {
-        public static IMessageActivity ForChannel(ITurnContext context, List<Choice> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
-        {
-            return ForChannel(Channel.GetChannelId(context), choices, text, speak, options);
-        }
-
-        public static IMessageActivity ForChannel(ITurnContext context, List<string> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
-        {
-            return ForChannel(Channel.GetChannelId(context), ToChoices(choices), text, speak, options);
-        }
-
-        public static IMessageActivity ForChannel(string channelId, List<string> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
-        {
-            return ForChannel(channelId, ToChoices(choices), text, speak, options);
-        }
-
         public static IMessageActivity ForChannel(string channelId, List<Choice> list, string text = null, string speak = null, ChoiceFactoryOptions options = null)
         {
+            channelId = channelId ?? string.Empty;
+
             list = list ?? new List<Choice>();
 
             // Find maximum title length
@@ -64,11 +51,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 // Show a numbered list.
                 return List(list, text, speak, options);
             }
-        }
-
-        public static Activity Inline(List<string> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
-        {
-            return Inline(ToChoices(choices), text, speak, options);
         }
 
         public static Activity Inline(List<Choice> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/BasePromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/BasePromptInternal.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
-using Microsoft.Bot.Schema;
 using static Microsoft.Bot.Builder.Dialogs.PromptValidatorEx;
 
 namespace Microsoft.Bot.Builder.Dialogs
@@ -26,41 +25,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         public BasePromptInternal(PromptValidator<T> validator = null)
         {
             _customValidator = validator;
-        }
-
-        /// <summary>
-        /// Sends a message to the user, using the context for the current turn.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="text">The text of the message to send.</param>
-        /// <param name="speak">Optional, text to be spoken by your bot on a speech-enabled
-        /// channel.</param>
-        /// <returns>A task that represents the work queued to execute.</returns>
-        /// <remarks>The message is sent with the "expectingInput" input hint.
-        /// <para>See the channel's documentation for limits imposed upon the contents of
-        /// <paramref name="text"/>.</para>
-        /// <para>To control various characteristics of your bot's speech such as voice,
-        /// rate, volume, pronunciation, and pitch, specify <paramref name="speak"/> in
-        /// Speech Synthesis Markup Language (SSML) format.</para>
-        /// </remarks>
-        public Task Prompt(ITurnContext context, string text, string speak = null)
-        {
-            IMessageActivity ma = Activity.CreateMessageActivity();
-            ma.Text = !string.IsNullOrWhiteSpace(text) ? text : null;
-            ma.Speak = !string.IsNullOrWhiteSpace(speak) ? speak : null;
-            ma.InputHint = InputHints.ExpectingInput;
-            return Prompt(context, ma);
-        }
-
-        /// <summary>
-        /// Sends a message to the user, using the context for the current turn.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <param name="activity">The message activity to send.</param>
-        /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task Prompt(ITurnContext context, IMessageActivity activity)
-        {
-            await context.SendActivity(activity);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ChoicePromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ChoicePromptInternal.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     break;
 
                 default:
-                    msg = ChoiceFactory.ForChannel(context, choices, prompt, speak, ChoiceOptions);
+                    msg = ChoiceFactory.ForChannel(context.Activity.ChannelId, choices, prompt, speak, ChoiceOptions);
                     break;
             }
 
@@ -94,18 +94,6 @@ namespace Microsoft.Bot.Builder.Dialogs
                 prompt.Speak = speak ?? prompt.Speak;
                 await context.SendActivity(prompt);
             }
-        }
-
-        public Task<ChoiceResult> Recognize(ITurnContext context, List<string> choices)
-        {
-            BotAssert.ContextNotNull(context);
-            BotAssert.ActivityNotNull(context.Activity);
-            if (context.Activity.Type != ActivityTypes.Message)
-                throw new InvalidOperationException("No Message to Recognize");
-            if (choices == null)
-                throw new ArgumentNullException(nameof(choices));
-
-            return Recognize(context, ChoiceFactory.ToChoices(choices));
         }
 
         public async Task<ChoiceResult> Recognize(ITurnContext context, List<Choice> choices)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ConfirmPromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ConfirmPromptInternal.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             return Prompt(context, ChoicesList, prompt, speak);
         }
 
-        public async Task Prompt(ITurnContext context, List<Choice> choices, string prompt = null, string speak = null)
+        private async Task Prompt(ITurnContext context, List<Choice> choices, string prompt = null, string speak = null)
         {
             BotAssert.ContextNotNull(context);
             if (Choices == null)
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     break;
 
                 default:
-                    msg = ChoiceFactory.ForChannel(context, ChoicesList, prompt, speak, ChoiceOptions);
+                    msg = ChoiceFactory.ForChannel(context.Activity.ChannelId, ChoicesList, prompt, speak, ChoiceOptions);
                     break;
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/OAuthPromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/OAuthPromptInternal.cs
@@ -73,31 +73,41 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (!ChannelSupportsOAuthCard(context.Activity.ChannelId))
             {
                 var link = await adapter.GetOauthSignInLink(context, _settings.ConnectionName).ConfigureAwait(false);
-                cardAttachment = new Attachment()
+                cardAttachment = new Attachment
                 {
                     ContentType = SigninCard.ContentType,
-                    Content = new SigninCard()
+                    Content = new SigninCard
                     {
                         Text = _settings.Text,
-                        Buttons = new CardAction[]
+                        Buttons = new []
                         {
-                        new CardAction() {Title = _settings.Title, Value = link, Type = ActionTypes.Signin }
+                            new CardAction
+                            {
+                                Title = _settings.Title,
+                                Value = link,
+                                Type = ActionTypes.Signin
+                            }
                         }
                     }
                 };
             }
             else
             {
-                cardAttachment = new Attachment()
+                cardAttachment = new Attachment
                 {
                     ContentType = OAuthCard.ContentType,
-                    Content = new OAuthCard()
+                    Content = new OAuthCard
                     {
                         Text = _settings.Text,
                         ConnectionName = _settings.ConnectionName,
-                        Buttons = new CardAction[]
+                        Buttons = new []
                         {
-                        new CardAction() {Title = _settings.Title, Text = _settings.Text, Type = ActionTypes.Signin }
+                            new CardAction
+                            {
+                                Title = _settings.Title,
+                                Text = _settings.Text,
+                                Type = ActionTypes.Signin
+                            }
                         }
                     }
                 };
@@ -117,7 +127,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 var tokenResponseObject = context.Activity.Value as JObject;
                 var tokenResponse = tokenResponseObject?.ToObject<TokenResponse>();
-                return new TokenResult() { Status = PromptStatus.Recognized, TokenResponse = tokenResponse };
+                return new TokenResult
+                {
+                    Status = PromptStatus.Recognized,
+                    TokenResponse = tokenResponse
+                };
             }
             else if (context.Activity.Type == ActivityTypes.Message)
             {
@@ -127,14 +141,23 @@ namespace Microsoft.Bot.Builder.Dialogs
                     var adapter = context.Adapter as BotFrameworkAdapter;
                     if (adapter == null)
                         throw new InvalidOperationException("OAuthPrompt.Recognize(): not supported by the current adapter");
+
                     var token = await adapter.GetUserToken(context, _settings.ConnectionName, matched.Value).ConfigureAwait(false);
-                    var tokenResult = new TokenResult() { Status = PromptStatus.Recognized, TokenResponse = token };
+                    var tokenResult = new TokenResult
+                    {
+                        Status = PromptStatus.Recognized,
+                        TokenResponse = token
+                    };
+
                     if (_promptValidator != null)
+                    {
                         await _promptValidator(context, tokenResult).ConfigureAwait(false);
+                    }
+
                     return tokenResult;
                 }
             }
-            return new TokenResult() { Status = PromptStatus.NotRecognized };
+            return new TokenResult { Status = PromptStatus.NotRecognized };
         }
 
         /// <summary>
@@ -152,21 +175,25 @@ namespace Microsoft.Bot.Builder.Dialogs
             TokenResult tokenResult = null;
             if (token == null)
             {
-                tokenResult = new TokenResult()
+                tokenResult = new TokenResult
                 {
                     Status = PromptStatus.NotRecognized
                 };
             }
             else
             {
-                tokenResult = new TokenResult()
+                tokenResult = new TokenResult
                 {
                     Status = PromptStatus.Recognized,
                     TokenResponse = token
                 };
             }
+
             if (_promptValidator != null)
+            {
                 await _promptValidator(context, tokenResult).ConfigureAwait(false);
+            }
+
             return tokenResult;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/PromptMessageFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/PromptMessageFactory.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    internal static class PromptMessageFactory
+    {
+        public static IMessageActivity CreateActivity(PromptOptions options, bool isRetry)
+        {
+            if (isRetry)
+            {
+                if (options.RetryPromptActivity != null)
+                {
+                    return CreateActivity(options.RetryPromptActivity);
+                }
+                if (options.RetryPromptString != null)
+                {
+                    return CreateActivity(options.RetryPromptString, options.RetrySpeak);
+                }
+            }
+            // else fall through and use non-retry prompt option
+
+            if (options.PromptActivity != null)
+            {
+                return CreateActivity(options.PromptActivity);
+            }
+            if (options.PromptString != null)
+            {
+                return CreateActivity(options.PromptString, options.Speak);
+            }
+
+            throw new ArgumentException("Missing required fields on PromptOptions", nameof(options));
+        }
+
+        private static IMessageActivity CreateActivity(string text, string speak)
+        {
+            IMessageActivity activity = Activity.CreateMessageActivity();
+            activity.InputHint = InputHints.ExpectingInput;
+            activity.Text = !string.IsNullOrWhiteSpace(text) ? text : null;
+            activity.Speak = !string.IsNullOrWhiteSpace(speak) ? speak : null;
+            return activity;
+        }
+
+        private static IMessageActivity CreateActivity(IActivity activity)
+        {
+            if (activity.Type != ActivityTypes.Message)
+            {
+                throw new ArgumentException("Provided Activity must be a Message Activity");
+            }
+            return activity.AsMessageActivity();
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -51,6 +51,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <Compile Remove="Prompts\BasicPrompt.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Bot.Builder.Core" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Builder.Core" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.Bot.Builder.Prompts" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AttachmentPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AttachmentPrompt.cs
@@ -22,29 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
 
-            if (isRetry)
-            {
-                if (options.RetryPromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptActivity.AsMessageActivity());
-                }
-                if (options.RetryPromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptString, options.RetrySpeak);
-                }
-            }
-            else
-            {
-                if (options.PromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptActivity);
-                }
-                if (options.PromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptString, options.Speak);
-                }
-            }
-            return Task.CompletedTask;
+            return dc.Context.SendActivity(PromptMessageFactory.CreateActivity(options, isRetry));
         }
 
         protected override async Task<AttachmentResult> OnRecognize(DialogContext dc, PromptOptions options)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/BasicPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/BasicPrompt.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Builder.Dialogs.Prompts
+{
+    public class BasicPrompt<T> : Prompt<T> where T: PromptResult
+    {
+        protected BasicPrompt()
+        {
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoiceResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoiceResult.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
 using Microsoft.Bot.Builder.Dialogs.Choices;
 
 namespace Microsoft.Bot.Builder.Dialogs

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmResult.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Bot.Builder.Dialogs
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Dialogs
 {
     public class ConfirmResult : PromptResult
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
@@ -23,29 +23,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
 
-            if (isRetry)
-            {
-                if (options.RetryPromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptActivity.AsMessageActivity());
-                }
-                if (options.RetryPromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptString, options.RetrySpeak);
-                }
-            }
-            else
-            {
-                if (options.PromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptActivity);
-                }
-                if (options.PromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptString, options.Speak);
-                }
-            }
-            return Task.CompletedTask;
+            return dc.Context.SendActivity(PromptMessageFactory.CreateActivity(options, isRetry));
         }
 
         protected override async Task<DateTimeResult> OnRecognize(DialogContext dc, PromptOptions options)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -22,29 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
 
-            if (isRetry)
-            {
-                if (options.RetryPromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptActivity.AsMessageActivity());
-                }
-                if (options.RetryPromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptString, options.RetrySpeak);
-                }
-            }
-            else
-            {
-                if (options.PromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptActivity);
-                }
-                if (options.PromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptString, options.Speak);
-                }
-            }
-            return Task.CompletedTask;
+            return dc.Context.SendActivity(PromptMessageFactory.CreateActivity(options, isRetry));
         }
 
         protected override async Task<NumberResult<T>> OnRecognize(DialogContext dc, PromptOptions options)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberResult.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
 namespace Microsoft.Bot.Builder.Dialogs
 {
     /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/TextPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/TextPrompt.cs
@@ -23,29 +23,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
 
-            if (isRetry)
-            {
-                if (options.RetryPromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptActivity.AsMessageActivity());
-                }
-                if (options.RetryPromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.RetryPromptString, options.RetrySpeak);
-                }
-            }
-            else
-            {
-                if (options.PromptActivity != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptActivity);
-                }
-                if (options.PromptString != null)
-                {
-                    return _prompt.Prompt(dc.Context, options.PromptString, options.Speak);
-                }
-            }
-            return Task.CompletedTask;
+            return dc.Context.SendActivity(PromptMessageFactory.CreateActivity(options, isRetry));
         }
 
         protected override async Task<TextResult> OnRecognize(DialogContext dc, PromptOptions options)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -12,7 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestCategory("Choice Tests")]
     public class ChoiceFactoryTests
     {
-        private static List<string> colorChoices = new List<string> { "red", "green", "blue" };
+        private static List<Choice> colorChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue") };
 
         [TestMethod]
         public void ShouldRenderChoicesInline()


### PR DESCRIPTION
- significant clean up across prompts
- next phase of clean up (not this check in) will be to consolidate Choice and Confirm
- at which point we should be consistent across all prompts and then (perhaps) remove the internal classes
- note a better name for the "internal" prompts would simply be "RecognizeAndValidate" because that is what they do - they simply add a user provided validate function to a recognizer
 