### PR TITLE
EndorsementsRetriever perf, hardening and unit test coverage

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             foreach (var key in keys)
             {
-                var keyId = key["keyid"]?.Value<string>();
+                var keyId = key[AuthenticationConstants.KeyIdHeader]?.Value<string>();
 
                 if (keyId != null
                         &&

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// and related issues.</param>
         public EndorsementsRetriever(HttpClient httpClient)
         {
-            _httpClient = httpClient;
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using RichardSzalay.MockHttp;
+using System.Net.Http;
+using Microsoft.IdentityModel.Protocols;
+using System.Threading;
+
+namespace Microsoft.Bot.Connector.Authentication.Tests
+{
+    public class EndorsementsRetrieverTests
+    {
+        public class ConstructorTests
+        {
+            [Fact]
+            public void NullHttpClientShouldThrow()
+            {
+                Action action = () => new EndorsementsRetriever(null);
+
+                action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("httpClient");
+            }
+
+            [Fact]
+            public void SucceedsWithValidParameters()
+            {
+                new EndorsementsRetriever(new HttpClient());
+            }
+        }
+
+        public class GetConfigurationAsyncTests
+        {
+            private const string FakeDocumentAddress = "http://fakeaddress";
+
+            private readonly Mock<IDocumentRetriever> _mockDocumentRetriever;
+            private readonly MockHttpMessageHandler _mockHttpMessageHandler;
+            private readonly EndorsementsRetriever _endorsementsRetriever;
+
+            public GetConfigurationAsyncTests()
+            {
+                _mockDocumentRetriever = new Mock<IDocumentRetriever>();
+                _mockHttpMessageHandler = new MockHttpMessageHandler();
+                _endorsementsRetriever = new EndorsementsRetriever(_mockHttpMessageHandler.ToHttpClient());
+            }
+
+            [Fact]
+            public void NullAddressParameterShouldThrow()
+            {
+                Func<Task> action = async () => await _endorsementsRetriever.GetConfigurationAsync(null, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("address");
+            }
+
+            [Fact]
+            public void NullDocumentRetrieverParameterShouldThrow()
+            {
+                Func<Task> action = async () => await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, null, CancellationToken.None);
+
+                action.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("retriever");
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyValues_EmptyObject()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync("{ }");
+
+                var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                results.Should().NotBeNull().And.BeEmpty();
+
+                _mockDocumentRetriever.Verify(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()), Times.Once());
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyValues_EmptyKeysArray()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(@"{ ""keys"": [ ] }");
+
+                var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                results.Should().NotBeNull().And.BeEmpty();
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyValues_NullKeysArray()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(@"{ ""keys"": null }");
+
+                var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                results.Should().NotBeNull().And.BeEmpty();
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyValues_InvalidKeyObjectInKeysArray()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(@"{ ""keys"": [ { } ] }");
+
+                var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                results.Should().NotBeNull().And.BeEmpty();
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyValues_SingleKeyWithNoEndorsements()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(@"{ ""keys"": [ { ""keyid"": ""keyid123"" } ] }");
+
+                var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                results.Should().NotBeNull().And.BeEmpty();
+            }
+
+            [Fact]
+            public async Task ReturnsEmptyValues_MultipleKeysWithNoEndorsements()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(@"{ ""keys"": [ { ""keyid"": ""keyid123"" }, { ""keyid"": ""keyid456"" }, { ""keyid"": ""keyid789"" } ] }");
+
+                var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                results.Should().NotBeNull().And.BeEmpty();
+            }
+
+            [Fact]
+            public void ThrowsIfDocumentRetrieverThrows()
+            {
+                _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new Exception(nameof(ThrowsIfDocumentRetrieverThrows)));
+
+                Func<Task> action = async () => await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
+
+                action.Should().Throw<Exception>().And.Message.Should().Be(nameof(ThrowsIfDocumentRetrieverThrows));
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Connector.Authentication.Tests
             public async Task ReturnsEmptyValues_SingleKeyWithNoEndorsements()
             {
                 _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(@"{ ""keys"": [ { ""keyid"": ""keyid123"" } ] }");
+                    .ReturnsAsync(@"{ ""keys"": [ { ""kid"": ""keyid123"" } ] }");
 
                 var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
 
@@ -122,7 +122,7 @@ namespace Microsoft.Bot.Connector.Authentication.Tests
             public async Task ReturnsEmptyValues_MultipleKeysWithNoEndorsements()
             {
                 _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(@"{ ""keys"": [ { ""keyid"": ""keyid123"" }, { ""keyid"": ""keyid456"" }, { ""keyid"": ""keyid789"" } ] }");
+                    .ReturnsAsync(@"{ ""keys"": [ { ""kid"": ""keyid123"" }, { ""kid"": ""keyid456"" }, { ""kid"": ""keyid789"" } ] }");
 
                 var results = await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, _mockDocumentRetriever.Object, CancellationToken.None);
 

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -19,9 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="1.6.0" />
+    <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
Per request from @cleemullins, this PR focuses on the `EndorsementsRetriever` class which is responsible for fetching and parsing keys out of OpenID Connect metadata documents to be used while validating JWT tokens.

Hardening wise I added better exception handling and propagation around HTTP level failures. NOTE: network level failures will still result in a raw `Exception` being propagated.

Test Coverage was initiated in this PR which brings coverage for the `EndorsementsRetriever` class from 0% to 100% coverage.

Performance wise the new implementation brings gains of ~35%-52% in CPU and more modest allocation gains of ~10-20% depending on the scenarios.

----

``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3110.0
  Job-KGFYSY : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3110.0

Jit=RyuJit  Platform=X86  Runtime=Clr  

```
|                          Method | JsonIndex |       Mean |    Error |    StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------------------------- |---------- |-----------:|---------:|----------:|-------:|---------:|-------:|----------:|
|           **GetConfigurationAsync** |         **0** |   **737.1 ns** | **14.57 ns** |  **15.59 ns** |   **1.00** |     **0.00** | **0.6380** |   **2.62 KB** |
| GetConfigurationAsync_OPTIMIZED |         0 |   476.3 ns | 12.49 ns |  35.23 ns |   0.65 |     0.05 | 0.5770 |   2.37 KB |
|                                 |           |            |          |           |        |          |        |           |
|           **GetConfigurationAsync** |         **1** | **2,253.2 ns** | **43.99 ns** |  **55.64 ns** |   **1.00** |     **0.00** | **0.8774** |   **3.61 KB** |
| GetConfigurationAsync_OPTIMIZED |         1 | 1,082.4 ns | 19.58 ns |  18.31 ns |   0.48 |     0.01 | 0.6905 |   2.83 KB |
|                                 |           |            |          |           |        |          |        |           |
|           **GetConfigurationAsync** |         **2** | **2,606.1 ns** | **51.52 ns** |  **99.26 ns** |   **1.00** |     **0.00** | **0.9079** |   **3.73 KB** |
| GetConfigurationAsync_OPTIMIZED |         2 | 1,382.6 ns | 26.04 ns |  48.28 ns |   0.53 |     0.03 | 0.7439 |   3.05 KB |
|                                 |           |            |          |           |        |          |        |           |
|           **GetConfigurationAsync** |         **3** | **3,130.5 ns** | **63.21 ns** | **109.04 ns** |   **1.00** |     **0.00** | **0.9346** |   **3.83 KB** |
| GetConfigurationAsync_OPTIMIZED |         3 | 1,636.2 ns | 31.70 ns |  26.47 ns |   0.52 |     0.02 | 0.7725 |   3.17 KB |
|                                 |           |            |          |           |        |          |        |           |
|           **GetConfigurationAsync** |         **4** | **3,572.7 ns** | **71.36 ns** |  **82.17 ns** |   **1.00** |     **0.00** | **0.9842** |   **4.04 KB** |
| GetConfigurationAsync_OPTIMIZED |         4 | 2,080.9 ns | 26.31 ns |  23.32 ns |   0.58 |     0.01 | 0.8240 |   3.39 KB |
|                                 |           |            |          |           |        |          |        |           |
|           **GetConfigurationAsync** |         **5** | **5,675.6 ns** | **75.83 ns** |  **70.93 ns** |   **1.00** |     **0.00** | **1.1749** |   **4.84 KB** |
| GetConfigurationAsync_OPTIMIZED |         5 | 3,279.1 ns | 58.80 ns |  55.00 ns |   0.58 |     0.01 | 0.9193 |   3.78 KB |
|                                 |           |            |          |           |        |          |        |           |
|           **GetConfigurationAsync** |         **6** | **6,987.5 ns** | **86.19 ns** |  **80.62 ns** |   **1.00** |     **0.00** | **1.2512** |   **5.14 KB** |
| GetConfigurationAsync_OPTIMIZED |         6 | 4,407.9 ns | 45.80 ns |  42.84 ns |   0.63 |     0.01 | 1.0071 |   4.15 KB |
