### PR TITLE
JWT validation perf - string[] to HashSet<string>

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Bot.Connector.Authentication
 {
     /// <summary>
@@ -42,7 +44,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// Allowed token signing algorithms. Tokens come from channels to the bot. The code
         /// that uses this also supports tokens coming from the emulator.
         /// </summary>
-        public static readonly string[] AllowedSigningAlgorithms = new[] { "RS256", "RS384", "RS512" };
+        public static readonly HashSet<string> AllowedSigningAlgorithms = new HashSet<string>(new [] { "RS256", "RS384", "RS512" });
 
         /// <summary>
         /// "azp" Claim. 

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// More details at:
     ///     https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-connector-authentication
     /// </summary>
-    public sealed class EndorsementsRetriever : IDocumentRetriever, IConfigurationRetriever<IDictionary<string, string[]>>
+    public sealed class EndorsementsRetriever : IDocumentRetriever, IConfigurationRetriever<IDictionary<string, HashSet<string>>>
     {
         private readonly HttpClient _httpClient;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         public const string JsonWebKeySetUri = "jwks_uri";
 
-        public async Task<IDictionary<string, string[]>> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancellationToken)
+        public async Task<IDictionary<string, HashSet<string>>> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancellationToken)
         {
             if (address == null)
             {
@@ -72,10 +72,10 @@ namespace Microsoft.Bot.Connector.Authentication
 
             if (keys == null)
             {
-                return new Dictionary<string, string[]>(0);
+                return new Dictionary<string, HashSet<string>>(0);
             }
 
-            var results = new Dictionary<string, string[]>(keys.Count);
+            var results = new Dictionary<string, HashSet<string>>(keys.Count);
 
             foreach (var key in keys)
             {
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
                     if (endorsementsToken != null)
                     {
-                        results.Add(keyId, endorsementsToken.Values<string>().ToArray());
+                        results.Add(keyId, new HashSet<string>(endorsementsToken.Values<string>()));
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.Bot.Connector.Authentication
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="endorsements">Whoever signed the JWT token is permitted to send activities only for
         /// some specific channels. That list is the endorsement list, and is validated here against the channelId.</param>
         /// <returns>True is the channelId is found in the Endorsement set. False if the channelId is not found.</returns>
-        public static bool Validate(string channelId, string[] endorsements)
+        public static bool Validate(string channelId, HashSet<string> endorsements)
         {
             // If the Activity came in and doesn't have a Channel ID then it's making no 
             // assertions as to who endorses it. This means it should pass. 
@@ -38,14 +39,8 @@ namespace Microsoft.Bot.Connector.Authentication
             //       -> 
             //          JWTTokenExtractor
 
-            // Does the set of endorsements match the channelId that was passed in? 
-
-            // ToDo: Consider moving this to a HashSet instead of a string
-            // array, to make lookups O(1) instead of O(N). To give a sense 
-            // of scope, tokens from WebChat have about 10 endorsements, and 
-            // tokens coming from Teams have about 20. 
-
-            bool endorsementPresent = endorsements.Contains(channelId);
+            // Does the set of endorsements match the channelId that was passed in?
+            var endorsementPresent = endorsements.Contains(channelId);
             return endorsementPresent;
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// Cache for Endorsement configuration managers (one per metadata URL)
         /// </summary>
-        private static readonly ConcurrentDictionary<string, ConfigurationManager<IDictionary<string, string[]>>> _endorsementsCache =
-            new ConcurrentDictionary<string, ConfigurationManager<IDictionary<string, string[]>>>();
+        private static readonly ConcurrentDictionary<string, ConfigurationManager<IDictionary<string, HashSet<string>>>> _endorsementsCache =
+            new ConcurrentDictionary<string, ConfigurationManager<IDictionary<string, HashSet<string>>>>();
 
         /// <summary>
         /// Token validation parameters for this instance
@@ -43,12 +43,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// Endorsements configuration manager for this instance
         /// </summary>
-        private readonly ConfigurationManager<IDictionary<string, string[]>> _endorsementsData;
+        private readonly ConfigurationManager<IDictionary<string, HashSet<string>>> _endorsementsData;
 
         /// <summary>
         /// Allowed signing algorithms
         /// </summary>
-        private readonly string[] _allowedSigningAlgorithms;
+        private readonly HashSet<string> _allowedSigningAlgorithms;
                 
         /// <summary>
         /// Extracts relevant data from JWT Tokens
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="metadataUrl"></param>
         /// <param name="allowedSigningAlgorithms"></param>
         /// <param name="validator"></param>
-        public JwtTokenExtractor(HttpClient httpClient, TokenValidationParameters tokenValidationParameters, string metadataUrl, string[] allowedSigningAlgorithms)
+        public JwtTokenExtractor(HttpClient httpClient, TokenValidationParameters tokenValidationParameters, string metadataUrl, HashSet<string> allowedSigningAlgorithms)
         {
             // Make our own copy so we can edit it
             _tokenValidationParameters = tokenValidationParameters.Clone();
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _endorsementsData = _endorsementsCache.GetOrAdd(metadataUrl, key =>
             {
                 var retriever = new EndorsementsRetriever(httpClient);
-                return new ConfigurationManager<IDictionary<string, string[]>>(metadataUrl, retriever, retriever);
+                return new ConfigurationManager<IDictionary<string, HashSet<string>>>(metadataUrl, retriever, retriever);
             });
         }
 
@@ -156,14 +156,14 @@ namespace Microsoft.Bot.Connector.Authentication
 
                 // Validate Channel / Token Endorsements. For this, the channelID present on the Activity 
                 // needs to be matched by an endorsement.  
-                string keyId = (string)parsedJwtToken?.Header?[AuthenticationConstants.KeyIdHeader];
+                var keyId = (string)parsedJwtToken?.Header?[AuthenticationConstants.KeyIdHeader];
                 var endorsements = await _endorsementsData.GetConfigurationAsync();
 
                 // Note: On the Emulator Code Path, the endorsements collection is empty so the validation code
                 // below won't run. This is normal. 
-                if (!string.IsNullOrEmpty(keyId) && endorsements.ContainsKey(keyId))
+                if (!string.IsNullOrEmpty(keyId) && endorsements.TryGetValue(keyId, out var endorsementsForKey))
                 {
-                    bool isEndorsed = EndorsementsValidator.Validate(channelId, endorsements[keyId]);
+                    var isEndorsed = EndorsementsValidator.Validate(channelId, endorsementsForKey);
                     if (!isEndorsed)
                     {
                         throw new UnauthorizedAccessException($"Could not validate endorsement for key: {keyId} with endorsements: {string.Join(",", endorsements[keyId])}");
@@ -172,7 +172,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
                 if (_allowedSigningAlgorithms != null)
                 {
-                    string algorithm = parsedJwtToken?.Header?.Alg;
+                    var algorithm = parsedJwtToken?.Header?.Alg;
                     if (!_allowedSigningAlgorithms.Contains(algorithm))
                     {
                         throw new UnauthorizedAccessException($"Token signing algorithm '{algorithm}' not in allowed list");
@@ -182,7 +182,7 @@ namespace Microsoft.Bot.Connector.Authentication
             }
             catch (SecurityTokenSignatureKeyNotFoundException)
             {
-                string keys = string.Join(", ", ((config?.SigningKeys) ?? Enumerable.Empty<SecurityKey>()).Select(t => t.KeyId));
+                var keys = string.Join(", ", ((config?.SigningKeys) ?? Enumerable.Empty<SecurityKey>()).Select(t => t.KeyId));
                 Trace.TraceError("Error finding key for token. Available keys: " + keys);
                 throw;
             }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsValidatorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.Bot.Connector.Authentication;
 using Xunit;
@@ -10,7 +11,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         [Fact]
         public void NullChannelIdParameterShouldPass()
         {
-            bool isEndorsed = EndorsementsValidator.Validate(null, new string[] { });
+            var isEndorsed = EndorsementsValidator.Validate(null, new HashSet<string>());
             isEndorsed.Should().BeTrue();
         }
 
@@ -24,35 +25,35 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         [Fact]
         public void UnendorsedChannelIdShouldFail()
         {
-            bool isEndorsed = EndorsementsValidator.Validate("channelOne", new string[] { });
+            var isEndorsed = EndorsementsValidator.Validate("channelOne", new HashSet<string>());
             isEndorsed.Should().BeFalse();
         }
 
         [Fact]
         public void MismatchedEndorsementsChannelIdShouldFail()
         {
-            bool isEndorsed = EndorsementsValidator.Validate("right", new[] { "wrong" });
+            var isEndorsed = EndorsementsValidator.Validate("right", new HashSet<string>(new[] { "wrong" }));
             isEndorsed.Should().BeFalse();
         }
 
         [Fact]
         public void EndorsedChannelIdShouldPass()
         {
-            bool isEndorsed = EndorsementsValidator.Validate("right", new[] { "right" });
+            var isEndorsed = EndorsementsValidator.Validate("right", new HashSet<string>(new[] { "right" }));
             isEndorsed.Should().BeTrue();
         }
 
         [Fact]
         public void EndorsedChannelIdShouldPassWithTwoEndorsements()
         {
-            bool isEndorsed = EndorsementsValidator.Validate("right", new[] { "right", "wrong" });
+            var isEndorsed = EndorsementsValidator.Validate("right", new HashSet<string>(new [] { "right", "wrong" }));
             isEndorsed.Should().BeTrue();
         }
 
         [Fact]
         public void UnaffinitizedActivityShouldPass()
         {
-            bool isEndorsed = EndorsementsValidator.Validate(string.Empty, new[] { "right", "wrong" });
+            var isEndorsed = EndorsementsValidator.Validate(string.Empty, new HashSet<string>(new[] { "right", "wrong" }));
             isEndorsed.Should().BeTrue();
         }
     }


### PR DESCRIPTION
There were a couple scenarios in JWT validation using `string[]`, thus
O(N) cost, vs using `HashSet<string>` (for O(1) cost.


``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3110.0
  Job-KGFYSY : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3110.0

Jit=RyuJit  Platform=X86  Runtime=Clr  

```
|                Method |     Mean |     Error |    StdDev | Scaled | ScaledSD | Allocated |
|---------------------- |---------:|----------:|----------:|-------:|---------:|----------:|
|   LookupInArray_Found | 70.50 ns | 1.5900 ns | 4.6632 ns |   1.00 |     0.00 |       0 B |
| LookupInHashSet_Found | 28.27 ns | 0.5958 ns | 0.8918 ns |   0.40 |     0.03 |       0 B |


``` ini

BenchmarkDotNet=v0.10.14, OS=Windows 10.0.17134
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3110.0
  Job-KGFYSY : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3110.0

Jit=RyuJit  Platform=X86  Runtime=Clr  

```
|                   Method |     Mean |     Error |    StdDev | Scaled | Allocated |
|------------------------- |---------:|----------:|----------:|-------:|----------:|
|   LookupInArray_NotFound | 73.61 ns | 1.5145 ns | 2.2200 ns |   1.00 |       0 B |
| LookupInHashSet_NotFound | 18.62 ns | 0.4312 ns | 0.9374 ns |   0.25 |       0 B |
