### PR TITLE
Move ConfigurationCredentialProvider out of core

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">4.0.0-local</Version>
@@ -55,12 +55,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-	  <PackageReference Include="Microsoft.Extensions.Configuration">
-	    <Version>2.0.1</Version>
-	  </PackageReference>
 	</ItemGroup>
 
 </Project>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationCredentialProvider.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationCredentialProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 using Microsoft.Bot.Connector.Authentication;
-#if NETSTANDARD2_0
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Bot.Builder.BotFramework
@@ -10,6 +8,12 @@ namespace Microsoft.Bot.Builder.BotFramework
     /// <summary>
     /// Credential provider which uses <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> to lookup appId and password.
     /// </summary>
+    /// <remarks>
+    /// This will populate the <see cref="SimpleCredentialProvider.AppId"/> from an configuration entry with the key of <see cref="MicrosoftAppCredentials.MicrosoftAppIdKey"/> 
+    /// and the <see cref="SimpleCredentialProvider.Password"/> from a configuration entry with the key of <see cref="MicrosoftAppCredentials.MicrosoftAppPasswordKey"/>.
+    /// 
+    /// NOTE: if the keys are not present, a <code>null</code> value will be used.
+    /// </remarks>
     public sealed class ConfigurationCredentialProvider : SimpleCredentialProvider
     {
         public ConfigurationCredentialProvider(IConfiguration configuration)
@@ -19,4 +23,3 @@ namespace Microsoft.Bot.Builder.BotFramework
         }
     }
 }
-#endif

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/ConfigurationCredentialProvider.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/ConfigurationCredentialProvider.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System.Configuration;
+using Microsoft.Bot.Connector.Authentication;
+
+namespace Microsoft.Bot.Builder.BotFramework
+{
+    /// <summary>
+    /// Loads credentials from the <see cref="ConfigurationManager.AppSettings"/>.
+    /// </summary>
+    /// <remarks>
+    /// This will populate the <see cref="SimpleCredentialProvider.AppId"/> from an app setting entry with the key of <see cref="MicrosoftAppCredentials.MicrosoftAppIdKey"/> 
+    /// and the <see cref="SimpleCredentialProvider.Password"/> from an app setting with the key of <see cref="MicrosoftAppCredentials.MicrosoftAppPasswordKey"/>.
+    /// 
+    /// NOTE: if the keys are not present, a <code>null</code> value will be used. 
+    /// </remarks>
+    public sealed class ConfigurationCredentialProvider : SimpleCredentialProvider
+    {
+        public ConfigurationCredentialProvider()
+        {
+            this.AppId = ConfigurationManager.AppSettings[MicrosoftAppCredentials.MicrosoftAppIdKey];
+            this.Password = ConfigurationManager.AppSettings[MicrosoftAppCredentials.MicrosoftAppPasswordKey];
+        }
+    }
+}


### PR DESCRIPTION
Fixes #255 by moving the `ConfigurationCredentialProvider` class out of
`Microsoft.Bot.Builder` and into the `AspNet.Core` integration library.

Also adds a specific `ConfigurationCredentialProvider` implementation
for WebAPI which loads settings from `AppSettings` instead.