### PR TITLE
Remove reference to removed assembly from sample

### DIFF
--- a/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/Microsoft.Bot.Samples.EchoBot-AspNetWebApi.csproj
+++ b/samples/Microsoft.Bot.Samples.EchoBot-AspNetWebApi/Microsoft.Bot.Samples.EchoBot-AspNetWebApi.csproj
@@ -167,10 +167,6 @@
       <Project>{bd0b82ef-1601-4e87-b78a-b43de7eb36b0}</Project>
       <Name>Microsoft.Bot.Builder.Integration.AspNet.WebApi</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Core\Microsoft.Bot.Builder.Core.csproj">
-      <Project>{f0c150e2-9b8a-444c-b70e-97ad918cb3d4}</Project>
-      <Name>Microsoft.Bot.Builder.Core</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj">
       <Project>{74908F42-3842-49B4-9344-60BB791FDE32}</Project>
       <Name>Microsoft.Bot.Builder</Name>


### PR DESCRIPTION
The ASP.NET WebAPI EchoBot sample project still had a reference to the
`Microsoft.Bot.Builder.Core` assembly which has now been removed.
Removing that refrerence to eliminate the build warning (and any
confusion that might have ensued).