### PR TITLE
Modified LocaleConverter to use CultureInfo patterns and support for es-es

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.Translation/LocaleConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.Translation/LocaleConverter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -72,30 +73,21 @@ namespace Microsoft.Bot.Builder.Ai.Translation
         {
             if (_mapLocaleToFunction.Count > 0)
                 return;
-            DateAndTimeLocaleFormat yearMonthDay = new DateAndTimeLocaleFormat
+            var supportedLocales = new string[]
             {
-                TimeFormat = "{0:hh:mm tt}",
-                DateFormat = "{0:yyyy-MM-dd}"
+                "en-us", "en-za", "en-ie", "en-gb", "en-ca", "fr-ca", "zh-cn", "zh-sg", "zh-hk", "zh-mo", "zh-tw",
+                "en-au", "fr-be", "fr-ch", "fr-fr", "fr-lu", "fr-mc", "de-at", "de-ch", "de-de", "de-lu", "de-li"
             };
-            DateAndTimeLocaleFormat dayMonthYear = new DateAndTimeLocaleFormat
+            foreach (string locale in supportedLocales)
             {
-                TimeFormat = "{0:hh:mm tt}",
-                DateFormat = "{0:dd/MM/yyyy}"
-            };
-            DateAndTimeLocaleFormat monthDayYEar = new DateAndTimeLocaleFormat
-            {
-                TimeFormat = "{0:hh:mm tt}",
-                DateFormat = "{0:MM/dd/yyyy}"
-            };
-            foreach (string locale in new string[] { "en-za", "en-ie", "en-gb", "en-ca", "fr-ca", "zh-cn", "zh-sg", "zh-hk", "zh-mo", "zh-tw" })
-            {
-                _mapLocaleToFunction[locale] = yearMonthDay;
+                CultureInfo cultureInfo = new CultureInfo(locale);
+                var dateTimeInfo = new DateAndTimeLocaleFormat()
+                {
+                    DateFormat = $"{{0:{cultureInfo.DateTimeFormat.ShortDatePattern}}}",
+                    TimeFormat = $"{{0:{cultureInfo.DateTimeFormat.ShortTimePattern}}}"
+                };
+                _mapLocaleToFunction[locale] = dateTimeInfo;
             }
-            foreach (string locale in new string[] { "en-au", "fr-be", "fr-ch", "fr-fr", "fr-lu", "fr-mc", "de-at", "de-ch", "de-de", "de-lu", "de-li" })
-            {
-                _mapLocaleToFunction[locale] = dayMonthYear;
-            }
-            _mapLocaleToFunction["en-us"] = monthDayYEar;
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/LocaleConverterMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/LocaleConverterMiddlewareTests.cs
@@ -37,8 +37,33 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Send("set my locale to fr-fr")
                     .AssertReply("Changing your locale to fr-fr")
                 .Send("Set a meeting on 30/9/2017")
-                    .AssertReply("Set a meeting on 09/30/2017")
+                    .AssertReply("Set a meeting on 9/30/2017")
                     .StartTest();
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("Locale Converter")]
+        public async Task LocaleConverterMiddleware_ConvertFromSpanishSpain()
+        {
+            TestAdapter adapter = new TestAdapter()
+                .Use(new UserState<LocaleState>(new MemoryStorage()))
+                .Use(new LocaleConverterMiddleware(GetActiveLocale, SetActiveLocale, "en-us", LocaleConverter.Converter));
+
+
+            await new TestFlow(adapter, (context) =>
+                {
+                    if (!context.Responded)
+                    {
+                        context.SendActivity(context.Activity.AsMessageActivity().Text);
+                    }
+                    return Task.CompletedTask;
+                })
+                .Send("set my locale to es-es")
+                .AssertReply("Changing your locale to es-es")
+                .Send("La reunión será a las 15:00")
+                .AssertReply("La reunión será a las 15:00")
+                .StartTest();
         }
 
         [TestMethod]
@@ -62,7 +87,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Send("set my locale to en-us")
                     .AssertReply("Changing your locale to en-us")
                 .Send("Book me a plane ticket for France on 12/25/2018")
-                    .AssertReply("Book me a plane ticket for France on 2018-12-25")
+                    .AssertReply("Book me a plane ticket for France on 2018/12/25")
                 .StartTest();
         }
 

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/LocaleConverterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/LocaleConverterTests.cs
@@ -20,7 +20,19 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
 
             var convertedMessage = localeConverter.Convert("Set a meeting on 30/9/2017", "fr-fr", "en-us");
             Assert.IsNotNull(convertedMessage);
-            Assert.AreEqual("Set a meeting on 09/30/2017", convertedMessage);
+            Assert.AreEqual("Set a meeting on 9/30/2017", convertedMessage);
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("Locale Converter")]
+        public void LocaleConverter_ConvertTimeFromSpanishSpain()
+        {
+            LocaleConverter localeConverter = LocaleConverter.Converter;
+
+            var convertedMessage = localeConverter.Convert("Book a meeting for 15:00", "es-es", "en-us");
+            Assert.IsNotNull(convertedMessage);
+            Assert.AreEqual("Book a meeting for 3:00 PM", convertedMessage);
         }
 
         [TestMethod]
@@ -32,7 +44,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
 
             var convertedMessage = localeConverter.Convert("Book me a plane ticket for France on 12/25/2018", "en-us", "zh-cn");
             Assert.IsNotNull(convertedMessage);
-            Assert.AreEqual("Book me a plane ticket for France on 2018-12-25", convertedMessage); 
+            Assert.AreEqual("Book me a plane ticket for France on 2018/12/25", convertedMessage); 
         }
 
         [TestMethod]
@@ -74,7 +86,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
 
             var convertedMessage = localeConverter.Convert("half past 9 am 02/03/2010", "en-us", "fr-fr");
             Assert.IsNotNull(convertedMessage);
-            Assert.AreEqual("03/02/2010 09:30 AM", convertedMessage);
+            Assert.AreEqual("03/02/2010 09:30", convertedMessage);
         }
 
         [TestMethod]
@@ -98,7 +110,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
 
             var convertedMessage = localeConverter.Convert("half past 9 am", "en-us", "fr-fr");
             Assert.IsNotNull(convertedMessage);
-            Assert.AreEqual("09:30 AM", convertedMessage);
+            Assert.AreEqual("09:30", convertedMessage);
         }
 
         [TestMethod]
@@ -110,7 +122,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
 
             var convertedMessage = localeConverter.Convert("from 10/21/2018 9 am to 10/23/2018 1 pm", "en-us", "fr-fr");
             Assert.IsNotNull(convertedMessage);
-            Assert.AreEqual("21/10/2018 09:00 AM - 23/10/2018 01:00 PM", convertedMessage);
+            Assert.AreEqual("21/10/2018 09:00 - 23/10/2018 13:00", convertedMessage);
         }
 
         [TestMethod]
@@ -134,7 +146,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
 
             var convertedMessage = localeConverter.Convert("from 9 am to 1 pm", "en-us", "fr-fr");
             Assert.IsNotNull(convertedMessage);
-            Assert.AreEqual("09:00 AM - 01:00 PM", convertedMessage);
+            Assert.AreEqual("09:00 - 13:00", convertedMessage);
         }
     }
 }


### PR DESCRIPTION
Modified LocaleConverter to use CultureInfo.ShortDatePattern and CultureInfo.ShortTimePattern so the conversion use the proper locales defined by the .NET core framework (the previous hardcoded locales weren't in line with the native formatting for each locale, i.e.: a lot of the supported locales use 24 hrs time format, not AM/PM, some date formatting assumptions were also wrong).

Added es-es as a supported locale (since Spanish is a supported culture for Microsoft.Recognizers.Text.Culture) and added realted unit tests.

Updated unit tests to use the proper locale formats in responses.