### PR TITLE
fixed up namespace and file headers in Ai.LUIS

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/Extensions.cs
@@ -1,42 +1,12 @@
-﻿// 
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
-// Microsoft Bot Framework: http://botframework.com
-// 
-// Bot Builder SDK GitHub:
-// https://github.com/Microsoft/BotBuilder
-// 
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-// 
-// MIT License:
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Cognitive.LUIS.Models;
 
-namespace Microsoft.Cognitive.LUIS
+namespace Microsoft.Bot.Builder.Ai.LUIS
 {
     /// <summary>
     /// LUIS extension methods.

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/LuisModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/LuisModel.cs
@@ -1,39 +1,9 @@
-// 
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
-// Microsoft Bot Framework: http://botframework.com
-// 
-// Bot Builder SDK GitHub:
-// https://github.com/Microsoft/BotBuilder
-// 
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-// 
-// MIT License:
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 using System;
 
-namespace Microsoft.Cognitive.LUIS
+namespace Microsoft.Bot.Builder.Ai.LUIS
 {
     /// <summary>
     /// Luis api version.

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/LuisOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/LuisOptions.cs
@@ -1,38 +1,7 @@
-﻿// 
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
-// Microsoft Bot Framework: http://botframework.com
-// 
-// Bot Builder SDK GitHub:
-// https://github.com/Microsoft/BotBuilder
-// 
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-// 
-// MIT License:
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
-
-namespace Microsoft.Cognitive.LUIS
+namespace Microsoft.Bot.Builder.Ai.LUIS
 {
     /// <summary>
     /// Interface containing optional parameters for a LUIS request.

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/LuisService.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/LuisService.cs
@@ -1,35 +1,5 @@
-﻿// 
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
-// Microsoft Bot Framework: http://botframework.com
-// 
-// Bot Builder SDK GitHub:
-// https://github.com/Microsoft/BotBuilder
-// 
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-// 
-// MIT License:
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 using System;
 using System.Collections.Generic;
@@ -40,7 +10,7 @@ using Microsoft.Cognitive.LUIS.Models;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 
-namespace Microsoft.Cognitive.LUIS
+namespace Microsoft.Bot.Builder.Ai.LUIS
 {
     /// <summary>
     /// Object that contains all the possible parameters to build Luis request.

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/Resolution.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/Resolution.cs
@@ -1,35 +1,5 @@
-﻿// 
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
-// Microsoft Bot Framework: http://botframework.com
-// 
-// Bot Builder SDK GitHub:
-// https://github.com/Microsoft/BotBuilder
-// 
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-// 
-// MIT License:
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 using System;
 using System.Collections.Generic;
@@ -37,7 +7,7 @@ using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.Cognitive.LUIS
+namespace Microsoft.Bot.Builder.Ai.LUIS
 {
     public abstract class Resolution
     {

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/SetField.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/Client/SetField.cs
@@ -1,40 +1,10 @@
-﻿// 
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
-// Microsoft Bot Framework: http://botframework.com
-// 
-// Bot Builder SDK GitHub:
-// https://github.com/Microsoft/BotBuilder
-// 
-// Copyright (c) Microsoft Corporation
-// All rights reserved.
-// 
-// MIT License:
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-// 
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
 
 using System;
 using System.Runtime.Serialization;
 
-namespace Microsoft.Cognitive.LUIS
+namespace Microsoft.Bot.Builder.Ai.LUIS
 {
     public static class SetField
     {

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using Microsoft.Cognitive.LUIS;
 
 namespace Microsoft.Bot.Builder.Ai.LUIS
 {

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisRecognizer.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Cognitive.LUIS;
 using Microsoft.Cognitive.LUIS.Models;
 using Newtonsoft.Json.Linq;
 

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisRecognizerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisRecognizerMiddleware.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
-using Microsoft.Cognitive.LUIS;
 using Microsoft.Cognitive.LUIS.Models;
 
 namespace Microsoft.Bot.Builder.Ai.LUIS

--- a/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisTraceInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Ai.LUIS/LuisTraceInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Cognitive.LUIS;
 using Microsoft.Cognitive.LUIS.Models;
 using Newtonsoft.Json;
 


### PR DESCRIPTION
- fixed the namespace on all the non-generated code
- consistent with other files removed the license from the header (its in the repo)