### PR TITLE
Fix Build Warnings by moving to a single file per class

### DIFF
--- a/libraries/Microsoft.Bot.Builder/IRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder/IRecognizer.cs
@@ -7,18 +7,6 @@ using System.Threading.Tasks;
 namespace Microsoft.Bot.Builder
 {
     /// <summary>
-    /// Can convert from a generic recognizer result to a strongly typed one.
-    /// </summary>
-    public interface IRecognizerConvert
-    {
-        /// <summary>
-        /// Convert recognizer result.
-        /// </summary>
-        /// <param name="result">Result to convert.</param>
-        void Convert(dynamic result);
-    }
-
-    /// <summary>
     /// Interface for Recognizers.
     /// </summary>
     public interface IRecognizer

--- a/libraries/Microsoft.Bot.Builder/IRecognizerConvert.cs
+++ b/libraries/Microsoft.Bot.Builder/IRecognizerConvert.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    /// Can convert from a generic recognizer result to a strongly typed one.
+    /// </summary>
+    public interface IRecognizerConvert
+    {
+        /// <summary>
+        /// Convert recognizer result.
+        /// </summary>
+        /// <param name="result">Result to convert.</param>
+        void Convert(dynamic result);
+    }
+}


### PR DESCRIPTION
Move the multiple interfaces in a single file to a "1 file per class" approach so the warnings go away. 