### PR TITLE
Fix TestAdapter - throws exception in timezone +01

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 var id = activity.Id = (_nextId++).ToString();
             }
 
-            if (activity.Timestamp == null || activity.Timestamp == default(DateTime))
+            if (activity.Timestamp == null || activity.Timestamp == default(DateTimeOffset))
             {
                 activity.Timestamp = DateTime.UtcNow;
             }


### PR DESCRIPTION
Fix compare between DateTimeOffset and DateTime.  In +<hour> timezones will have issues because time become out of range.