### PR TITLE
basic cleanup copyright headers etc

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotStateSet.cs
+++ b/libraries/Microsoft.Bot.Builder/BotStateSet.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,51 +12,32 @@ namespace Microsoft.Bot.Builder
     ///  Middleware that will call `read()` and `write()` in parallel on multiple `BotState`
     ///  instances.
     /// </summary>
-    /// <remarks>
-    ///     This example shows boilerplate code for reading and writing conversation and user state within
-    ///      a bot:
-    ///
-    ///      ```JavaScript
-    ///      const { BotStateSet, ConversationState, UserState, MemoryStorage } = require('botbuilder');
-    ///
-    ///      const storage = new MemoryStorage();
-    ///      const conversationState = new ConversationState(storage);
-    ///      const userState = new UserState(storage);
-    ///
-    ///      adapter.use(new BotStateSet(conversationState, userState));
-    ///
-    ///      server.post('/api/messages', (req, res) => {
-    ///      adapter.processActivity(req, res, async (context) => {
-    ///            // ... route activity ...
-    ///
-    ///  ```
-    /// </remarks>
     public class BotStateSet : IMiddleware
     {
-        private List<BotState> botStates = new List<BotState>();
+        private readonly List<BotState> _botStates = new List<BotState>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BotStateSet"/> class.
         /// </summary>
-        /// <param name="botStates">initial list of BotState to manage</param>
+        /// <param name="botStates">initial list of BotState to manage.</param>
         public BotStateSet(params BotState[] botStates)
         {
-            this.botStates.AddRange(botStates);
+            _botStates.AddRange(botStates);
         }
 
         /// <summary>
         /// Add a BotState to the list of sources to load.
         /// </summary>
-        /// <param name="botState">botState to manage</param>
-        /// <returns>botstateset for chaining more .Use()</returns>
+        /// <param name="botState">botState to manage.</param>
+        /// <returns>botstateset for chaining more .Use().</returns>
         public BotStateSet Use(BotState botState)
         {
-            this.botStates.Add(botState);
+            _botStates.Add(botState);
             return this;
         }
 
         /// <summary>
-        /// Middleware implementation which loads/savesChanges automatically
+        /// Middleware implementation which loads/savesChanges automatically.
         /// </summary>
         /// <param name="context">turn context.</param>
         /// <param name="next">next middlware.</param>
@@ -61,21 +45,21 @@ namespace Microsoft.Bot.Builder
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task OnTurnAsync(ITurnContext context, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.LoadAsync(context, true).ConfigureAwait(false);
+            await LoadAsync(context, true, cancellationToken).ConfigureAwait(false);
             await next(cancellationToken).ConfigureAwait(false);
-            await this.SaveChangesAsync(context).ConfigureAwait(false);
+            await SaveChangesAsync(context, false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Load all BotState records in parallel.
         /// </summary>
-        /// <param name="context">turn context</param>
+        /// <param name="context">turn context.</param>
         /// <param name="force">should data be forced into cache.</param>
         /// <param name="cancellationToken">Cancelation token.</param>
         /// <returns>task</returns>
         public async Task LoadAsync(ITurnContext context, bool force = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var tasks = this.botStates.Select(bs => bs.LoadAsync(context, force, cancellationToken)).ToList();
+            var tasks = _botStates.Select(bs => bs.LoadAsync(context, force, cancellationToken)).ToList();
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
@@ -84,10 +68,11 @@ namespace Microsoft.Bot.Builder
         /// </summary>
         /// <param name="context">turn context.</param>
         /// <param name="force">should data be forced to save even if no change were detected.</param>
+        /// <param name="cancellationToken">Cancelation token.</param>
         /// <returns>task</returns>
         public async Task SaveChangesAsync(ITurnContext context, bool force = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var tasks = this.botStates.Select(bs => bs.SaveChangesAsync(context, force, cancellationToken)).ToList();
+            var tasks = _botStates.Select(bs => bs.SaveChangesAsync(context, force, cancellationToken)).ToList();
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
     }

--- a/libraries/Microsoft.Bot.Builder/ConversationState.cs
+++ b/libraries/Microsoft.Bot.Builder/ConversationState.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Bot.Builder
     /// <summary>
     /// Handles persistence of a conversation state object using the conversation ID as part of the key.
     /// </summary>
-    /// <typeparam name="TState">The type of the conversation state object.</typeparam>
     public class ConversationState : BotState
     {
         /// <summary>
@@ -14,8 +13,10 @@ namespace Microsoft.Bot.Builder
         /// </summary>
         /// <param name="storage">The storage provider to use.</param>
         public ConversationState(IStorage storage)
-            : base(storage, nameof(ConversationState), (context) => $"conversation/{context.Activity.ChannelId}/{context.Activity.Conversation.Id}")
+            : base(storage, nameof(ConversationState))
         {
         }
+
+        protected override string GetStorageKey(ITurnContext context) => $"conversation/{context.Activity.ChannelId}/{context.Activity.Conversation.Id}";
     }
 }

--- a/libraries/Microsoft.Bot.Builder/IStatePropertyAccessor.cs
+++ b/libraries/Microsoft.Bot.Builder/IStatePropertyAccessor.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder

--- a/libraries/Microsoft.Bot.Builder/IStatePropertyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/IStatePropertyInfo.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
 
 namespace Microsoft.Bot.Builder
 {

--- a/libraries/Microsoft.Bot.Builder/UserState.cs
+++ b/libraries/Microsoft.Bot.Builder/UserState.cs
@@ -6,16 +6,17 @@ namespace Microsoft.Bot.Builder
     /// <summary>
     /// Handles persistence of a user state object using the user ID as part of the key.
     /// </summary>
-    /// <typeparam name="TState">The type of the user state object.</typeparam>
     public class UserState : BotState
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserState{TState}"/> class.
+        /// Initializes a new instance of the <see cref="UserState"/> class.
         /// </summary>
         /// <param name="storage">The storage provider to use.</param>
         public UserState(IStorage storage)
-            : base(storage, nameof(UserState), (context) => $"user/{context.Activity.ChannelId}/{context.Activity.From.Id}")
+            : base(storage, nameof(UserState))
         {
         }
+
+        protected override string GetStorageKey(ITurnContext context) => $"user/{context.Activity.ChannelId}/{context.Activity.From.Id}";
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Bot.Builder.Core.Extensions.Tests;
+using Microsoft.Bot.Builder.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Azure.Tests

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateSetTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     [TestClass]
     [TestCategory("State Management")]
@@ -20,43 +20,43 @@ namespace Microsoft.Bot.Builder.Core.Extensions.Tests
 
             // setup userstate
             var userState = new UserState(storage);
-            var userProperty = userState.CreateProperty<int>("userCount", () => 100);
+            var userProperty = userState.CreateProperty("userCount", () => 100);
 
             // setup convState
             var convState = new ConversationState(storage);
-            var convProperty = convState.CreateProperty<int>("convCount", () => 10);
+            var convProperty = convState.CreateProperty("convCount", () => 10);
 
             var adapter = new TestAdapter()
                 .Use(new BotStateSet(userState, convState));
 
             Func<ITurnContext, Task> botLogic = async (context) =>
-                        {
-                            // get userCount and convCount from botStateSet
-                            var userCount = await userProperty.GetAsync(context).ConfigureAwait(false);
-                            var convCount = await convProperty.GetAsync(context).ConfigureAwait(false);
+            {
+                // get userCount and convCount from botStateSet
+                var userCount = await userProperty.GetAsync(context).ConfigureAwait(false);
+                var convCount = await convProperty.GetAsync(context).ConfigureAwait(false);
                             
-                            // System.Diagnostics.Debug.WriteLine($"{context.Activity.Id} UserCount({context.Activity.From.Id}):{userCount} convCount({context.Activity.Conversation.Id}):{convCount}");
+                // System.Diagnostics.Debug.WriteLine($"{context.Activity.Id} UserCount({context.Activity.From.Id}):{userCount} convCount({context.Activity.Conversation.Id}):{convCount}");
 
-                            if (context.Activity.Type == ActivityTypes.Message)
-                            {
-                                if (context.Activity.Text == "get userCount")
-                                {
-                                    await context.SendActivityAsync(context.Activity.CreateReply($"{userCount}"));
-                                }
-                                else if (context.Activity.Text == "get convCount")
-                                {
-                                    await context.SendActivityAsync(context.Activity.CreateReply($"{convCount}"));
-                                }
-                            }
+                if (context.Activity.Type == ActivityTypes.Message)
+                {
+                    if (context.Activity.Text == "get userCount")
+                    {
+                        await context.SendActivityAsync(context.Activity.CreateReply($"{userCount}"));
+                    }
+                    else if (context.Activity.Text == "get convCount")
+                    {
+                        await context.SendActivityAsync(context.Activity.CreateReply($"{convCount}"));
+                    }
+                }
 
-                            // increment userCount and save (since it's a value type, or changed object you don't need to call Set)
-                            userCount++;
-                            await userProperty.SetAsync(context, userCount);
+                // increment userCount and save (since it's a value type, or changed object you don't need to call Set)
+                userCount++;
+                await userProperty.SetAsync(context, userCount);
 
-                            // increment convCount and save (since it's a value type, or changed object you don't need to call Set)
-                            convCount++;
-                            await convProperty.SetAsync(context, convCount);
-                        };
+                // increment convCount and save (since it's a value type, or changed object you don't need to call Set)
+                convCount++;
+                await convProperty.SetAsync(context, convCount);
+            };
 
             await new TestFlow(adapter, botLogic)
                 .Send("test1")

--- a/tests/Microsoft.Bot.Builder.Tests/MemoryStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MemoryStorageTests.cs
@@ -4,7 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     [TestClass]
     [TestCategory("Storage")]

--- a/tests/Microsoft.Bot.Builder.Tests/MemoryTranscriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MemoryTranscriptTests.cs
@@ -1,10 +1,10 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     [TestClass]
     public class MemoryTranscriptTests : TranscriptBaseTests

--- a/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     [TestClass]
     [TestCategory("Message")]

--- a/tests/Microsoft.Bot.Builder.Tests/OnTurnErrorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/OnTurnErrorTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     [TestClass]
     public class OnTurnErrorTests

--- a/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     [TestClass]
     public class ShowTyping_MiddlewareTests

--- a/tests/Microsoft.Bot.Builder.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/StorageBaseTests.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     public class StorageBaseTests
     {

--- a/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
@@ -14,16 +14,22 @@ namespace Microsoft.Bot.Builder.Tests
     {
         public static TurnContext CreateEmptyContext()
         {
-            TestAdapter b = new TestAdapter();
-            Activity a = new Activity
+            var b = new TestAdapter();
+            var a = new Activity
             {
-                Type = ActivityTypes.Message
+                Type = ActivityTypes.Message,
+                ChannelId = "EmptyContext",
+                From = new ChannelAccount
+                {
+                    Id = "empty@empty.context.org",
+                }
             };
-            TurnContext bc = new TurnContext(b, a);
+            var bc = new TurnContext(b, a);
 
             return bc;
         }
 
+        /*
         public static T CreateEmptyContext<T>() where T:ITurnContext
         {
             TestAdapter b = new TestAdapter();
@@ -36,6 +42,7 @@ namespace Microsoft.Bot.Builder.Tests
             else
                 throw new ArgumentException($"Unknown Type {typeof(T).Name}");            
         }
+        */
 
         static Lazy<Dictionary<string, string>> environmentKeys = new Lazy<Dictionary<string, string>>(()=>
         {

--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptBaseTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,7 +9,7 @@ using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
-namespace Microsoft.Bot.Builder.Core.Extensions.Tests
+namespace Microsoft.Bot.Builder.Tests
 {
     public class TranscriptBaseTests
     {

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/CoreExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/CoreExtensionsTests.cs
@@ -177,11 +177,11 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
         {
             public const string PropertyName = "Microsoft.Bot.Builder.Transcripts.Tests.CustomState";
 
-            public CustomState(IStorage storage) : base(storage, PropertyName, (context) => "CustomKey")
+            public CustomState(IStorage storage) : base(storage, PropertyName)
             {
             }
 
+            protected override string GetStorageKey(ITurnContext context) => "CustomKey";
         }
-
     }
 }


### PR DESCRIPTION
This is just a basic clean up of the storage. Copyright headers, namespaces, naming, dead code etc.

NOT included here the simplifications to the model: remove the the accessor interface(s), remove the async, the associated force flag etc.
