### PR TITLE
cancellation in callback

### DIFF
--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -66,7 +66,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.Builder.Integ
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Tests", "tests\Microsoft.Bot.Builder.Tests\Microsoft.Bot.Builder.Tests.csproj", "{35F9B8A8-1974-4795-930B-5E4980EE85E5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.Builder.Transcripts.Tests", "tests\Microsoft.Bot.Builder.Transcripts.Tests\Microsoft.Bot.Builder.Transcripts.Tests.csproj", "{71698D71-4C6F-40D5-8BDE-2587514CA21C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Transcripts.Tests", "tests\Microsoft.Bot.Builder.Transcripts.Tests\Microsoft.Bot.Builder.Transcripts.Tests.csproj", "{71698D71-4C6F-40D5-8BDE-2587514CA21C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             IDictionary<string, object> result = null;
             var dc = new DialogContext(dialogs, context, state, (r) => { result = r; });
 
-            await dc.BeginAsync("dialog", options);
+            await dc.BeginAsync("dialog", options).ConfigureAwait(false);
             return dc.ActiveDialog != null
                     ?
                 new DialogCompletion { IsActive = true, IsCompleted = false }
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             var dc = new DialogContext(dialogs, context, state, (r) => { result = r; });
             if (dc.ActiveDialog != null)
             {
-                await dc.ContinueAsync();
+                await dc.ContinueAsync().ConfigureAwait(false);
                 return dc.ActiveDialog != null
                         ?
                     new DialogCompletion { IsActive = true, IsCompleted = false }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -34,12 +34,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Start the controls entry point dialog.
             IDictionary<string, object> result = null;
             var cdc = new DialogContext(this.Dialogs, dc.Context, dc.ActiveDialog.State, (r) => { result = r; });
-            await cdc.BeginAsync(DialogId, dialogArgs);
+            await cdc.BeginAsync(DialogId, dialogArgs).ConfigureAwait(false);
 
             // End if the controls dialog ends.
             if (cdc.ActiveDialog == null)
             {
-                await dc.EndAsync(result);
+                await dc.EndAsync(result).ConfigureAwait(false);
             }
         }
 
@@ -53,12 +53,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Continue controls dialog stack.
             IDictionary<string, object> result = null;
             var cdc = new DialogContext(this.Dialogs, dc.Context, dc.ActiveDialog.State, (r) => { result = r; });
-            await cdc.ContinueAsync();
+            await cdc.ContinueAsync().ConfigureAwait(false);
 
             // End if the controls dialog ends.
             if (cdc.ActiveDialog == null)
             {
-                await dc.EndAsync(result);
+                await dc.EndAsync(result).ConfigureAwait(false);
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             Stack.Insert(0, instance);
 
             // Call dialogs begin() method.
-            await dialog.DialogBeginAsync(this, dialogArgs);
+            await dialog.DialogBeginAsync(this, dialogArgs).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 if (dialog is IDialogContinue)
                 {
                         // Continue execution of dialog
-                        await ((IDialogContinue)dialog).DialogContinueAsync(this);
+                        await ((IDialogContinue)dialog).DialogContinueAsync(this).ConfigureAwait(false);
                 }
             }
         }
@@ -202,12 +202,12 @@ namespace Microsoft.Bot.Builder.Dialogs
                 if (dialog is IDialogResume)
                 {
                     // Return result to previous dialog
-                    await ((IDialogResume)dialog).DialogResumeAsync(this, result);
+                    await ((IDialogResume)dialog).DialogResumeAsync(this, result).ConfigureAwait(false);
                 }
                 else
                 {
                     // Just end the dialog and pass result to parent dialog
-                    await EndAsync(result);
+                    await EndAsync(result).ConfigureAwait(false);
                 }
             }
             else
@@ -243,7 +243,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             // Start replacement dialog
-            await BeginAsync(dialogId, dialogArgs);
+            await BeginAsync(dialogId, dialogArgs).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/AttachmentPromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/AttachmentPromptInternal.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 {
                     attachmentResult.Status = PromptStatus.Recognized;
                     attachmentResult.Attachments.AddRange(message.Attachments);
-                    await ValidateAsync(context, attachmentResult);
+                    await ValidateAsync(context, attachmentResult).ConfigureAwait(false);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ChoicePromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ChoicePromptInternal.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             msg.InputHint = InputHints.ExpectingInput;
-            await context.SendActivityAsync(msg);
+            await context.SendActivityAsync(msg).ConfigureAwait(false);
         }
 
         public async Task PromptAsync(ITurnContext context, IMessageActivity prompt = null, string speak = null)
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (prompt != null)
             {
                 prompt.Speak = speak ?? prompt.Speak;
-                await context.SendActivityAsync(prompt);
+                await context.SendActivityAsync(prompt).ConfigureAwait(false);
             }
         }
 
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var result = new ChoiceResult { Status = PromptStatus.Recognized, Value = value };
                 if (Validator != null)
                 {
-                    await Validator(context, result);
+                    await Validator(context, result).ConfigureAwait(false);
                 }
 
                 return result;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ConfirmPromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/ConfirmPromptInternal.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (prompt != null)
             {
                 prompt.Speak = speak ?? prompt.Speak;
-                await context.SendActivityAsync(prompt);
+                await context.SendActivityAsync(prompt).ConfigureAwait(false);
             }
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     confirmResult.Text = result.Text;
                     if (Validator != null)
                     {
-                        await Validator(context, confirmResult);
+                        await Validator(context, confirmResult).ConfigureAwait(false);
                     }
                 }
             }
@@ -156,7 +156,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             msg.InputHint = InputHints.ExpectingInput;
-            await context.SendActivityAsync(msg);
+            await context.SendActivityAsync(msg).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/DateTimePromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/DateTimePromptInternal.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         dateTimeResult.Resolution.Add(ReadResolution(value));
                     }
 
-                    await ValidateAsync(context, dateTimeResult);
+                    await ValidateAsync(context, dateTimeResult).ConfigureAwait(false);
                     return dateTimeResult;
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/NumberPromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/NumberPromptInternal.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         numberResult.Status = PromptStatus.Recognized;
                         numberResult.Value = (T)(object)value;
                         numberResult.Text = result.Text;
-                        await ValidateAsync(context, numberResult);
+                        await ValidateAsync(context, numberResult).ConfigureAwait(false);
                     }
                 }
                 else if (typeof(T) == typeof(int))
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         numberResult.Status = PromptStatus.Recognized;
                         numberResult.Value = (T)(object)value;
                         numberResult.Text = result.Text;
-                        await ValidateAsync(context, numberResult);
+                        await ValidateAsync(context, numberResult).ConfigureAwait(false);
                     }
                 }
                 else if (typeof(T) == typeof(long))
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         numberResult.Status = PromptStatus.Recognized;
                         numberResult.Value = (T)(object)value;
                         numberResult.Text = result.Text;
-                        await ValidateAsync(context, numberResult);
+                        await ValidateAsync(context, numberResult).ConfigureAwait(false);
                     }
                 }
                 else if (typeof(T) == typeof(double))
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         numberResult.Status = PromptStatus.Recognized;
                         numberResult.Value = (T)(object)value;
                         numberResult.Text = result.Text;
-                        await ValidateAsync(context, numberResult);
+                        await ValidateAsync(context, numberResult).ConfigureAwait(false);
                     }
                 }
                 else if (typeof(T) == typeof(decimal))
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         numberResult.Status = PromptStatus.Recognized;
                         numberResult.Value = (T)(object)value;
                         numberResult.Text = result.Text;
-                        await ValidateAsync(context, numberResult);
+                        await ValidateAsync(context, numberResult).ConfigureAwait(false);
                     }
                 }
                 else

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Internal/TextPromptInternal.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Internal/TextPromptInternal.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 textResult.Status = PromptStatus.Recognized;
                 textResult.Value = message.Text;
                 textResult.Text = message.Text;
-                await ValidateAsync(context, textResult);
+                await ValidateAsync(context, textResult).ConfigureAwait(false);
             }
 
             return textResult;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AttachmentPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AttachmentPrompt.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return await _prompt.RecognizeAsync(dc.Context);
+            return await _prompt.RecognizeAsync(dc.Context).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -60,22 +60,22 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 if (options.RetryPromptActivity != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, options.RetryPromptActivity.AsMessageActivity(), options.Speak);
+                    await _prompt.PromptAsync(dc.Context, options.RetryPromptActivity.AsMessageActivity(), options.Speak).ConfigureAwait(false);
                 }
                 else if (options.RetryPromptString != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, choices, options.RetryPromptString, options.RetrySpeak);
+                    await _prompt.PromptAsync(dc.Context, choices, options.RetryPromptString, options.RetrySpeak).ConfigureAwait(false);
                 }
             }
             else
             {
                 if (options.PromptActivity != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, options.PromptActivity, options.Speak);
+                    await _prompt.PromptAsync(dc.Context, options.PromptActivity, options.Speak).ConfigureAwait(false);
                 }
                 else if (options.PromptString != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, choices, options.PromptString, options.Speak);
+                    await _prompt.PromptAsync(dc.Context, choices, options.PromptString, options.Speak).ConfigureAwait(false);
                 }
             }
         }
@@ -94,7 +94,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             var choices = (options as ChoicePromptOptions)?.Choices ?? new List<Choice>();
 
-            return await _prompt.RecognizeAsync(dc.Context, choices);
+            return await _prompt.RecognizeAsync(dc.Context, choices).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -74,22 +74,22 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 if (options.RetryPromptActivity != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, options.RetryPromptActivity.AsMessageActivity());
+                    await _prompt.PromptAsync(dc.Context, options.RetryPromptActivity.AsMessageActivity()).ConfigureAwait(false);
                 }
                 else if (options.RetryPromptString != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, options.RetryPromptString, options.RetrySpeak);
+                    await _prompt.PromptAsync(dc.Context, options.RetryPromptString, options.RetrySpeak).ConfigureAwait(false);
                 }
             }
             else
             {
                 if (options.PromptActivity != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, options.PromptActivity);
+                    await _prompt.PromptAsync(dc.Context, options.PromptActivity).ConfigureAwait(false);
                 }
                 else if (options.PromptString != null)
                 {
-                    await _prompt.PromptAsync(dc.Context, options.PromptString, options.Speak);
+                    await _prompt.PromptAsync(dc.Context, options.PromptString, options.Speak).ConfigureAwait(false);
                 }
             }
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return await _prompt.RecognizeAsync(dc.Context);
+            return await _prompt.RecognizeAsync(dc.Context).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return await _prompt.RecognizeAsync(dc.Context);
+            return await _prompt.RecognizeAsync(dc.Context).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return await _prompt.RecognizeAsync(dc.Context);
+            return await _prompt.RecognizeAsync(dc.Context).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 // send supplied prompt and then OAuthCard
                 await dc.Context.SendActivityAsync(promptOptions.PromptString, promptOptions.Speak).ConfigureAwait(false);
-                await _prompt.PromptAsync(dc.Context);
+                await _prompt.PromptAsync(dc.Context).ConfigureAwait(false);
             }
             else
             {
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 }
                 else
                 {
-                    await _prompt.PromptAsync(dc.Context, promptOptions.PromptActivity);
+                    await _prompt.PromptAsync(dc.Context, promptOptions.PromptActivity).ConfigureAwait(false);
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             instance.State = promptOptions;
 
             // Send initial prompt
-            await OnPromptAsync(dc, promptOptions, false);
+            await OnPromptAsync(dc, promptOptions, false).ConfigureAwait(false);
         }
 
         public async Task DialogContinueAsync(DialogContext dc)
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // Recognize value
             var instance = dc.ActiveDialog;
-            var recognized = await OnRecognizeAsync(dc, (PromptOptions)instance.State);
+            var recognized = await OnRecognizeAsync(dc, (PromptOptions)instance.State).ConfigureAwait(false);
 
             // TODO: resolve the inconsistency of approach between the Node SDK and what we have here
             if (!recognized.Succeeded())
@@ -64,12 +64,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (recognized != null)
             {
                 // Return recognized value
-                await dc.EndAsync(recognized);
+                await dc.EndAsync(recognized).ConfigureAwait(false);
             }
             else if (!dc.Context.Responded)
             {
                 // Send retry prompt
-                await OnPromptAsync(dc, (PromptOptions)instance.State, true);
+                await OnPromptAsync(dc, (PromptOptions)instance.State, true).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/TextPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/TextPrompt.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return await _prompt.RecognizeAsync(dc.Context);
+            return await _prompt.RecognizeAsync(dc.Context).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Waterfall.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Waterfall.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
                 dc.ActiveDialog.Step++;
-                await RunStepAsync(dc, new Dictionary<string, object> { { "Activity", dc.Context.Activity } });
+                await RunStepAsync(dc, new Dictionary<string, object> { { "Activity", dc.Context.Activity } }).ConfigureAwait(false);
             }
         }
 
@@ -76,12 +76,12 @@ namespace Microsoft.Bot.Builder.Dialogs
                 };
 
                 // Execute step
-                await _steps[step](dc, result, next);
+                await _steps[step](dc, result, next).ConfigureAwait(false);
             }
             else
             {
                 // End of waterfall so just return to parent
-                await dc.EndAsync(result);
+                await dc.EndAsync(result).ConfigureAwait(false);
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task ProcessActivityAsync(Activity activity, Func<ITurnContext, Task> callback, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task ProcessActivityAsync(Activity activity, BotCallbackHandler callback, CancellationToken cancellationToken = default(CancellationToken))
         {
             lock (_conversationLock)
             {
@@ -277,13 +277,13 @@ namespace Microsoft.Bot.Builder.Adapters
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>This resets the <see cref="ActiveQueue"/>, and does not maintain multiple converstion queues.</remarks>
-        public Task CreateConversationAsync(string channelId, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public Task CreateConversationAsync(string channelId, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             ActiveQueue.Clear();
             var update = Activity.CreateConversationUpdateActivity();
             update.Conversation = new ConversationAccount() { Id = Guid.NewGuid().ToString("n") };
             var context = new TurnContext(this, (Activity)update);
-            return callback(context);
+            return callback(context, cancellationToken);
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="TestFlow.Send(string)"/>
-        public Task SendTextToBotAsync(string userSays, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public Task SendTextToBotAsync(string userSays, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             return ProcessActivityAsync(MakeActivity(userSays), callback, cancellationToken);
         }

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="adapter">The test adapter to use.</param>
         /// <param name="bot">The bot containing the turn processing logic to test.</param>
         public TestFlow(TestAdapter adapter, IBot bot)
-            : this(adapter, (ctx, cancellationToken) => bot.OnTurnAsync(ctx, cancellationToken))
+            : this(adapter, bot.OnTurnAsync)
         {
         }
 
@@ -72,10 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <remarks>This methods sends the activities from the user to the bot and
         /// checks the responses from the bot based on the activiies described in the
         /// current test flow.</remarks>
-        public Task StartTestAsync()
-        {
-            return _testTask;
-        }
+        public Task StartTestAsync() => _testTask;
 
         /// <summary>
         /// Adds a message activity from the user to the bot.

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -28,14 +28,14 @@ namespace Microsoft.Bot.Builder.Adapters
     {
         private readonly TestAdapter _adapter;
         private readonly Task _testTask;
-        private Func<ITurnContext, Task> _callback;
+        private BotCallbackHandler _callback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestFlow"/> class.
         /// </summary>
         /// <param name="adapter">The test adapter to use.</param>
         /// <param name="callback">The bot turn processing logic to test.</param>
-        public TestFlow(TestAdapter adapter, Func<ITurnContext, Task> callback = null)
+        public TestFlow(TestAdapter adapter, BotCallbackHandler callback = null)
         {
             _adapter = adapter;
             _callback = callback;
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="adapter">The test adapter to use.</param>
         /// <param name="bot">The bot containing the turn processing logic to test.</param>
         public TestFlow(TestAdapter adapter, IBot bot)
-            : this(adapter, (ctx) => bot.OnTurnAsync(ctx))
+            : this(adapter, (ctx, cancellationToken) => bot.OnTurnAsync(ctx, cancellationToken))
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotAdapter.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder
         /// Most _channels require a user to initiate a conversation with a bot
         /// before the bot can send activities to the user.</remarks>
         /// <seealso cref="RunPipelineAsync(ITurnContext, Func{ITurnContext, Task}, CancellationToken)"/>
-        public virtual Task ContinueConversationAsync(string botId, ConversationReference reference, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public virtual Task ContinueConversationAsync(string botId, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             using (var context = new TurnContext(this, reference.GetContinuationActivity()))
             {
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder
         /// initiated by a call to <see cref="ContinueConversationAsync(string, ConversationReference, Func{ITurnContext, Task}, CancellationToken)"/>
         /// (proactive messaging), the callback method is the callback method that was provided in the call.</para>
         /// </remarks>
-        protected async Task RunPipelineAsync(ITurnContext context, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        protected async Task RunPipelineAsync(ITurnContext context, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(context);
 
@@ -183,7 +183,7 @@ namespace Microsoft.Bot.Builder
                 // call back to caller on proactive case
                 if (callback != null)
                 {
-                    await callback(context).ConfigureAwait(false);
+                    await callback(context, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder/BotCallbackHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/BotCallbackHandler.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder
+{
+    public delegate Task BotCallbackHandler(ITurnContext context, CancellationToken cancellationToken);
+}

--- a/libraries/Microsoft.Bot.Builder/BotCallbackHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/BotCallbackHandler.cs
@@ -6,5 +6,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder
 {
+    /// <summary>
+    /// The callback delegate for application code.
+    /// </summary>
+    /// <param name="context">The turn context.</param>
+    /// <param name="cancellationToken">The task cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public delegate Task BotCallbackHandler(ITurnContext context, CancellationToken cancellationToken);
 }

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         /// <seealso cref="ProcessActivityAsync(string, Activity, Func{ITurnContext, Task}, CancellationToken)"/>
         /// <seealso cref="BotAdapter.RunPipelineAsync(ITurnContext, Func{ITurnContext, Task}, CancellationToken)"/>
-        public override async Task ContinueConversationAsync(string botAppId, ConversationReference reference, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public override async Task ContinueConversationAsync(string botAppId, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(botAppId))
             {
@@ -170,9 +170,9 @@ namespace Microsoft.Bot.Builder
         /// <item><see cref="IConnectorClient"/>, the channel connector client to use this turn.</item>
         /// </list></para>
         /// </remarks>
-        /// <seealso cref="ContinueConversationAsync(string, ConversationReference, Func{ITurnContext, Task}, CancellationToken)"/>
-        /// <seealso cref="BotAdapter.RunPipelineAsync(ITurnContext, Func{ITurnContext, Task}, CancellationToken)"/>
-        public async Task<InvokeResponse> ProcessActivityAsync(string authHeader, Activity activity, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        /// <seealso cref="ContinueConversationAsync(string, ConversationReference, BotCallbackHandler, CancellationToken)"/>
+        /// <seealso cref="BotAdapter.RunPipelineAsync(ITurnContext, BotCallbackHandler, CancellationToken)"/>
+        public async Task<InvokeResponse> ProcessActivityAsync(string authHeader, Activity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             BotAssert.ActivityNotNull(activity);
 
@@ -189,7 +189,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task<InvokeResponse> ProcessActivityAsync(ClaimsIdentity identity, Activity activity, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public async Task<InvokeResponse> ProcessActivityAsync(ClaimsIdentity identity, Activity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             BotAssert.ActivityNotNull(activity);
 
@@ -576,7 +576,7 @@ namespace Microsoft.Bot.Builder
         /// specified users, the ID of the activity's <see cref="IActivity.Conversation"/>
         /// will contain the ID of the new conversation.</para>
         /// </remarks>
-        public virtual async Task CreateConversationAsync(string channelId, string serviceUrl, MicrosoftAppCredentials credentials, ConversationParameters conversationParameters, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public virtual async Task CreateConversationAsync(string channelId, string serviceUrl, MicrosoftAppCredentials credentials, ConversationParameters conversationParameters, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             var connectorClient = CreateConnectorClient(serviceUrl, credentials);
 

--- a/libraries/Microsoft.Bot.Builder/IBot.cs
+++ b/libraries/Microsoft.Bot.Builder/IBot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder
@@ -32,11 +33,12 @@ namespace Microsoft.Bot.Builder
         /// When implemented in a bot, handles an incoming activity.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>The <paramref name="turnContext"/> provides information about the
         /// incoming activity, and other data needed to process the activity.</remarks>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        Task OnTurnAsync(ITurnContext turnContext);
+        Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/libraries/Microsoft.Bot.Builder/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder/MiddlewareSet.cs
@@ -62,12 +62,12 @@ namespace Microsoft.Bot.Builder
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task ReceiveActivityWithStatusAsync(ITurnContext context, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public async Task ReceiveActivityWithStatusAsync(ITurnContext context, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             await ReceiveActivityInternalAsync(context, callback, 0, cancellationToken).ConfigureAwait(false);
         }
 
-        private Task ReceiveActivityInternalAsync(ITurnContext context, Func<ITurnContext, Task> callback, int nextMiddlewareIndex, CancellationToken cancellationToken)
+        private Task ReceiveActivityInternalAsync(ITurnContext context, BotCallbackHandler callback, int nextMiddlewareIndex, CancellationToken cancellationToken)
         {
             // Check if we're at the end of the middleware list yet
             if (nextMiddlewareIndex == _middleware.Count)
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder
                 // to run as expected.
 
                 // If a callback was provided invoke it now and return its task, otherwise just return the completed task
-                return callback?.Invoke(context) ?? Task.CompletedTask;
+                return callback?.Invoke(context, cancellationToken) ?? Task.CompletedTask;
             }
 
             // Get the next piece of middleware

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -14,7 +13,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
 {
     public class BotMessageHandler : BotMessageHandlerBase
     {
-        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, BotFrameworkAdapter botFrameworkAdapter, Func<ITurnContext, Task> botCallbackHandler, CancellationToken cancellationToken)
+        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, BotFrameworkAdapter botFrameworkAdapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
             var activity = default(Activity);
 
@@ -27,7 +26,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                     request.Headers["Authorization"],
                     activity,
                     botCallbackHandler,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
             return invokeResponse;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                 activity = BotMessageHandlerBase.BotMessageSerializer.Deserialize<Activity>(bodyReader);
             }
 
+#pragma warning disable UseConfigureAwait // Use ConfigureAwait
             var invokeResponse = await botFrameworkAdapter.ProcessActivityAsync(
                     request.Headers["Authorization"],
                     activity,
                     botCallbackHandler,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
+#pragma warning restore UseConfigureAwait // Use ConfigureAwait
 
             return invokeResponse;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                     request,
                     botFrameworkAdapter,
                     bot.OnTurnAsync,
-                    default(CancellationToken));
+                    default(CancellationToken)).ConfigureAwait(false);
 
                 if (invokeResponse == null)
                 {
@@ -97,6 +97,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
             }
         }
 
-        protected abstract Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, BotFrameworkAdapter botFrameworkAdapter, Func<ITurnContext, Task> botCallbackHandler, CancellationToken cancellationToken);
+        protected abstract Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, BotFrameworkAdapter botFrameworkAdapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken);
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
@@ -67,11 +67,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
             try
             {
                 // TODO wire up cancellation
+#pragma warning disable UseConfigureAwait // Use ConfigureAwait
                 var invokeResponse = await ProcessMessageRequestAsync(
                     request,
                     botFrameworkAdapter,
                     bot.OnTurnAsync,
-                    default(CancellationToken)).ConfigureAwait(false);
+                    default(CancellationToken));
+#pragma warning restore UseConfigureAwait // Use ConfigureAwait
 
                 if (invokeResponse == null)
                 {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotProactiveMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotProactiveMessageHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
 {
     public class BotProactiveMessageHandler : BotMessageHandlerBase
     {
-        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, BotFrameworkAdapter botFrameworkAdapter, Func<ITurnContext, Task> botCallbackHandler, CancellationToken cancellationToken)
+        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, BotFrameworkAdapter botFrameworkAdapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
             const string BotAppIdHttpHeaderName = "MS-BotFramework-BotAppId";
             const string BotIdQueryStringParameterName = "BotAppId";
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                 conversationReference = BotMessageHandlerBase.BotMessageSerializer.Deserialize<ConversationReference>(bodyReader);
             }
 
-            await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken);
+            await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken).ConfigureAwait(false);
 
             return null;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotProactiveMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotProactiveMessageHandler.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                 conversationReference = BotMessageHandlerBase.BotMessageSerializer.Deserialize<ConversationReference>(bodyReader);
             }
 
-            await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken).ConfigureAwait(false);
+#pragma warning disable UseConfigureAwait // Use ConfigureAwait
+            await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken);
+#pragma warning restore UseConfigureAwait // Use ConfigureAwait
 
             return null;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
@@ -18,15 +18,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
         {
         }
 
-        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequestMessage request, BotFrameworkAdapter botFrameworkAdapter, Func<ITurnContext, Task> botCallbackHandler, CancellationToken cancellationToken)
+        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequestMessage request, BotFrameworkAdapter botFrameworkAdapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
-            var activity = await request.Content.ReadAsAsync<Activity>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken);
+            var activity = await request.Content.ReadAsAsync<Activity>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
 
             var invokeResponse = await botFrameworkAdapter.ProcessActivityAsync(
                 request.Headers.Authorization?.ToString(),
                 activity,
                 botCallbackHandler,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             return invokeResponse;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
         {
             var activity = await request.Content.ReadAsAsync<Activity>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
 
+#pragma warning disable UseConfigureAwait // Use ConfigureAwait
             var invokeResponse = await botFrameworkAdapter.ProcessActivityAsync(
                 request.Headers.Authorization?.ToString(),
                 activity,
                 botCallbackHandler,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken);
+#pragma warning restore UseConfigureAwait // Use ConfigureAwait
 
             return invokeResponse;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 
             try
             {
+#pragma warning disable UseConfigureAwait // Use ConfigureAwait
                 var invokeResponse = await ProcessMessageRequestAsync(
                     request,
                     _botFrameworkAdapter,
@@ -87,7 +88,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 
                         return bot.OnTurnAsync(context);
                     },
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken);
+#pragma warning restore UseConfigureAwait // Use ConfigureAwait
 
                 if (invokeResponse == null)
                 {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
                 var invokeResponse = await ProcessMessageRequestAsync(
                     request,
                     _botFrameworkAdapter,
-                    context =>
+                    (context, ct) =>
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 
                         return bot.OnTurnAsync(context);
                     },
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
                 if (invokeResponse == null)
                 {
@@ -114,6 +114,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
             }
         }
 
-        protected abstract Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequestMessage request, BotFrameworkAdapter botFrameworkAdapter, Func<ITurnContext, Task> botCallbackHandler, CancellationToken cancellationToken);
+        protected abstract Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequestMessage request, BotFrameworkAdapter botFrameworkAdapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken);
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotProactiveMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotProactiveMessageHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
         {
         }
 
-        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequestMessage request, BotFrameworkAdapter botFrameworkAdapter, Func<ITurnContext, Task> botCallbackHandler, CancellationToken cancellationToken)
+        protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequestMessage request, BotFrameworkAdapter botFrameworkAdapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
             const string BotAppIdHttpHeaderName = "MS-BotFramework-BotAppId";
             const string BotAppIdQueryStringParameterName = "BotAppId";
@@ -43,9 +43,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
                 throw new InvalidOperationException($"Expected a Bot App ID in a header named \"{BotAppIdHttpHeaderName}\" or in a querystring parameter named \"{BotAppIdQueryStringParameterName}\".");
             }
 
-            var conversationReference = await request.Content.ReadAsAsync<ConversationReference>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken);
+            var conversationReference = await request.Content.ReadAsAsync<ConversationReference>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
 
-            await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken);
+            await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken).ConfigureAwait(false);
 
             return null;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotProactiveMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotProactiveMessageHandler.cs
@@ -43,7 +43,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
                 throw new InvalidOperationException($"Expected a Bot App ID in a header named \"{BotAppIdHttpHeaderName}\" or in a querystring parameter named \"{BotAppIdQueryStringParameterName}\".");
             }
 
-            var conversationReference = await request.Content.ReadAsAsync<ConversationReference>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
+#pragma warning disable UseConfigureAwait // Use ConfigureAwait
+            var conversationReference = await request.Content.ReadAsAsync<ConversationReference>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken);
+#pragma warning restore UseConfigureAwait // Use ConfigureAwait
 
             await botFrameworkAdapter.ContinueConversationAsync(botAppId, conversationReference, botCallbackHandler, cancellationToken).ConfigureAwait(false);
 

--- a/tests/FormTest/ConsoleAdapter.cs
+++ b/tests/FormTest/ConsoleAdapter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Classic.FormFlowTest
             return this;
         }
 
-        public async Task ProcessActivity(Func<ITurnContext, Task> callback = null)
+        public async Task ProcessActivity(BotCallbackHandler callback = null)
         {
             while (true)
             {

--- a/tests/FormTest/Program.cs
+++ b/tests/FormTest/Program.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Bot.Builder.Classic.FormFlowTest
             using (var container = builder.Build())
             {
                 var adapter = new ConsoleAdapter();
-                adapter.ProcessActivity(async (context) =>
+                adapter.ProcessActivity(async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {

--- a/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUIS.Tests/LuisRecognizerTests.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Bot.Builder.Ai.Luis.Tests
             var adapter = new TestAdapter(null, true);
             const string utterance = @"My name is Emad";
             const string botResponse = @"Hi Emad";
-            await new TestFlow(adapter, async context =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (context.Activity.Text == utterance)
                 {

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/LocaleConverterMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/LocaleConverterMiddlewareTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Use(userState)
                 .Use(new LocaleConverterMiddleware(userLocaleProperty, "en-us", LocaleConverter.Converter));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     if (!await ChangeLocaleRequest(context, userLocaleProperty))
                     {
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Use(userState)
                 .Use(new LocaleConverterMiddleware(userLocaleProperty, "en-us", LocaleConverter.Converter));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     if (!await ChangeLocaleRequest(context, userLocaleProperty))
                     {
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Use(new LocaleConverterMiddleware(userLocaleProperty, "zh-cn", LocaleConverter.Converter));
 
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (!await ChangeLocaleRequest(context, userLocaleProperty))
                 {

--- a/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.Translation.Tests/TranslatorMiddlewareTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
             var adapter = new TestAdapter(sendTraceActivity: true)
                 .Use(new SpecializedTranslatorMiddleware(new[] { "en" }, _translatorKey, mockHttp.ToHttpClient()));
 
-            await new TestFlow(adapter, context =>
+            await new TestFlow(adapter, (context, cancellationToken) =>
                 {
                     if (!context.Responded)
                     {
@@ -96,7 +96,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
             var adapter = new TestAdapter()
                 .Use(new TranslationMiddleware(new[] { "en" }, _translatorKey, httpClient: mockHttp.ToHttpClient()));
 
-            await new TestFlow(adapter, async context =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     if (!await HandleChangeLanguageRequest(context, languageStateProperty))
                     {
@@ -131,7 +131,7 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Use(userState)
                 .Use(new TranslationMiddleware(new[] { "en" }, _translatorKey, new Dictionary<string, List<string>>(), new CustomDictionary(), languageStateProperty, httpClient: mockHttp.ToHttpClient()));
 
-            await new TestFlow(adapter, async context =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     if (!await HandleChangeLanguageRequest(context, languageStateProperty))
                     {
@@ -165,13 +165,13 @@ namespace Microsoft.Bot.Builder.Ai.Translation.Tests
                 .Respond("application/xml", GetResponse("TranslatorMiddleware_TranslateFrenchToEnglishToUserLanguage_Hello.xml"));
 
             var userState = new UserState(new MemoryStorage());
-            var languageStateProperty = userState.CreateProperty<string>("languageState", () => "en");
+            var languageStateProperty = userState.CreateProperty("languageState", () => "en");
             
             var adapter = new TestAdapter()
                 .Use(userState)
                 .Use(new TranslationMiddleware(new[] { "en" }, _translatorKey, new Dictionary<string, List<string>>(), new CustomDictionary(), languageStateProperty, true, mockHttp.ToHttpClient()));
 
-            await new TestFlow(adapter, async context =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     if (!await HandleChangeLanguageRequest(context, languageStateProperty))
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/BotTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/BotTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
         async Task IBot.PostAsync(Activity activity, CancellationToken token)
         {
-            await this.adapter.ProcessActivityAsync(activity, async (context) =>
+            await this.adapter.ProcessActivityAsync(activity, async (context, cancellationToken) =>
             {
                 using (var scope = DialogModule.BeginLifetimeScope(this.Container, context))
                 {
@@ -948,7 +948,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 var toBot = MakeTestMessage();
                 toBot.Text = "hi";
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -981,7 +981,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             {
                 var toBot = MakeTestMessage();
                 toBot.Text = "hi";
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -1025,7 +1025,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             {
                 var toBot = MakeTestMessage();
                 toBot.Text = "hi";
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -1070,7 +1070,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             {
                 var toBot = MakeTestMessage();
                 toBot.Text = "hi";
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -1118,7 +1118,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 var toBot = MakeTestMessage();
                 toBot.Text = "hi";
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/ChainTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/ChainTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 foreach (var word in words)
                 {
                     toBot.Text = word;
-                    await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                    await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                     {
                         using (var scope = DialogModule.BeginLifetimeScope(container, context))
                         {
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 var toBot = MakeTestMessage();
                 toBot.Text = Phrase;
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 toBot.Text = true.ToString();
 
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -186,7 +186,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 var toBot = MakeTestMessage();
                 toBot.Text = false.ToString();
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
 
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
@@ -254,7 +254,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 foreach (var word in words)
                 {
                     toBot.Text = word;
-                    await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                    await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                     {
                         using (var scope = DialogModule.BeginLifetimeScope(container, context))
                         {
@@ -291,7 +291,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 foreach (var word in words)
                 {
                     toBot.Text = word;
-                    await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                    await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                     {
 
                         using (var scope = DialogModule.BeginLifetimeScope(container, context))
@@ -329,7 +329,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 foreach (var word in words)
                 {
                     toBot.Text = word;
-                    await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                    await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                     {
                         using (var scope = DialogModule.BeginLifetimeScope(container, context))
                         {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/ConversationTest.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/ConversationTest.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             {
                 var msg = DialogTestBase.MakeTestMessage();
                 msg.Text = "test";
-                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -390,7 +390,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
 
                 msg.Text = "inputhint";
-                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -406,7 +406,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 });
 
                 msg.Text = "reset";
-                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -436,7 +436,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             {
                 var msg = DialogTestBase.MakeTestMessage();
                 msg.Text = "testMsg";
-                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)msg, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -457,7 +457,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
                 var conversationReference = msg.ToConversationReference();
                 var continuationActivity = conversationReference.GetContinuationActivity();
-                await new TestAdapter().ProcessActivityAsync((Activity)continuationActivity, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)continuationActivity, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/DialogTaskManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/DialogTaskManagerTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 string foo = "foo";
                 string bar = "bar";
                 toBot.Text = foo;
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
                 //create another dialog task and make sure that it is not overriding the default dialog task
                 toBot.Text = bar;
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -146,7 +146,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 string foo = "foo";
                 string bar = "bar";
                 toBot.Text = foo;
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -173,7 +173,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/DialogTaskTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/DialogTaskTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (new FiberTestBase.ResolveMoqAssembly(dialog.Object))
             using (var container = Build(Options.MockConnectorFactory, dialog.Object))
             {
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 dialog.Verify(d => d.MessageReceived(It.IsAny<IDialogContext>(), It.IsAny<IAwaitable<IMessageActivity>>()), Times.Once);
                 dialog.Verify(d => d.Throw(It.IsAny<IDialogContext>(), It.IsAny<IAwaitable<IMessageActivity>>()), Times.Never);
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -112,7 +112,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -140,7 +140,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 dialog.Verify(d => d.Throw(It.IsAny<IDialogContext>(), It.IsAny<IAwaitable<IMessageActivity>>()), Times.Once);
 
                 //make sure that data is persisted with connector
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -153,7 +153,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -165,7 +165,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -202,7 +202,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (new FiberTestBase.ResolveMoqAssembly(dialog.Object))
             using (var container = Build(Options.None, dialog.Object))
             {
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -225,7 +225,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -298,7 +298,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (new FiberTestBase.ResolveMoqAssembly(dialog.Object))
             using (var container = Build(Options.None, dialog.Object))
             {
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -322,7 +322,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -385,7 +385,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (new FiberTestBase.ResolveMoqAssembly(dialogOne.Object, dialogTwo.Object))
             using (var container = Build(Options.None, dialogOne.Object, dialogTwo.Object))
             {
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -489,7 +489,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (new FiberTestBase.ResolveMoqAssembly(dialogOne.Object, dialogTwo.Object, dialogNew.Object))
             using (var container = Build(Options.None, dialogOne.Object, dialogTwo.Object, dialogNew.Object))
             {
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -707,7 +707,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (new FiberTestBase.ResolveMoqAssembly(dialogOne.Object))
             using (var container = Build(Options.None, dialogOne.Object))
             {
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -721,7 +721,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -789,7 +789,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             {
                 int count = 2;
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     for (int i = 0; i < count; i++)
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/DialogTestBase.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/DialogTestBase.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                 var toBotText = pairs[index];
                 toBot.Text = toBotText;
 
-                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context) =>
+                await new TestAdapter().ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/DispatchDialogTests .cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/DispatchDialogTests .cs
@@ -226,7 +226,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
 
         public override async Task ActAsync()
         {
-            await new TestAdapter().ProcessActivityAsync((Activity)this.activity, async (context) =>
+            await new TestAdapter().ProcessActivityAsync((Activity)this.activity, async (context, cancellationToken) =>
             {
                 using (var scope = DialogModule.BeginLifetimeScope(this.container, context))
                 {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/PromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/PromptTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (var container = Build(Options.ScopedQueue, dialogRoot.Object))
             {
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -126,7 +126,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -369,7 +369,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             using (var container = Build(Options.ScopedQueue, dialogRoot.Object))
             {
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -382,7 +382,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {
@@ -395,7 +395,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
                     }
                 });
 
-                await adapter.ProcessActivityAsync((Activity)toBot, async (context) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (context, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, context))
                     {

--- a/tests/Microsoft.Bot.Builder.Classic.Tests/Script.cs
+++ b/tests/Microsoft.Bot.Builder.Classic.Tests/Script.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             var toBot = MakeTestMessage();
 
             var adapter = new TestAdapter();
-            await adapter.ProcessActivityAsync((Activity)toBot, async (ctx) =>
+            await adapter.ProcessActivityAsync((Activity)toBot, async (ctx, cancellationToken) =>
             {
                 using (var containerScope = DialogModule.BeginLifetimeScope(container, ctx))
                 {
@@ -131,7 +131,7 @@ namespace Microsoft.Bot.Builder.Classic.Tests
             while ((input = ReadLine(stream, out label)) != null)
             {
                 var adapter = new TestAdapter();
-                await adapter.ProcessActivityAsync((Activity)toBot, async (ctx) =>
+                await adapter.ProcessActivityAsync((Activity)toBot, async (ctx, cancellationToken) =>
                 {
                     using (var scope = DialogModule.BeginLifetimeScope(container, ctx))
                     {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/AttachmentPromptTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var attachment = new Attachment { Content = "some content", ContentType = "text/plain" };
             var activityWithAttachment = MessageFactory.Attachment(attachment);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new AttachmentPrompt();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -92,12 +92,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public async Task ShouldSendPromptAsAnInlineList()
         {
             ConversationState convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convoState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -128,7 +128,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -199,7 +199,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -230,7 +230,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -262,7 +262,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -293,7 +293,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -324,7 +324,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -362,7 +362,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English);
@@ -411,7 +411,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 return Task.CompletedTask;
             };
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ChoicePrompt(Culture.English, validator);
@@ -457,7 +457,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 return Task.CompletedTask;
             };
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext); 
                 var prompt = new ChoicePrompt(Culture.English, validator);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ConfirmPrompt(Culture.English);
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ConfirmPrompt(Culture.English);
@@ -103,7 +103,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ConfirmPrompt(Culture.English);
@@ -147,11 +147,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public async Task ConfirmPromptChoiceOptionsNoNumbers()
         {
             var convState = new ConversationState(new MemoryStorage());
-            var testProperty = convState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convState.CreateProperty("test", () => new Dictionary<string, object>());
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new ConfirmPrompt(Culture.English);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogChoicePromptTests.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             );
 
             ConversationState convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convoState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var dc = dialogs.CreateContext(turnContext, state);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogDateTimePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogDateTimePromptTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new DateTimePrompt(Culture.English);
@@ -51,12 +51,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public async Task MultipleResolutionsDateTimePrompt()
         {
             ConversationState convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convoState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new DateTimePrompt(Culture.English);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<int>(Culture.English);
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<int>(Culture.English);
@@ -103,7 +103,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 await Task.CompletedTask;
             };
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<int>(Culture.English, validator);
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<float>(Culture.English);
@@ -174,7 +174,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<long>(Culture.English);
@@ -206,7 +206,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<double>(Culture.English);
@@ -233,12 +233,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public async Task DecimalNumberPrompt()
         {
             ConversationState convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convoState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new NumberPrompt<decimal>(Culture.English);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new TextPrompt();
@@ -53,12 +53,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public async Task TextPrompt()
         {
             ConversationState convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convoState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new TextPrompt();
@@ -98,7 +98,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 await Task.CompletedTask;
             };
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var prompt = new TextPrompt(validator);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var waterfall = new Waterfall(new WaterfallStep[]
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var dialogs = new DialogSet();
@@ -129,12 +129,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public async Task WaterfallNested()
         {
             ConversationState convoState = new ConversationState(new MemoryStorage());
-            var testProperty = convoState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convoState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
                 var dialogs = new DialogSet();
@@ -188,7 +188,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var adapter = new TestAdapter()
                 .Use(convoState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 var state = await testProperty.GetAsync(turnContext);
 

--- a/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/TemplateManagerTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Register(new DictionaryRenderer(templates1))
                 .Register(new DictionaryRenderer(templates2));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     var templateId = context.Activity.AsMessageActivity().Text.Trim();
                     await templateManager.ReplyWith(context, templateId, new { name = "joe" });
@@ -135,7 +135,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Register(new DictionaryRenderer(templates1))
                 .Register(new DictionaryRenderer(templates2));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 context.Activity.AsMessageActivity().Locale = "en"; // force to english
                 var templateId = context.Activity.AsMessageActivity().Text.Trim();
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Register(new DictionaryRenderer(templates1))
                 .Register(new DictionaryRenderer(templates2));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     context.Activity.AsMessageActivity().Locale = "fr"; // force to french
                     var templateId = context.Activity.AsMessageActivity().Text.Trim();
@@ -175,7 +175,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Register(new DictionaryRenderer(templates1))
                 .Register(new DictionaryRenderer(templates2));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     context.Activity.AsMessageActivity().Locale = "fr"; // force to french
                     var templateId = context.Activity.AsMessageActivity().Text.Trim();
@@ -195,7 +195,7 @@ namespace Microsoft.Bot.Builder.TemplateManager.Tests
                 .Register(new DictionaryRenderer(templates1))
                 .Register(new DictionaryRenderer(templates2));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     var templateId = context.Activity.AsMessageActivity().Text.Trim();
                     await templateManager.ReplyWith(context, templateId, new { name = "joe" });

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterBracketingTest.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterBracketingTest.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(new BeforeAFterMiddlware());
 
-            async Task Echo(ITurnContext ctx)
+            async Task Echo(ITurnContext ctx, CancellationToken cancellationToken)
             {
                 string toEcho = "ECHO:" + ctx.Activity.AsMessageActivity().Text;
-                await ctx.SendActivityAsync(ctx.Activity.CreateReply(toEcho)); 
+                await ctx.SendActivityAsync(ctx.Activity.CreateReply(toEcho), cancellationToken); 
             }
 
             await new TestFlow(adapter, Echo)
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(new CatchExceptionMiddleware());
 
-            async Task EchoWithException(ITurnContext ctx)
+            async Task EchoWithException(ITurnContext ctx, CancellationToken cancellationToken)
             {
                 string toEcho = "ECHO:" + ctx.Activity.AsMessageActivity().Text;
                 await ctx.SendActivityAsync(ctx.Activity.CreateReply(toEcho));

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateSetTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Tests
             var adapter = new TestAdapter()
                 .Use(new BotStateSet(userState, convState));
 
-            Func<ITurnContext, Task> botLogic = async (context) =>
+            BotCallbackHandler botLogic = async (context, cancellationToken) =>
             {
                 // get userCount and convCount from botStateSet
                 var userCount = await userProperty.GetAsync(context).ConfigureAwait(false);

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             TestAdapter adapter = new TestAdapter();
 
-            await new TestFlow(adapter, (context) =>
+            await new TestFlow(adapter, (context, cancellationToken) =>
                    {
                        var obj = context.Services.Get<UserState>();
                        Assert.IsNull(obj, "context.state should not exist");
@@ -157,7 +157,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Use(userState);
 
             await new TestFlow(adapter,
-                    async (context) =>
+                    async (context, cancellationToken) =>
                     {
                         var state = await testProperty.GetAsync(context);
                         Assert.IsNotNull(state, "user state should exist");
@@ -186,7 +186,7 @@ namespace Microsoft.Bot.Builder.Tests
             var adapter = new TestAdapter()
                 .Use(userState);
             await new TestFlow(adapter,
-                    async (context) =>
+                    async (context, cancellationToken) =>
                     {
                         var testPocoState = await testPocoProperty.GetAsync(context);
                         Assert.IsNotNull(userState, "user state should exist");
@@ -216,7 +216,7 @@ namespace Microsoft.Bot.Builder.Tests
             var adapter = new TestAdapter()
                 .Use(userState);
             await new TestFlow(adapter,
-                    async (context) =>
+                    async (context, cancellationToken) =>
                     {
                         var conversationState = await testProperty.GetAsync(context);
                         Assert.IsNotNull(conversationState, "state.conversation should exist");
@@ -245,7 +245,7 @@ namespace Microsoft.Bot.Builder.Tests
             var adapter = new TestAdapter()
                 .Use(userState);
             await new TestFlow(adapter,
-                    async (context) =>
+                    async (context, cancellationToken) =>
                     {
                         var conversationState = await testPocoProperty.GetAsync(context);
                         Assert.IsNotNull(conversationState, "state.conversation should exist");
@@ -277,7 +277,7 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(customState);
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                     {
                         var test = await testProperty.GetAsync(context);
                         switch (context.Activity.AsMessageActivity().Text)
@@ -311,7 +311,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Use(convoState);
 
             await new TestFlow(adapter,
-                    async (context) =>
+                    async (context, cancellationToken) =>
                     {
                         var conversation = await testProperty.GetAsync(context);
                         Assert.IsNotNull(conversation, "conversationstate should exist");
@@ -338,7 +338,7 @@ namespace Microsoft.Bot.Builder.Tests
             var adapter = new TestAdapter();
 
             await new TestFlow(adapter,
-                    async (context) =>
+                    async (context, cancellationToken) =>
                     {
                     var botStateManager = new TestBotState(new MemoryStorage());
 

--- a/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mime;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
@@ -389,7 +390,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
             TestAdapter adapter = new TestAdapter();                 
 
-            async Task ReplyWithimBackBack(ITurnContext ctx)
+            async Task ReplyWithimBackBack(ITurnContext ctx, CancellationToken cancellationToken)
             {
                 if (ctx.Activity.AsMessageActivity().Text == "test")
                 {
@@ -426,7 +427,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
             TestAdapter adapter = new TestAdapter();
 
-            async Task ReplyWithimBackBack(ITurnContext ctx)
+            async Task ReplyWithimBackBack(ITurnContext ctx, CancellationToken cancellationToken)
             {
                 if (ctx.Activity.AsMessageActivity().Text == "test")
                 {

--- a/tests/Microsoft.Bot.Builder.Tests/MiddlewareSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MiddlewareSetTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
             var m = new MiddlewareSet();
             bool wasCalled = false;
-            Task CallMe(ITurnContext context)
+            Task CallMe(ITurnContext context, CancellationToken cancellationToken)
             {
                 wasCalled = true;
                 return Task.CompletedTask;
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Tests
             var simple = new WasCalledMiddlware();
 
             bool wasCalled = false;
-            Task CallMe(ITurnContext context)
+            Task CallMe(ITurnContext context, CancellationToken cancellationToken)
             {
                 wasCalled = true;
                 return Task.CompletedTask;
@@ -126,7 +126,7 @@ namespace Microsoft.Bot.Builder.Tests
             WasCalledMiddlware two = new WasCalledMiddlware();
 
             int called = 0;
-            Task CallMe(ITurnContext context)
+            Task CallMe(ITurnContext context, CancellationToken cancellationToken)
             {
                 called++;
                 return Task.CompletedTask;
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             // The middlware in this pipeline calls next(), so the delegate should be called
             bool didAllRun = false;
-            await m.ReceiveActivityWithStatusAsync(null, (ctx) =>
+            await m.ReceiveActivityWithStatusAsync(null, (ctx, cancellationToken) =>
             {
                 didAllRun = true;
                 return Task.CompletedTask;
@@ -200,7 +200,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             // This middlware pipeline has no entries. This should result in
             // the status being TRUE. 
-            await m.ReceiveActivityWithStatusAsync(null, (ctx) =>
+            await m.ReceiveActivityWithStatusAsync(null, (ctx, cancellationToken) =>
             {
                 didAllRun = true;
                 return Task.CompletedTask;
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder.Tests
             m.Use(two);
 
             bool didAllRun = false;
-            await m.ReceiveActivityWithStatusAsync(null, (ctx) =>
+            await m.ReceiveActivityWithStatusAsync(null, (ctx, cancellationToken) =>
             {
                 didAllRun = true;
                 return Task.CompletedTask;
@@ -257,7 +257,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             // The middlware in this pipeline DOES NOT call next(), so this must not be called 
             bool didAllRun = false;
-            await m.ReceiveActivityWithStatusAsync(null, (ctx) =>
+            await m.ReceiveActivityWithStatusAsync(null, (ctx, cancellationToken) =>
             {
                 didAllRun = true;
                 return Task.CompletedTask;

--- a/tests/Microsoft.Bot.Builder.Tests/OnTurnErrorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/OnTurnErrorTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Builder.Tests
                 }
             };
 
-            await new TestFlow(adapter, (context) =>
+            await new TestFlow(adapter, (context, cancellationToken) =>
                 {
                     if (context.Activity.AsMessageActivity().Text == "foo")
                     {

--- a/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(new ShowTypingMiddleware(100, 1000));
             
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(2500));
                     await context.SendActivityAsync("Message sent after delay");
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(new ShowTypingMiddleware(100, 5000));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(2000));
                     await context.SendActivityAsync("Message sent after delay");
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(new ShowTypingMiddleware(2000, 5000));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     await context.SendActivityAsync("Message sent after delay");
                     await Task.CompletedTask;

--- a/tests/Microsoft.Bot.Builder.Tests/SimpleAdapter.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/SimpleAdapter.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.Tests
             return Task.FromResult(new ResourceResponse(activity.Id)); // echo back the Id
         }
 
-        public async Task ProcessRequest(Activity activty, Func<ITurnContext, Task> callback, CancellationToken cancellationToken)
+        public async Task ProcessRequest(Activity activty, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             using (var ctx = new TurnContext(this, activty))
             {

--- a/tests/Microsoft.Bot.Builder.Tests/TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TestAdapterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
@@ -14,7 +15,7 @@ namespace Microsoft.Bot.Builder.Tests
     [TestCategory("Adapter")]
     public class TestAdapterTests
     {
-        public async Task MyBotLogic(ITurnContext context)
+        public async Task MyBotLogic(ITurnContext context, CancellationToken cancellationToken)
         {
             switch (context.Activity.AsMessageActivity().Text)
             {
@@ -40,7 +41,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             try
             {
-                await new TestFlow(adapter, async (context) =>
+                await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     await context.SendActivityAsync(context.Activity.CreateReply("one"));
                 })
@@ -63,7 +64,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             try
             {
-                await new TestFlow(adapter, (context) => { throw new Exception(uniqueExceptionId); })
+                await new TestFlow(adapter, (context, cancellationToken) => { throw new Exception(uniqueExceptionId); })
                     .Test("test", activity => Assert.IsNull(null), "uh oh!")
                     .StartTestAsync();
 
@@ -83,7 +84,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             try
             {
-                await new TestFlow(adapter, async (context) => 
+                await new TestFlow(adapter, async (context, cancellationToken) => 
                 {
                     await context.SendActivityAsync(context.Activity.CreateReply("one"));
                 })
@@ -165,7 +166,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
             var adapter = new TestAdapter();
 
-            TestFlow testFlow = new TestFlow(adapter, (ctx) =>
+            TestFlow testFlow = new TestFlow(adapter, (ctx, cancellationToken) =>
                 {
                     Exception innerException = (Exception)Activator.CreateInstance(exceptionType);
                     var taskSource = new TaskCompletionSource<bool>();

--- a/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Use(new TranscriptLoggerMiddleware(transcriptStore));
             string conversationId = null;
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     conversationId = context.Activity.Conversation.Id;
                     var typingActivity = new Activity
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Use(new TranscriptLoggerMiddleware(transcriptStore));
             string conversationId = null;
             Activity activityToUpdate = null;
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 conversationId = context.Activity.Conversation.Id;
                 if (context.Activity.Text == "update")
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Use(new TranscriptLoggerMiddleware(transcriptStore));
             string conversationId = null;
             Activity activityToUpdate = null;
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 conversationId = context.Activity.Conversation.Id;
                 if (context.Activity.Text == "update")
@@ -167,7 +167,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .Use(new TranscriptLoggerMiddleware(transcriptStore));
             string conversationId = null;
             string activityId = null;
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 conversationId = context.Activity.Conversation.Id;
                 if (context.Activity.Text == "deleteIt")

--- a/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
@@ -477,7 +478,7 @@ namespace Microsoft.Bot.Builder.Tests
             }            
         }        
 
-        public async Task MyBotLogic(ITurnContext context)
+        public async Task MyBotLogic(ITurnContext context, CancellationToken cancellationToken)
         {
             switch (context.Activity.AsMessageActivity().Text)
             {

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/CoreExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/CoreExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(userState);
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (context.Activity.Type == ActivityTypes.Message)
                 {
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convoState);
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (context.Activity.Type == ActivityTypes.Message)
                 {
@@ -115,7 +115,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(customState);
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (context.Activity.Type == ActivityTypes.Message)
                 {

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/CoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/CoreTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
                 return;
             };
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 switch (context.Activity.Type)
                 {

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/DialogsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/DialogsTests.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
         {
             var activities = TranscriptUtilities.GetFromTestContext(TestContext);
             var convState = new ConversationState(new MemoryStorage());
-            var testProperty = convState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -125,7 +125,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -170,7 +170,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -216,7 +216,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -262,7 +262,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -302,7 +302,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -339,7 +339,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {
@@ -404,12 +404,12 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
             var activities = TranscriptUtilities.GetFromTestContext(TestContext);
 
             var convState = new ConversationState(new MemoryStorage());
-            var testProperty = convState.CreateProperty<Dictionary<string, object>>("test", () => new Dictionary<string, object>());
+            var testProperty = convState.CreateProperty("test", () => new Dictionary<string, object>());
 
             TestAdapter adapter = new TestAdapter()
                 .Use(convState);
 
-            await new TestFlow(adapter, async (turnContext) =>
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 if (turnContext.Activity.Type == ActivityTypes.Message)
                 {

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/TranslationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/TranslationTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
                 .Use(userState)
                 .Use(new TranslationMiddleware(nativeLanguages, translatorKey, patterns, new CustomDictionary(), userLangProp, false));
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (!context.Responded)
                 {
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
                 .Use(userState)
                 .Use(new TranslationMiddleware(nativeLanguages, translatorKey, patterns, new CustomDictionary(), userLangProp, true));
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (!context.Responded)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Transcripts.Tests
                 .Use(userState)
                 .Use(new LocaleConverterMiddleware(userLangProp, botLocale, LocaleConverter.Converter));
 
-            var flow = new TestFlow(adapter, async (context) =>
+            var flow = new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (context.Activity.Type == ActivityTypes.Message)
                 {

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,7 +68,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
         public sealed class ServiceRegistrationTestBot : IBot
         {
-            public Task OnTurnAsync(ITurnContext turnContext)
+            public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException("This test bot has no implementation and is intended only for testing service registration.");
             }

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceResolutionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Bot.Connector.Authentication;
@@ -86,7 +87,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
         public sealed class ServiceResolutionTestBot : IBot
         {
-            public Task OnTurnAsync(ITurnContext turnContext)
+            public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 throw new NotImplementedException("This test bot has no implementation and is intended only for testing service resolution.");
             }


### PR DESCRIPTION
- Cancellation is still a work in progress but this should be a big step.

- This follows @drub0y comments in @769 and introduced the delegate

- Cancellation is propagated - perhaps test cases could propagate further but that is not a priority (and not detectable)

- Next steps: cancellation in the integration projects and in the dialogs. And a testing strategy around this.

- But I've held off on the dialogs for todays because we are expecting some changes there.

Note this PR also includes a bunch more ConfigureAwait - from the warnings
