### PR TITLE
Add Responded collection to TurnContext

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ITurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/ITurnContext.cs
@@ -108,6 +108,11 @@ namespace Microsoft.Bot.Builder
         bool Responded { get; }
 
         /// <summary>
+        /// Gets a list of activities that have been sent as responses.
+        /// </summary>
+        List<IActivity> Responses { get; }
+
+        /// <summary>
         /// Sends a message activity to the sender of the incoming activity.
         /// </summary>
         /// <param name="textReplyToSend">The text of the message to send.</param>

--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Bot.Builder
         {
             Adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
             Activity = activity ?? throw new ArgumentNullException(nameof(activity));
+            Responses = new List<IActivity>();
         }
 
         /// <summary>
@@ -64,6 +65,12 @@ namespace Microsoft.Bot.Builder
         /// <value><c>true</c> if at least one response was sent for the current turn.</value>
         /// <remarks><see cref="ITraceActivity"/> activities on their own do not set this flag.</remarks>
         public bool Responded
+        {
+            get;
+            private set;
+        }
+
+        public List<IActivity> Responses
         {
             get;
             private set;
@@ -280,6 +287,8 @@ namespace Microsoft.Bot.Builder
                 {
                     Responded = true;
                 }
+
+                Responses.AddRange(bufferedActivities);
 
                 return responses;
             }

--- a/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.QnA.Tests/QnAMakerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -373,6 +374,8 @@ namespace Microsoft.Bot.Builder.Ai.QnA.Tests
         public Activity Activity { get; }
 
         public bool Responded => throw new NotImplementedException();
+
+        List<IActivity> ITurnContext.Responses => throw new NotImplementedException();
 
         public Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
@@ -137,6 +137,39 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
+        public async Task SendandGetActivities()
+        {
+            var a = new SimpleAdapter(); 
+            var c = new TurnContext(a, new Activity());
+            Assert.IsFalse(c.Responded);
+
+
+            var message1 = new Activity()
+            {
+                Type = ActivityTypes.Typing,
+                Text = "message1",
+                Id = "message1id",
+            };
+            var message2 = new Activity()
+            {
+                Type = ActivityTypes.Message,
+                Text = "message2",
+                Id = "message2id",
+            };
+
+            var response = await c.SendActivitiesAsync(new IActivity[] { message1, message2 });
+
+            Assert.IsTrue(c.Responded);
+            Assert.IsTrue(c.Responses.Count == 2);
+            Assert.IsTrue(c.Responses.Where(resp => resp.Type == ActivityTypes.Typing).Any());
+            Assert.IsTrue(c.Responses.Where(resp => resp.Type == ActivityTypes.Message).Any());
+            Assert.IsFalse(c.Responses.Where(resp => resp.Type == ActivityTypes.EndOfConversation).Any());
+            Assert.IsTrue(c.Responses.Count == 2);
+            Assert.IsTrue(response[0].Id == "message1id");
+            Assert.IsTrue(response[1].Id == "message2id");
+        }
+
+        [TestMethod]
         public async Task SendAndSetRespondedUsingIMessageActivity()
         {
             var a = new SimpleAdapter();


### PR DESCRIPTION
This PR adds a Responses collection to the TurnContext.  The BotFrameWorkAdapter will then add all sent activities to the collection.

This allows middleware and other logic to query what has responded based on Message type instead of using the responded boolean.

Example usage:   The typing middleWare currently breaks any code that uses "if (context.Responded)" because it responds to everything with a typing event.  Now using LINQ you could instead do "if (context.Responses.Where(r => r.Type != ActivityTypes.Typing).Any())"

This would resolve issue #800 