### PR TITLE
Fix OAuth Prompt for Teams

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (IsTeamsVerificationInvoke(context))
             {
                 var value = context.Activity.Value as JObject;
-                magicCode = value.GetValue("state").ToString();
+                magicCode = value.GetValue("state")?.ToString();
             }
             
             if (context.Activity.Type == ActivityTypes.Message && _magicCodeRegex.IsMatch(context.Activity.Text))
@@ -311,7 +311,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             else if (IsTeamsVerificationInvoke(context))
             {
                 var magicCodeObject = context.Activity.Value as JObject;
-                var magicCode = magicCodeObject.GetValue("state").ToString();
+                var magicCode = magicCodeObject.GetValue("state")?.ToString();
 
                 if (!(context.Adapter is BotFrameworkAdapter adapter))
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         private const int DefaultPromptTimeout = 54000000;
 
         // regex to check if code supplied is a 6 digit numerical code (hence, a magic code).
-        private readonly Regex magicCodeRegex = new Regex(@"(\d{6})");
+        private readonly Regex _magicCodeRegex = new Regex(@"(\d{6})");
 
         private OAuthPromptSettings _settings;
         private PromptValidator<TokenResponse> _validator;
@@ -194,11 +194,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             
             if (IsTeamsVerificationInvoke(context))
             {
-                JObject value = context.Activity.Value as JObject;
+                var value = context.Activity.Value as JObject;
                 magicCode = value.GetValue("state").ToString();
             }
             
-            if (context.Activity.Type == ActivityTypes.Message && magicCodeRegex.IsMatch(context.Activity.Text))
+            if (context.Activity.Type == ActivityTypes.Message && _magicCodeRegex.IsMatch(context.Activity.Text))
             {
                 magicCode = context.Activity.Text;
             }
@@ -327,7 +327,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
             else if (context.Activity.Type == ActivityTypes.Message)
             {
-                var matched = magicCodeRegex.Match(context.Activity.Text);
+                var matched = _magicCodeRegex.Match(context.Activity.Text);
                 if (matched.Success)
                 {
                     if (!(context.Adapter is BotFrameworkAdapter adapter))


### PR DESCRIPTION
This change enables the OAuth prompt to be used with teams without the magic code.  Teams sends an invoke activity as opposed to a message activity when the user enters a magic code.  This will handle that.  

**Note**:  This will also need to be handled by developers in their bot code.
**See**: https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/authentication/auth-oauth-card#getting-started-with-oauthcard-in-teams
**Manifest Schema Here**: https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema