### PR TITLE
fix race and added Responded check

### DIFF
--- a/tests/Microsoft.Bot.Builder.TestBot/TestBotAccessors.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/TestBotAccessors.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Threading;
 using Microsoft.Bot.Builder.Dialogs;
 
 namespace Microsoft.Bot.Builder.TestBot
@@ -8,5 +9,7 @@ namespace Microsoft.Bot.Builder.TestBot
     public class TestBotAccessors
     {
         public IStatePropertyAccessor<DialogState> ConversationDialogState { get; set; }
+
+        public SemaphoreSlim SemaphoreSlim { get; } = new SemaphoreSlim(1, 1);
     }
 }


### PR DESCRIPTION
see comments in code.
- added a globally scoped SemaphoreSlim to protect from concurrent activities breaking the shared (global) state
- note clarification on use of Responded. You can decide whether you want to start over or begin a fresh waterfall. It depends on how you want your waterfall to behave. It depends on where you want the initial activity to land. It probably makes most sense to check responded.