### PR TITLE
show typing activity doesn't set Responded

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -110,7 +110,14 @@ namespace Microsoft.Bot.Builder
                 Type = ActivityTypes.Typing,
                 RelatesTo = turnContext.Activity.RelatesTo,
             };
-            await turnContext.SendActivityAsync(typingActivity, cancellationToken).ConfigureAwait(false);
+
+            // sending the Activity directly on the Adapter avoids other Middleware and avoids setting the Responded
+            // flag, however, this also requires that the conversation reference details are explicitly added.
+            var conversationReference = turnContext.Activity.GetConversationReference();
+            typingActivity.ApplyConversationReference(conversationReference);
+
+            // make sure to send the Activity directly on the Adapter rather than via the TurnContext
+            await turnContext.Adapter.SendActivitiesAsync(turnContext, new Activity[] { typingActivity }, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Bot.Builder.TestBot
                 IStorage dataStore = new MemoryStorage();
                 options.State.Add(new ConversationState(dataStore));
                 options.Middleware.Add(new BotStateSet(options.State.ToArray()));
+                options.Middleware.Add(new ShowTypingMiddleware());
             });
 
             services.AddSingleton(sp =>

--- a/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
@@ -22,6 +22,10 @@ namespace Microsoft.Bot.Builder.Tests
             await new TestFlow(adapter, async (context, cancellationToken) =>
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(2500));
+
+                    // note the ShowTypingMiddleware should not cause the Responded flag to be set
+                    Assert.IsFalse(context.Responded);
+
                     await context.SendActivityAsync("Message sent after delay");
                     await Task.CompletedTask;
                 })


### PR DESCRIPTION
By sending the Activity directly through the Adapter rather than using the TurnContext the Responded flag is not set.