### PR TITLE
Enable bots to use alternative endpoints for Open ID metadata documents and OAuth APIs

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Bot.Builder
                 return new OAuthClient(client, turnContext.Activity.ServiceUrl);
             }
 
-            return new OAuthClient(client, AuthenticationConstants.OAuthUrl);
+            return new OAuthClient(client, OAuthClient.OAuthEndpoint);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
@@ -29,6 +29,16 @@ namespace Microsoft.Bot.Connector.Authentication
         /// OAuth Url used to get a token from OAuthApiClient
         /// </summary>
         public const string OAuthUrl = "https://api.botframework.com";
+        
+        /// <summary>
+        /// Application Setting Key for the OpenIdMetadataUrl value
+        /// </summary>
+        public const string BotOpenIdMetadataKey = "BotOpenIdMetadata";
+        
+        /// <summary>
+        /// Application Setting Key for the OAuthUrl value
+        /// </summary>
+        public const string OAuthUrlKey = "OAuthApiEndpoint";
 
         /// <summary>
         /// TO BOT FROM CHANNEL: OpenID metadata document for tokens coming from MSA

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Bot.Connector.Authentication
     public static class ChannelValidation
     {
         /// <summary>
+        /// The default endpoint that is used for Open ID Metadata requests.
+        /// </summary>
+        public static string OpenIdMetadataUrl { get; set; } = AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl;
+
+        /// <summary>
         /// TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot
         /// </summary>
         public static readonly TokenValidationParameters ToBotFromChannelTokenValidationParameters =
@@ -46,7 +51,7 @@ namespace Microsoft.Bot.Connector.Authentication
         {
             var tokenExtractor = new JwtTokenExtractor(httpClient,
                   ToBotFromChannelTokenValidationParameters,
-                  AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
+                  OpenIdMetadataUrl,
                   AuthenticationConstants.AllowedSigningAlgorithms);
 
             var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId);

--- a/libraries/Microsoft.Bot.Connector/OAuthApiClient.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthApiClient.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Bot.Connector
         private readonly ConnectorClient _client;
         private readonly string _uri;
 
+        /// <summary>
+        /// The default endpoint that is used for API requests.
+        /// </summary>
+        public static string OAuthEndpoint { get; set; } = AuthenticationConstants.OAuthUrl;
 
         /// <summary>
         /// Initializes an new instance of the <see cref="OAuthClient"/> class.

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
@@ -4,6 +4,9 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -30,6 +33,26 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             }
 
             var applicationServices = applicationBuilder.ApplicationServices;
+
+            var configuration = applicationServices.GetService<IConfiguration>();
+
+            if (configuration != null)
+            {
+                var openIdEndpoint = configuration.GetSection(AuthenticationConstants.BotOpenIdMetadataKey)?.Value;
+
+                if (!string.IsNullOrEmpty(openIdEndpoint))
+                {
+                    ChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
+                }
+
+                var oauthApiEndpoint = configuration.GetSection(AuthenticationConstants.OAuthUrlKey)?.Value;
+
+                if (!string.IsNullOrEmpty(oauthApiEndpoint))
+                {
+                    OAuthClient.OAuthEndpoint = oauthApiEndpoint;
+                }
+            }
+
             var options = applicationServices.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
 
             var paths = options.Paths;

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpConfigurationExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Configuration;
 using System.Web.Http;
 using Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
@@ -49,6 +50,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
 
             ConfigureBotRoutes(httpConfiguration, options, botFrameworkAdapter);
 
+            ConfigureCustomEndpoints();
+
             return httpConfiguration;
         }
 
@@ -76,6 +79,27 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
             }
 
             return new SimpleCredentialProvider(ConfigurationManager.AppSettings[MicrosoftAppCredentials.MicrosoftAppIdKey], ConfigurationManager.AppSettings[MicrosoftAppCredentials.MicrosoftAppPasswordKey]);
+        }
+
+        /// <summary>
+        /// Sets custom endpoints for the Open ID Metadata Document and OAuth API Endpoint 
+        /// from the App Settings.
+        /// </summary>
+        private static void ConfigureCustomEndpoints()
+        {
+            var openIdEndpoint = ConfigurationManager.AppSettings[AuthenticationConstants.BotOpenIdMetadataKey];
+
+            if (!string.IsNullOrEmpty(openIdEndpoint))
+            {
+                ChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
+            }
+
+            var oauthApiEndpoint = ConfigurationManager.AppSettings[AuthenticationConstants.OAuthUrlKey];
+
+            if (!string.IsNullOrEmpty(oauthApiEndpoint))
+            {
+                OAuthClient.OAuthEndpoint = oauthApiEndpoint;
+            }
         }
     }
 }


### PR DESCRIPTION
This change brings the two settings properties from the V3 SDK into the V4 SDK:

1. "BotOpenIdMetadata" - to customize the Open ID Metadata endpoint
2. "OAuthApiEndpoint" - to customize the OAuth API endpoint