### PR TITLE
Added JsonConverter attribute so we could deserialize any bot config string …

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Bot.Configuration
         /// Gets or sets connected services.
         /// </summary>
         [JsonProperty("services")]
+        [JsonConverter(typeof(BotConfigConverter))]
         public List<ConnectedService> Services { get; set; } = new List<ConnectedService>();
 
         /// <summary>


### PR DESCRIPTION
If we have bot config string, Json deserialize doesn't work (service didn't get converted to the right type), deserialization only works from BotConfiguration.LoadAsync(filepath…).  This change will make json deserialization given bot configuration works.