### PR TITLE
Fix Adapter ConnectorClient cache

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Bot.Connector;
 
 namespace Microsoft.Bot.Builder
 {
@@ -106,6 +107,13 @@ namespace Microsoft.Bot.Builder
             {
                 if (entry is IDisposable disposableService)
                 {
+                    // Don't dispose the ConnectorClient, since this is cached in the adapter (singleton).
+                    // Disposing will release the HttpClient causing Response Sends to fail.
+                    if (entry is IConnectorClient)
+                    {
+                        continue;
+                    }
+
                     disposableService.Dispose();
                 }
             }

--- a/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
@@ -507,6 +507,7 @@ namespace Microsoft.Bot.Builder.Tests
             var disposableObject1 = new TrackDisposed();
             var disposableObject2 = new TrackDisposed();
             var disposableObject3 = new TrackDisposed();
+            Assert.IsFalse(disposableObject1.Disposed);
             Assert.IsTrue(disposableObject1 is IDisposable);
 
             var connector = new ConnectorClientThrowExceptionOnDispose();
@@ -573,6 +574,11 @@ namespace Microsoft.Bot.Builder.Tests
 
         public void Dispose() => throw new Exception("Should not be disposed!");
     }
+
+    /// <summary>
+    /// Vanilla <see cref="IDisposable"/> tracks if Dispose has been called.
+    /// </summary>
+    /// <remarks>Moq failed to create this properly.  Boo moq!</remarks>
     public class TrackDisposed : IDisposable
     {
         public bool Disposed { get; private set; } = false;

--- a/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
@@ -497,11 +497,34 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.IsTrue(connector is IConnectorClient);
 
             var stateCollection = new TurnContextStateCollection();
-            stateCollection.Add(connector);
+            stateCollection.Add("connector", connector);
             stateCollection.Dispose();
         }
 
-        
+        [TestMethod]
+        public void TurnContextStateDisposeNonConnectorClient()
+        {
+            var disposableObject1 = new TrackDisposed();
+            var disposableObject2 = new TrackDisposed();
+            var disposableObject3 = new TrackDisposed();
+            Assert.IsTrue(disposableObject1 is IDisposable);
+
+            var connector = new ConnectorClientThrowExceptionOnDispose();
+            Assert.IsTrue(connector is IDisposable);
+            Assert.IsTrue(connector is IConnectorClient);
+
+            var stateCollection = new TurnContextStateCollection();
+            stateCollection.Add("disposable1", disposableObject1);
+            stateCollection.Add("disposable2", disposableObject2);
+            stateCollection.Add("disposable3", disposableObject3);
+            stateCollection.Add("connector", connector);
+            stateCollection.Dispose();
+
+            Assert.IsTrue(disposableObject1.Disposed);
+            Assert.IsTrue(disposableObject2.Disposed);
+            Assert.IsTrue(disposableObject3.Disposed);
+        }
+
 
         public async Task MyBotLogic(ITurnContext turnContext, CancellationToken cancellationToken)
         {
@@ -549,6 +572,14 @@ namespace Microsoft.Bot.Builder.Tests
         public IConversations Conversations => throw new NotImplementedException();
 
         public void Dispose() => throw new Exception("Should not be disposed!");
+    }
+    public class TrackDisposed : IDisposable
+    {
+        public bool Disposed { get; private set; } = false;
+        public void Dispose()
+        {
+            Disposed = true;
+        }
     }
 
 }


### PR DESCRIPTION
The second turn for a client will fail to Send responses from bot back to user. 

Here's the conditions which sets up the problem:
- ConnectorClient is placed in TurnContextStateCollection.
- ConnectorClient is cached in the Adapter (singleton).
- ConnectorClient implements IDisposable.
- TurnContextStateCollection disposes all elements after turn.
- ConnectorClient Dispose() cleans up HttpClient.

On a second turn, we attempt to use the Adapter's cached ConnectorClient which is now invalid.

Notes:
ConnectorClient has a "ignore the Dispose call" constructor.  @cleemullins and I looked at fixing in ConnectorClient, but decided this may be more durable fix as there are currently many constructors, and a new one could easily circumvent.