### PR TITLE
Tiens

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Bot.Configuration
         /// Gets or sets connected services.
         /// </summary>
         [JsonProperty("services")]
+        [JsonConverter(typeof(BotConfigConverter))]
         public List<ConnectedService> Services { get; set; } = new List<ConnectedService>();
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -454,6 +454,11 @@ namespace Microsoft.Bot.Configuration
         /// </summary>
         internal class BotServiceConverter : JsonConverter
         {
+            public override bool CanWrite
+            {
+                get { return false; }
+            }
+
             /// <summary>
             /// Checks whether the connected service can be converted to the provided type.
             /// </summary>


### PR DESCRIPTION
Dispatch needs to be able deserialize bot config json string (from std in) BUT it doesn't have access to the converter (internal only).  Better way is to decorate the Services property with the JsonConverter attribute and now anyone can json deserialize BotConfiguration json string (via JsonConvert.DeserializeObject<BotConfiguration>(json) without having to define a json converter separately.