### PR TITLE
Fixes to get EmulateOAuthCards working

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// Application Setting Key for the OAuthUrl value
         /// </summary>
         public const string OAuthUrlKey = "OAuthApiEndpoint";
+        
+        /// <summary>
+        /// Application Settings Key for whether to emulate OAuthCards when using the emulator
+        /// </summary>
+        public const string EmulateOAuthCardsKey = "EmulateOAuthCards";
 
         /// <summary>
         /// TO BOT FROM CHANNEL: OpenID metadata document for tokens coming from MSA

--- a/libraries/Microsoft.Bot.Connector/OAuthApiClient.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthApiClient.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Bot.Connector
         /// </summary>
         public static string OAuthEndpoint { get; set; } = AuthenticationConstants.OAuthUrl;
 
+
+        /// <summary>
+        /// When using the Emulator, whether to emulate the OAuthCard behavior or use connected flows
+        /// </summary>
+        public static bool EmulateOAuthCards { get; set; } = false;
+
         /// <summary>
         /// Initializes an new instance of the <see cref="OAuthClient"/> class.
         /// </summary>
@@ -35,7 +41,7 @@ namespace Microsoft.Bot.Connector
         /// <param name="uri">The URL to use to get a token.</param>
         public OAuthClient(ConnectorClient client, string uri)
         {
-            if (!(Uri.TryCreate(uri, UriKind.Absolute, out var uriResult) && uriResult.Scheme == Uri.UriSchemeHttps))
+            if (!(Uri.TryCreate(uri, UriKind.Absolute, out var uriResult)))
                 throw new ArgumentException("Please supply a valid https uri");
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _uri = uri;
@@ -94,9 +100,6 @@ namespace Microsoft.Bot.Connector
             HttpResponseMessage httpResponse = null;
             httpRequest.Method = new HttpMethod("GET");
             httpRequest.RequestUri = new Uri(tokenUrl);
-
-            // add botframework api service url to the list of trusted service url's for these app credentials.
-            MicrosoftAppCredentials.TrustServiceUrl(tokenUrl);
 
             // Set Credentials
             if (_client.Credentials != null)
@@ -253,10 +256,7 @@ namespace Microsoft.Bot.Connector
             tokenUrl = tokenUrl.Replace("{finalRedirectParam}", string.IsNullOrEmpty(finalRedirect) ?
                 String.Empty :
                 $"&finalRedirect={Uri.EscapeDataString(finalRedirect)}");
-
-            // add botframework api service url to the list of trusted service url's for these app credentials.
-            MicrosoftAppCredentials.TrustServiceUrl(tokenUrl);
-
+            
             // Create HTTP transport objects
             var httpRequest = new HttpRequestMessage();
             HttpResponseMessage httpResponse = null;
@@ -416,9 +416,6 @@ namespace Microsoft.Bot.Connector
             httpRequest.Method = new HttpMethod("POST");
             httpRequest.RequestUri = new Uri(tokenUrl);
             
-            // add botframework api service url to the list of trusted service url's for these app credentials.
-            MicrosoftAppCredentials.TrustServiceUrl(tokenUrl);
-
             // Set Credentials
             if (_client.Credentials != null)
             {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
@@ -51,6 +51,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 {
                     OAuthClient.OAuthEndpoint = oauthApiEndpoint;
                 }
+
+                var emulateOAuthCards = configuration.GetSection(AuthenticationConstants.EmulateOAuthCardsKey)?.Value;
+
+                if (!string.IsNullOrEmpty(emulateOAuthCards) && bool.TryParse(emulateOAuthCards, out bool emualteOAuthCardsValue))
+                {
+                    OAuthClient.EmulateOAuthCards = emualteOAuthCardsValue;
+                }
             }
 
             var options = applicationServices.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpConfigurationExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpConfigurationExtensions.cs
@@ -99,6 +99,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
             {
                 OAuthClient.OAuthEndpoint = oauthApiEndpoint;
             }
+
+            var emulateOAuthCards = ConfigurationManager.AppSettings[AuthenticationConstants.EmulateOAuthCardsKey];
+
+            if (!string.IsNullOrEmpty(emulateOAuthCards) && bool.TryParse(emulateOAuthCards, out bool emualteOAuthCardsValue))
+            {
+                OAuthClient.EmulateOAuthCards = emualteOAuthCardsValue;
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -15,9 +15,10 @@ namespace Connector.Tests
         private ConnectorClient mockConnectorClient = new ConnectorClient(new Uri("https://localhost"));
 
         [Fact]
-        public void OAuthClient_ShouldThrowOnInvalidUrl()
+        public void OAuthClient_ShouldNotThrowOnHttpUrl()
         {
-            Assert.Throws<ArgumentException>(() => new OAuthClient(mockConnectorClient, "http://localhost"));
+            var client = new OAuthClient(mockConnectorClient, "http://localhost");
+            Assert.NotNull(client);
         }
 
         [Fact]


### PR DESCRIPTION
Work to enable:
1. EmulateOAuthCards for when you are connecting to the emulator and you don't want to actually retrieve remote tokens
2. Ability to use OAuthCards when you haven't specified an appid and password (uses the EmulateOAuthCards path)