### PR TITLE
Adding GetAadTokens API

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -655,6 +655,37 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
+        /// Retrieves Azure Active Directory tokens for particular resources on a configured connection.
+        /// </summary>
+        /// <param name="context">Context for the current turn of conversation with the user.</param>
+        /// <param name="connectionName">The name of the Azure Active Direcotry connection configured with this bot.</param>
+        /// <param name="resourceUrls">The list of resource URLs to retrieve tokens for.</param>
+        /// <param name="userId">The user Id for which tokens are retrieved. If passing in null the userId is taken from the Activity in the ITurnContext.</param>
+        /// <returns>Dictionary of resourceUrl to the corresponding TokenResponse.</returns>
+        public async Task<Dictionary<string, TokenResponse>> GetAadTokensAsync(ITurnContext context, string connectionName, string[] resourceUrls, string userId = null)
+        {
+            BotAssert.ContextNotNull(context);
+
+            if (string.IsNullOrWhiteSpace(connectionName))
+            {
+                throw new ArgumentNullException(nameof(connectionName));
+            }
+
+            if (resourceUrls == null)
+            {
+                throw new ArgumentNullException(nameof(userId));
+            }
+
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                userId = context.Activity?.From?.Id;
+            }
+
+            var client = await this.CreateOAuthApiClientAsync(context).ConfigureAwait(false);
+            return await client.GetAadTokensAsync(userId, connectionName, resourceUrls).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Creates a conversation on the specified channel.
         /// </summary>
         /// <param name="channelId">The ID for the channel.</param>

--- a/libraries/Microsoft.Bot.Schema/AadResourceUrls.cs
+++ b/libraries/Microsoft.Bot.Schema/AadResourceUrls.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// A collection of Azure Active Directory resource URLs
+    /// </summary>
+    public class AadResourceUrls
+    {
+        /// <summary>
+        /// An array of resource URLs to use with Azure Active Directory
+        /// </summary>
+        [JsonProperty("resourceUrls")]
+        public string[] ResourceUrls { get; set; }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -93,12 +93,50 @@ namespace Connector.Tests
             var client = new OAuthClient(mockConnectorClient, "https://localhost");
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetSignInLinkAsync(null));
         }
-        
+
         [Fact]
         public async Task GetTokenStatus_ShouldThrowOnNullUserId()
         {
             var client = new OAuthClient(mockConnectorClient, "https://localhost");
             await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetTokenStatusAsync(null));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNullUserId()
+        {
+            var client = new OAuthClient(mockConnectorClient, "https://localhost");
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync(null, "connection", new string[] { "hello" }));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync("", "connection", new string[] { "hello" }));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNullConncetionName()
+        {
+            var client = new OAuthClient(mockConnectorClient, "https://localhost");
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync("user", null, new string[] { "hello" }));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync("user", "", new string[] { "hello" }));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNullResourceUrls()
+        {
+            var client = new OAuthClient(mockConnectorClient, "https://localhost");
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.GetAadTokensAsync("user", "connection", null));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnNullResourceUrl()
+        {
+            var client = new OAuthClient(mockConnectorClient, "https://localhost");
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAadTokensAsync("user", "connection", new string[] { null }));
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAadTokensAsync("user", "connection", new string[] { "" }));
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsync_ShouldThrowOnEmptyResourceUrls()
+        {
+            var client = new OAuthClient(mockConnectorClient, "https://localhost");
+            await Assert.ThrowsAsync<ArgumentException>(() => client.GetAadTokensAsync("user", "connection", new string[] { }));
         }
     }
 }


### PR DESCRIPTION
Added the GetAadToken APIs to the OAuth client

This API allows users of OAuth Connection Settings using an Azure Active Directory connection to exchange the AAD token for a token that can be used with outher AAD resource URLs.