### PR TITLE
make encrypt pass through for empy and null values

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/EncryptUtilities.cs
+++ b/libraries/Microsoft.Bot.Configuration/EncryptUtilities.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Bot.Configuration.Encryption
         /// <returns>encrypted value as Base64 string</returns>
         public static string Encrypt(this string plainText, string key)
         {
-            if (plainText == null)
+            if (string.IsNullOrEmpty(plainText))
             {
-                throw new ArgumentNullException("Missing plainText");
+                return plainText;
             }
 
-            if (key == null)
+            if (string.IsNullOrEmpty(key))
             {
                 throw new ArgumentNullException("Missing key");
             }
@@ -54,12 +54,12 @@ namespace Microsoft.Bot.Configuration.Encryption
         /// <returns>original unecrypted value</returns>
         public static string Decrypt(this string encryptedText, string key)
         {
-            if (encryptedText == null)
+            if (string.IsNullOrEmpty(encryptedText))
             {
-                throw new ArgumentNullException("Missing encryptedText");
+                return encryptedText;
             }
 
-            if (key == null)
+            if (string.IsNullOrEmpty(key))
             {
                 throw new ArgumentNullException("Missing key");
             }

--- a/tests/Microsoft.Bot.Configuration.Tests/EncryptionTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/EncryptionTests.cs
@@ -22,6 +22,30 @@ namespace Microsoft.Bot.Configuration.Tests
         }
 
         [TestMethod]
+        public void EncryptDecryptEmptyWorks()
+        {
+            var key = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
+
+            string encrypted = string.Empty.Encrypt(key);
+            Assert.AreEqual(string.Empty, encrypted, "encryption failed");
+
+            string decrypted = encrypted.Decrypt(key);
+            Assert.AreEqual(string.Empty, decrypted, "decryption failed");
+        }
+
+        [TestMethod]
+        public void EncryptDecryptNullWorks()
+        {
+            var key = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
+
+            string encrypted = EncryptUtilities.Encrypt(null, key);
+            Assert.AreEqual(null, encrypted, "encryption failed");
+
+            string decrypted = EncryptUtilities.Decrypt(encrypted, key);
+            Assert.AreEqual(null, decrypted, "decryption failed");
+        }
+
+        [TestMethod]
         public void GenerateKeyWorks()
         {
             string value = "1234567890";


### PR DESCRIPTION
recipes can have empty values which cause the encrypt routines to blow up on last phase
https://github.com/Microsoft/botbuilder-tools/issues/510