### PR TITLE
[DO NOT MERGE] Low Pri: Remove ConcurrentDictionary from CachedBotState

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Bot.Builder
         {
             public CachedBotState(IDictionary<string, object> state = null)
             {
-                State = state ?? new ConcurrentDictionary<string, object>();
+                State = state ?? new Dictionary<string, object>();
                 Hash = ComputeHash(State);
             }
 


### PR DESCRIPTION
The ConcurrentDictionary in CachedBotState presents a problem when serializing.

This reproduces in the Cafebot when serializing state.  
`  at System.Collections.Concurrent.ConcurrentDictionary'2.System.Collections.IDictionary.set_Item(Object key, Object value)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateDictionary(IDictionary dictionary, JsonReader reader, JsonDictionaryContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType, JsonSerializer jsonSerializer)
   at Newtonsoft.Json.Linq.JToken.ToObject[T](JsonSerializer jsonSerializer)
   at Microsoft.Bot.Builder.MemoryStorage.ReadAsync(String[] keys, CancellationToken cancellationToken) in C:\Users\daveta\bots\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\MemoryStorage.cs:line 77
   at Microsoft.Bot.Builder.BotState.<LoadAsync>d__4.MoveNext() in C:\Users\daveta\bots\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\BotState.cs:line 67
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Bot.Builder.BotState.BotStatePropertyAccessor'1.<SetAsync>d__8.MoveNext() in C:\Users\daveta\bots\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\BotState.cs:line 314
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.BotBuilderSamples.CafeBot.<OnTurnAsync>d__19.MoveNext() in C:\Samples\51.cafe-bot\CafeBot.cs:line 132
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Bot.Builder.AutoSaveStateMiddleware.<OnTurnAsync>d__7.MoveNext() in C:\Users\daveta\bots\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\AutoSaveStateMiddleware.cs:line 60
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Bot.Builder.MiddlewareSet.<ReceiveActivityWithStatusAsync>d__3.MoveNext() in C:\Users\daveta\bots\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\MiddlewareSet.cs:line 55
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Bot.Builder.BotAdapter.<RunPipelineAsync>d__13.MoveNext() in C:\Users\daveta\bots\botbuilder-dotnet\libraries\Microsoft.Bot.Builder\BotAdapter.cs:line 167
`
