### PR TITLE
Broken tests due to merge of PR #1017

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptLocTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptLocTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     public class ConfirmPromptLocTests
     {
         [TestMethod]
-        [DataRow(Culture.Dutch, "(1) Ja of (2) Niet", "Ja", "1")]
-        [DataRow(Culture.Dutch, "(1) Ja of (2) Niet", "Niet", "0")]
+        [DataRow(Culture.Dutch, "(1) Ja of (2) Nee", "Ja", "1")]
+        [DataRow(Culture.Dutch, "(1) Ja of (2) Nee", "Nee", "0")]
         [DataRow(Culture.Spanish, "(1) Sí o (2) No", "Sí", "1")]
         [DataRow(Culture.Spanish, "(1) Sí o (2) No", "No", "0")]
         [DataRow(Culture.English, "(1) Yes or (2) No", "Yes", "1")]


### PR DESCRIPTION
If PR #1017, I took the change even though the build hadn't run. The build didn't run because Azure Devops isn't setup to run builds for external pull requests. 

I looked at the change, confirmed the translation, and merged it it.... thinking, "This looks good. Nothing will break". 

Sigh. 

Tests should be passing now.