### PR TITLE
confirm prompt fixes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -152,14 +152,21 @@ namespace Microsoft.Bot.Builder.Dialogs
                 }
                 else
                 {
-                    // The text may be a number in which case we will interpret that as a choice.
-                    var confirmChoices = ConfirmChoices ?? DefaultConfirmChoices[culture];
-                    var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
-                    var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(message.Text, choices);
-                    if (secondAttemptResults.Count > 0)
+                    // First check whether the prompt was sent to the user with numbers - if it was we should recognize numbers
+                    var choiceOptions = ChoiceOptions ?? DefaultChoiceOptions[culture];
+
+                    // This logic reflects the fact that IncludeNumbers is nullable and True is the default set in Inline style
+                    if (!choiceOptions.IncludeNumbers.HasValue || choiceOptions.IncludeNumbers.Value)
                     {
-                        result.Succeeded = true;
-                        result.Value = secondAttemptResults[0].Resolution.Index == 0;
+                        // The text may be a number in which case we will interpret that as a choice.
+                        var confirmChoices = ConfirmChoices ?? DefaultConfirmChoices[culture];
+                        var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
+                        var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(message.Text, choices);
+                        if (secondAttemptResults.Count > 0)
+                        {
+                            result.Succeeded = true;
+                            result.Value = secondAttemptResults[0].Resolution.Index == 0;
+                        }
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -150,6 +150,18 @@ namespace Microsoft.Bot.Builder.Dialogs
                         result.Value = value;
                     }
                 }
+                else
+                {
+                    // The text may be a number in which case we will interpret that as a choice.
+                    var confirmChoices = ConfirmChoices ?? DefaultConfirmChoices[culture];
+                    var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
+                    var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(message.Text, choices);
+                    if (secondAttemptResults.Count > 0)
+                    {
+                        result.Succeeded = true;
+                        result.Value = secondAttemptResults[0].Resolution.Index == 0;
+                    }
+                }
             }
 
             return Task.FromResult(result);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -164,6 +165,9 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Update prompt with text and actions
             if (prompt != null)
             {
+                // clone the prompt the set in the options (note ActivityEx has Properties so this is the safest mechanism)
+                prompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt));
+
                 prompt.Text = msg.Text;
                 if (msg.SuggestedActions != null && msg.SuggestedActions.Actions != null && msg.SuggestedActions.Actions.Count > 0)
                 {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptTests.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             })
             .Send("hello")
             .AssertReply("Please confirm. Yes or No")
-            .Send("lala")
+            .Send("2")
             .AssertReply("Please confirm, say 'yes' or 'no' or something like that. Yes or No")
             .Send("no")
             .AssertReply("Not confirmed.")


### PR DESCRIPTION
2 fixes:
- repeated failed attempts - fix is to add a deep copy
- accepting numbers on confirm prompt
