### PR TITLE
Add build status for 4.0 branch build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Bot Builder SDK v4
-
-[![Build status](https://fuselabs.visualstudio.com/SDK_v4/_apis/build/status/Bot.Builder-DotNet?branchName=master)](https://fuselabs.visualstudio.com/SDK_v4/_build/latest?definitionId=215&branchName=master)
-[![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-dotnet/badge.svg)](https://coveralls.io/github/Microsoft/botbuilder-dotnet)
+ | Branch        | Build Status | Coverage Status |
+ |---------------|--------------|-----------------|
+ |master |[![Build status](https://fuselabs.visualstudio.com/SDK_v4/_apis/build/status/Bot.Builder-DotNet?branchName=master)](https://fuselabs.visualstudio.com/SDK_v4/_build/latest?definitionId=215&branchName=master) |[![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-dotnet/badge.svg)](https://coveralls.io/github/Microsoft/botbuilder-dotnet)
+ |4.0 | [![Build status](https://fuselabs.visualstudio.com/SDK_v4/_apis/build/status/Bot.Builder-DotNet-4.0%20Branch?branchName=4.0)](https://fuselabs.visualstudio.com/SDK_v4/_build/latest?definitionId=341) | N/A |
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Microsoft/botbuilder-dotnet/blob/master/LICENSE)
 [![Gitter](https://img.shields.io/gitter/room/Microsoft/BotBuilder.svg)](https://gitter.im/Microsoft/BotBuilder)


### PR DESCRIPTION
Updated the Readme to show a build badge for the 4.0 branch. 
[![Build status](https://fuselabs.visualstudio.com/SDK_v4/_apis/build/status/Bot.Builder-DotNet-4.0%20Branch?branchName=4.0)](https://fuselabs.visualstudio.com/SDK_v4/_build/latest?definitionId=341)

Also, update the 4.0 branch build *only* build against master. CI builds should now run the 4.0-branch build only when the 4.0 branch is actually updates. You can see in #1014 that the 4.0 build incorrectly runs even though the PR was against master. 

![image](https://user-images.githubusercontent.com/1165321/46896489-2937a780-ce32-11e8-953c-8b742e3a702e.png)

**To fix this, the build triggers were changed:**
![image](https://user-images.githubusercontent.com/1165321/46896421-d2ca6900-ce31-11e8-92a8-61afb1252c24.png)

**Pull Requests against this branch should also trigger a 4.0 branch build:**
![image](https://user-images.githubusercontent.com/1165321/46896444-ebd31a00-ce31-11e8-87ef-274c40bee49c.png)


Note that some features - such as code coverage -  are not available in our 4.0 branch build. 
