### PR TITLE
Add simple trace messages to BotFrameworkAdapter

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             }
 
             string topIntent = null;
-            double topScore = -1.0;
+            var topScore = -1.0;
             if (results.Intents.Count > 0)
             {
                 foreach (var intent in results.Intents)
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             }
 
             return !string.IsNullOrEmpty(topIntent) ? topIntent : defaultIntent;
-	}
+        }
 
         /// <inheritdoc />
         public async Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             }
 
             string topIntent = null;
-            var topScore = -1.0;
+            double topScore = -1.0;
             if (results.Intents.Count > 0)
             {
                 foreach (var intent in results.Intents)

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
 using Microsoft.Rest.TransientFaultHandling;
 using Newtonsoft.Json;
 
@@ -47,6 +48,7 @@ namespace Microsoft.Bot.Builder
         private readonly IChannelProvider _channelProvider;
         private readonly HttpClient _httpClient;
         private readonly RetryPolicy _connectorClientRetryPolicy;
+        private readonly ILogger<BotFrameworkAdapter> _logger;
         private ConcurrentDictionary<string, MicrosoftAppCredentials> _appCredentialMap = new ConcurrentDictionary<string, MicrosoftAppCredentials>();
 
         // There is a significant boost in throughput if we reuse a connectorClient
@@ -68,12 +70,19 @@ namespace Microsoft.Bot.Builder
         /// components in the conustructor. Use the <see cref="Use(IMiddleware)"/> method to
         /// add additional middleware to the adapter after construction.
         /// </remarks>
-        public BotFrameworkAdapter(ICredentialProvider credentialProvider, IChannelProvider channelProvider = null, RetryPolicy connectorClientRetryPolicy = null, HttpClient customHttpClient = null, IMiddleware middleware = null)
+        public BotFrameworkAdapter(
+            ICredentialProvider credentialProvider,
+            IChannelProvider channelProvider = null,
+            RetryPolicy connectorClientRetryPolicy = null,
+            HttpClient customHttpClient = null,
+            IMiddleware middleware = null,
+            ILogger<BotFrameworkAdapter> logger = null)
         {
             _credentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
             _channelProvider = channelProvider;
             _httpClient = customHttpClient ?? DefaultHttpClient;
             _connectorClientRetryPolicy = connectorClientRetryPolicy;
+            _logger = logger;
 
             if (middleware != null)
             {
@@ -123,6 +132,11 @@ namespace Microsoft.Bot.Builder
             if (callback == null)
             {
                 throw new ArgumentNullException(nameof(callback));
+            }
+
+            if (_logger != null)
+            {
+                _logger.LogInformation($"Sending proactive message.  botAppId: {botAppId}");
             }
 
             using (var context = new TurnContext(this, reference.GetContinuationActivity()))
@@ -202,6 +216,11 @@ namespace Microsoft.Bot.Builder
         {
             BotAssert.ActivityNotNull(activity);
 
+            if (_logger != null)
+            {
+                _logger.LogInformation($"Received an incoming activity.  ActivityId: {activity.Id}");
+            }
+
             using (var context = new TurnContext(this, activity))
             {
                 context.TurnState.Add<IIdentity>(BotIdentityKey, identity);
@@ -272,6 +291,11 @@ namespace Microsoft.Bot.Builder
             {
                 var activity = activities[index];
                 var response = default(ResourceResponse);
+
+                if (_logger != null)
+                {
+                    _logger.LogInformation($"Sending activity.  ReplyToId: {activity.ReplyToId}");
+                }
 
                 if (activity.Type == ActivityTypesEx.Delay)
                 {

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -134,10 +134,7 @@ namespace Microsoft.Bot.Builder
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            if (_logger != null)
-            {
-                _logger.LogInformation($"Sending proactive message.  botAppId: {botAppId}");
-            }
+            _logger?.LogInformation($"Sending proactive message.  botAppId: {botAppId}");
 
             using (var context = new TurnContext(this, reference.GetContinuationActivity()))
             {
@@ -216,10 +213,7 @@ namespace Microsoft.Bot.Builder
         {
             BotAssert.ActivityNotNull(activity);
 
-            if (_logger != null)
-            {
-                _logger.LogInformation($"Received an incoming activity.  ActivityId: {activity.Id}");
-            }
+            _logger?.LogInformation($"Received an incoming activity.  ActivityId: {activity.Id}");
 
             using (var context = new TurnContext(this, activity))
             {
@@ -292,10 +286,7 @@ namespace Microsoft.Bot.Builder
                 var activity = activities[index];
                 var response = default(ResourceResponse);
 
-                if (_logger != null)
-                {
-                    _logger.LogInformation($"Sending activity.  ReplyToId: {activity.ReplyToId}");
-                }
+                _logger?.LogInformation($"Sending activity.  ReplyToId: {activity.ReplyToId}");
 
                 if (activity.Type == ActivityTypesEx.Delay)
                 {

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -15,6 +15,7 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest.TransientFaultHandling;
 using Newtonsoft.Json;
 
@@ -82,7 +83,7 @@ namespace Microsoft.Bot.Builder
             _channelProvider = channelProvider;
             _httpClient = customHttpClient ?? DefaultHttpClient;
             _connectorClientRetryPolicy = connectorClientRetryPolicy;
-            _logger = logger;
+            _logger = logger ?? NullLogger<BotFrameworkAdapter>.Instance;
 
             if (middleware != null)
             {
@@ -134,7 +135,7 @@ namespace Microsoft.Bot.Builder
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            _logger?.LogInformation($"Sending proactive message.  botAppId: {botAppId}");
+            _logger.LogInformation($"Sending proactive message.  botAppId: {botAppId}");
 
             using (var context = new TurnContext(this, reference.GetContinuationActivity()))
             {
@@ -213,7 +214,7 @@ namespace Microsoft.Bot.Builder
         {
             BotAssert.ActivityNotNull(activity);
 
-            _logger?.LogInformation($"Received an incoming activity.  ActivityId: {activity.Id}");
+            _logger.LogInformation($"Received an incoming activity.  ActivityId: {activity.Id}");
 
             using (var context = new TurnContext(this, activity))
             {
@@ -286,7 +287,7 @@ namespace Microsoft.Bot.Builder
                 var activity = activities[index];
                 var response = default(ResourceResponse);
 
-                _logger?.LogInformation($"Sending activity.  ReplyToId: {activity.ReplyToId}");
+                _logger.LogInformation($"Sending activity.  ReplyToId: {activity.ReplyToId}");
 
                 if (activity.Type == ActivityTypesEx.Delay)
                 {

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -55,6 +55,7 @@
 		<PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 	</ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -54,10 +54,9 @@
 	<ItemGroup>
 		<PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="2.0.1" />
 		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -37,11 +37,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 services.Configure(configureAction);
             }
 
-            services.AddSingleton(sp =>
+            services.AddSingleton<ILogger<BotFrameworkAdapter>>(sp =>
             {
                 // Loggers introduce a lock during creation, make a singleton.
                 var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-                return loggerFactory.CreateLogger<BotFrameworkAdapter>();
+                return new Logger<BotFrameworkAdapter>(loggerFactory);
             });
 
             services.AddTransient<IBot, TBot>();

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@
 using System;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
+
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core
@@ -35,12 +37,26 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 services.Configure(configureAction);
             }
 
+            services.AddSingleton(sp =>
+            {
+                // Loggers introduce a lock during creation, make a singleton.
+                var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+                return loggerFactory.CreateLogger<BotFrameworkAdapter>();
+            });
+
             services.AddTransient<IBot, TBot>();
 
             services.AddSingleton(sp =>
             {
                 var options = sp.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
-                var botFrameworkAdapter = new BotFrameworkAdapter(options.CredentialProvider, options.ChannelProvider, options.ConnectorClientRetryPolicy, options.HttpClient)
+                var logger = sp.GetRequiredService<ILogger<BotFrameworkAdapter>>();
+                var botFrameworkAdapter = new BotFrameworkAdapter(
+                                options.CredentialProvider,
+                                options.ChannelProvider,
+                                options.ConnectorClientRetryPolicy,
+                                options.HttpClient,
+                                null,
+                                logger)
                 {
                     OnTurnError = options.OnTurnError,
                 };

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -36,6 +37,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IBot) && sd.ImplementationType == typeof(ServiceRegistrationTestBot) && sd.Lifetime == ServiceLifetime.Transient)));
                 serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(BotFrameworkAdapter) && sd.Lifetime == ServiceLifetime.Singleton)));
                 serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IConfigureOptions<BotFrameworkOptions>))), Times.Never());
+                serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(ILogger<BotFrameworkAdapter>))), Times.Once());
             }
 
             [Fact]
@@ -48,21 +50,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IBot) && sd.ImplementationType == typeof(ServiceRegistrationTestBot) && sd.Lifetime == ServiceLifetime.Transient)));
                 serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(BotFrameworkAdapter) && sd.Lifetime == ServiceLifetime.Singleton)));
                 serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IConfigureOptions<BotFrameworkOptions>))), Times.Never());
-            }
-
-            [Fact]
-            public void WithConfigurationCallback()
-            {
-                var serviceCollectionMock = new Mock<IServiceCollection>();
-
-                serviceCollectionMock.Object.AddBot<ServiceRegistrationTestBot>(options => 
-                {
-                    options.Should().NotBeNull();
-                });
-
-                serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IBot) && sd.ImplementationType == typeof(ServiceRegistrationTestBot) && sd.Lifetime == ServiceLifetime.Transient)));
-                serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(BotFrameworkAdapter) && sd.Lifetime == ServiceLifetime.Singleton)));
-                serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IConfigureOptions<BotFrameworkOptions>))), Times.Once());
+                serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(ILogger<BotFrameworkAdapter>))), Times.Once());
             }
         }
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceResolutionTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -52,8 +53,14 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             [Fact]
             public void BotFrameworkAdapterShouldResolve()
             {
+                // Simulate a LoggerFactory (could be AppInsights/etc)
+                var mockLog = new Mock<ILogger<BotFrameworkAdapter>>();
+                var mockLogFactory = new Mock<ILoggerFactory>();
+                mockLogFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(mockLog.Object);
+
                 var serviceCollection = new ServiceCollection()
                     .AddOptions()
+                    .AddSingleton<ILoggerFactory>(mockLogFactory.Object)
                     .AddBot<ServiceResolutionTestBot>(options =>
                     {
                         options.CredentialProvider = Mock.Of<ICredentialProvider>();
@@ -66,6 +73,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 botFrameworkAdapter.Should().NotBeNull();
             }
         }
+
 
         public class ResolveIBot
         {
@@ -84,6 +92,33 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                     .And.BeOfType<ServiceResolutionTestBot>();
             }
         }
+
+        public class ResolveILogger
+        {
+            [Fact]
+            public void BotFrameworkAdapterILoggerShouldResolve()
+            {
+                // Simulate a LoggerFactory (could be AppInsights/etc)
+                var mockLog = new Mock<ILogger<BotFrameworkAdapter>>();
+                var mockLogFactory = new Mock<ILoggerFactory>();
+                mockLogFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(mockLog.Object);
+
+                var serviceCollection = new ServiceCollection()
+                    .AddSingleton<ILoggerFactory>(mockLogFactory.Object)
+                    .AddOptions()
+                    .AddBot<ServiceResolutionTestBot>(options =>
+                    {
+                        options.CredentialProvider = Mock.Of<ICredentialProvider>();
+                    });
+
+                var serviceProvider = serviceCollection.BuildServiceProvider();
+
+                var frameworkLogger = serviceProvider.GetService<ILogger<BotFrameworkAdapter>>();
+
+                frameworkLogger.Should().NotBeNull();
+            }
+        }
+
 
         public sealed class ServiceResolutionTestBot : IBot
         {


### PR DESCRIPTION
Add a few simple traces to the BotFrameworkAdapter for *very simple* diagnostics so new developers can verify messages getting through/being sent.