### PR TITLE
Add assertion for new Database and DocumentCollection request options

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbCustomClientOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbCustomClientOptions.cs
@@ -1,33 +1,12 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System;
-using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.Client;
+﻿using Microsoft.Azure.Documents.Client;
 
 namespace Microsoft.Bot.Builder.Azure
 {
     /// <summary>
-    /// Cosmos DB Storage Options.
+    /// CosmosDB options for custom client.
     /// </summary>
-    public class CosmosDbStorageOptions
+    public class CosmosDbCustomClientOptions
     {
-        /// <summary>
-        /// Gets or sets the CosmosDB endpoint.
-        /// </summary>
-        /// <value>
-        /// The CosmosDB endpoint.
-        /// </value>
-        public Uri CosmosDBEndpoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the authentication key for Cosmos DB.
-        /// </summary>
-        /// <value>
-        /// The authentication key for Cosmos DB.
-        /// </value>
-        public string AuthKey { get; set; }
-
         /// <summary>
         /// Gets or sets the database identifier for Cosmos DB instance.
         /// </summary>
@@ -43,19 +22,6 @@ namespace Microsoft.Bot.Builder.Azure
         /// The collection identifier.
         /// </value>
         public string CollectionId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the connection policy configurator. This action allows you to customise the connection parameters.
-        /// </summary>
-        /// <remarks>You can use this delegate to
-        /// further customize the connection to CosmosDB,
-        /// such as setting connection mode, retry options, timeouts, and so on.
-        /// See https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.connectionpolicy?view=azure-dotnet
-        /// for more information.</remarks>
-        /// <value>
-        /// The connection policy configurator.
-        /// </value>
-        public Action<ConnectionPolicy> ConnectionPolicyConfigurator { get; set; } = (options) => { };
 
         /// <summary>
         /// Gets or sets the CosmosDB <see cref="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.requestoptions?view=azure-dotnet"/>RequestOptions that

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Builder.Azure
         private readonly string _collectionId;
         private readonly RequestOptions _documentCollectionCreationRequestOptions = null;
         private readonly RequestOptions _databaseCreationRequestOptions = null;
-        private readonly DocumentClient _client;
+        private readonly IDocumentClient _client;
         private string _collectionLink = null;
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Invoke CollectionPolicy delegate to further customize settings
             cosmosDbStorageOptions.ConnectionPolicyConfigurator?.Invoke(connectionPolicy);
-            _client = new DocumentClient(cosmosDbStorageOptions.CosmosDBEndpoint, cosmosDbStorageOptions.AuthKey, connectionPolicy);
+            _client = cosmosDbStorageOptions.DocumentClient ?? new DocumentClient(cosmosDbStorageOptions.CosmosDBEndpoint, cosmosDbStorageOptions.AuthKey, connectionPolicy);
         }
 
         [Obsolete("Replaced by CosmosDBKeyEscape.EscapeKey.")]

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -77,7 +77,42 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Invoke CollectionPolicy delegate to further customize settings
             cosmosDbStorageOptions.ConnectionPolicyConfigurator?.Invoke(connectionPolicy);
-            _client = cosmosDbStorageOptions.DocumentClient ?? new DocumentClient(cosmosDbStorageOptions.CosmosDBEndpoint, cosmosDbStorageOptions.AuthKey, connectionPolicy);
+            _client = new DocumentClient(cosmosDbStorageOptions.CosmosDBEndpoint, cosmosDbStorageOptions.AuthKey, connectionPolicy);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosDbStorage"/> class.
+        /// This constructor should only be used if the default behavior of the DocumentClient needs to be changed.
+        /// The <see cref="CosmosDbStorage(CosmosDbStorageOptions)"/> constructor is preferer for most cases.
+        /// </summary>
+        /// <param name="documentClient">The custom implementation of IDocumentClient.</param>
+        /// <param name="cosmosDbCustomClientOptions">Custom client configuration options.</param>
+        public CosmosDbStorage(IDocumentClient documentClient, CosmosDbCustomClientOptions cosmosDbCustomClientOptions)
+        {
+            if (cosmosDbCustomClientOptions == null)
+            {
+                throw new ArgumentNullException(nameof(cosmosDbCustomClientOptions));
+            }
+
+            if (string.IsNullOrEmpty(cosmosDbCustomClientOptions.DatabaseId))
+            {
+                throw new ArgumentException("DatabaseId is required.", nameof(cosmosDbCustomClientOptions.DatabaseId));
+            }
+
+            if (string.IsNullOrEmpty(cosmosDbCustomClientOptions.CollectionId))
+            {
+                throw new ArgumentException("CollectionId is required.", nameof(cosmosDbCustomClientOptions.CollectionId));
+            }
+
+            _client = documentClient ?? throw new ArgumentNullException(nameof(documentClient), "An implementation of IDocumentClient for CosmosDB is required.");
+            _databaseId = cosmosDbCustomClientOptions.DatabaseId;
+            _collectionId = cosmosDbCustomClientOptions.CollectionId;
+            _documentCollectionCreationRequestOptions = cosmosDbCustomClientOptions.DocumentCollectionRequestOptions;
+            _databaseCreationRequestOptions = cosmosDbCustomClientOptions.DatabaseCreationRequestOptions;
+
+            // Inject BotBuilder version to CosmosDB Requests
+            var version = GetType().Assembly.GetName().Version;
+            _client.ConnectionPolicy.UserAgentSuffix = $"Microsoft-BotFramework {version}";
         }
 
         [Obsolete("Replaced by CosmosDBKeyEscape.EscapeKey.")]

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 
 namespace Microsoft.Bot.Builder.Azure
@@ -73,5 +74,13 @@ namespace Microsoft.Bot.Builder.Azure
         /// The set of options passed into <see cref="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.documentclient.createdatabaseifnotexistsasync?view=azure-dotnet"/>CreateDatabaseIfNotExistsAsync.
         /// </value>
         public RequestOptions DatabaseCreationRequestOptions { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the <a href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.idocumentclient?view=azure-dotnet">IDocumentClient</a> to be used internally.
+        /// </summary>
+        /// <value>
+        /// The IDocumentClient interface captures the API signatures of the Azure Cosmos DB service.
+        /// </value>
+        public IDocumentClient DocumentClient { get; set; } = null;
     }
 }


### PR DESCRIPTION
The new test `Database_Creation_Request_Options_Should_Be_Used` in `CosmosDbStorageTests` does not perform any assertion.

We added a new option for `CosmosDbStorageOptions` that allows to use a custom `IDocumentClient`. This change is required to test the new `DocumentCollectionRequestOptions` and `DatabaseCreationRequestOptions` properties.