### PR TITLE
Remove Stack Overflow link to v4 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Gitter](https://img.shields.io/gitter/room/Microsoft/BotBuilder.svg)](https://gitter.im/Microsoft/BotBuilder)
 
 [![StackExchange](https://img.shields.io/stackexchange/stackoverflow/t/botframework.svg)](https://stackoverflow.com/questions/tagged/botframework)
-[![StackExchange](https://img.shields.io/stackexchange/stackoverflow/t/botframework-v4.svg)](https://stackoverflow.com/questions/tagged/botframework-v4)
 
 This repository contains code for the .NET version of the [Microsoft Bot Builder SDK](https://github.com/Microsoft/botbuilder). The Bot Builder SDK v4 is the latest SDK for building bot applications.  
 


### PR DESCRIPTION
The tag was merged into a single one.

https://meta.stackoverflow.com/q/374974

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/botbuilder-dotnet/1051)
<!-- Reviewable:end -->
