### PR TITLE
Adding 'channelService' property to the bot file's endpoint service type

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/Services/EndpointService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/EndpointService.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Bot.Configuration
         public string AppPassword { get; set; }
 
         /// <summary>
+        /// Gets or sets the channel service (Azure or US Government Azure) for the bot.
+        /// </summary>
+        [JsonProperty("channelService")]
+        public string ChannelService { get; set; }
+
+        /// <summary>
         /// Gets or sets endpoint url for the bot.
         /// </summary>
         [JsonProperty("endpoint")]

--- a/tests/Microsoft.Bot.Configuration.Tests/ConfigurationLoadAndSaveTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ConfigurationLoadAndSaveTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -404,6 +405,20 @@ namespace Microsoft.Bot.Configuration.Tests
             File.Delete("save.bot");
             Assert.IsTrue(!String.IsNullOrEmpty(config.Padlock), "padlock should exist");
             Assert.IsNull(config.Properties["secretKey"], "secretKey should not exist");
+        }
+
+        [TestMethod]
+        public void LoadAndVerifyChannelServiceSync()
+        {
+            var publicConfig = BotConfiguration.Load(@"..\..\test.bot");
+            var endpointSvc = publicConfig.Services.Single(x => x.Type == ServiceTypes.Endpoint) as EndpointService;
+            Assert.IsNotNull(endpointSvc);
+            Assert.IsNull(endpointSvc.ChannelService);
+            
+            var govConfig = BotConfiguration.Load(@"..\..\govTest.bot");
+            endpointSvc = govConfig.Services.Single(x => x.Type == ServiceTypes.Endpoint) as EndpointService;
+            Assert.IsNotNull(endpointSvc);
+            Assert.AreEqual("https://botframework.azure.us", endpointSvc.ChannelService);
         }
     }
 }

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="legacy.bot" />
+    <None Include="govTest.bot" />
     <None Include="test.bot" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Microsoft.Bot.Configuration.Tests/govTest.bot
+++ b/tests/Microsoft.Bot.Configuration.Tests/govTest.bot
@@ -1,0 +1,18 @@
+{
+    "name": "govTest",
+    "description": "gov test description",
+    "version": "2.0",
+    "extra": true,
+    "services": [
+      {
+        "type": "endpoint",
+        "name": "testEndpoint",
+        "id": "5",
+        "appId": "00000003-0000-0000-0000-000000000000",
+        "appPassword": "testpassword",
+        "endpoint": "https://test.azurewebsites.net/api/messages",
+        "channelService": "https://botframework.azure.us"
+      }
+    ],
+    "secretKey": ""
+}


### PR DESCRIPTION
This property 'channelService' is used to drive decisions in the Bot Builder SDK about whether to use public Azure or US Government Azure authentication constants. I am adding this property to the .bot file.