### PR TITLE
BotConfiguration backed ICredentialProvider

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfigurationEndpointServiceCredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfigurationEndpointServiceCredentialProvider.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Connector.Authentication;
+
+namespace Microsoft.BotBuilderSamples
+{
+    /// <summary>
+    ///     A <see cref="ICredentialProvider">credential provider</see> which provides credentials
+    ///     based on an <see cref="EndpointService">endpoint</see> from a <c>.bot</c> configuration file.
+    /// </summary>
+    /// <seealso cref="BotConfiguration"/>
+    public sealed class BotConfigurationEndpointServiceCredentialProvider : ICredentialProvider
+    {
+        public static readonly string DefaultEnvironmentName = "development";
+
+        private readonly EndpointService _endpointService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotConfigurationEndpointServiceCredentialProvider"/> class
+        /// which exposes the credentials from the given <paramref name="endpointService">endpoint</paramref>.
+        /// </summary>
+        /// <param name="endpointService">The <see cref="EndpointService"/> instance containing the credentials that should be used.</param>
+        public BotConfigurationEndpointServiceCredentialProvider(EndpointService endpointService)
+        {
+            _endpointService = endpointService ?? throw new ArgumentNullException(nameof(endpointService));
+        }
+
+        /// <summary>
+        ///     Given an existing <see cref="BotConfiguration"/> instance, finds the endpoint service that corresponds to the
+        /// <paramref name="environmentName">given environment</paramref>.
+        /// </summary>
+        /// <param name="botConfiguration">
+        ///     An <see cref="BotConfiguration"/> instance containing one or more <see cref="EndpointService">endpoint services</see>.</param>
+        /// <param name="environmentName">
+        ///     Optional environment name that should be used to locate the correct <see cref="EndpointService">endpoint</see>
+        ///     from the configuration file based on its <c>name</c>.
+        /// </param>
+        /// <returns>
+        ///     An instance of a <see cref="BotConfigurationEndpointServiceCredentialProvider"/> loaded from the
+        ///     <paramref name="botConfiguration">specified <see cref="BotConfiguration"/></paramref> populated
+        ///     with the <see cref="EndpointService">endpoint</see> resolved based on the <paramref name="environmentName"/>.
+        /// </returns>
+        public static BotConfigurationEndpointServiceCredentialProvider FromConfiguration(BotConfiguration botConfiguration, string environmentName = null)
+        {
+            if (botConfiguration == null)
+            {
+                throw new ArgumentNullException(nameof(botConfiguration));
+            }
+
+            return new BotConfigurationEndpointServiceCredentialProvider(FindEndpointServiceForEnvironment(botConfiguration, environmentName ?? DefaultEnvironmentName));
+        }
+
+        /// <summary>
+        ///     Attempts to load and create an <see cref="BotConfigurationEndpointServiceCredentialProvider"/> from the
+        ///     by searching the <see cref="Environment.CurrentDirectory">current directory</see> for a <c>.bot</c> configuration file.
+        /// </summary>
+        /// <param name="botFileSecretKey">
+        ///     Optional key that should be used to decrypt secrets inside the configuration file.
+        /// </param>
+        /// <param name="environmentName">
+        ///     Optional environment name that should be used to locate the correct <see cref="EndpointService">endpoint</see>
+        ///     from the configuration file based on its <c>name</c>.
+        /// </param>
+        /// <remarks>
+        ///     If no value is provided for <paramref name="botFileSecretKey"/>, it is assumed that the contents of
+        ///     the configuration file are not encrypted.
+        ///
+        ///     If no value is provided for <paramref name="environmentName"/>, it will use
+        ///     <see cref="DefaultEnvironmentName">the default environment</see>.
+        /// </remarks>
+        /// <returns>
+        ///     An instance of a <see cref="BotConfigurationEndpointServiceCredentialProvider"/> populated with the
+        ///     <see cref="EndpointService">endpoint</see> resolved based on the <paramref name="environmentName"/>.
+        /// </returns>
+        /// <seealso cref="BotConfiguration"/>
+        public static BotConfigurationEndpointServiceCredentialProvider Load(string botFileSecretKey = null, string environmentName = null) =>
+            LoadBotConfiguration(() => BotConfiguration.LoadFromFolder(Environment.CurrentDirectory, botFileSecretKey), environmentName);
+
+        /// <summary>
+        /// Attempts to load and create an <see cref="BotConfigurationEndpointServiceCredentialProvider"/> from the
+        /// <paramref name="botConfigurationFilePath">specified <c>.bot</c> configuration file</paramref>.
+        /// </summary>
+        /// <param name="botConfigurationFilePath">
+        ///     A path to the .bot configuration file that should be loaded.
+        /// </param>
+        /// <param name="botFileSecretKey">
+        ///     Optional key that should be used to decrypt secrets inside the configuration file.
+        /// </param>
+        /// <param name="environmentName">
+        ///     Optional environment name that should be used to locate the correct <see cref="EndpointService">endpoint</see>
+        ///     from the configuration file based on its <c>name</c>.
+        /// </param>
+        /// <remarks>
+        ///     If no value is provided for <paramref name="botFileSecretKey"/>, it is assumed that the contents of
+        ///     the configuration file are not encrypted.
+        ///
+        ///     If no value is provided for <paramref name="environmentName"/>, it will use
+        ///     <see cref="DefaultEnvironmentName">the default environment</see>.
+        /// </remarks>
+        /// <returns>
+        ///     An instance of a <see cref="BotConfigurationEndpointServiceCredentialProvider"/> loaded from the
+        ///     <paramref name="botConfigurationFilePath">specified <c>.bot</c> configuration file</paramref> populated
+        ///     with the <see cref="EndpointService">endpoint</see> resolved based on the <paramref name="environmentName"/>.
+        /// </returns>
+        /// <seealso cref="BotConfiguration"/>
+        public static BotConfigurationEndpointServiceCredentialProvider LoadFrom(string botConfigurationFilePath, string botFileSecretKey = null, string environmentName = null)
+        {
+            if (string.IsNullOrEmpty(botConfigurationFilePath))
+            {
+                throw new ArgumentException(nameof(botConfigurationFilePath));
+            }
+
+            return LoadBotConfiguration(() => BotConfiguration.Load(botConfigurationFilePath, botFileSecretKey), environmentName);
+        }
+
+        /// <inheritdoc />
+        public Task<string> GetAppPasswordAsync(string appId) => Task.FromResult<string>(_endpointService.AppPassword);
+
+        /// <inheritdoc />
+        public Task<bool> IsAuthenticationDisabledAsync() => Task.FromResult(string.IsNullOrWhiteSpace(_endpointService.AppId) && _endpointService.Name.Equals("development", StringComparison.InvariantCultureIgnoreCase));
+
+        /// <inheritdoc />
+        public Task<bool> IsValidAppIdAsync(string appId) => Task.FromResult(appId == _endpointService.AppId);
+
+        private static BotConfigurationEndpointServiceCredentialProvider LoadBotConfiguration(Func<BotConfiguration> loader, string environmentName)
+        {
+            var botConfiguration = default(BotConfiguration);
+
+            try
+            {
+                botConfiguration = loader();
+            }
+            catch (Exception exception)
+            {
+                throw new Exception(
+                    @"Error reading .bot file; check inner exception for more details. Please ensure you have valid botFilePath and botFileSecret set for your environment.
+        - You can find the botFilePath and botFileSecret in the Azure App Service application settings.
+        - If you are running this bot locally, consider adding a appsettings.json file with botFilePath and botFileSecret.
+        - See https://aka.ms/about-bot-file to learn more about .bot file its use and bot configuration.
+        ",
+                    exception);
+            }
+
+            return new BotConfigurationEndpointServiceCredentialProvider(FindEndpointServiceForEnvironment(botConfiguration, environmentName));
+        }
+
+        private static EndpointService FindEndpointServiceForEnvironment(BotConfiguration botConfiguration, string environmentName)
+        {
+            environmentName = environmentName ?? DefaultEnvironmentName;
+
+            var endpointServiceForEnvironment = botConfiguration.Services.OfType<EndpointService>().FirstOrDefault(s => s.Name.Equals(environmentName, StringComparison.InvariantCultureIgnoreCase));
+
+            if (endpointServiceForEnvironment == null)
+            {
+                throw new InvalidOperationException($"The .bot file does not appear to contain an endpoint service with the name \"{environmentName}\".");
+            }
+
+            return endpointServiceForEnvironment;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Configuration/BotConfigurationEndpointServiceCredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfigurationEndpointServiceCredentialProvider.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Connector.Authentication;
 
-namespace Microsoft.BotBuilderSamples
+namespace Microsoft.Bot.Configuration
 {
     /// <summary>
     ///     A <see cref="ICredentialProvider">credential provider</see> which provides credentials

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -61,6 +61,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
+    <PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Configuration.Tests/BotConfigurationEndpointServiceCredentialProviderTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/BotConfigurationEndpointServiceCredentialProviderTests.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Configuration.Tests
+{
+    public class BotConfigurationEndpointServiceCredentialProviderTests
+    {
+        [TestClass]
+        public class ConstructorTests
+        {
+            [TestMethod]
+            public void NullEndpointServiceThrowsExpectedException()
+            {
+                try
+                {
+                    new BotConfigurationEndpointServiceCredentialProvider(null);
+
+                    Assert.Fail("Should have thrown when endpoint service was null.");
+                }
+                catch (ArgumentNullException exception)
+                {
+                    Assert.AreEqual<string>("endpointService", exception.ParamName);
+                }
+            }
+
+            [TestMethod]
+            public void SucceedsWithNonNullEndpointService() => new BotConfigurationEndpointServiceCredentialProvider(new EndpointService());
+        }
+
+        public class LoadingTests
+        {
+            [TestClass]
+            public class LoadTests
+            {
+                [TestMethod]
+                public void WhenNoBotFilesExistThrows()
+                {
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.Load();
+
+                        Assert.Fail("Should have thrown an exception.");
+                    }
+                    catch (Exception exception)
+                    {
+                        Assert.IsInstanceOfType(exception.InnerException, typeof(FileNotFoundException));
+                    }
+                }
+
+                [TestMethod]
+                public void WhenBotFileDoesExistLoads()
+                {
+                    var provider = BotConfigurationEndpointServiceCredentialProvider.Load(endpointName: "testEndpoint");
+
+                    Assert.IsNotNull(provider);
+                }
+            }
+
+            [TestClass]
+            public class LoadFromTests
+            {
+                [TestMethod]
+                public void NullBotFilePathThrows()
+                {
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.LoadFrom(null);
+
+                        Assert.Fail("Should have thrown an exception.");
+                    }
+                    catch (ArgumentException exception)
+                    {
+                        Assert.AreEqual("botConfigurationFilePath", exception.ParamName);
+                    }
+                }
+
+                [TestMethod]
+                public void EmptyBotFilePathThrows()
+                {
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.LoadFrom(string.Empty);
+
+                        Assert.Fail("Should have thrown an exception.");
+                    }
+                    catch (ArgumentException exception)
+                    {
+                        Assert.AreEqual("botConfigurationFilePath", exception.ParamName);
+                    }
+                }
+
+                [TestMethod]
+                public void BotFilePathDoesNotExistThrows()
+                {
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.LoadFrom("no-such-file.bot");
+                    }
+                    catch (Exception exception)
+                    {
+                        Assert.IsNotNull(exception.InnerException);
+                    }
+                }
+
+                [TestMethod]
+                public void ValidBotFilePathWithValidEndpointNameLoads()
+                {
+                    var provider = BotConfigurationEndpointServiceCredentialProvider.LoadFrom("test.bot", endpointName: "testEndpoint");
+
+                    Assert.IsNotNull(provider);
+                }
+
+                [TestMethod]
+                public void ValidBotFilePathWithMissingEndpointNameThrows()
+                {
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.LoadFrom("test.bot", endpointName: "no-such-endpoint");
+
+                        Assert.Fail("Expected an exception to be thrown.");
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+                }
+            }
+
+            [TestClass]
+            public class FromConfigurationTests
+            {
+                [TestMethod]
+                public void NullBotConfigurationThrows()
+                {
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.FromConfiguration(null);
+
+                        Assert.Fail("Expected an exception to be thrown.");
+                    }
+                    catch (ArgumentNullException exception)
+                    {
+                        Assert.AreEqual<string>("botConfiguration", exception.ParamName);
+                    }
+                }
+
+                [TestMethod]
+                public void MissingEndpointNameThrows()
+                {
+                    var configuration = new BotConfiguration();
+
+                    try
+                    {
+                        BotConfigurationEndpointServiceCredentialProvider.FromConfiguration(configuration, endpointName: "no-such-endpoint");
+
+                        Assert.Fail("Expected an exception to be thrown.");
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+                }
+
+                [TestMethod]
+                public void ValidEndpointNameResolves()
+                {
+                    var configuration = new BotConfiguration();
+                    configuration.Services.Add(new EndpointService
+                    {
+                        Name = "test-endpoint"
+                    });
+
+                    BotConfigurationEndpointServiceCredentialProvider.FromConfiguration(configuration, endpointName: "test-endpoint");
+                }
+            }
+        }
+
+        public class ICredentialProviderTests
+        {
+            private static readonly EndpointService TestEndpointService = new EndpointService
+            {
+                Name = "unit-test",
+                AppId = "test-appid",
+                AppPassword = "test-apppassword"
+            };
+
+            private readonly BotConfigurationEndpointServiceCredentialProvider _provider = new BotConfigurationEndpointServiceCredentialProvider(TestEndpointService);
+
+
+            [TestClass]
+            public class IsValidAppIdAsync : ICredentialProviderTests
+            {
+                [TestMethod]
+                public async Task ReturnsTrueForMatchingAppId()
+                {
+                    Assert.IsTrue(await _provider.IsValidAppIdAsync(TestEndpointService.AppId));
+                }
+
+                [TestMethod]
+                public async Task ReturnsFalseForNonMatchingAppId()
+                {
+
+                    Assert.IsFalse(await _provider.IsValidAppIdAsync("not-the-right-appid"));
+                }
+
+                [TestMethod]
+                public async Task ReturnsFalseForNullAppId()
+                {
+                    Assert.IsFalse(await _provider.IsValidAppIdAsync(null));
+                }
+            }
+
+            [TestClass]
+            public class GetAppPasswordAsync : ICredentialProviderTests
+            {
+                [TestMethod]
+                public async Task ReturnsExpectedPasswordForValidAppId()
+                {
+                    Assert.AreEqual<string>(TestEndpointService.AppPassword, await _provider.GetAppPasswordAsync(TestEndpointService.AppId));
+                }
+
+                [TestMethod]
+                public async Task ReturnsNullPasswordForUnknownAppId()
+                {
+                    var password = await _provider.GetAppPasswordAsync("unknown-appid");
+
+                    Assert.IsNull(password);
+                }
+
+                [TestMethod]
+                public async Task ReturnsNullPasswordForNullAppId()
+                {
+                    var password = await _provider.GetAppPasswordAsync(null);
+
+                    Assert.IsNull(password);
+                }
+            }
+
+            [TestClass]
+            public class IsAuthenticationDisabledAsync : ICredentialProviderTests
+            {
+                [TestMethod]
+                public async Task IsFalseForEndpointWithAppIdSet()
+                {
+                    Assert.IsFalse(await _provider.IsAuthenticationDisabledAsync());
+                }
+
+                [TestMethod]
+                public async Task IsFalseForEndpointWithNoAppIdSetAndNotNamedDevelopment()
+                {
+                    var providerWithEndpointWithNoAppId = new BotConfigurationEndpointServiceCredentialProvider(
+                        new EndpointService
+                        {
+                        });
+
+                    Assert.IsFalse(await providerWithEndpointWithNoAppId.IsAuthenticationDisabledAsync());
+                }
+
+                [TestMethod]
+                public async Task IsTrueForEndpointWithNoAppIdSetAndNamedDevelopment()
+                {
+                    var providerWithEndpointWithNoAppId = new BotConfigurationEndpointServiceCredentialProvider(
+                        new EndpointService
+                        {
+                            Name = "development"
+                        });
+
+                    Assert.IsTrue(await providerWithEndpointWithNoAppId.IsAuthenticationDisabledAsync());
+                }
+            }
+        }
+
+    }
+}

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BotConfigurationEndpointServiceCredentialProviderTests.cs" />
     <Compile Include="ConnectionTests.cs" />
     <Compile Include="ConfigurationLoadAndSaveTests.cs" />
     <Compile Include="ServiceTests.cs" />
@@ -63,12 +64,18 @@
     <None Include="packages.config" />
     <None Include="legacy.bot" />
     <None Include="govTest.bot" />
-    <None Include="test.bot" />
+    <None Include="test.bot">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Configuration\Microsoft.Bot.Configuration.csproj">
       <Project>{0b8abfdb-f9cf-4ec6-988e-9c32d9e01c26}</Project>
       <Name>Microsoft.Bot.Configuration</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj">
+      <Project>{6462da5d-27dc-4cd5-9467-5efb998fd838}</Project>
+      <Name>Microsoft.Bot.Connector</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />


### PR DESCRIPTION
Adds the `BotConfigurationEndpointServiceCredentialProvider` which is
an `ICredentialProvider` implementation that can be used to provide
credentials from an endpoint service defined in a `.bot` file.

Fixes #1164