### PR TITLE
fixed force flag on save following clear

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -112,11 +112,8 @@ namespace Microsoft.Bot.Builder
                 throw new ArgumentNullException(nameof(turnContext));
             }
 
-            var cachedState = turnContext.TurnState.Get<CachedBotState>(_contextServiceKey);
-            if (cachedState != null)
-            {
-                turnContext.TurnState[_contextServiceKey] = new CachedBotState();
-            }
+            // Explicitly setting the hash will mean IsChanged is always true. And that will force a Save.
+            turnContext.TurnState[_contextServiceKey] = new CachedBotState { Hash = string.Empty };
 
             return Task.CompletedTask;
         }

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -100,11 +100,12 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// Reset the state cache in the turn context to it's default form.
+        /// Clears any state currently stored in this state scope.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
         /// <param name="cancellationToken">cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>NOTE: that SaveChangesAsync must be called in order for the cleared state to be persisted to the underlying store.</remarks>
         public Task ClearStateAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (turnContext == null)

--- a/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.Dialogs;
@@ -32,45 +33,52 @@ namespace Microsoft.Bot.Builder.TestBot
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton(sp =>
+            //services.AddSingleton<IAdapterIntegration>(sp =>
+            //{
+            //    var options = sp.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
+            //    var accessors = sp.GetRequiredService<TestBotAccessors>();
+
+            //    options.Middleware.Add(new AutoSaveStateMiddleware(accessors.ConversationState));
+            //    options.Middleware.Add(new ShowTypingMiddleware());
+
+            //    var botFrameworkAdapter = new BotFrameworkAdapter(options.CredentialProvider, options.ChannelProvider, options.ConnectorClientRetryPolicy, options.HttpClient)
+            //    {
+            //        OnTurnError = options.OnTurnError,
+            //    };
+
+            //    foreach (var middleware in options.Middleware)
+            //    {
+            //        botFrameworkAdapter.Use(middleware);
+            //    }
+
+            //    //return botFrameworkAdapter;
+
+            //    return new InteceptorAdapter(botFrameworkAdapter);
+            //});
+
+            IStorage dataStore = new MemoryStorage();
+            var conversationState = new ConversationState(dataStore);
+
+            var accessors = new TestBotAccessors
             {
-                IStorage dataStore = new MemoryStorage();
+                ConversationDialogState = conversationState.CreateProperty<DialogState>("DialogState"),
+                ConversationState = conversationState
+            };
 
-                var conversationState = new ConversationState(dataStore);
-
-                var accessors = new TestBotAccessors
+            services.AddBot<IBot>(
+                (IServiceProvider sp) =>
                 {
-                    ConversationDialogState = conversationState.CreateProperty<DialogState>("DialogState"),
-                    ConversationState = new ConversationState(dataStore)
-                };
-
-                return accessors;
-            });
-
-            services.AddSingleton<IAdapterIntegration>(sp =>
-            {
-                var options = sp.GetRequiredService<IOptions<BotFrameworkOptions>>().Value;
-                var accessors = sp.GetRequiredService<TestBotAccessors>();
-
-                options.Middleware.Add(new AutoSaveStateMiddleware(accessors.ConversationState));
-                options.Middleware.Add(new ShowTypingMiddleware());
-
-                var botFrameworkAdapter = new BotFrameworkAdapter(options.CredentialProvider, options.ChannelProvider, options.ConnectorClientRetryPolicy, options.HttpClient)
+                    return new TestBot(accessors);
+                },
+                (BotFrameworkOptions options) =>
                 {
-                    OnTurnError = options.OnTurnError,
-                };
-
-                foreach (var middleware in options.Middleware)
-                {
-                    botFrameworkAdapter.Use(middleware);
-                }
-
-                //return botFrameworkAdapter;
-
-                return new InteceptorAdapter(botFrameworkAdapter);
-            });
-
-            services.AddBot<TestBot>();
+                    options.OnTurnError = async (turnContext, exception) =>
+                    {
+                        await conversationState.ClearStateAsync(turnContext);
+                        await conversationState.SaveChangesAsync(turnContext);
+                    };
+                    options.Middleware.Add(new AutoSaveStateMiddleware(conversationState));
+                });
 
             //services.AddBot<TestBot>(options =>
             //{

--- a/tests/Microsoft.Bot.Builder.TestBot/TestBot.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/TestBot.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
@@ -35,6 +36,11 @@ namespace Microsoft.Bot.Builder.TestBot
             try
             {
                 await _semaphore.WaitAsync();
+
+                if (turnContext.Activity.Type == ActivityTypes.Message && turnContext.Activity.Text == "throw")
+                {
+                    throw new Exception("oh dear");
+                }
 
                 // run the DialogSet - let the framework identify the current state of the dialog from 
                 // the dialog stack and figure out what (if any) is the active dialog
@@ -82,6 +88,12 @@ namespace Microsoft.Bot.Builder.TestBot
             if (stepContext.Values != null)
             {
                 var numberResult = (int)stepContext.Result;
+
+                if (numberResult == 0)
+                {
+                    throw new Exception("zero is not a number");
+                }
+
                 await stepContext.Context.SendActivityAsync(MessageFactory.Text($"Thanks for '{numberResult}'"), cancellationToken);
             }
             return await stepContext.PromptAsync("number", new PromptOptions { Prompt = MessageFactory.Text("Enter another number.") }, cancellationToken);


### PR DESCRIPTION
This is a bug fix.

If you clear the state you currently have to include the force flag on an subsequent save operation. This is a fix for that - essentially clear always invalidates the hidden internal cache and so the save will actually work as expected even skipping the force flag.
