### PR TITLE
Updating to validate JWT tokens from the emulator

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]"</param>
         /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="channelProvider">The channelService value that distinguishes public Azure from US Government Azure.</param>
         /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
         /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to 
         /// setup and teardown, so a shared HttpClient is recommended.</param>

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Bot.Connector.Authentication
                     "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",                    // Auth v3.1, 1.0 token
                     "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0",      // Auth v3.1, 2.0 token
                     "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/",                    // Auth v3.2, 1.0 token
-                    "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0"       // Auth v3.2, 2.0 token
+                    "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0",      // Auth v3.2, 2.0 token
+                    "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/",                    // Auth for US Gov, 1.0 token
+                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0"        // Auth for US Gov, 2.0 token
                 },                
                 ValidateAudience = false,   // Audience validation takes place manually in code. 
                 ValidateLifetime = true,
@@ -105,12 +107,16 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
-        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId)
+        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId)
         {
+            var openIdMetadataUrl = (channelProvider != null && channelProvider.IsGovernment()) ?
+                GovernmentAuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl :
+                AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl;
+
             var tokenExtractor = new JwtTokenExtractor(
                     httpClient,
                     ToBotFromEmulatorTokenValidationParameters,
-                    AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
+                    openIdMetadataUrl,
                     AuthenticationConstants.AllowedSigningAlgorithms);
 
             var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId);

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentAuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentAuthenticationConstants.cs
@@ -39,5 +39,10 @@ namespace Microsoft.Bot.Connector.Authentication
         /// TO BOT FROM GOVERNMANT CHANNEL: OpenID metadata document for tokens coming from MSA
         /// </summary>
         public const string ToBotFromChannelOpenIdMetadataUrl = "https://login.botframework.azure.us/v1/.well-known/openidconfiguration";
+
+        /// <summary>
+        /// TO BOT FROM GOVERNMENT EMULATOR: OpenID metadata document for tokens coming from MSA
+        /// </summary>
+        public const string ToBotFromEmulatorOpenIdMetadataUrl = "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0/.well-known/openid-configuration";
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             if (usingEmulator)
             {
-                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, httpClient ?? _httpClient, channelId);
+                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient ?? _httpClient, channelId);
             }
             else if(channelProvider == null || channelProvider.IsPublicAzure())
             {


### PR DESCRIPTION
## Description
When the emulator is configured (via the channelService property in the .bot file) to use the US Government Azure AAD endpoint, this causes a different set of issuers and a different open id metadata URL to be needed to validate the emulator's JWT token.

## Testing
Because this involves testing JWT tokens which I cannot check-in, I validated with:
1. Emulator configured to use Gov talking connecting to a local .NET core bot configured to use Gov running locally 
2. Emulator configured to use Gov talking connecting to an Azure hosted .NET core bot configured to use Gov running locally 
3. DirectLine talking to the same bot (via US Gov)

You can go here to play with the test bot:
https://helloworldgov.azurewebsites.net/