### PR TITLE
Make CosmosDB provider consistent with Blob Storage provider

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -129,7 +129,12 @@ namespace Microsoft.Bot.Builder.Azure
         /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
         public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken)
         {
-            if (keys == null || keys.Length == 0)
+            if (keys == null)
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
+            if (keys.Length == 0)
             {
                 return;
             }
@@ -160,7 +165,12 @@ namespace Microsoft.Bot.Builder.Azure
         /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
         public async Task<IDictionary<string, object>> ReadAsync(string[] keys, CancellationToken cancellationToken)
         {
-            if (keys == null || keys.Length == 0)
+            if (keys == null)
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
+            if (keys.Length == 0)
             {
                 // No keys passed in, no result to return.
                 return new Dictionary<string, object>();
@@ -209,7 +219,12 @@ namespace Microsoft.Bot.Builder.Azure
         /// <seealso cref="ReadAsync(string[], CancellationToken)"/>
         public async Task WriteAsync(IDictionary<string, object> changes, CancellationToken cancellationToken)
         {
-            if (changes == null || changes.Count == 0)
+            if (changes == null)
+            {
+                throw new ArgumentNullException(nameof(changes));
+            }
+
+            if (changes.Count == 0)
             {
                 return;
             }

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -41,6 +41,11 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
         public Task DeleteAsync(string[] keys, CancellationToken cancellationToken)
         {
+            if (keys == null)
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
             lock (_syncroot)
             {
                 foreach (var key in keys)
@@ -65,6 +70,11 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
         public Task<IDictionary<string, object>> ReadAsync(string[] keys, CancellationToken cancellationToken)
         {
+            if (keys == null)
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
             var storeItems = new Dictionary<string, object>(keys.Length);
             lock (_syncroot)
             {
@@ -94,6 +104,11 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="ReadAsync(string[], CancellationToken)"/>
         public Task WriteAsync(IDictionary<string, object> changes, CancellationToken cancellationToken)
         {
+            if (changes == null)
+            {
+                throw new ArgumentNullException(nameof(changes));
+            }
+
             lock (_syncroot)
             {
                 foreach (var change in changes)


### PR DESCRIPTION
This change makes CosmosDB, Memory and Azure Blob Storage all throw exceptions when passed nulls for the keys or changes on the Read, Write and Delete methods. Prior to this only Azure Blob Storage was doing this correctly.

