### PR TITLE
Add verification to BotTelemetryClient unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.ApplicationInsights/BotTelemetryClient.cs
+++ b/libraries/Microsoft.Bot.Builder.ApplicationInsights/BotTelemetryClient.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights
 
         public BotTelemetryClient(TelemetryClient telemetryClient)
         {
-            _telemetryClient = telemetryClient;
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         }
 
         /// <summary>


### PR DESCRIPTION
The existing unit tests simply called the methods, but didn't verify the implementation was doing what it is supposed to be with the underlying `TelemetryClient`. You can't mock `TelemetryClient` because there is no interface; what you do is mock an `ITelemetryChannel` that the client is tunneling its output through and you then do your verifications against that.

Details:
  * Better unit test structure
  * Added better verification of `BotTelemetryClient` constructor and filled out missing scenario where a `null` `TelemetryClient` was not causing an exception to be thrown.
  * Added verification of all calls to the `TrackXXX` methods