### PR TITLE
add reply conversation ref method to activity

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -401,6 +401,21 @@ namespace Microsoft.Bot.Schema
         }
 
         /// <summary>
+        /// Create a ConversationReference based on this Activity's Conversation info and the ResourceResponse from sending an activity.
+        /// </summary>
+        /// <param name="reply">ResourceResponse returned from sendActivity</param>
+        /// <returns>A ConversationReference that can be stored and used later to delete or update the activity.</returns>
+        /// <exception cref="ArgumentNullException"/>
+        public ConversationReference GetReplyConversationReference(ResourceResponse reply)
+        {
+            var reference = GetConversationReference();
+
+            // Update the reference with the new outgoing Activity's id.
+            reference.ActivityId = reply.Id;
+            return reference;
+        }
+
+        /// <summary>
         /// Updates this activity with the delivery information from an existing 
         /// conversation reference.
         /// </summary>
@@ -434,6 +449,5 @@ namespace Microsoft.Bot.Schema
             }
             return this;
         }
-
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Schema.Tests
+{
+    [TestClass]
+    public class ActivityTest
+    {
+        [TestMethod]
+        public void GetConversationReference()
+        {
+            var activity = CreateActivity();
+
+            var conversationReference = activity.GetConversationReference();
+
+            Assert.AreEqual(activity.Id, conversationReference.ActivityId);
+            Assert.AreEqual(activity.From.Id, conversationReference.User.Id);
+            Assert.AreEqual(activity.Recipient.Id, conversationReference.Bot.Id);
+            Assert.AreEqual(activity.Conversation.Id, conversationReference.Conversation.Id);
+            Assert.AreEqual(activity.ChannelId, conversationReference.ChannelId);
+            Assert.AreEqual(activity.ServiceUrl, conversationReference.ServiceUrl);
+        }
+
+        [TestMethod]
+        public void GetReplyConversationReference()
+        {
+            var activity = CreateActivity();
+
+            var reply = new ResourceResponse
+            {
+                Id = "1234"
+            };
+
+            var conversationReference = activity.GetReplyConversationReference(reply);
+
+            Assert.AreEqual(reply.Id, conversationReference.ActivityId);
+            Assert.AreEqual(activity.From.Id, conversationReference.User.Id);
+            Assert.AreEqual(activity.Recipient.Id, conversationReference.Bot.Id);
+            Assert.AreEqual(activity.Conversation.Id, conversationReference.Conversation.Id);
+            Assert.AreEqual(activity.ChannelId, conversationReference.ChannelId);
+            Assert.AreEqual(activity.ServiceUrl, conversationReference.ServiceUrl);
+        }
+
+        [TestMethod]
+        public void ApplyConversationReference_isIncoming()
+        {
+            var activity = CreateActivity();
+
+            var conversationReference = new ConversationReference
+            {
+                ChannelId = "cr_123",
+                ServiceUrl = "cr_serviceUrl",
+                Conversation = new ConversationAccount
+                {
+                    Id = "cr_456"
+                },
+                User = new ChannelAccount
+                {
+                    Id = "cr_abc"
+                },
+                Bot = new ChannelAccount
+                {
+                    Id = "cr_def"
+                },
+                ActivityId = "cr_12345"
+            };
+
+            activity.ApplyConversationReference(conversationReference, true);
+
+            Assert.AreEqual(conversationReference.ChannelId, activity.ChannelId);
+            Assert.AreEqual(conversationReference.ServiceUrl, activity.ServiceUrl);
+            Assert.AreEqual(conversationReference.Conversation.Id, activity.Conversation.Id);
+
+            Assert.AreEqual(conversationReference.User.Id, activity.From.Id);
+            Assert.AreEqual(conversationReference.Bot.Id, activity.Recipient.Id);
+            Assert.AreEqual(conversationReference.ActivityId, activity.Id);
+        }
+
+        [TestMethod]
+        public void ApplyConversationReference()
+        {
+            var activity = CreateActivity();
+
+            var conversationReference = new ConversationReference
+            {
+                ChannelId = "123",
+                ServiceUrl = "serviceUrl",
+                Conversation = new ConversationAccount
+                {
+                    Id = "456"
+                },
+                User = new ChannelAccount
+                {
+                    Id = "abc"
+                },
+                Bot = new ChannelAccount
+                {
+                    Id = "def"
+                },
+                ActivityId = "12345"
+            };
+
+            activity.ApplyConversationReference(conversationReference, false);
+
+            Assert.AreEqual(conversationReference.ChannelId, activity.ChannelId);
+            Assert.AreEqual(conversationReference.ServiceUrl, activity.ServiceUrl);
+            Assert.AreEqual(conversationReference.Conversation.Id, activity.Conversation.Id);
+
+            Assert.AreEqual(conversationReference.Bot.Id, activity.From.Id);
+            Assert.AreEqual(conversationReference.User.Id, activity.Recipient.Id);
+            Assert.AreEqual(conversationReference.ActivityId, activity.ReplyToId);
+        }
+
+        private Activity CreateActivity()
+        {
+            var account1 = new ChannelAccount
+            {
+                Id = "ChannelAccount_Id_1",
+                Name = "ChannelAccount_Name_1",
+                Properties = new JObject { { "Name", "Value" } },
+                Role = "ChannelAccount_Role_1"
+            };
+
+            var account2 = new ChannelAccount
+            {
+                Id = "ChannelAccount_Id_2",
+                Name = "ChannelAccount_Name_2",
+                Properties = new JObject { { "Name", "Value" } },
+                Role = "ChannelAccount_Role_2"
+            };
+
+            var conversationAccount = new ConversationAccount
+            {
+                ConversationType = "a",
+                Id = "123",
+                IsGroup = true,
+                Name = "Name",
+                Properties = new JObject { { "Name", "Value" } },
+                Role = "ConversationAccount_Role"
+            };
+
+            var activity = new Activity
+            {
+                Id = "123",
+                From = account1,
+                Recipient = account2,
+                Conversation = conversationAccount,
+                ChannelId = "ChannelId123",
+                ServiceUrl = "ServiceUrl123"
+            };
+
+            return activity;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/EntitySchemaValidationTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/EntitySchemaValidationTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 


### PR DESCRIPTION

This fixes https://github.com/Microsoft/BotBuilder/issues/5128

And brings parity with the JavaScript. However note the implementation has slightly different factoring because the C# makes use of partial classes and adds these methods to Activity rather than TurnContext. This checkin builds on what's there already in the C#.