### PR TITLE
Telemetry: Add instanceId to WaterfallDialog logging

### DIFF
--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
@@ -158,9 +158,12 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
             // Event DialogId is set correctly.
             Assert.IsTrue(saved_properties["WaterfallComplete_3"].ContainsKey("DialogId"));
             Assert.IsTrue(saved_properties["WaterfallComplete_3"]["DialogId"] == "test");
+            Assert.IsTrue(saved_properties["WaterfallComplete_3"].ContainsKey("InstanceId"));
+            Assert.IsTrue(saved_properties["WaterfallStep_0"].ContainsKey("InstanceId"));
             // Verify naming on lambda's is "StepXofY"
             Assert.IsTrue(saved_properties["WaterfallStep_0"].ContainsKey("StepName"));
             Assert.IsTrue(saved_properties["WaterfallStep_0"]["StepName"] == "Step1of3");
+            Assert.IsTrue(saved_properties["WaterfallStep_0"].ContainsKey("InstanceId"));
             Assert.IsTrue(waterfallDialog.EndDialogCalled);
         }
 
@@ -217,6 +220,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
             Assert.IsTrue(saved_properties["WaterfallCancel_3"].ContainsKey("DialogId"));
             Assert.IsTrue(saved_properties["WaterfallCancel_3"]["DialogId"] == "test");
             Assert.IsTrue(saved_properties["WaterfallCancel_3"].ContainsKey("StepName"));
+            Assert.IsTrue(saved_properties["WaterfallCancel_3"].ContainsKey("InstanceId"));
             // Event contains "StepName"
             // Event naming on lambda's is "StepXofY"
             Assert.IsTrue(saved_properties["WaterfallCancel_3"]["StepName"] == "Step3of3");

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -103,10 +103,10 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
 
             Assert.IsTrue(sentItems.Count == 1);
             var telem = sentItems[0] as EventTelemetry;
+            var properties = (ISupportProperties)telem;
             Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Context.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Context.Properties["activityType"] == "message");
-            //Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(properties.Properties["activityId"] == activityID);
+            Assert.IsTrue(properties.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
             Assert.IsTrue(telem.Properties["hello"] == "value");
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);


### PR DESCRIPTION
Enables WaterfallDialog to emit an InstanceId.  

This makes it possible to distinguish between two instances of the same dialog firing.

This is a requirement for VA metrics.  

This is added to the WaterfallStep, WaterfallCancel and WaterfallEnd events.

For more context see [spec](https://github.com/daveta/analytics/blob/master/va_reports.md#customevent-waterfallstep-botflowstatus)