### PR TITLE
Add WaterfallDialog StartEvent for VA

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallDialog.cs
@@ -61,9 +61,17 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // Initialize waterfall state
             var state = dc.ActiveDialog.State;
+            var instanceId = Guid.NewGuid().ToString();
             state[PersistedOptions] = options;
             state[PersistedValues] = new Dictionary<string, object>();
-            state[PersistedInstanceId] = Guid.NewGuid().ToString();
+            state[PersistedInstanceId] = instanceId;
+
+            var properties = new Dictionary<string, string>()
+                {
+                    { "DialogId", Id },
+                    { "InstanceId", instanceId },
+                };
+            TelemetryClient.TrackEvent("WaterfallStart", properties);
 
             // Run first step
             return await RunStepAsync(dc, 0, DialogReason.BeginCalled, null, cancellationToken).ConfigureAwait(false);

--- a/libraries/integration/Microsoft.Bot.Builder.ApplicationInsights.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.ApplicationInsights.Core/ServiceCollectionExtensions.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core
         /// <param name="botConfiguration">Bot configuration that contains the Application Insights configuration information.</param>
         /// <param name="appInsightsServiceInstanceName">(OPTIONAL) Specifies a Application Insights instance name in the Bot configuration.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
-        /// <remarks>If the BotTelemtryClient is not overridden (and Application Insights is configured in the botConfiguration), a default Application Insights client will be used.
-        /// If Application Insights is not configured, the Null logger will be used.</remarks>
         public static IServiceCollection AddBotApplicationInsights(this IServiceCollection services, BotConfiguration botConfiguration, string appInsightsServiceInstanceName = null)
         {
             if (botConfiguration == null)
@@ -71,7 +69,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core
         /// <param name="services">The <see cref="IServiceCollection"/> which specifies the contract for a collection of service descriptors.</param>
         /// <param name="botTelemetryClient">Bot Telemetry Client that logs event information.</param>
         /// <param name="instrumentationKey">If Bot Telemetry Client is using Application Insights, provide the instumentation key.</param>
-        /// <returns>The IServiceCollection</returns>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
         public static IServiceCollection AddBotApplicationInsights(this IServiceCollection services, IBotTelemetryClient botTelemetryClient, string instrumentationKey = null)
         {
             if (botTelemetryClient == null)

--- a/libraries/integration/Microsoft.Bot.Builder.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core
         {
             var request = httpContext.Request;
 
-            if (request.Method == "POST" && request.ContentType == "application/json")
+            if (request.Method == "POST" && request.ContentType.StartsWith("application/json"))
             {
                 var items = httpContext.Items;
                 request.EnableBuffering();

--- a/libraries/integration/Microsoft.Bot.Builder.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.WebApi
                         {
                             conversationId = (string)conversation["id"];
                         }
+
                         var context = telemetry.Context;
 
                         // Set the user id on the Application Insights telemetry item.

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/BotTelemetryClientTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/BotTelemetryClientTests.cs
@@ -3,76 +3,138 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using System.Collections.Generic;
 using System;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+using Microsoft.ApplicationInsights.Channel;
 
 namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
 {
-    [TestClass]
     public class BotTelemetryClientTests
     {
-
-        [TestMethod]
-        public void Construct()
+        [TestClass]
+        public class ConstructorTests
         {
-            var telemetryClient = new TelemetryClient();
-            var client = new BotTelemetryClient(telemetryClient);
-            Assert.IsNotNull(client);
+            [TestMethod]
+            public void NullTelemetryClientThrows()
+            {
+                try
+                {
+                    new BotTelemetryClient(null);
 
-        }
-        
-        [TestMethod]
-        public void TrackAvailabilityTest()
-        {
-            // Just invoke underlying TelemetryClient.  Not configured, just tests if it can be invoked.
-            // Class is sealed, so nothing to mock here.
-            var telemetryClient = new TelemetryClient();
-            var client = new BotTelemetryClient(telemetryClient);
+                    Assert.Fail("Expected an exception to be thrown.");
+                }
+                catch (ArgumentNullException exception)
+                {
+                    Assert.AreEqual<string>("telemetryClient", exception.ParamName);
+                }
+            }
 
-            client.TrackAvailability("test", DateTimeOffset.Now, new TimeSpan(1000), "run location", true,
-                "message", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
-        }
+            [TestMethod]
+            public void NonNullTelemtryClientSucceeds()
+            {
+                var telemetryClient = new TelemetryClient();
 
-
-        [TestMethod]
-        public void TrackEventTest()
-        {
-            // Just invoke underlying TelemetryClient.  Not configured, just tests if it can be invoked.
-            // Class is sealed, so nothing to mock here.
-            var telemetryClient = new TelemetryClient();
-            var client = new BotTelemetryClient(telemetryClient);
-
-            client.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
+                var botTelemetryClient = new BotTelemetryClient(telemetryClient);
+            }
         }
 
-        [TestMethod]
-        public void TrackDependencyTest()
+        [TestClass]
+        public class TrackTelemetryTests
         {
-            // Just invoke underlying TelemetryClient.  Not configured, just tests if it can be invoked.
-            // Class is sealed, so nothing to mock here.
-            var telemetryClient = new TelemetryClient();
-            var client = new BotTelemetryClient(telemetryClient);
-            client.TrackDependency("test", "target", "dependencyname", "data", DateTimeOffset.Now, new TimeSpan(10000), "result", false );
-        }
+            private BotTelemetryClient _botTelemetryClient;
+            private Mock<ITelemetryChannel> _mockTelemetryChannel;
 
-        [TestMethod]
-        public void TrackExceptionTest()
-        {
-            // Just invoke underlying TelemetryClient.  Not configured, just tests if it can be invoked.
-            // Class is sealed, so nothing to mock here.
-            var telemetryClient = new TelemetryClient();
-            var client = new BotTelemetryClient(telemetryClient);
-            client.TrackException(new Exception(), new Dictionary<string, string>() { { "foo", "bar" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
-        }
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                _mockTelemetryChannel = new Mock<ITelemetryChannel>();
 
-        [TestMethod]
-        public void TrackTraceTest()
-        {
-            // Just invoke underlying TelemetryClient.  Not configured, just tests if it can be invoked.
-            // Class is sealed, so nothing to mock here.
-            var telemetryClient = new TelemetryClient();
-            var client = new BotTelemetryClient(telemetryClient);
-            client.TrackTrace("hello", Severity.Critical, new Dictionary<string, string>() { { "foo", "bar" } });
+                var telemetryConfiguration = new TelemetryConfiguration("UNITTEST-INSTRUMENTATION-KEY", _mockTelemetryChannel.Object);
+                var telemetryClient = new TelemetryClient(telemetryConfiguration);
+
+                _botTelemetryClient = new BotTelemetryClient(telemetryClient);
+            }
+
+            [TestMethod]
+            public void TrackAvailabilityTest()
+            {
+                _botTelemetryClient.TrackAvailability("test", DateTimeOffset.Now, new TimeSpan(1000), "run location", true,
+                    "message", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
+
+                _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<AvailabilityTelemetry>(t =>
+                    t.Name == "test"
+                        &&
+                    t.Message == "message"
+                        &&
+                    t.Properties["hello"] == "value"
+                        &&
+                    t.Metrics["metric"] == 0.6)));
+            }
+
+
+            [TestMethod]
+            public void TrackEventTest()
+            {
+                _botTelemetryClient.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
+
+                _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<EventTelemetry>(t =>
+                    t.Name == "test"
+                        &&
+                    t.Properties["hello"] == "value"
+                        &&
+                    t.Metrics["metric"] == 0.6
+                )));
+            }
+
+            [TestMethod]
+            public void TrackDependencyTest()
+            {
+                _botTelemetryClient.TrackDependency("test", "target", "dependencyname", "data", DateTimeOffset.Now, new TimeSpan(10000), "result", false);
+
+                _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<DependencyTelemetry>(t =>
+                    t.Type == "test"
+                        &&
+                    t.Target == "target"
+                        &&
+                    t.Name == "dependencyname"
+                        &&
+                    t.Data == "data"
+                        &&
+                    t.ResultCode == "result"
+                        &&
+                    t.Success == false)));
+            }
+
+            [TestMethod]
+            public void TrackExceptionTest()
+            {
+                var expectedException = new Exception("test-exception");
+
+                _botTelemetryClient.TrackException(expectedException, new Dictionary<string, string>() { { "foo", "bar" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
+
+                _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<ExceptionTelemetry>(t =>
+                    t.Exception == expectedException
+                        &&
+                    t.Properties["foo"] == "bar"
+                        &&
+                    t.Metrics["metric"] == 0.6)));
+            }
+
+            [TestMethod]
+            public void TrackTraceTest()
+            {
+                _botTelemetryClient.TrackTrace("hello", Severity.Critical, new Dictionary<string, string>() { { "foo", "bar" } });
+
+                _mockTelemetryChannel.Verify(tc => tc.Send(It.Is<TraceTelemetry>(t =>
+                    t.Message == "hello"
+                        &&
+                    t.SeverityLevel == SeverityLevel.Critical
+                        &&
+                    t.Properties["foo"] == "bar")));
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
             .Send("hello")
             .AssertReply("step3")
             .StartTestAsync();
-            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string,string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(3));
+            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string,string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(4));
             Console.WriteLine("Complete");
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
             .Send("hello")
             .AssertReply("step3")
             .StartTestAsync();
-            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(3));
+            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(4));
         }
 
 
@@ -150,20 +150,20 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
             .Send("hello")
             .AssertReply("step1")
             .StartTestAsync();
-            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(5));
+            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(7));
             // Verify:
             // Event name is "WaterfallComplete"
             // Event occurs on the 4th event logged
             // Event contains DialogId
             // Event DialogId is set correctly.
-            Assert.IsTrue(saved_properties["WaterfallComplete_3"].ContainsKey("DialogId"));
-            Assert.IsTrue(saved_properties["WaterfallComplete_3"]["DialogId"] == "test");
-            Assert.IsTrue(saved_properties["WaterfallComplete_3"].ContainsKey("InstanceId"));
-            Assert.IsTrue(saved_properties["WaterfallStep_0"].ContainsKey("InstanceId"));
+            Assert.IsTrue(saved_properties["WaterfallComplete_4"].ContainsKey("DialogId"));
+            Assert.IsTrue(saved_properties["WaterfallComplete_4"]["DialogId"] == "test");
+            Assert.IsTrue(saved_properties["WaterfallComplete_4"].ContainsKey("InstanceId"));
+            Assert.IsTrue(saved_properties["WaterfallStep_1"].ContainsKey("InstanceId"));
             // Verify naming on lambda's is "StepXofY"
-            Assert.IsTrue(saved_properties["WaterfallStep_0"].ContainsKey("StepName"));
-            Assert.IsTrue(saved_properties["WaterfallStep_0"]["StepName"] == "Step1of3");
-            Assert.IsTrue(saved_properties["WaterfallStep_0"].ContainsKey("InstanceId"));
+            Assert.IsTrue(saved_properties["WaterfallStep_1"].ContainsKey("StepName"));
+            Assert.IsTrue(saved_properties["WaterfallStep_1"]["StepName"] == "Step1of3");
+            Assert.IsTrue(saved_properties["WaterfallStep_1"].ContainsKey("InstanceId"));
             Assert.IsTrue(waterfallDialog.EndDialogCalled);
         }
 
@@ -211,19 +211,21 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
             .Send("hello")
             .AssertReply("step1")
             .StartTestAsync();
-            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(5));
+            telemetryClient.Verify(m => m.TrackEvent(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<IDictionary<string, double>>()), Times.Exactly(7));
             // Verify:
             // Event name is "WaterfallCancel"
             // Event occurs on the 4th event logged
             // Event contains DialogId
             // Event DialogId is set correctly.
-            Assert.IsTrue(saved_properties["WaterfallCancel_3"].ContainsKey("DialogId"));
-            Assert.IsTrue(saved_properties["WaterfallCancel_3"]["DialogId"] == "test");
-            Assert.IsTrue(saved_properties["WaterfallCancel_3"].ContainsKey("StepName"));
-            Assert.IsTrue(saved_properties["WaterfallCancel_3"].ContainsKey("InstanceId"));
+            Assert.IsTrue(saved_properties["WaterfallStart_0"].ContainsKey("DialogId"));
+            Assert.IsTrue(saved_properties["WaterfallStart_0"].ContainsKey("InstanceId"));
+            Assert.IsTrue(saved_properties["WaterfallCancel_4"].ContainsKey("DialogId"));
+            Assert.IsTrue(saved_properties["WaterfallCancel_4"]["DialogId"] == "test");
+            Assert.IsTrue(saved_properties["WaterfallCancel_4"].ContainsKey("StepName"));
+            Assert.IsTrue(saved_properties["WaterfallCancel_4"].ContainsKey("InstanceId"));
             // Event contains "StepName"
             // Event naming on lambda's is "StepXofY"
-            Assert.IsTrue(saved_properties["WaterfallCancel_3"]["StepName"] == "Step3of3");
+            Assert.IsTrue(saved_properties["WaterfallCancel_4"]["StepName"] == "Step3of3");
             Assert.IsTrue(waterfallDialog.CancelDialogCalled);
             Assert.IsFalse(waterfallDialog.EndDialogCalled);
         }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -29,6 +29,9 @@
     <None Update="testbot.bot.default">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="testbot.bot.multiple_app_insights">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="testbot.bot.no_app_insights">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
@@ -74,13 +74,13 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void BotFile_NoAppInsights()
+        public void BotFile_NoAppInsightsInBot()
         {
+            // Should default to the Null TelemetryClient
             ArrangeBotFile("no_app_insights"); // Invalid bot file
             ArrangeAppSettings(); // Default app settings
             var server = new TestServer(new WebHostBuilder()
-                .UseStartup<Startup>());
+                .UseStartup<StartupVerifyNullTelemetry>());
         }
 
         [TestMethod]
@@ -93,6 +93,7 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
             Assert.IsTrue(true);
         }
 
+
         [TestMethod]
         public void ServiceResolution_VerifyTelemetryClient()
         {
@@ -103,14 +104,34 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
                 .UseStartup<StartupVerifyTelemetryClient>());
         }
 
+
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
-        public void ServiceResolution_VerifyTelemetryClientFail()
+        public void ServiceResolution_OverrideTelemetry()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder() // No App Insights registered!
-                .UseStartup<StartupVerifyTelemetryClient>());
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupOverideTelemClient>());
+            Assert.IsTrue(true);
+        }
+
+        [TestMethod]
+        public void ServiceResolution_MultipleAppInsights()
+        {
+            ArrangeBotFile("multiple_app_insights"); // Default bot file
+            ArrangeAppSettings(); // Default app settings
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupMultipleAppInsights>());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ServiceResolution_InvalidInstance()
+        {
+            ArrangeBotFile("multiple_app_insights"); // Default bot file
+            ArrangeAppSettings(); // Default app settings
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupInvalidInstance>());
         }
 
         /// <summary>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
+{
+    internal class StartupInvalidInstance
+    {
+        public StartupInvalidInstance(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var botConfig = BotConfiguration.Load("testbot.bot", null);
+            services.AddBotApplicationInsights(botConfig, "invalidinstance");
+
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // registered.
+            services.AddSingleton<IConfiguration>(this.Configuration);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseBotApplicationInsights();
+            var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsTrue(telemetryClient is NullBotTelemetryClient);
+        }
+
+    }
+}

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
+{
+    internal class StartupMultipleAppInsights
+    {
+        public StartupMultipleAppInsights(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var botConfig = BotConfiguration.Load("testbot.bot", null);
+
+            services.AddBotApplicationInsights(botConfig, "instance2");
+
+
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // registered.
+            services.AddSingleton<IConfiguration>(this.Configuration);
+
+
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseBotApplicationInsights();
+            var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsTrue(telemetryClient is BotTelemetryClient);
+        }
+
+    }
+}

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
+{
+    internal class StartupVerifyNullTelemetry
+    {
+        public StartupVerifyNullTelemetry(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var botConfig = BotConfiguration.Load("testbot.bot", null);
+            services.AddBotApplicationInsights(botConfig);
+
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // registered.
+            services.AddSingleton<IConfiguration>(this.Configuration);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseBotApplicationInsights();
+            var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsTrue(telemetryClient is NullBotTelemetryClient);
+        }
+
+    }
+}

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryOverrideTelemClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryOverrideTelemClient.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Bot.Builder.ApplicationInsights.Core.Tests
+{
+    internal class StartupOverideTelemClient
+    {
+        private readonly Mock<IBotTelemetryClient> _telemClient;
+        public StartupOverideTelemClient(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+            _telemClient = new Mock<IBotTelemetryClient>();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var botConfig = BotConfiguration.Load("testbot.bot", null);
+            
+            services.AddBotApplicationInsights(_telemClient.Object);
+
+
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // registered.
+            services.AddSingleton<IConfiguration>(this.Configuration);
+
+
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseBotApplicationInsights();
+            var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
+            Assert.IsNotNull(telemetryClient);
+            Assert.AreEqual(telemetryClient, _telemClient.Object);
+        }
+
+    }
+}

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/testbot.bot.default
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/testbot.bot.default
@@ -97,7 +97,7 @@
             "serviceName": "myservice",
             "subscriptionId": "00000000-0000-0000-0000-000000000000",
             "tenantId": "00000000-0000-0000-0000-000000000000"
-        },
+        }
     ],
     "padlock": "",
     "version": "2.0"

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/testbot.bot.multiple_app_insights
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/testbot.bot.multiple_app_insights
@@ -1,0 +1,129 @@
+﻿{
+  "name": "alldeleted",
+  "description": "",
+  "services": [
+    {
+      "type": "endpoint",
+      "id": "1",
+      "name": "development",
+      "appId": "",
+      "appPassword": "",
+      "endpoint": "http://localhost:3978/api/messages"
+    },
+    {
+      "type": "blob",
+      "id": "2",
+      "name": "fake",
+      "serviceName": "fake",
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "subscriptionId": "00000000-0000-0000-0000-000000000000",
+      "resourceGroup": "fake",
+      "connectionString": "DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net;AccountName=eb66xfjtsmstorage;AccountKey=000000000000000000000",
+      "container": "transcripts"
+    },
+    {
+      "type": "cosmosdb",
+      "id": "8",
+      "name": "fake",
+      "serviceName": "fake",
+      "tenantId": "00000000-0000-0000-0000-000000000000",
+      "subscriptionId": "00000000-0000-0000-0000-000000000000",
+      "resourceGroup": "fake",
+      "endpoint": "https://fake.documents.azure.com:443/",
+      "key": "00000000000000000000000",
+      "database": "fake-db",
+      "collection": "botstate-collection"
+    },
+    {
+      "type": "generic",
+      "id": "5",
+      "name": "ContentModerator",
+      "url": "",
+      "configuration": {
+        "key": "",
+        "region": ""
+      }
+    },
+    {
+      "type": "generic",
+      "id": "364",
+      "name": "Authentication",
+      "url": "",
+      "configuration": {
+        "Azure Active Directory v2": ""
+      }
+    },
+    {
+      "type": "luis",
+      "name": "fake",
+      "appId": "00000000-0000-0000-0000-000000000000",
+      "authoringKey": "00000000000000000000000000",
+      "subscriptionKey": "000000000000000000",
+      "version": "0.1",
+      "region": "westus",
+      "id": "120"
+    },
+    {
+      "type": "qna",
+      "name": "FAQ",
+      "id": "85",
+      "kbId": "00000000-0000-0000-0000-000000000000",
+      "subscriptionKey": "00000000000000000000",
+      "endpointKey": "deadbeef-7692-491b-b4d8-3552b2d14746",
+      "hostname": "https://fake-qnahost.azurewebsites.net/qnamaker"
+    },
+    {
+      "type": "dispatch",
+      "serviceIds": [
+        "120",
+        "85"
+      ],
+      "name": "fake_Dispatch",
+      "appId": "00000000-0000-0000-0000-000000000000",
+      "authoringKey": "0000000000000000000",
+      "subscriptionKey": "000000000000000000000000000",
+      "version": "Dispatch",
+      "region": "westus",
+      "id": "152"
+    },
+    {
+      "type": "appInsights",
+      "apiKeys": {},
+      "applicationId": "00000000-0000-0000-0000-000000000000",
+      "id": "3",
+      "instrumentationKey": "00000000-0000-0000-0000-000000000002",
+      "name": "instance2",
+      "resourceGroup": "myresource",
+      "serviceName": "myservice",
+      "subscriptionId": "00000000-0000-0000-0000-000000000000",
+      "tenantId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+      "type": "appInsights",
+      "apiKeys": {},
+      "applicationId": "00000000-0000-0000-0000-000000000000",
+      "id": "30",
+      "instrumentationKey": "00000000-0000-0000-0000-000000000001",
+      "name": "instance1",
+      "resourceGroup": "myresource",
+      "serviceName": "myservice",
+      "subscriptionId": "00000000-0000-0000-0000-000000000000",
+      "tenantId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+      "type": "appInsights",
+      "apiKeys": {},
+      "applicationId": "00000000-0000-0000-0000-000000000000",
+      "id": "30",
+      "instrumentationKey": "00000000-0000-0000-0000-000000000003",
+      "name": "instance3",
+      "resourceGroup": "myresource",
+      "serviceName": "myservice",
+      "subscriptionId": "00000000-0000-0000-0000-000000000000",
+      "tenantId": "00000000-0000-0000-0000-000000000000"
+    }
+
+  ],
+  "padlock": "",
+  "version": "2.0"
+}


### PR DESCRIPTION
Add support for WaterfallStart event.
Also:
- Support multiple Application Insights configs within BotConfig
- Include BotTelemetryClient tests