### PR TITLE
add options to individual QnAMaker calls

### DIFF
--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/InterceptRequestHandler.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/InterceptRequestHandler.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.AI.QnA.Tests
+{
+    class InterceptRequestHandler : DelegatingHandler
+    {
+        public InterceptRequestHandler(HttpMessageHandler handler)
+            : base(handler)
+        {
+        }
+
+        public string Content { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Content = await ((StringContent)request.Content).ReadAsStringAsync();
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/InterceptRequestHandler.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/InterceptRequestHandler.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -263,6 +263,46 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
+        public async Task QnaMaker_ReturnsAnswerWithFiltering()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer.json"));
+
+            var interceptHttp = new InterceptRequestHandler(mockHttp);
+
+            var qna = GetQnAMaker(interceptHttp,
+                new QnAMakerEndpoint
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = _hostname
+                });
+
+            var options = new QnAMakerOptions
+            {
+                StrictFilters = new Metadata[]
+                {
+                    new Metadata() { Name = "topic", Value = "value" }
+                },
+                Top = 1
+            };
+
+            var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"), options);
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Length, 1, "should get one result");
+            StringAssert.StartsWith(results[0].Answer, "BaseCamp: You can use a damp rag to clean around the Power Pack");
+
+            // verify we are actually passing on the options
+            var obj = JObject.Parse(interceptHttp.Content);
+            Assert.AreEqual(1, obj["top"].Value<int>());
+            Assert.AreEqual("topic", obj["strictFilters"][0]["name"].Value<string>());
+            Assert.AreEqual("value", obj["strictFilters"][0]["value"].Value<string>());
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
         public async Task QnaMaker_TestThreshold()
         {
             var mockHttp = new MockHttpMessageHandler();


### PR DESCRIPTION
This is basically the code from @adiazcan (much appreciated, thanks!)

- rebased
- dropped "ref" from ValidateOptions (C# is by-ref by default for classes)
- tightened up test case a little to validate the sent JSON contains the options we want to see