### PR TITLE
Add DialogSet.SetTelemetryClient(), and modify ComponentDialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -24,6 +24,20 @@ namespace Microsoft.Bot.Builder.Dialogs
             _dialogs = new DialogSet();
         }
 
+        public new IBotTelemetryClient TelemetryClient
+        {
+            get
+            {
+                return base.TelemetryClient;
+            }
+
+            set
+            {
+                _dialogs.SetTelemetryClient(value);
+                base.TelemetryClient = value;
+            }
+        }
+
         protected string InitialDialogId { get; set; }
 
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext outerDc, object options = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             _dialogs = new DialogSet();
         }
 
+        /// <summary>
+        /// Gets or sets or set the <see cref="IBotTelemetryClient"/> to use.
+        /// When setting this property, all the contained dialogs TelemetryClient properties are also set.
+        /// </summary>
+        /// <value>The <see cref="IBotTelemetryClient"/> to use when logging.</value>
         public new IBotTelemetryClient TelemetryClient
         {
             get
@@ -33,8 +38,8 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             set
             {
-                _dialogs.SetTelemetryClient(value);
-                base.TelemetryClient = value;
+                base.TelemetryClient = value ?? NullBotTelemetryClient.Instance;
+                _dialogs.TelemetryClient = base.TelemetryClient;
             }
         }
 
@@ -128,6 +133,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <param name="dialog">The dialog to add.</param>
         /// <returns>The updated <see cref="ComponentDialog"/>.</returns>
+        /// <remarks>Adding a new dialog will inherit the <see cref="IBotTelemetryClient"/> of the ComponentDialog.</remarks>
         public ComponentDialog AddDialog(Dialog dialog)
         {
             _dialogs.Add(dialog);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     public abstract class Dialog
     {
         public static readonly DialogTurnResult EndOfTurn = new DialogTurnResult(DialogTurnStatus.Waiting);
+        private IBotTelemetryClient _telemetryClient;
 
         public Dialog(string dialogId)
         {
@@ -21,6 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(dialogId));
             }
 
+            _telemetryClient = NullBotTelemetryClient.Instance;
             Id = dialogId;
         }
 
@@ -30,7 +32,18 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Gets or sets the telemetry client for logging events.
         /// </summary>
         /// <value>The Telemetry Client logger.</value>
-        public IBotTelemetryClient TelemetryClient { get; set; } = NullBotTelemetryClient.Instance;
+        public IBotTelemetryClient TelemetryClient
+        {
+            get
+            {
+                return _telemetryClient;
+            }
+
+            set
+            {
+                _telemetryClient = value;
+            }
+        }
 
         /// <summary>
         /// Method called when a new dialog has been pushed onto the stack and is being activated.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -86,5 +86,22 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             return null;
         }
+
+        /// <summary>
+        /// Sets the IBotTelemetryClient for all the dialogs in the set.
+        /// </summary>
+        /// <param name="telemetryClient">The new IBotTelemetryClient to use in all dialogs.</param>
+        public void SetTelemetryClient(IBotTelemetryClient telemetryClient)
+        {
+            if (telemetryClient == null)
+            {
+                throw new ArgumentNullException(nameof(telemetryClient));
+            }
+
+            foreach (var dialog in _dialogs.Values)
+            {
+                dialog.TelemetryClient = telemetryClient;
+            }
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/TelemetryWaterfallTests.cs
@@ -32,8 +32,10 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
                 async (step, cancellationToken) => { await step.Context.SendActivityAsync("step1"); return Dialog.EndOfTurn; },
                 async (step, cancellationToken) => { await step.Context.SendActivityAsync("step2"); return Dialog.EndOfTurn; },
                 async (step, cancellationToken) => { await step.Context.SendActivityAsync("step3"); return Dialog.EndOfTurn; },
-            })
-            { TelemetryClient = telemetryClient.Object });
+            }));
+
+            dialogs.TelemetryClient = telemetryClient.Object;
+            
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -71,10 +73,11 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step1"); return Dialog.EndOfTurn; },
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step2"); return Dialog.EndOfTurn; },
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step3"); return Dialog.EndOfTurn; },
-            })
-            { TelemetryClient = telemetryClient.Object };
+            });
+
 
             dialogs.Add(waterfallDialog);
+            dialogs.TelemetryClient = telemetryClient.Object;
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -127,10 +130,10 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step1"); return Dialog.EndOfTurn; },
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step2"); return Dialog.EndOfTurn; },
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step3"); return Dialog.EndOfTurn; },
-            })
-            { TelemetryClient = telemetryClient.Object };
+            });
 
             dialogs.Add(waterfallDialog);
+            dialogs.TelemetryClient = telemetryClient.Object;
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
@@ -190,10 +193,10 @@ namespace Microsoft.Bot.Builder.ApplicationInsights.Tests
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step1"); return Dialog.EndOfTurn; },
                     async (step, cancellationToken) => { await step.Context.SendActivityAsync("step2"); return Dialog.EndOfTurn; },
                     async (step, cancellationToken) => { await step.CancelAllDialogsAsync(); return Dialog.EndOfTurn; },
-            })
-            { TelemetryClient = telemetryClient.Object };
+            });
 
             dialogs.Add(waterfallDialog);
+            dialogs.TelemetryClient = telemetryClient.Object;
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -52,6 +54,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .Send("64")
             .AssertReply("Bot received the number '64'.")
             .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TelemtryBasicWaterfallTest()
+        {
+            var testComponentDialog = new TestComponentDialog();
+            Assert.IsTrue(testComponentDialog.TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is NullBotTelemetryClient);
+
+            testComponentDialog.TelemetryClient = new MyBotTelemetryClient();
+            Assert.IsTrue(testComponentDialog.TelemetryClient is MyBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is MyBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is MyBotTelemetryClient);
+            await Task.CompletedTask;
         }
 
         [TestMethod]
@@ -204,5 +221,45 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 AddDialog(new TestComponentDialog());
             }
         }
+        private class MyBotTelemetryClient : IBotTelemetryClient
+        {
+            public MyBotTelemetryClient()
+            {
+
+            }
+
+            public void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackAvailability(string name, DateTimeOffset timeStamp, TimeSpan duration, string runLocation, bool success, string message = null, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackDependency(string dependencyTypeName, string target, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, string resultCode, bool success)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackTrace(string message, Severity severityLevel, IDictionary<string, string> properties)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
     }
+
 }
+

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        public async Task TelemtryBasicWaterfallTest()
+        public async Task TelemetryBasicWaterfallTest()
         {
             var testComponentDialog = new TestComponentDialog();
             Assert.IsTrue(testComponentDialog.TelemetryClient is NullBotTelemetryClient);
@@ -70,6 +70,60 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is MyBotTelemetryClient);
             await Task.CompletedTask;
         }
+
+        [TestMethod]
+        public async Task TelemetryHeterogeneousLoggerTest()
+        {
+            var testComponentDialog = new TestComponentDialog();
+            Assert.IsTrue(testComponentDialog.TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is NullBotTelemetryClient);
+
+            testComponentDialog.FindDialog("test-waterfall").TelemetryClient = new MyBotTelemetryClient();
+
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is MyBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is NullBotTelemetryClient);
+            await Task.CompletedTask;
+        }
+
+
+        [TestMethod]
+        public async Task TelemetryAddWaterfallTest()
+        {
+            var testComponentDialog = new TestComponentDialog();
+            Assert.IsTrue(testComponentDialog.TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is NullBotTelemetryClient);
+
+            testComponentDialog.TelemetryClient = new MyBotTelemetryClient();
+            testComponentDialog.AddDialog(new WaterfallDialog("C"));
+            
+            Assert.IsTrue(testComponentDialog.FindDialog("C").TelemetryClient is MyBotTelemetryClient);
+            await Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public async Task TelemetryNullUpdateAfterAddTest()
+        {
+            var testComponentDialog = new TestComponentDialog();
+            Assert.IsTrue(testComponentDialog.TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is NullBotTelemetryClient);
+
+            testComponentDialog.TelemetryClient = new MyBotTelemetryClient();
+            testComponentDialog.AddDialog(new WaterfallDialog("C"));
+
+            Assert.IsTrue(testComponentDialog.FindDialog("C").TelemetryClient is MyBotTelemetryClient);
+            testComponentDialog.TelemetryClient = null;
+
+            Assert.IsTrue(testComponentDialog.FindDialog("test-waterfall").TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("number").TelemetryClient is NullBotTelemetryClient);
+            Assert.IsTrue(testComponentDialog.FindDialog("C").TelemetryClient is NullBotTelemetryClient);
+
+            await Task.CompletedTask;
+        }
+
+
 
         [TestMethod]
         public async Task BasicComponentDialogTest()

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -58,6 +59,63 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.IsNotNull(ds.Find("B"), "B is missing");
             Assert.IsNull(ds.Find("C"), "C should not be found");
             await Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public async Task DialogSet_TelemetrySet()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
+            var ds = new DialogSet(dialogStateProperty)
+                .Add(new WaterfallDialog("A"))
+                .Add(new WaterfallDialog("B"));
+            Assert.IsTrue(ds.Find("A").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
+            Assert.IsTrue(ds.Find("B").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
+
+            var myTelemetryClient = new MyBotTelemetryClient();
+            ds.SetTelemetryClient(myTelemetryClient);
+
+            Assert.IsTrue(ds.Find("A").TelemetryClient is MyBotTelemetryClient, "A not MyBotTelemetryClient");
+            Assert.IsTrue(ds.Find("B").TelemetryClient is MyBotTelemetryClient, "A not MyBotTelemetryClient");
+            await Task.CompletedTask;
+        }
+
+        private class MyBotTelemetryClient : IBotTelemetryClient
+        {
+            public MyBotTelemetryClient()
+            {
+
+            }
+
+            public void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackAvailability(string name, DateTimeOffset timeStamp, TimeSpan duration, string runLocation, bool success, string message = null, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackDependency(string dependencyTypeName, string target, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, string resultCode, bool success)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void TrackTrace(string message, Severity severityLevel, IDictionary<string, string> properties)
+            {
+                throw new NotImplementedException();
+            }
         }
 
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -80,6 +80,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await Task.CompletedTask;
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task DialogSet_NullTelemetrySet()
+        {
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
+            var ds = new DialogSet(dialogStateProperty)
+                .Add(new WaterfallDialog("A"))
+                .Add(new WaterfallDialog("B"));
+            ds.SetTelemetryClient(null);
+        }
+
+
         private class MyBotTelemetryClient : IBotTelemetryClient
         {
             public MyBotTelemetryClient()


### PR DESCRIPTION
## Incorporate Feedback from @Stevenic:
This enables ComponentDialog to set the TelemetryClient and updates all the underlying dialog's TelemetryClient
- Add `DialogSet.TelemetryClient` which will set the telemetryClient on all contained dialogs.
- Modify DialogSet.Add to set the `TelemetryClient` property on the dialog being added.
- Modify setter on `ComponentDialog.TelemetryClient` to set contained dialogs.
- Modify `ComponentDialog.Add` to set `TelemetryClient` property on the dialog being added.

