### PR TITLE
Dialogs.OAuthPrompt.GetUserTokenAsync bugfix

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 magicCode = value.GetValue("state")?.ToString();
             }
 
-            if (turnContext.Activity.Type == ActivityTypes.Message && _magicCodeRegex.IsMatch(turnContext.Activity.Text))
+            if (turnContext.Activity.Type == ActivityTypes.Message && turnContext.Activity.Text != null && _magicCodeRegex.IsMatch(turnContext.Activity.Text))
             {
                 magicCode = turnContext.Activity.Text;
             }


### PR DESCRIPTION
Fixing a ArgumentNullException bug which is triggered if I call the `Dialogs.OAuthPrompt.GetUserTokenAsync` after a non-text message (ex. button click), and `context.Activity.Text` is not set.