### PR TITLE
update autorest.csharp dependency to 2.3.82

### DIFF
--- a/libraries/Swagger/package-lock.json
+++ b/libraries/Swagger/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@microsoft.azure/autorest.csharp": {
-      "version": "2.3.80",
-      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.csharp/-/autorest.csharp-2.3.80.tgz",
-      "integrity": "sha512-wRbAJMnEjWcokLQ5NzRdKA5Sw0cNpNhQOPChQWJYKzs4SktYoVSrpSXxJMXICNTBa8JjkM7925VI38Z0oR1tfA==",
+      "version": "2.3.82",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.csharp/-/autorest.csharp-2.3.82.tgz",
+      "integrity": "sha512-7KD0UMgr4b/XqF9UZ+dikN/FoNxskg5s15gCei54lkVTfMb0IUsYBnaP8CEASlbUg9azCqIxNKWzKGaitDMSyw==",
       "dev": true,
       "requires": {
         "dotnet-2.0.0": "^1.4.4"

--- a/libraries/Swagger/package.json
+++ b/libraries/Swagger/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "author": "",
   "devDependencies": {
-    "@microsoft.azure/autorest.csharp": "2.3.80",
+    "@microsoft.azure/autorest.csharp": "2.3.82",
     "autorest": "2.0.4283",
     "replace": "^1.0.0"
   },


### PR DESCRIPTION
Fixes #1207 

### Changes:
- Update `"@microsoft.azure/autorest.csharp"` dependency in Swagger/package.json to 2.3.82

### Notes:
- Latest generated code had no differences from currently checked in code, hence this PR only contains the package.json and package-lock.json.