### PR TITLE
TranscriptLoggerMiddleware bugfix

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Bot.Builder
             // log incoming activity at beginning of turn
             if (turnContext.Activity != null)
             {
+                if (turnContext.Activity.From == null) turnContext.Activity.From = new ChannelAccount();
+
                 if (string.IsNullOrEmpty((string)turnContext.Activity.From.Properties["role"]))
                 {
                     turnContext.Activity.From.Properties["role"] = "user";


### PR DESCRIPTION
Fixing a NullReferenceException bug which is thrown if the incoming Activity's From property is null in `TranscriptLoggerMiddleware`. Eg. if `BotFrameworkAdapter.CreateConversationAsync()` is triggering an 'event' Activity and for some reason does not sets the From property.