### PR TITLE
Update LongIdAddTest to work with Azure Storage Library v9.4.2

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // These tests require Azure Storage Emulator v5.7
         [TestMethod]
-        [ExpectedException(typeof(AggregateException))]
+        [ExpectedException(typeof(StorageException))]
         public async Task LongIdAddTest()
         {
             var a = CreateActivity(0, 0, LongId);


### PR DESCRIPTION
Update LongIdAddTest expected exception to work with the new version of the Windows Azure Library v 9.4.2
![imagen](https://user-images.githubusercontent.com/27219455/50485301-8ecc1680-09d3-11e9-9e5f-eada8c735cfc.png)
