### PR TITLE
Token refresh revamping: rewriting client credential flow using ADAL.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -874,8 +874,8 @@ namespace Microsoft.Bot.Builder
             // NOTE: we can't do async operations inside of a AddOrUpdate, so we split access pattern
             string appPassword = await _credentialProvider.GetAppPasswordAsync(appId).ConfigureAwait(false);
             appCredentials = (_channelProvider != null && _channelProvider.IsGovernment()) ?
-                new MicrosoftGovernmentAppCredentials(appId, appPassword) :
-                new MicrosoftAppCredentials(appId, appPassword);
+                new MicrosoftGovernmentAppCredentials(appId, appPassword, _httpClient) :
+                new MicrosoftAppCredentials(appId, appPassword, _httpClient);
             _appCredentialMap[appId] = appCredentials;
             return appCredentials;
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    public class ThrottleException : Exception
+    {
+        public RetryParams RetryParams { get; set; }
+    }
+    
+    public class AdalAuthenticator 
+    {
+        // Our ADAL context. Acquires tokens and manages token caching for us.
+        private readonly AuthenticationContext authContext;
+
+        // Semaphore to control concurrency while refreshing tokens from ADAL.
+        // Whenever a token expires, we want only one request to retrieve a token. 
+        // Cached requests take less than 0.1 millisecond to resolve, so the semaphore doesn't hurt performance under load tests
+        // unless we have more than 10,000 requests per second, but in that case other things would break first.
+        private static Semaphore tokenRefreshSemaphore = new Semaphore(1, 1);
+        private static readonly TimeSpan SemaphoreTimeout = TimeSpan.FromSeconds(10);
+
+        // Depending on the responses we get from the service, we update a shared retry policy with the RetryAfter header
+        // from the HTTP 429 we receive.
+        // When everything seems to be OK, this retry policy will be empty.
+        // The reason for this is that if a request gets throttled, even if we wait to retry that, another thread will try again right away.
+        // With the shared retry policy, if a request gets throttled, we know that other threads have to wait as well.
+        // This variable is guarded by the authContextSemaphore semphore. Don't modify it outside of the semaphore scope.
+        private static volatile RetryParams currentRetryPolicy;
+
+        private readonly ClientCredential clientCredential;
+        private readonly IOAuthConfiguration oAuthConfig;
+
+        private const string msalTemporarilyUnavailable = "temporarily_unavailable";
+
+        public AdalAuthenticator(ClientCredential clientCredential, IOAuthConfiguration oAuthConfig)
+        {
+            this.oAuthConfig = oAuthConfig;
+            this.clientCredential = clientCredential ?? throw new ArgumentNullException(nameof(clientCredential));
+            this.authContext = new AuthenticationContext(oAuthConfig.Authority);
+        }
+
+        public async Task<AuthenticationResult> GetTokenAsync(bool forceRefresh = false)
+        {
+            return await Retry.Run(
+                task: () => AcquireTokenAsync(forceRefresh),
+                retryExceptionHandler: (ex, ct) => HandleAdalException(ex, ct)).ConfigureAwait(false);
+        }
+
+        private async Task<AuthenticationResult> AcquireTokenAsync(bool forceRefresh = false)
+        {
+            bool acquired = false;
+
+            if (forceRefresh)
+            {
+                authContext.TokenCache.Clear();
+            }
+
+            try
+            {
+                // The ADAL client team recommends limiting concurrency of calls. When the Token is in cache there is never 
+                // contention on this semaphore, but when tokens expire there is some. However, after measuring performance
+                // with and without the semaphore (and different configs for the semaphore), not limiting concurrency actually
+                // results in higher response times overall. Without the use of this semaphore calls to AcquireTokenAsync can take up
+                // to 5 seconds under high concurrency scenarios.
+                acquired = tokenRefreshSemaphore.WaitOne(SemaphoreTimeout);
+
+                // If we are allowed to enter the semaphore, acquire the token.
+                if (acquired)
+                {
+                    // Acquire token async using MSAL.NET
+                    // https://github.com/AzureAD/azure-activedirectory-library-for-dotnet
+                    // Given that this is a ClientCredential scenario, it will use the cache without the 
+                    // need to call AcquireTokenSilentAsync (which is only for user credentials).
+                    // Scenario details: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Client-credential-flows#it-uses-the-application-token-cache
+                    var res = await authContext.AcquireTokenAsync(oAuthConfig.Scope, this.clientCredential).ConfigureAwait(false);
+                    // This means we acquired a valid token successfully. We can make our retry policy null.
+                    // Note that the retry policy is set under the semaphore so no additional synchronization is needed.
+                    if (currentRetryPolicy != null)
+                    {
+                        currentRetryPolicy = null;
+                    }
+
+                    return res;
+                }
+                else
+                {
+                    // If the token is taken, it means that one thread is trying to acquire a token from the server.
+                    // If we already received information about how much to throttle, it will be in the currentRetryPolicy.
+                    // Use that to inform our next delay before trying.
+                    throw new ThrottleException() { RetryParams = currentRetryPolicy };
+                }
+            }
+            catch (Exception ex)
+            {
+                // If we are getting throttled, we set the retry policy according to the RetryAfter headers
+                // that we receive from the auth server.
+                // Note that the retry policy is set under the semaphore so no additional synchronization is needed.
+                if (IsAdalServiceUnavailable(ex))
+                {
+                    currentRetryPolicy = ComputeAdalRetry(ex);
+                }
+                throw ex;
+            }
+            finally
+            {
+                // Always release the semaphore if we acquired it.
+                if (acquired)
+                {
+                    tokenRefreshSemaphore.Release();
+                }
+            }
+        }
+
+        private RetryParams HandleAdalException(Exception ex, int currentRetryCount)
+        {
+            if (IsAdalServiceUnavailable(ex))
+            {
+                return ComputeAdalRetry(ex);
+            }
+            else if (ex is ThrottleException)
+            {
+                // This is an exception that we threw, with knowledge that 
+                // one of our threads is trying to acquire a token from the server
+                // Use the retry parameters recommended in the exception
+                ThrottleException throttlException = (ThrottleException)ex;
+                return throttlException.RetryParams ?? RetryParams.DefaultBackOff(currentRetryCount);
+            }
+            else
+            {
+                // We end up here is the exception is not an ADAL exception. An example, is under high traffic
+                // where we could have a timeout waiting to acquire a token, waiting on the semaphore.
+                // If we hit a timeout, we want to retry a reasonable number of times.
+                return RetryParams.DefaultBackOff(currentRetryCount);
+            }
+        }
+
+        private bool IsAdalServiceUnavailable(Exception ex)
+        {
+            AdalServiceException adalServiceException = ex as AdalServiceException;
+            if (adalServiceException == null)
+            {
+                return false;
+            }
+
+            // When the Service Token Server (STS) is too busy because of “too many requests”, 
+            // it returns an HTTP error 429
+            return adalServiceException.ErrorCode == msalTemporarilyUnavailable || adalServiceException.StatusCode == 429;
+        }
+
+        private RetryParams ComputeAdalRetry(Exception ex)
+        {
+            if (ex is AdalServiceException)
+            {
+                AdalServiceException adalServiceException = (AdalServiceException)ex;
+
+                // When the Service Token Server (STS) is too busy because of “too many requests”, 
+                // it returns an HTTP error 429 with a hint about when you can try again (Retry-After response field) as a delay in seconds
+                if (adalServiceException.ErrorCode == msalTemporarilyUnavailable || adalServiceException.StatusCode == 429)
+                {
+                    RetryConditionHeaderValue retryAfter = adalServiceException.Headers.RetryAfter;
+
+                    // Depending on the service, the recommended retry time may be in retryAfter.Delta or retryAfter.Date. Check both.
+                    if (retryAfter != null && retryAfter.Delta.HasValue)
+                    {
+                        return new RetryParams(retryAfter.Delta.Value);
+                    }
+                    else if (retryAfter != null && retryAfter.Date.HasValue)
+                    {
+                        return new RetryParams(retryAfter.Date.Value.Offset);
+                    }
+                    // We got a 429 but didn't get a specific back-off time. Use the default
+                    return RetryParams.DefaultBackOff(0);
+                }
+            }
+            return RetryParams.DefaultBackOff(0);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConstants.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// TO CHANNEL FROM BOT: Login URL
         /// </summary>
-        public const string ToChannelFromBotLoginUrl = "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token";
+        public const string ToChannelFromBotLoginUrl = "https://login.microsoftonline.com/botframework.com";
 
         /// <summary>
         /// TO CHANNEL FROM BOT: OAuth scope to request
         /// </summary>
-        public const string ToChannelFromBotOAuthScope = "https://api.botframework.com/.default";
+        public const string ToChannelFromBotOAuthScope = "https://api.botframework.com";
         
         /// <summary>
         /// TO BOT FROM CHANNEL: Token issuer

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentAuthenticationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentAuthenticationConstants.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// TO GOVERNMENT CHANNEL FROM BOT: Login URL
         /// </summary>
-        public const string ToChannelFromBotLoginUrl = "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/oauth2/v2.0/token";
+        public const string ToChannelFromBotLoginUrl = "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e";
 
         /// <summary>
         /// TO GOVERNMENT CHANNEL FROM BOT: OAuth scope to request
         /// </summary>
-        public const string ToChannelFromBotOAuthScope = "https://api.botframework.us/.default";
+        public const string ToChannelFromBotOAuthScope = "https://api.botframework.us";
 
         /// <summary>
         /// TO BOT FROM GOVERNMENT CHANNEL: Token issuer

--- a/libraries/Microsoft.Bot.Connector/Authentication/IOAuthConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/IOAuthConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// Configuration for OAuth client credential authentication.
+    /// </summary>
+    public interface IOAuthConfiguration
+    {
+        /// <summary>
+        /// OAuth Authority for authentication.
+        /// </summary>
+        string Authority { get; set; }
+
+        /// <summary>
+        /// OAuth scope for authentication.
+        /// </summary>
+        string Scope { get; set; }
+    }
+
+    public class OAuthConfiguration : IOAuthConfiguration
+    {
+        public string Authority { get; set; }
+        public string Scope { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -9,6 +9,7 @@ using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 
@@ -46,27 +47,9 @@ namespace Microsoft.Bot.Connector.Authentication
         };
 
         /// <summary>
-        /// A cache of the outstanding uncompleted or completed tasks for a given token, for ensuring that we never have more then 1 token request in flight
-        /// per token at a time.
+        /// Authenticator abstraction used to obtain tokens through the Client Credentials OAuth 2.0 flow
         /// </summary>
-        protected static readonly Dictionary<string, Task<OAuthResponse>> TokenTaskCache = new Dictionary<string, Task<OAuthResponse>>();
-
-        /// <summary>
-        /// The time at which we will next refresh each token.
-        /// </summary>
-        protected static readonly ConcurrentDictionary<string, DateTime> AutoRefreshTimes = new ConcurrentDictionary<string, DateTime>();
-
-        /// <summary>
-        /// A cache of the actual valid tokens, this is what is consumed 99.99% of the time regardless o whether there is a token refresh task in flight.
-        /// We refresh tokens on a schedule which is faster then their expiration, and if there is a network failure, we continue to use the good token from
-        /// the tokenCache while a new background refresh task gets scheduled.
-        /// </summary>
-        protected static readonly ConcurrentDictionary<string, OAuthResponse> TokenCache = new ConcurrentDictionary<string, OAuthResponse>();
-
-        /// <summary>
-        /// The actual key we use for the token cache.
-        /// </summary>
-        protected readonly string TokenCacheKey;
+        private readonly Lazy<AdalAuthenticator> authenticator;
 
         /// <summary>
         /// Creates a new instance of the <see cref="MicrosoftAppCredentials"/> class.
@@ -77,7 +60,12 @@ namespace Microsoft.Bot.Connector.Authentication
         {
             this.MicrosoftAppId = appId;
             this.MicrosoftAppPassword = password;
-            this.TokenCacheKey = $"{MicrosoftAppId}-cache";
+
+            authenticator = new Lazy<AdalAuthenticator>(() =>
+                new AdalAuthenticator(
+                    new ClientCredential(MicrosoftAppId, MicrosoftAppPassword),
+                    new OAuthConfiguration() { Authority = OAuthEndpoint, Scope = OAuthScope }),
+                LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
         /// <summary>
@@ -99,12 +87,6 @@ namespace Microsoft.Bot.Connector.Authentication
         /// Gets the OAuth scope to use.
         /// </summary>
         public virtual string OAuthScope { get { return AuthenticationConstants.ToChannelFromBotOAuthScope; } }
-
-
-        /// <summary>
-        /// The time window within which the token will be automatically updated.
-        /// </summary>
-        public static TimeSpan AutoTokenRefreshTimeSpan { get; set; } = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// Adds the host of service url to <see cref="MicrosoftAppCredentials"/> trusted hosts.
@@ -163,112 +145,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="forceRefresh">True to force a refresh of the token; or false to get
         /// a cached token if it exists.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        /// <remarks>If the task is successful, the result contains the access token string.
+        /// <remarks>If the task is successful, the result contains the access token string.</remarks>
         public async Task<string> GetTokenAsync(bool forceRefresh = false)
         {
-            Task<OAuthResponse> oAuthTokenTask = null;
-            OAuthResponse oAuthToken = null;
-
-            // get tokenTask from cache 
-            lock (TokenTaskCache)
-            {
-                // if we are being forced or don't have a token in our cache at all
-                if (forceRefresh || !TokenCache.TryGetValue(TokenCacheKey, out oAuthToken))
-                {
-                    // we will await this task, because we don't have a token and we need it
-                    oAuthTokenTask = _getCurrentTokenTask(forceRefresh: forceRefresh);
-                }
-                else
-                {
-                    // we have an oAuthToken
-                    // check to see if our token is expired 
-                    if (IsTokenExpired(oAuthToken))
-                    {
-                        // it is, we should await the current task (someone could have already asked for a new token)
-                        oAuthTokenTask = _getCurrentTokenTask(forceRefresh: false);
-
-                        // if the task is completed and is the expired token, then we need to force a new one 
-                        // (This happens if bot has been 100% idle past the expiration point)
-                        if (oAuthTokenTask.Status == TaskStatus.RanToCompletion && oAuthTokenTask.Result.access_token == oAuthToken.access_token)
-                        {
-                            oAuthTokenTask = _getCurrentTokenTask(forceRefresh: true);
-                        }
-                    }
-
-                    // always check the autorefresh
-                    CheckAutoRefreshToken();
-                }
-            }
-
-            // if we have an oAuthTokenTask then we need to await it
-            if (oAuthTokenTask != null)
-            {
-                oAuthToken = await oAuthTokenTask;
-                TokenCache[TokenCacheKey] = oAuthToken;
-            }
-
-            return oAuthToken?.access_token;
-        }
-
-        private void CheckAutoRefreshToken()
-        {
-            // get the current autorefreshTime for this key
-            DateTime refreshTime;
-            if (AutoRefreshTimes.TryGetValue(TokenCacheKey, out refreshTime))
-            {
-                // if we are past the refresh time
-                if (DateTime.UtcNow > refreshTime)
-                {
-                    // set new refresh time (this keeps only one outstanding refresh Task at a time)
-                    AutoRefreshTimes[TokenCacheKey] = DateTime.UtcNow + AutoTokenRefreshTimeSpan;
-
-                    // background task to refresh the token
-                    // NOTE: This is not awaited, but is observed with the ContinueWith() clause.  
-                    // It is gated by the AutoRefreshTimes[] array
-                    RefreshTokenAsync()
-                        .ContinueWith(task =>
-                        {
-                            // observe the background task and put in cache when done
-                            if (task.Status == TaskStatus.RanToCompletion)
-                            {
-                                // update the cache with completed task so all new requests will get it
-                                TokenTaskCache[TokenCacheKey] = task;
-                            }
-                            else
-                            {
-                                // it failed, shorten the refresh time for another task to try again in a 30s
-                                AutoRefreshTimes[TokenCacheKey] = DateTime.UtcNow + TimeSpan.FromSeconds(30);
-                            }
-                        });
-                }
-            }
-        }
-
-        private Task<OAuthResponse> _getCurrentTokenTask(bool forceRefresh)
-        {
-            Task<OAuthResponse> oAuthTokenTask;
-
-            // if there is not a task or we are forcing it
-            if (forceRefresh || TokenTaskCache.TryGetValue(TokenCacheKey, out oAuthTokenTask) == false)
-            {
-                // create it
-                oAuthTokenTask = RefreshTokenAsync();
-                TokenTaskCache[TokenCacheKey] = oAuthTokenTask;
-
-                // set initial refresh time
-                AutoRefreshTimes[TokenCacheKey] = DateTime.UtcNow + AutoTokenRefreshTimeSpan;
-            }
-            // if task is in faulted or canceled state then replace it with another attempt
-            else if (oAuthTokenTask.IsFaulted || oAuthTokenTask.IsCanceled)
-            {
-                oAuthTokenTask = RefreshTokenAsync();
-                TokenTaskCache[TokenCacheKey] = oAuthTokenTask;
-
-                // set initial refresh time
-                AutoRefreshTimes[TokenCacheKey] = DateTime.UtcNow + AutoTokenRefreshTimeSpan;
-            }
-
-            return oAuthTokenTask;
+            var token = await authenticator.Value.GetTokenAsync(forceRefresh).ConfigureAwait(false);
+            return token.AccessToken;
         }
 
         private bool ShouldSetToken(HttpRequestMessage request)
@@ -313,87 +194,5 @@ namespace Microsoft.Bot.Connector.Authentication
             {
             }
         }
-
-        private async Task<OAuthResponse> RefreshTokenAsync()
-        {
-            var content = new FormUrlEncodedContent(new Dictionary<string, string>()
-                {
-                    { "grant_type", "client_credentials" },
-                    { "client_id", MicrosoftAppId },
-                    { "client_secret", MicrosoftAppPassword },
-                    { "scope", OAuthScope }
-                });
-
-            using (var response = await DefaultHttpClient.PostAsync(OAuthEndpoint, content).ConfigureAwait(false))
-            {
-                string body = null;
-                try
-                {
-                    response.EnsureSuccessStatusCode();
-                    body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var oauthResponse = JsonConvert.DeserializeObject<OAuthResponse>(body);
-                    oauthResponse.expiration_time = DateTime.UtcNow.AddSeconds(oauthResponse.expires_in).Subtract(TimeSpan.FromSeconds(60));
-                    return oauthResponse;
-                }
-                catch (Exception error)
-                {
-                    throw new OAuthException(body ?? response.ReasonPhrase, error);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Has the token expired?  If so, then we await on every attempt to get a new token
-        /// </summary>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsTokenExpired(OAuthResponse token) 
-        {
-            return DateTime.UtcNow > token.expiration_time;
-        }
-
-        /// <summary>
-        /// has token reached half/life ? If so, we get more agressive about trying to refresh it in the background
-        /// </summary>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsTokenOld(OAuthResponse token)
-        {
-            var halfwayExpiration = (token.expiration_time - TimeSpan.FromSeconds(token.expires_in / 2));
-            return DateTime.UtcNow > halfwayExpiration;
-        }
-
-#pragma warning disable IDE1006
-        /// <summary>
-        /// Describes the structure of an OAuth access token response.
-        /// </summary>
-        /// <remarks>
-        /// Member variables to this class follow the RFC Naming conventions, rather than C# naming conventions. 
-        /// </remarks>
-        protected class OAuthResponse
-        {
-            /// <summary>
-            /// Gets or sets the type of token.
-            /// </summary>
-            public string token_type { get; set; }
-
-            /// <summary>
-            /// Gets or sets the time in seconds until the token expires.
-            /// </summary>
-            public int expires_in { get; set; }
-
-            /// <summary>
-            /// Gets or sets the access token string.
-            /// </summary>
-            public string access_token { get; set; }
-
-            /// <summary>
-            /// Gets or sets the time at which the token expires.
-            /// </summary>
-            public DateTime expiration_time { get; set; }
-        }
-#pragma warning restore IDE1006
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         public const string MicrosoftAppPasswordKey = "MicrosoftAppPassword";
 
-        private static readonly HttpClient DefaultHttpClient = new HttpClient();
-
         private static readonly IDictionary<string, DateTime> TrustedHostNames = new Dictionary<string, DateTime>()
         {
             // { "state.botframework.com", DateTime.MaxValue }, // deprecated state api
@@ -56,7 +54,8 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="appId">The Microsoft app ID.</param>
         /// <param name="password">The Microsoft app password.</param>
-        public MicrosoftAppCredentials(string appId, string password)
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        public MicrosoftAppCredentials(string appId, string password, HttpClient customHttpClient = null)
         {
             this.MicrosoftAppId = appId;
             this.MicrosoftAppPassword = password;
@@ -64,7 +63,8 @@ namespace Microsoft.Bot.Connector.Authentication
             authenticator = new Lazy<AdalAuthenticator>(() =>
                 new AdalAuthenticator(
                     new ClientCredential(MicrosoftAppId, MicrosoftAppPassword),
-                    new OAuthConfiguration() { Authority = OAuthEndpoint, Scope = OAuthScope }),
+                    new OAuthConfiguration() { Authority = OAuthEndpoint, Scope = OAuthScope },
+                    customHttpClient),
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
@@ -176,22 +176,6 @@ namespace Microsoft.Bot.Connector.Authentication
                     }
                 }
                 return false;
-            }
-        }
-
-        /// <summary>
-        /// Represents an OAuth exception.
-        /// </summary>
-        public sealed class OAuthException : Exception
-        {
-            /// <summary>
-            /// Creates a new instance of the <see cref="OAuthException"/> class.
-            /// </summary>
-            /// <param name="body">The OAuth response body or reason.</param>
-            /// <param name="inner">The exception thown during the OAuth request.</param>
-            public OAuthException(string body, Exception inner)
-                : base(body, inner)
-            {
             }
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftGovernmentAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftGovernmentAppCredentials.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -14,13 +15,14 @@ namespace Microsoft.Bot.Connector.Authentication
         /// An empty set of credentials.
         /// </summary>
         public static new readonly MicrosoftGovernmentAppCredentials Empty = new MicrosoftGovernmentAppCredentials(null, null);
-        
+
         /// <summary>
         /// Creates a new instance of the <see cref="MicrosoftGovernmentAppCredentials"/> class.
         /// </summary>
         /// <param name="appId">The Microsoft app ID.</param>
         /// <param name="password">The Microsoft app password.</param>
-        public MicrosoftGovernmentAppCredentials(string appId, string password) : base(appId, password)
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        public MicrosoftGovernmentAppCredentials(string appId, string password, HttpClient customHttpClient = null) : base(appId, password, customHttpClient)
         {
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/OAuthConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/OAuthConfiguration.cs
@@ -7,22 +7,16 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Configuration for OAuth client credential authentication.
     /// </summary>
-    public interface IOAuthConfiguration
+    public class OAuthConfiguration
     {
         /// <summary>
         /// OAuth Authority for authentication.
         /// </summary>
-        string Authority { get; set; }
+        public string Authority { get; set; }
 
         /// <summary>
         /// OAuth scope for authentication.
         /// </summary>
-        string Scope { get; set; }
-    }
-
-    public class OAuthConfiguration : IOAuthConfiguration
-    {
-        public string Authority { get; set; }
         public string Scope { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 if (retry.ShouldRetry)
                 {
                     currentRetryCount++;
-                    await Task.Delay(retry.RetryAfter.WithRandomNoise()).ConfigureAwait(false);
+                    await Task.Delay(retry.RetryAfter.WithJitter()).ConfigureAwait(false);
                 }
 
             } while (retry.ShouldRetry);
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Connector.Authentication
     {
         private static Random random = new Random();
 
-        public static TimeSpan WithRandomNoise(this TimeSpan delay, double multiplier = 0.1)
+        public static TimeSpan WithJitter(this TimeSpan delay, double multiplier = 0.1)
         {
             // Generate an uniform distribution between zero and 10% of the proposed delay and add it as 
             // random noise. The reason for this is that if there are multiple threads about to retry

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    public static class Retry
+    {
+        public static async Task<TResult> Run<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
+        {
+            RetryParams retry = RetryParams.StopRetrying;
+            List<Exception> exceptions = new List<Exception>();
+            int currentRetryCount = 0;
+
+            do
+            {
+                try
+                {
+                    return await task().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+
+                    retry = retryExceptionHandler(ex, currentRetryCount);
+                }
+
+                if (retry.ShouldRetry)
+                {
+                    currentRetryCount++;
+                    await Task.Delay(retry.RetryAfter.WithRandomNoise()).ConfigureAwait(false);
+                }
+
+            } while (retry.ShouldRetry);
+
+            throw new AggregateException("Failed to acquire token for client credentials.", exceptions);
+        }
+    }
+
+    public static class TimeSpanExtensions
+    {
+        private static Random random = new Random();
+
+        public static TimeSpan WithRandomNoise(this TimeSpan delay, double multiplier = 0.1)
+        {
+            // Generate an uniform distribution between zero and 10% of the proposed delay and add it as 
+            // random noise. The reason for this is that if there are multiple threads about to retry
+            // at the same time, it can overload the server again and trigger throttling again.
+            // By adding a bit of random noise, we distribute requests a across time.
+            return delay + TimeSpan.FromMilliseconds(random.NextDouble() * delay.TotalMilliseconds * 0.1);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/RetryParams.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/RetryParams.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    public class RetryParams
+    {
+        private const int maxRetries = 10;
+        private static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan DefaultBackOffTime = TimeSpan.FromMilliseconds(50);
+
+        public static RetryParams StopRetrying { get; } = new RetryParams() { ShouldRetry = false };
+
+        public bool ShouldRetry { get; set; }
+        public TimeSpan RetryAfter { get; set; }
+
+        public RetryParams() { }
+
+        public RetryParams(TimeSpan retryAfter, bool shouldRetry = true)
+        {
+            ShouldRetry = shouldRetry;
+            RetryAfter = retryAfter;
+
+            // We don't allow more than maxDelaySeconds seconds delay.
+            if (RetryAfter > MaxDelay)
+            {
+                // We don't want to throw here though - if the server asks for more delay
+                // than we are willing to, just enforce the upper bound for the delay 
+                RetryAfter = MaxDelay;
+            }
+        }
+
+        public static RetryParams DefaultBackOff(int retryCount)
+        {
+            if (retryCount < maxRetries)
+            {
+                return new RetryParams(DefaultBackOffTime);
+            }
+            else
+            {
+                return RetryParams.StopRetrying;
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -56,7 +56,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
+		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.1" />
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.13" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -56,6 +56,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.1" />
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.13" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Tests
         [Fact]
         public async Task TokenTests_GetCredentialsWorks()
         {
-            MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("12604f0f-bc92-4318-a6dd-aed704445ba4", "H_k}}7b75BEl+KY1");
+            MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("645cd89f-a83e-4af9-abb5-a454e917cbc4", "jvoMWRBA67:zjgePZ359_-_");
             var result = await credentials.GetTokenAsync();
             Assert.NotNull(result);
         }

--- a/tests/Microsoft.Bot.Connector.Tests/MicrosoftGovernmentAppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/MicrosoftGovernmentAppCredentialsTests.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Bot.Connector.Tests
         public void GovernmentAuthenticationConstants_ToChannelFromBotLoginUrl_IsRight()
         {
             // This value should not change
-            Assert.Equal("https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/oauth2/v2.0/token", GovernmentAuthenticationConstants.ToChannelFromBotLoginUrl);
+            Assert.Equal("https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e", GovernmentAuthenticationConstants.ToChannelFromBotLoginUrl);
         }
 
         [Fact]
         public void GovernmentAuthenticationConstants_ToChannelFromBotOAuthScope_IsRight()
         {
             // This value should not change
-            Assert.Equal("https://api.botframework.us/.default", GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope);
+            Assert.Equal("https://api.botframework.us", GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Connector.Tests/RetryParamsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/RetryParamsTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests
+{
+    public class RetryParamsTests
+    {
+        [Fact]
+        public void RetryParams_StopRetryingValidation()
+        {
+            RetryParams retryParams = RetryParams.StopRetrying;
+            Assert.False(retryParams.ShouldRetry);
+        }
+
+        [Fact]
+        public void RetryParams_DefaultBackOffShouldRetryOnFirstRetry()
+        {
+            RetryParams retryParams = RetryParams.DefaultBackOff(0);
+
+            // If this is the first time we retry, it should retry by default
+            Assert.True(retryParams.ShouldRetry);
+            Assert.Equal(TimeSpan.FromMilliseconds(50), retryParams.RetryAfter);
+        }
+
+        [Fact]
+        public void RetryParams_DefaultBackOffShouldNotRetryAfter5Retries()
+        {
+            RetryParams retryParams = RetryParams.DefaultBackOff(10);
+            Assert.False(retryParams.ShouldRetry);
+        }
+
+        [Fact]
+        public void RetryParams_DelayOutOfBounds()
+        {
+            RetryParams retryParams = new RetryParams(TimeSpan.FromSeconds(11), true);
+
+            // RetryParams should enforce the upper bound on delay time
+            Assert.Equal(TimeSpan.FromSeconds(10), retryParams.RetryAfter);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/RetryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/RetryTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests
+{
+    public class RetryTests
+    {
+        [Fact]
+        public async Task Retry_NoRetryWhenTaskSucceeds()
+        {
+            FaultyClass faultyClass = new FaultyClass()
+            {
+                ExceptionToThrow = null
+            };
+
+            var result = await Retry.Run(
+                task: () => faultyClass.FaultyTask(),
+                retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct));
+
+            Assert.Null(faultyClass.ExceptionReceived);
+            Assert.Equal(1, faultyClass.CallCount);
+        }
+
+        [Fact]
+        public async Task Retry_RetryThenSucceed()
+        {
+            FaultyClass faultyClass = new FaultyClass()
+            {
+                ExceptionToThrow = new ArgumentNullException(),
+                TriesUntilSuccess = 3
+            };
+
+            var result = await Retry.Run(
+                task: () => faultyClass.FaultyTask(),
+                retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct));
+
+            Assert.NotNull(faultyClass.ExceptionReceived);
+            Assert.Equal(3, faultyClass.CallCount);
+        }
+
+        [Fact]
+        public async Task Retry_RetryUntilFailure()
+        {
+            FaultyClass faultyClass = new FaultyClass()
+            {
+                ExceptionToThrow = new ArgumentNullException(),
+                TriesUntilSuccess = 12
+            };
+
+            await Assert.ThrowsAsync<AggregateException>(async () => 
+                await Retry.Run(
+                    task: () => faultyClass.FaultyTask(),
+                    retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct)));
+        }
+    }
+
+    public class FaultyClass
+    {
+        public Exception ExceptionToThrow { get; set; }
+        public Exception ExceptionReceived { get; set; } = null;
+        public int LatestRetryCount { get; set; }
+        public int CallCount { get; set; } = 0;
+        public int TriesUntilSuccess { get; set; } = 0;
+
+
+        public async Task<string> FaultyTask()
+        {
+            CallCount++;
+
+            if (CallCount < TriesUntilSuccess && ExceptionToThrow != null)
+            {
+                throw ExceptionToThrow;
+            }
+
+            return string.Empty;
+        }
+
+        public RetryParams ExceptionHandler(Exception ex, int currentRetryCount)
+        {
+            ExceptionReceived = ex;
+            LatestRetryCount = currentRetryCount;
+
+            return RetryParams.DefaultBackOff(currentRetryCount);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/SessionRecords/Connector.Tests.ConversationsTest/CreateDirectConversationAsyncWithValidData.json
+++ b/tests/Microsoft.Bot.Connector.Tests/SessionRecords/Connector.Tests.ConversationsTest/CreateDirectConversationAsyncWithValidData.json
@@ -1,0 +1,62 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/v3/conversations",
+      "EncodedRequestUri": "L3YzL2NvbnZlcnNhdGlvbnM=",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"bot\": {\r\n    \"id\": \"B21UTEF8S:T03CWQ0QB\"\r\n  },\r\n  \"members\": [\r\n    {\r\n      \"id\": \"U19KH8EHJ:T03CWQ0QB\"\r\n    }\r\n  ],\r\n  \"activity\": {\r\n    \"type\": \"message\",\r\n    \"from\": {\r\n      \"id\": \"B21UTEF8S:T03CWQ0QB\"\r\n    },\r\n    \"recipient\": {\r\n      \"id\": \"U19KH8EHJ:T03CWQ0QB\"\r\n    },\r\n    \"membersAdded\": [],\r\n    \"membersRemoved\": [],\r\n    \"reactionsAdded\": [],\r\n    \"reactionsRemoved\": [],\r\n    \"text\": \"TEST Create Conversation\",\r\n    \"attachments\": [],\r\n    \"entities\": []\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "486"
+        ],
+        "User-Agent": [
+          "FxVersion/4.7.2600.0",
+          "OSName/Windows10Enterprise",
+          "OSVersion/6.3.16299",
+          "Microsoft.Bot.Connector.ConnectorClient/0.0.0.0",
+          "Microsoft-BotFramework/4.0",
+          "(BotBuilder .Net/0.0.0.0)"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"activityId\": \"1516641076.000062\",\r\n  \"id\": \"B21UTEF8S:T03CWQ0QB:D2369CT7C\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "83"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Request-Context": [
+          "appId=cid-v1:6814484e-c0d5-40ea-9dba-74ff29ca4f62"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 22 Jan 2018 17:11:15 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {}
+}

--- a/tests/Microsoft.Bot.Connector.Tests/SessionRecords/Connector.Tests.ConversationsTest/CreateDirectConversationSyncWithValidData.json
+++ b/tests/Microsoft.Bot.Connector.Tests/SessionRecords/Connector.Tests.ConversationsTest/CreateDirectConversationSyncWithValidData.json
@@ -1,0 +1,62 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/v3/conversations",
+      "EncodedRequestUri": "L3YzL2NvbnZlcnNhdGlvbnM=",
+      "RequestMethod": "POST",
+      "RequestBody": "{\r\n  \"bot\": {\r\n    \"id\": \"B21UTEF8S:T03CWQ0QB\"\r\n  },\r\n  \"members\": [\r\n    {\r\n      \"id\": \"U19KH8EHJ:T03CWQ0QB\"\r\n    }\r\n  ],\r\n  \"activity\": {\r\n    \"type\": \"message\",\r\n    \"from\": {\r\n      \"id\": \"B21UTEF8S:T03CWQ0QB\"\r\n    },\r\n    \"recipient\": {\r\n      \"id\": \"U19KH8EHJ:T03CWQ0QB\"\r\n    },\r\n    \"membersAdded\": [],\r\n    \"membersRemoved\": [],\r\n    \"reactionsAdded\": [],\r\n    \"reactionsRemoved\": [],\r\n    \"text\": \"TEST Create Conversation\",\r\n    \"attachments\": [],\r\n    \"entities\": []\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "486"
+        ],
+        "User-Agent": [
+          "FxVersion/4.7.2600.0",
+          "OSName/Windows10Enterprise",
+          "OSVersion/6.3.16299",
+          "Microsoft.Bot.Connector.ConnectorClient/0.0.0.0",
+          "Microsoft-BotFramework/4.0",
+          "(BotBuilder .Net/0.0.0.0)"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"activityId\": \"1516641076.000062\",\r\n  \"id\": \"B21UTEF8S:T03CWQ0QB:D2369CT7C\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "83"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Request-Context": [
+          "appId=cid-v1:6814484e-c0d5-40ea-9dba-74ff29ca4f62"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Mon, 22 Jan 2018 17:11:15 GMT"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {}
+}


### PR DESCRIPTION
Revamping the token acquisition code that obtains a token given the bot App id and password. This is an effective execution of the OAuth client credentials flow, which is supported by the ADAL dotnet library.

Some implementation details and considerations below to complement the source changes:

*Token cache:* We use ADAL built-in token cache. Given that Adal handles much of the token caching nowadays, we consider it better to leverage ADAL library implementation, leaving less responsibilities in our code. However, after working with the ADAL team we are still responsible for maintaining low concurrency (done through semaphores in this case) and retrying, using the retry after headers received from AAD when we get HttpStatusCode 429. 

*Testing:* We ran long haul load test, in addition to mini-load tests and unit tests. We were able to reproduce token renewal under extremely high load, and even though there were failures, these were retried and ZERO threads ended up without a token. The longest delay observed in our load test was 600 ms, which happened for a total of 40 requests, then going back to 1 millisecond when reading from cache.

*Verifying assumptions* Even though the ADAL team recommended limiting concurrency, we removed the semaphore and re-ran the load tests. These results were extremely bad, with latencies up to 5 seconds and multiple failures, confirming ADAL teams' recommendation.

*Next steps*: We would like to eventually expose the token cache to users so they can provide durable token caches (this is supported by adal). This scenario is awesome for horizontal scaling scenarios where multiple instances share perhaps a redis cache for example.

*Coming soon: MSAL library*: The ADAL team is working on the MSAL library, which will take care of the concurrency control as well. Eventually we'll move to that. GA for MSAL is coming soon.