### PR TITLE
Fix: Can pass QnAMakerOptions into both constructor and QnAMaker.GetAnswersAsync() w/o unintentional overwrite

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Bot.Builder.AI.QnA
         private readonly QnAMakerEndpoint _endpoint;
         private readonly QnAMakerOptions _options;
 
+        private readonly bool _isLegacyProtocol;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="QnAMaker"/> class.
         /// </summary>
@@ -58,37 +60,11 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 throw new ArgumentException(nameof(endpoint.EndpointKey));
             }
 
+            _isLegacyProtocol = _endpoint.Host.EndsWith("v2.0") || _endpoint.Host.EndsWith("v3.0");
+
             _options = options ?? new QnAMakerOptions();
 
-            if (_options.ScoreThreshold == 0)
-            {
-                _options.ScoreThreshold = 0.3F;
-            }
-
-            if (_options.Top == 0)
-            {
-                _options.Top = 1;
-            }
-
-            if (_options.ScoreThreshold < 0 || _options.ScoreThreshold > 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(_options.ScoreThreshold), "Score threshold should be a value between 0 and 1");
-            }
-
-            if (_options.Top < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(_options.Top), "Top should be an integer greater than 0");
-            }
-
-            if (_options.StrictFilters == null)
-            {
-                _options.StrictFilters = new Metadata[] { };
-            }
-
-            if (_options.MetadataBoost == null)
-            {
-                _options.MetadataBoost = new Metadata[] { };
-            }
+            ValidateOptions(_options);
         }
 
         /// <summary>
@@ -107,9 +83,9 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// Generates an answer from the knowledge base.
         /// </summary>
         /// <param name="turnContext">The Turn Context that contains the user question to be queried against your knowledge base.</param>
-        /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
+        /// <param name="queryOptions">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
-        public async Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options = null)
+        public async Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions queryOptions = null)
         {
             if (turnContext == null)
             {
@@ -120,13 +96,6 @@ namespace Microsoft.Bot.Builder.AI.QnA
             {
                 throw new ArgumentNullException(nameof(turnContext.Activity));
             }
-
-            if (options == null)
-            {
-                options = _options;
-            }
-
-            ValidateOptions(options);
 
             var messageActivity = turnContext.Activity.AsMessageActivity();
             if (messageActivity == null)
@@ -139,102 +108,49 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 throw new ArgumentException("Null or empty text");
             }
 
-            var requestUrl = $"{_endpoint.Host}/knowledgebases/{_endpoint.KnowledgeBaseId}/generateanswer";
+            var options = HydrateOptions(queryOptions);
+            ValidateOptions(options);
 
-            var request = new HttpRequestMessage(HttpMethod.Post, requestUrl);
+            var result = await QueryQnaServiceAsync((Activity)messageActivity, options).ConfigureAwait(false);
 
-            var jsonRequest = JsonConvert.SerializeObject(
-                new
-                {
-                    question = messageActivity.Text,
-                    top = options.Top,
-                    strictFilters = options.StrictFilters,
-                    metadataBoost = options.MetadataBoost,
-                }, Formatting.None);
-
-            request.Content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
-
-            var isLegacyProtocol = _endpoint.Host.EndsWith("v2.0") || _endpoint.Host.EndsWith("v3.0");
-
-            if (isLegacyProtocol)
-            {
-                request.Headers.Add("Ocp-Apim-Subscription-Key", _endpoint.EndpointKey);
-            }
-            else
-            {
-                request.Headers.Add("Authorization", $"EndpointKey {_endpoint.EndpointKey}");
-            }
-
-            AddUserAgent(request);
-
-            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
-            {
-                return null;
-            }
-
-            var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-            var results = isLegacyProtocol ?
-                ConvertLegacyResults(JsonConvert.DeserializeObject<InternalQueryResults>(jsonResponse))
-                    :
-                JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
-
-            foreach (var answer in results.Answers)
-            {
-                answer.Score = answer.Score / 100;
-            }
-
-            var result = results.Answers.Where(answer => answer.Score > options.ScoreThreshold).ToArray();
-
-            var traceInfo = new QnAMakerTraceInfo
-            {
-                Message = (Activity)messageActivity,
-                QueryResults = result,
-                KnowledgeBaseId = _endpoint.KnowledgeBaseId,
-                ScoreThreshold = options.ScoreThreshold,
-                Top = options.Top,
-                StrictFilters = options.StrictFilters,
-                MetadataBoost = options.MetadataBoost,
-            };
-            var traceActivity = Activity.CreateTraceActivity(QnAMakerName, QnAMakerTraceType, traceInfo, QnAMakerTraceLabel);
-            await turnContext.SendActivityAsync(traceActivity).ConfigureAwait(false);
+            await EmitTraceInfoAsync(turnContext, (Activity)messageActivity, result, options).ConfigureAwait(false);
 
             return result;
         }
 
-        private void AddUserAgent(HttpRequestMessage request)
+        /// <summary>
+        /// Combines QnAMakerOptions passed into the QnAMaker constructor with the options passed as arguments into GetAnswersAsync().
+        /// </summary>
+        /// <param name="queryOptions">The options for the QnA Maker knowledge base.</param>
+        private QnAMakerOptions HydrateOptions(QnAMakerOptions queryOptions)
         {
-            // Bot Builder Package name and version
-            var assemblyName = this.GetType().Assembly.GetName();
-            request.Headers.UserAgent.Add(new ProductInfoHeaderValue(assemblyName.Name, assemblyName.Version.ToString()));
+            var hydratedOptions = _options;
 
-            // Platform information: OS and language runtime
-            var framework = Assembly
-                .GetEntryAssembly()?
-                .GetCustomAttribute<TargetFrameworkAttribute>()?
-                .FrameworkName;
-            var comment = $"({Environment.OSVersion.VersionString};{framework})";
-            request.Headers.UserAgent.Add(new ProductInfoHeaderValue(comment));
+            if (queryOptions != null)
+            {
+                if (HasScoreThresholdQueryOption(hydratedOptions, queryOptions))
+                {
+                    hydratedOptions.ScoreThreshold = queryOptions.ScoreThreshold;
+                }
+
+                if (HasTopQueryOption(hydratedOptions, queryOptions))
+                {
+                    hydratedOptions.Top = queryOptions.Top;
+                }
+
+                if (HasStrictFiltersQueryOption(queryOptions))
+                {
+                   hydratedOptions.StrictFilters = queryOptions.StrictFilters;
+                }
+
+                if (HasMetadataBoostQueryOption(queryOptions))
+                {
+                   hydratedOptions.MetadataBoost = queryOptions.MetadataBoost;
+                }
+            }
+
+            return hydratedOptions;
         }
-
-        // The old version of the protocol returns the id in a field called qnaId the
-        // following classes and helper function translate this old structure
-        private QueryResults ConvertLegacyResults(InternalQueryResults legacyResults) => new QueryResults
-        {
-            Answers = legacyResults.Answers
-                    .Select(answer => new QueryResult
-                    {
-                        // The old version of the protocol returns the "id" in a field called "qnaId"
-                        Id = answer.QnaId,
-                        Answer = answer.Answer,
-                        Metadata = answer.Metadata,
-                        Score = answer.Score,
-                        Source = answer.Source,
-                        Questions = answer.Questions,
-                    })
-                    .ToArray(),
-        };
 
         private void ValidateOptions(QnAMakerOptions options)
         {
@@ -268,6 +184,140 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 options.MetadataBoost = new Metadata[] { };
             }
         }
+
+        private async Task<QueryResult[]> QueryQnaServiceAsync(Activity messageActivity, QnAMakerOptions options)
+        {
+            var request = BuildRequest(messageActivity, options);
+
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            var result = await FormatQnaResultAsync(response, options).ConfigureAwait(false);
+
+            return result;
+        }
+
+        private async Task EmitTraceInfoAsync(ITurnContext turnContext, Activity messageActivity, QueryResult[] result, QnAMakerOptions options)
+        {
+            var traceInfo = new QnAMakerTraceInfo
+            {
+                Message = (Activity)messageActivity,
+                QueryResults = result,
+                KnowledgeBaseId = _endpoint.KnowledgeBaseId,
+                ScoreThreshold = options.ScoreThreshold,
+                Top = options.Top,
+                StrictFilters = options.StrictFilters,
+                MetadataBoost = options.MetadataBoost,
+            };
+            var traceActivity = Activity.CreateTraceActivity(QnAMakerName, QnAMakerTraceType, traceInfo, QnAMakerTraceLabel);
+            await turnContext.SendActivityAsync(traceActivity).ConfigureAwait(false);
+        }
+
+        private HttpRequestMessage BuildRequest(Activity messageActivity, QnAMakerOptions options)
+        {
+            var requestUrl = $"{_endpoint.Host}/knowledgebases/{_endpoint.KnowledgeBaseId}/generateanswer";
+
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUrl);
+
+            var jsonRequest = JsonConvert.SerializeObject(
+                new
+                {
+                    question = messageActivity.Text,
+                    top = options.Top,
+                    strictFilters = options.StrictFilters,
+                    metadataBoost = options.MetadataBoost,
+                    scoreThreshold = options.ScoreThreshold,
+                }, Formatting.None);
+
+            request.Content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
+
+            SetHeaders(request);
+
+            return request;
+        }
+
+        private async Task<QueryResult[]> FormatQnaResultAsync(HttpResponseMessage response, QnAMakerOptions options)
+        {
+            var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            var results = _isLegacyProtocol ?
+                ConvertLegacyResults(JsonConvert.DeserializeObject<InternalQueryResults>(jsonResponse))
+                    :
+                JsonConvert.DeserializeObject<QueryResults>(jsonResponse);
+
+            foreach (var answer in results.Answers)
+            {
+                answer.Score = answer.Score / 100;
+            }
+
+            var result = results.Answers.Where(answer => answer.Score > options.ScoreThreshold).ToArray();
+
+            return result;
+        }
+
+        private void SetHeaders(HttpRequestMessage request)
+        {
+            if (_isLegacyProtocol)
+            {
+                request.Headers.Add("Ocp-Apim-Subscription-Key", _endpoint.EndpointKey);
+            }
+            else
+            {
+                request.Headers.Add("Authorization", $"EndpointKey {_endpoint.EndpointKey}");
+            }
+
+            AddUserAgent(request);
+        }
+
+        private void AddUserAgent(HttpRequestMessage request)
+        {
+            // Bot Builder Package name and version
+            var assemblyName = this.GetType().Assembly.GetName();
+            request.Headers.UserAgent.Add(new ProductInfoHeaderValue(assemblyName.Name, assemblyName.Version.ToString()));
+
+            // Platform information: OS and language runtime
+            var framework = Assembly
+                .GetEntryAssembly()
+                .GetCustomAttribute<TargetFrameworkAttribute>()?
+                .FrameworkName;
+            var comment = $"({Environment.OSVersion.VersionString};{framework})";
+            request.Headers.UserAgent.Add(new ProductInfoHeaderValue(comment));
+        }
+
+        // The old version of the protocol returns the id in a field called qnaId the
+        // following classes and helper function translate this old structure
+        // This method can consume results from v3.0 of QnA API, but not v2.0.
+        private QueryResults ConvertLegacyResults(InternalQueryResults legacyResults) => new QueryResults
+        {
+            Answers = legacyResults.Answers
+                    .Select(answer => new QueryResult
+                    {
+                        // The old version of the protocol returns the "id" in a field called "qnaId"
+                        Id = answer.QnaId,
+                        Answer = answer.Answer,
+                        Metadata = answer.Metadata,
+                        Score = answer.Score,
+                        Source = answer.Source,
+                        Questions = answer.Questions,
+                    })
+                    .ToArray(),
+        };
+
+        private bool HasScoreThresholdQueryOption(QnAMakerOptions serviceOptions, QnAMakerOptions queryOptions) =>
+            queryOptions.ScoreThreshold != serviceOptions.ScoreThreshold
+            && queryOptions.ScoreThreshold != 0;
+
+        private bool HasTopQueryOption(QnAMakerOptions serviceOptions, QnAMakerOptions queryOptions) =>
+            queryOptions.Top != serviceOptions.Top
+            && queryOptions.Top != 0;
+
+        private bool HasStrictFiltersQueryOption(QnAMakerOptions queryOptions) => queryOptions.StrictFilters?.Length > 0;
+
+        private bool HasMetadataBoostQueryOption(QnAMakerOptions queryOptions) => queryOptions.MetadataBoost?.Length > 0;
 
         private class InternalQueryResult : QueryResult
         {

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
-                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer.json"));
+                .Respond("application/json", GetResponse("QnaMaker_UsesStrictFilters_ToReturnAnswer.json"));
 
             var interceptHttp = new InterceptRequestHandler(mockHttp);
 
@@ -292,12 +292,42 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.IsNotNull(results);
             Assert.AreEqual(results.Length, 1, "should get one result");
             StringAssert.StartsWith(results[0].Answer, "BaseCamp: You can use a damp rag to clean around the Power Pack");
+            Assert.AreEqual("topic", results[0].Metadata[0].Name);
+            Assert.AreEqual("value", results[0].Metadata[0].Value);
 
             // verify we are actually passing on the options
             var obj = JObject.Parse(interceptHttp.Content);
             Assert.AreEqual(1, obj["top"].Value<int>());
             Assert.AreEqual("topic", obj["strictFilters"][0]["name"].Value<string>());
             Assert.AreEqual("value", obj["strictFilters"][0]["value"].Value<string>());
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_SetScoreThresholdWhenThresholdIsZero()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer.json"));
+            
+            var qnaWithZeroValueThreshold = GetQnAMaker(mockHttp,
+                new QnAMakerEndpoint
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = _hostname
+                },
+                new QnAMakerOptions()
+                {
+                    ScoreThreshold = 0.0F
+                });
+            
+            var results = await qnaWithZeroValueThreshold
+                .GetAnswersAsync(GetContext("how do I clean the stove?"), new QnAMakerOptions() { Top = 1 });
+            
+            Assert.IsNotNull(results);
+            Assert.AreEqual(1, results.Length);
         }
 
         [TestMethod]
@@ -331,20 +361,45 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public void QnaMaker_Test_ScoreThreshold_OutOfRange()
+        public void QnaMaker_Test_ScoreThresholdTooLarge_OutOfRange()
         {
-            var qna = new QnAMaker(
-                new QnAMakerEndpoint
-                {
-                    KnowledgeBaseId = _knowlegeBaseId,
-                    EndpointKey = _endpointKey,
-                    Host = _hostname
-                },
-                new QnAMakerOptions
-                {
-                    Top = 1,
-                    ScoreThreshold = 1.1F
-                });
+            var endpoint = new QnAMakerEndpoint
+            {
+                KnowledgeBaseId = _knowlegeBaseId,
+                EndpointKey = _endpointKey,
+                Host = _hostname
+            };
+
+            var tooLargeThreshold = new QnAMakerOptions
+            {
+                ScoreThreshold = 1.1F,
+                Top = 1
+            };
+
+            var qnaWithLargeThreshold = new QnAMaker(endpoint, tooLargeThreshold);
+
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void QnaMaker_Test_ScoreThresholdTooSmall_OutOfRange()
+        {
+            var endpoint = new QnAMakerEndpoint
+            {
+                KnowledgeBaseId = _knowlegeBaseId,
+                EndpointKey = _endpointKey,
+                Host = _hostname
+            };
+
+            var tooSmallThreshold = new QnAMakerOptions
+            {
+                ScoreThreshold = -9000.0F,
+                Top = 1
+            };
+
+            var qnaWithSmallThreshold = new QnAMaker(endpoint, tooSmallThreshold);
         }
 
         [TestMethod]
@@ -365,6 +420,54 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
                     Top = -1,
                     ScoreThreshold = 0.5F
                 });
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void QnaMaker_Test_Endpoint_EmptyKbId()
+        {
+            var qnaNullEndpoint = new QnAMaker(
+                new QnAMakerEndpoint()
+                {
+                    KnowledgeBaseId = "",
+                    EndpointKey = _endpointKey,
+                    Host = _hostname
+                }
+            );
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void QnaMaker_Test_Endpoint_EmptyEndpointKey()
+        {
+            var qnaNullEndpoint = new QnAMaker(
+                new QnAMakerEndpoint()
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = "",
+                    Host = _hostname
+                }
+            );
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void QnaMaker_Test_Endpoint_EmptyHost()
+        {
+            var qnaNullEndpoint = new QnAMaker(
+                new QnAMakerEndpoint()
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = ""
+                }
+            );
         }
 
         [TestMethod]
@@ -400,10 +503,132 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.IsTrue(interceptHttp.UserAgent.Contains("Microsoft.Bot.Builder.AI.QnA/4"));
         }
 
-        private string GetRequestUrl()
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_V3LegacyEndpoint_ConvertsToHaveIdPropertyInResult()
         {
-            return $"{_hostname}/knowledgebases/{_knowlegeBaseId}/generateanswer";
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetV3LegacyRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_LegacyEndpointAnswer.json"));
+            
+            var v3LegacyEndpoint = new QnAMakerEndpoint
+            {
+                KnowledgeBaseId = _knowlegeBaseId,
+                EndpointKey = _endpointKey,
+                Host = $"{_hostname}/v3.0"
+            };
+
+            var v3Qna = GetQnAMaker(mockHttp, v3LegacyEndpoint);
+            
+            var v3legacyResult = await v3Qna.GetAnswersAsync(GetContext("How do I be the best?"));
+
+            Assert.IsNotNull(v3legacyResult);
+            Assert.IsTrue(v3legacyResult[0]?.Id != null);
         }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_ReturnsAnswerWithMetadataBoost()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswersWithMetadataBoost.json"));
+
+            var interceptHttp = new InterceptRequestHandler(mockHttp);
+
+            var qna = GetQnAMaker(
+                interceptHttp,
+                new QnAMakerEndpoint
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = _hostname
+                });
+            
+            var options = new QnAMakerOptions
+            {
+                MetadataBoost = new Metadata[]
+                {
+                    new Metadata() { Name = "artist", Value = "drake" }
+                },
+                Top = 1
+            };
+
+            var results = await qna.GetAnswersAsync(GetContext("who loves me?"), options);
+            
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Length, 1, "should get one result");
+            StringAssert.StartsWith(results[0].Answer, "Kiki");
+
+
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_TestThresholdInQueryOption()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer_GivenScoreThresholdQueryOption.json"));
+            
+            var interceptHttp = new InterceptRequestHandler(mockHttp);
+
+            var qna = GetQnAMaker(
+                interceptHttp, 
+                new QnAMakerEndpoint()
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = _hostname
+                });
+            
+            var queryOptionsWithScoreThreshold = new QnAMakerOptions()
+            {
+                ScoreThreshold = 0.5F,
+                Top = 2
+            };
+
+            var result = await qna.GetAnswersAsync(
+                    GetContext("What happens when you hug a porcupine?"), 
+                    queryOptionsWithScoreThreshold
+            );
+
+            Assert.IsNotNull(result);
+
+            var obj = JObject.Parse(interceptHttp.Content);
+            Assert.AreEqual(2, obj["top"].Value<int>());
+            Assert.AreEqual(0.5F, obj["scoreThreshold"].Value<float>());
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
+        public async Task QnaMaker_Test_UnsuccessfulResponse()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetRequestUrl())
+                .Respond(System.Net.HttpStatusCode.BadGateway);
+            
+            var qna = GetQnAMaker(
+                mockHttp,
+                new QnAMakerEndpoint()
+                {
+                    KnowledgeBaseId = _knowlegeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = _hostname
+                });
+            
+            var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"));
+
+            Assert.IsNull(results);
+        }        
+
+        private string GetV3LegacyRequestUrl() => $"{_hostname}/v3.0/knowledgebases/{_knowlegeBaseId}/generateanswer";
+
+        private string GetRequestUrl() => $"{_hostname}/knowledgebases/{_knowlegeBaseId}/generateanswer";
 
         private Stream GetResponse(string fileName)
         {

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_LegacyEndpointAnswer.json
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_LegacyEndpointAnswer.json
@@ -1,0 +1,13 @@
+{
+    "answers": [
+        {
+            "score": 30.500827898,
+            "qnaId": 18,
+            "answer": "To be the very best, you gotta catch 'em all",
+            "source": "Custom Editorial",
+            "questions": [
+                "How do I be the best?"
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_ReturnsAnswer_GivenScoreThresholdQueryOption.json
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_ReturnsAnswer_GivenScoreThresholdQueryOption.json
@@ -1,0 +1,19 @@
+{
+    "answers": [
+      {
+        "score": 68.54820341616869,
+        "Id": 22,
+        "answer": "Why do you ask?",
+        "source": "Custom Editorial",
+        "questions": [
+          "what happens when you hug a procupine?"
+        ],
+        "metadata": [
+          {
+            "name": "animal",
+            "value": "procupine"
+          }
+        ]
+      }
+    ]
+  }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_ReturnsAnswersWithMetadataBoost.json
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_ReturnsAnswersWithMetadataBoost.json
@@ -1,0 +1,19 @@
+{
+    "answers": [
+        {
+            "questions": [
+                "Who loves me?"
+            ],
+            "answer": "Kiki",
+            "score": 100,
+            "id": 29,
+            "source": "Editorial",
+            "metadata": [
+                {
+                    "name": "artist",
+                    "value": "drake"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_UsesStrictFilters_ToReturnAnswer.json
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/TestData/QnaMaker_UsesStrictFilters_ToReturnAnswer.json
@@ -1,0 +1,19 @@
+{
+    "answers": [
+        {
+            "questions": [
+                "how do I clean the stove?"
+            ],
+            "answer": "BaseCamp: You can use a damp rag to clean around the Power Pack",
+            "score": 100,
+            "id": 5,
+            "source": "Editorial",
+            "metadata": [
+                {
+                    "name": "topic",
+                    "value": "value"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #1239, #1286 

## Description
* Can pass `QnAMakerOptions` into `QnAMaker` constructor and `QnAMaker.GetAnswersAsync()` without accidentally overwriting the options passed into the constructor
* Refactored code to make changes similar to the ones in https://github.com/Microsoft/botbuilder-js/pull/704 that cleans up QnAMaker readability on the js side, to keep with parity
* Replaced repeated code in constructor with `ValidateOptions()` (DRY)

## Specific Changes
* Can pass `QnAMakerOptions` into `QnAMaker` constructor and `QnAMaker.GetAnswersAsync()` without accidentally overwriting the options passed into the constructor
   * Added private method `HydrateOptions()` to combine options passed into the constructor and `GetAnswersAsync()` call
  * for example if I specified in the constructor `ScoreThreshold = 0.5F` and in `GetAnswersAsync()` I provide an addition option that I want `Top = 3` results, your options in the request to the `QnAMaker` service will specify both `ScoreThreshold = 0.5F` and `Top = 3` 
  * previously the behavior is that it would overwrite constructor-passed `ScoreThreshold = 0.5F` to default `ScoreThreshold = 0.3F` and take only the `GetAnswersAsync()` option  


* Exercised clean coding practice of abstracting lower-level detailed processes into helper functions to make code more expressive/readable. See below for functions
  * `GetAnswersAsync()`: `HydrateOptions()`, `QueryQnaServiceAsync()`, `EmitTraceInfoAsync()`
    * `QueryQnaServiceAsync()`: `BuildRequest()`, `FormatQnaResultAsync()`
      * `BuildRequest()`: `SetHeaders()`