### PR TITLE
Fixed state-dependant / order dependant bug in transcript tests

### DIFF
--- a/specs/BotBuilderOpenSourcePlans.md
+++ b/specs/BotBuilderOpenSourcePlans.md
@@ -9,7 +9,7 @@ The BotBuilder SDK is an open-source project on GitHub that aspires to:
 * Leverage existing best-practices wherever they are found. 
 * Keep all platform implementations of the BotBuilder in Sync.
 
-## Non-Goals:
+## Non-Goals
 * TBD
 
 # Exemplar Projects


### PR DESCRIPTION
Fixes #1297

The Transcript Tests that were failing were doing so when tests were ran in parallel or in a different order. The relevant tests had state dependencies as they were doing "counting" validation. 

If a different test ran first and stored data, that data would cause a subsequent test to fail. 

Note: The only machine we've seen this on is my home machine (latest VS, latest emulator). 