### PR TITLE
Don't warn about docs during standard debug builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,9 @@
     <NoWarn>$(NoWarn);SA0001</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration) == 'Debug - NuGet Packages'">
+    <!-- For debug Nuget builds, we don't generate documentation. Supress the StyleCop rule that warns about this. -->
+    <NoWarn>$(NoWarn);SA0001</NoWarn>
+
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,10 @@
     -->
     <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration) == 'Debug'">
+    <!-- For debug builds, we don't generate documentation. Supress the StyleCop rule that warns about this. -->
+    <NoWarn>$(NoWarn);SA0001</NoWarn>
+  </PropertyGroup>
   <PropertyGroup Condition="$(Configuration) == 'Debug - NuGet Packages'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
Debug builds - which are the norm - don't build docs. This is done to make the builds go faster. 

The PR suppresses those warnings. 