### PR TITLE
Move Code Coverage to an explicit include model

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -7,12 +7,20 @@
         <Configuration>
           <CodeCoverage>
             <ModulePaths>
-              <Exclude>
-                <ModulePath>.*moq.dll</ModulePath>
-                <ModulePath>.*tests.dll</ModulePath>
-                <ModulePath>.*Microsoft.Azure.Storage.*</ModulePath>
-                <ModulePath>.*fluentassertions.dll</ModulePath>
-              </Exclude>
+              <Include>
+                <ModulePath>.*\Microsoft.Bot.Builder.AI.Luis.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.AI.QnA.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Integration.AspNet.Core.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.ApplicationInsights.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Azure.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Dialogs.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.TemplateManager.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Configuration.dll</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Connector.dll</ModulePath>
+                <!-- <ModulePath>Microsoft.Bot.Builder.Schema.dll</ModulePath> -->
+              </Include>
             </ModulePaths>
           </CodeCoverage>
         </Configuration>
@@ -20,3 +28,4 @@
     </DataCollectors>
   </DataCollectionRunSettings>
 </RunSettings>
+

--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -8,18 +8,18 @@
           <CodeCoverage>
             <ModulePaths>
               <Include>
-                <ModulePath>.*\Microsoft.Bot.Builder.AI.Luis.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.AI.QnA.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.Integration.AspNet.Core.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.ApplicationInsights.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.Azure.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.Dialogs.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.TemplateManager.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.Configuration.dll</ModulePath>
-                <ModulePath>.*\Microsoft.Bot.Builder.Connector.dll</ModulePath>
-                <!-- <ModulePath>Microsoft.Bot.Builder.Schema.dll</ModulePath> -->
+                <ModulePath>.*\Microsoft.Bot.Builder.AI.Luis.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.AI.QnA.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Integration.AspNet.Core.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.ApplicationInsights.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Azure.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Dialogs.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.TemplateManager.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Configuration.dll$</ModulePath>
+                <ModulePath>.*\Microsoft.Bot.Builder.Connector.dll$</ModulePath>
+                <!-- <ModulePath>Microsoft.Bot.Builder.Schema.dll$</ModulePath> -->
               </Include>
             </ModulePaths>
           </CodeCoverage>


### PR DESCRIPTION
Update the runsettings file to be explicit about only including certain DLL's. 

Note that the auto-generated project (.schema) is NOT in this list. 

It's my belief that we're testing quite a few DLLs now that we don't mean to, and moving to an include model should provide more accurate results. 