### PR TITLE
Change 15-hour timeout to 15 minutes (#1307)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -52,8 +52,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         private const string PersistedState = "state";
         private const string PersistedExpires = "expires";
 
-            // Default prompt timeout of 15 minutes (in ms)
-        private const int DefaultPromptTimeout = 54000000;
+        // Default prompt timeout of 15 minutes (in ms)
+        private const int DefaultPromptTimeout = 900000;
 
         // regex to check if code supplied is a 6 digit numerical code (hence, a magic code).
         private readonly Regex _magicCodeRegex = new Regex(@"(\d{6})");


### PR DESCRIPTION
This pull request changes the default timeout in OAuthPrompt.cs from 54000000 (15 hours in milliseconds)  to 900000 (15 minutes in milliseconds).

Fixes https://github.com/Microsoft/botbuilder-dotnet/issues/1307