### PR TITLE
Fix method signature to eliminate warning

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
@@ -90,11 +90,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
-        public Task WaterfallWithStepsNull()
+        public void WaterfallWithStepsNull()
         {
             var waterfall = new WaterfallDialog("test");
-            waterfall.AddStep(null);
-            return Task.CompletedTask;
+            waterfall.AddStep(null);            
         }
 
         [TestMethod]


### PR DESCRIPTION
The signature on the WaterfallWithStepsNull was incorrect and resulting in a warning.