### PR TITLE
Bug fixes for OAuthCard & Teams, and Task.Run

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                                 {
                                     Title = _settings.Title,
                                     Value = link,
-                                    Type = ActionTypes.Signin,
+                                    Type = turnContext.Activity.ChannelId == "msteams" ? ActionTypes.OpenUrl : ActionTypes.Signin,
                                 },
                             },
                         },

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -776,7 +776,9 @@ namespace Microsoft.Bot.Builder
             if (OAuthClient.EmulateOAuthCards)
             {
                 var oauthClient = new OAuthClient(client, turnContext.Activity.ServiceUrl);
-                Task.Run(async () => await oauthClient.SendEmulateOAuthCardsAsync(OAuthClient.EmulateOAuthCards).ConfigureAwait(false)).Wait();
+
+                // do not await task - we want this to run in the background
+                var task = Task.Run(() => oauthClient.SendEmulateOAuthCardsAsync(OAuthClient.EmulateOAuthCards));
                 return oauthClient;
             }
 


### PR DESCRIPTION
Address these two issues:

https://github.com/Microsoft/botbuilder-dotnet/issues/1236
...Use OpenUrl for'msteams' SignIn card instead of SignIn CardAction

https://github.com/Microsoft/botbuilder-dotnet/issues/1273
...Properly run the task in the background