### PR TITLE
change accessor to return null not throw with no factory

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Bot.Builder
                     // ask for default value from factory
                     if (defaultValueFactory == null)
                     {
-                        throw new MissingMemberException("Property not set and no default provided.");
+                        return default(T);
                     }
 
                     var result = defaultValueFactory();

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
@@ -151,7 +151,6 @@ namespace Microsoft.Bot.Builder.Tests
 
         [TestMethod,
          Description("Cannot get a string with no default set")]
-        [ExpectedException(typeof(MissingMemberException), "Get on unset member should throw MissingMemberException")]
         public async Task State_GetNoLoadNoDefault()
         {
             // Arrange
@@ -162,51 +161,61 @@ namespace Microsoft.Bot.Builder.Tests
             // Act
             var propertyA = userState.CreateProperty<string>("propertyA");
             var valueA = await propertyA.GetAsync(context);
+
+            // Assert
+            Assert.IsNull(valueA);
         }
 
         [TestMethod,
          Description("Cannot get a POCO with no default set")]
-        [ExpectedException(typeof(MissingMemberException), "Get on unset member should throw MissingMemberException")]
         public async Task State_POCO_NoDefault()
         {
+            // Arrange
             var dictionary = new Dictionary<string, JObject>();
             var userState = new UserState(new MemoryStorage(dictionary));
             var context = TestUtilities.CreateEmptyContext();
 
+            // Act
             var testProperty = userState.CreateProperty<TestPocoState>("test");
-
             var value = await testProperty.GetAsync(context);
+
+            // Assert
+            Assert.IsNull(value);
         }
 
 
         [TestMethod,
          Description("Cannot get a bool with no default set")]
-        [ExpectedException(typeof(MissingMemberException), "Get on unset member should throw MissingMemberException")]
         public async Task State_bool_NoDefault()
         {
+            // Arange
             var dictionary = new Dictionary<string, JObject>();
             var userState = new UserState(new MemoryStorage(dictionary));
             var context = TestUtilities.CreateEmptyContext();
 
+            // Act
             var testProperty = userState.CreateProperty<bool>("test");
-
             var value = await testProperty.GetAsync(context);
-            Assert.IsFalse(value);
 
+            // Assert
+            Assert.IsFalse(value);
         }
 
         [TestMethod,
          Description("Cannot get a int with no default set")]
-        [ExpectedException(typeof(MissingMemberException), "Get on unset member should throw MissingMemberException")]
         public async Task State_int_NoDefault()
         {
+            // Arrange
             var dictionary = new Dictionary<string, JObject>();
             var userState = new UserState(new MemoryStorage(dictionary));
             var context = TestUtilities.CreateEmptyContext();
 
+            // Act
             var testProperty = userState.CreateProperty<int>("test");
             var value = await testProperty.GetAsync(context);
 
+            // Assert
+            Assert.AreEqual(0, value);
         }
 
 


### PR DESCRIPTION
fixes #1191 

Note this is actually a change of behavior - but it is closer to the JavaScript.

Not exactly the same because JavaScript has the notion of undefined - and null is not the same. This is particularly evident if the accessor model is being used to access raw properties - as is done in the unit tests.

As the conversation in the issue suggests, its very hard to imagine this being used in this way out side of the immediate context of the dialog system where currently it must be passed in. And as other issues have covered, even in that context it is only ever used in a one particular way (as a ref and so only Get is called.)

And the change is safe for the usage in the Dialog system.


