### PR TITLE
Prevent Cortana from trying to use suggested actions in prompts (#1173)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -29,12 +29,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
             // Determine list style
             var supportsSuggestedActions = Channel.SupportsSuggestedActions(channelId, list.Count);
-            var supportsCardActions = Channel.SupportsCardActions(channelId, list.Count);
             var maxActionTitleLength = Channel.MaxActionTitleLength(channelId);
-            var hasMessageFeed = Channel.HasMessageFeed(channelId);
             var longTitles = maxTitleLength > maxActionTitleLength;
 
-            if (!longTitles && (supportsSuggestedActions || (!hasMessageFeed && supportsCardActions)))
+            if (!longTitles && supportsSuggestedActions)
             {
                 // We always prefer showing choices using suggested actions. If the titles are too long, however,
                 // we'll have to show them as a text list.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Connector;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
@@ -13,6 +14,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     public class ChoiceFactoryTests
     {
         private static List<Choice> colorChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue") };
+        private static List<Choice> extraChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue"), new Choice("alpha") };
 
         [TestMethod]
         public void ShouldRenderChoicesInline()
@@ -56,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [TestMethod]
         public void ShouldAutomaticallyChooseRenderStyleBasedOnChannelType()
         {
-            var activity = ChoiceFactory.ForChannel("emulator", colorChoices, "select from:");
+            var activity = ChoiceFactory.ForChannel(Channels.Emulator, colorChoices, "select from:");
             Assert.AreEqual("select from:", activity.Text);
             Assert.IsNotNull(activity.SuggestedActions);
             Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
@@ -69,6 +71,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual("imBack", activity.SuggestedActions.Actions[2].Type);
             Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Value);
             Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Title);
+        }
+
+        [TestMethod]
+        public void ShouldChooseCorrectStylesForCortana()
+        {
+            var activity = ChoiceFactory.ForChannel(Channels.Cortana, colorChoices, "select from:");
+            Assert.AreEqual("select from: (1) red, (2) green, or (3) blue", activity.Text);
+            Assert.IsNull(activity.SuggestedActions);
+
+            activity = ChoiceFactory.ForChannel(Channels.Cortana, extraChoices, "select from:");
+            Assert.AreEqual("select from:\n\n   1. red\n   2. green\n   3. blue\n   4. alpha", activity.Text);
+            Assert.IsNull(activity.SuggestedActions);
         }
     }
 }


### PR DESCRIPTION
I have modified ChoiceFactory.cs by removing `hasMessageFeed` and `supportsCardActions` from the `if` condition so that now a channel _must_ support suggested actions in order for the SDK to automatically select them as the list style. I have also deleted those local variables for cleanliness since they aren't being used anywhere else.

Fixes #1173 