### PR TITLE
Supress NU1701 for the Azure Project

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -22,6 +22,21 @@
 	<PropertyGroup>
 	  <CodeAnalysisRuleSet>Microsoft.Bot.Builder.Azure.ruleset</CodeAnalysisRuleSet>
 	</PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- The KeyVault package, picked up as a transitive dependency of the Azure Storage libraries 
+        doesn't yet support NetStandard20. I confirmed with the Azure Storage team that this warning
+        is fine, and can be supressed. 
+        
+        It does appear the Azure SDK team is "in-process" of supporting NetStandard20 as seen in this
+        Commit: https://github.com/Azure/azure-sdk-for-net/commit/b0d42d14bfe92a24996826b2487ba592e644f581
+        
+        We cannot apply the no-warn supression directly to the package links below as 
+        they're not picked up across transitive dependencies. See this GitHub Issue for details:
+        https://github.com/NuGet/Home/issues/5740
+        -->
+    <NoWarn>NU1701</NoWarn>
+  </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />


### PR DESCRIPTION
The KeyVault.Core package ( [GitHub Repo here](https://github.com/Azure/azure-sdk-for-net/tree/master/src/SDKs/KeyVault/data-plane) ), picked up as a transitive dependency of the Azure Storage libraries doesn't yet support NetStandard20. I confirmed with the Azure Storage team that this warning is fine, and can be supressed. 

> [12:20 PM] Keith Farmer
> So, our only dependency on that is the definitions of two interfaces, which are stable.  Not the implementation.  The warning should be ignorable in that case.
      
It does appear the Azure SDK team is "in-process" of supporting NetStandard20 as seen in [this Commit](https://github.com/Azure/azure-sdk-for-net/commit/b0d42d14bfe92a24996826b2487ba592e644f581).
        
We cannot apply the no-warn suppression directly to the package links below as they're not picked up across transitive dependencies. See [this GitHub Issue](https://github.com/NuGet/Home/issues/5740) for details.
