### PR TITLE
Added new HeroCard prompt style for ChoicePrompt as per #1170

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -172,6 +172,30 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             return MessageFactory.SuggestedActions(actions, text, speak, InputHints.ExpectingInput);
         }
 
+        public static IMessageActivity HeroCard(IList<Choice> choices, string text = null, string speak = null)
+        {
+            choices = choices ?? new List<Choice>();
+
+            var actions = new List<CardAction>();
+            foreach (var choice in choices)
+            {
+                actions.Add(new CardAction
+                {
+                    Type = ActionTypes.ImBack,
+                    Title = choice.Value,
+                    Value = choice.Value
+                });
+            }
+
+            var attachments = new List<Attachment>
+            {
+                new HeroCard(text: text, buttons: actions).ToAttachment()
+            };
+
+            // Return activity with choices as HeroCard with buttons
+            return MessageFactory.Attachment(attachments, null, speak, InputHints.ExpectingInput);
+        }
+
         public static IList<Choice> ToChoices(IList<string> choices)
         {
             return (choices == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ListStyle.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ListStyle.cs
@@ -33,5 +33,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// Add choices to prompt as suggested actions.
         /// </summary>
         SuggestedAction,
+
+        /// <summary>
+        /// Add choices to prompt as a HeroCard with buttons.
+        /// </summary>
+        HeroCard,
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Choices;
@@ -152,6 +153,10 @@ namespace Microsoft.Bot.Builder.Dialogs
                     msg = ChoiceFactory.SuggestedAction(choices, text);
                     break;
 
+                case ListStyle.HeroCard:
+                    msg = ChoiceFactory.HeroCard(choices, text);
+                    break;
+
                 case ListStyle.None:
                     msg = Activity.CreateMessageActivity();
                     msg.Text = text;
@@ -162,16 +167,22 @@ namespace Microsoft.Bot.Builder.Dialogs
                     break;
             }
 
-            // Update prompt with text and actions
+            // Update prompt with text, actions and attachments
             if (prompt != null)
             {
                 // clone the prompt the set in the options (note ActivityEx has Properties so this is the safest mechanism)
                 prompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt));
 
                 prompt.Text = msg.Text;
+
                 if (msg.SuggestedActions != null && msg.SuggestedActions.Actions != null && msg.SuggestedActions.Actions.Count > 0)
                 {
                     prompt.SuggestedActions = msg.SuggestedActions;
+                }
+
+                if (msg.Attachments != null && msg.Attachments.Any())
+                {
+                    prompt.Attachments = msg.Attachments;
                 }
 
                 return prompt;


### PR DESCRIPTION
This is to provide support (other than plain text) for channels that do not support suggested actions, such as Teams. Test added. 