### PR TITLE
Update NuGet Package authoring attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ To use the daily builds, which are published to MyGet, please follow the instruc
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.LUIS.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.LUIS.csproj
@@ -23,7 +23,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
@@ -23,7 +23,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Builder.ApplicationInsights/Microsoft.Bot.Builder.ApplicationInsights.csproj
+++ b/libraries/Microsoft.Bot.Builder.ApplicationInsights/Microsoft.Bot.Builder.ApplicationInsights.csproj
@@ -24,7 +24,7 @@
 
   <PropertyGroup>
     <Company>Microsoft</Company>
-    <Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+    <Authors>Microsoft</Authors>
     <Product>Microsoft Bot Builder SDK</Product>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -22,7 +22,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -24,7 +24,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.csproj
+++ b/libraries/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<Version Condition=" '$(PackageVersion)' == '' ">4.0.0-local</Version>
@@ -24,7 +24,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -28,7 +28,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
     <Company>Microsoft</Company>
-    <Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+    <Authors>Microsoft</Authors>
     <Product>Microsoft Bot Builder SDK</Product>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -23,7 +23,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Connector</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
+++ b/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Version Condition=" '$(PackageVersion)' == '' ">4.0.0-local</Version>
 		<Version Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</Version>
@@ -23,7 +23,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Framework</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -24,7 +24,7 @@
 
   <PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
@@ -23,7 +23,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -24,7 +24,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
@@ -24,7 +24,7 @@
 
 	<PropertyGroup>
 		<Company>Microsoft</Company>
-		<Authors>microsoft,BotFramework,nugetbotbuilder</Authors>
+		<Authors>Microsoft</Authors>
 		<Product>Microsoft Bot Builder SDK</Product>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>


### PR DESCRIPTION
This PR, against the 4.2 branch, updates the "Author" attribute of every nuget package. 

Per [the rules](https://aka.ms/Microsoft-NuGet-Compliance), which recently seem to have changed, our author attribute is incorrect. This is causing Nuget to reject all of our package pushes:

```
Pushing Microsoft.Bot.Builder.4.2.1.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  BadRequest https://www.nuget.org/api/v2/package/ 1591ms
Response status code does not indicate success: 400 (The package is not compliant with metadata requirements for Microsoft packages on NuGet.org. Go to https://aka.ms/Microsoft-NuGet-Compliance for more information. Policy violations: The package metadata is missing required author 'Microsoft'.).
```
This PR cleans up the 4.2 branch, so that we can cut 4.2.2 and attempt to publish. Once this is validated, Master is next.

Interestingly, the [V3 SDK has this correct](https://github.com/Microsoft/BotBuilder-V3/blob/8dcc75a73325f40fefccf0705df7565e705fed92/CSharp/Library/Microsoft.Bot.Builder/Microsoft.Bot.Builder.nuspec#L6). 