### PR TITLE
QnAMaker class now throws NotSupportedException for legacy v2.0 of qn…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -60,7 +60,12 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 throw new ArgumentException(nameof(endpoint.EndpointKey));
             }
 
-            _isLegacyProtocol = _endpoint.Host.EndsWith("v2.0") || _endpoint.Host.EndsWith("v3.0");
+            if (_endpoint.Host.EndsWith("v2.0"))
+            {
+                throw new NotSupportedException("v2.0 of QnA Maker service is no longer supported in the Bot Framework. Please upgrade your QnA Maker service at www.qnamaker.ai.");
+            }
+
+            _isLegacyProtocol = _endpoint.Host.EndsWith("v3.0");
 
             _options = options ?? new QnAMakerOptions();
 

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -506,6 +506,31 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
+        [ExpectedException(typeof(NotSupportedException))]
+        public async Task QnaMaker_V2LegacyEndpoint_ConvertsToHaveIdPropertyInResult()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetV2LegacyRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_LegacyEndpointAnswer.json"));
+            
+            var v2LegacyEndpoint = new QnAMakerEndpoint
+            {
+                KnowledgeBaseId = _knowlegeBaseId,
+                EndpointKey = _endpointKey,
+                Host = $"{_hostname}/v2.0"
+            };
+
+            var v2Qna = GetQnAMaker(mockHttp, v2LegacyEndpoint);
+            
+            var v2legacyResult = await v2Qna.GetAnswersAsync(GetContext("How do I be the best?"));
+
+            Assert.IsNotNull(v2legacyResult);
+            Assert.IsTrue(v2legacyResult[0]?.Id != null);
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
         public async Task QnaMaker_V3LegacyEndpoint_ConvertsToHaveIdPropertyInResult()
         {
             var mockHttp = new MockHttpMessageHandler();
@@ -625,6 +650,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"));
         }        
 
+        private string GetV2LegacyRequestUrl() => $"{_hostname}/v2.0/knowledgebases/{_knowlegeBaseId}/generateanswer";
         private string GetV3LegacyRequestUrl() => $"{_hostname}/v3.0/knowledgebases/{_knowlegeBaseId}/generateanswer";
 
         private string GetRequestUrl() => $"{_hostname}/knowledgebases/{_knowlegeBaseId}/generateanswer";


### PR DESCRIPTION
Fixes #1285 

## Description
Will inform user that Legacy QnA Maker `v2.0` is no longer supported by throwing `NotSupportedException`

## Specific Changes
* `QnAMaker` class constructor now checks if legacy `v2.0` QnA host is used.
  * if yes, throws `NotSupportedException`
* `_isLegacyProtocol` now is only set to true if the QnA service host is `v3.0`, and no longer checks for `v2.0`