### PR TITLE
Fix a few things regarding choices and actions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         public string Value { get; set; }
 
         /// <summary>
-        /// Gets or sets the action to use when rendering the choice as a suggested action. This is optional.
+        /// Gets or sets the action to use when rendering the choice as a suggested action or hero card.
+        /// This is optional.
         /// </summary>
         /// <value>
-        /// The action to use when rendering the choice as a suggested action.
+        /// The action to use when rendering the choice as a suggested action or hero card.
         /// </value>
         public CardAction Action { get; set; }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -154,10 +154,36 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
         public static IMessageActivity SuggestedAction(IList<Choice> choices, string text = null, string speak = null)
         {
+            // Return activity with choices as suggested actions
+            return MessageFactory.SuggestedActions(ExtractActions(choices), text, speak, InputHints.ExpectingInput);
+        }
+
+        public static IMessageActivity HeroCard(IList<Choice> choices, string text = null, string speak = null)
+        {
+            var attachments = new List<Attachment>
+            {
+                new HeroCard(text: text, buttons: ExtractActions(choices)).ToAttachment(),
+            };
+
+            // Return activity with choices as HeroCard with buttons
+            return MessageFactory.Attachment(attachments, null, speak, InputHints.ExpectingInput);
+        }
+
+        public static IList<Choice> ToChoices(IList<string> choices)
+        {
+            return (choices == null)
+                    ?
+                new List<Choice>()
+                    :
+                choices.Select(choice => new Choice { Value = choice }).ToList();
+        }
+
+        private static List<CardAction> ExtractActions(IList<Choice> choices)
+        {
             choices = choices ?? new List<Choice>();
 
             // Map choices to actions
-            var actions = choices.Select((choice) =>
+            return choices.Select((choice) =>
             {
                 if (choice.Action != null)
                 {
@@ -173,42 +199,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                     };
                 }
             }).ToList();
-
-            // Return activity with choices as suggested actions
-            return MessageFactory.SuggestedActions(actions, text, speak, InputHints.ExpectingInput);
-        }
-
-        public static IMessageActivity HeroCard(IList<Choice> choices, string text = null, string speak = null)
-        {
-            choices = choices ?? new List<Choice>();
-
-            var actions = new List<CardAction>();
-            foreach (var choice in choices)
-            {
-                actions.Add(new CardAction
-                {
-                    Type = ActionTypes.ImBack,
-                    Title = choice.Value,
-                    Value = choice.Value
-                });
-            }
-
-            var attachments = new List<Attachment>
-            {
-                new HeroCard(text: text, buttons: actions).ToAttachment()
-            };
-
-            // Return activity with choices as HeroCard with buttons
-            return MessageFactory.Attachment(attachments, null, speak, InputHints.ExpectingInput);
-        }
-
-        public static IList<Choice> ToChoices(IList<string> choices)
-        {
-            return (choices == null)
-                    ?
-                new List<Choice>()
-                    :
-                choices.Select(choice => new Choice { Value = choice }).ToList();
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -17,6 +17,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     {
         private static List<Choice> colorChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue") };
         private static List<Choice> extraChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue"), new Choice("alpha") };
+        private static List<Choice> choicesWithActions = new List<Choice>
+        {
+            new Choice("ImBack") { Action = new CardAction(ActionTypes.ImBack, "ImBack Action", value: "ImBack Value") },
+            new Choice("MessageBack") { Action = new CardAction(ActionTypes.MessageBack, "MessageBack Action", value: "MessageBack Value") },
+            new Choice("PostBack") { Action = new CardAction(ActionTypes.PostBack, "PostBack Action", value: "PostBack Value") },
+        };
 
         [TestMethod]
         public void ShouldRenderChoicesInline()
@@ -46,15 +52,36 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual("select from:", activity.Text);
             Assert.IsNotNull(activity.SuggestedActions);
             Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
-            Assert.AreEqual("imBack", activity.SuggestedActions.Actions[0].Type);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
             Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Value);
             Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Title);
-            Assert.AreEqual("imBack", activity.SuggestedActions.Actions[1].Type);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
             Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Value);
             Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Title);
-            Assert.AreEqual("imBack", activity.SuggestedActions.Actions[2].Type);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
             Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Value);
             Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Title);
+        }
+
+        [TestMethod]
+        public void ShouldRenderChoicesAsHeroCard()
+        {
+            var activity = ChoiceFactory.HeroCard(colorChoices, "select from:");
+
+            Assert.IsNotNull(activity.Attachments);
+
+            var heroCard = (HeroCard)activity.Attachments.First().Content;
+
+            Assert.AreEqual(3, heroCard.Buttons.Count);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
+            Assert.AreEqual("red", heroCard.Buttons[0].Value);
+            Assert.AreEqual("red", heroCard.Buttons[0].Title);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[1].Type);
+            Assert.AreEqual("green", heroCard.Buttons[1].Value);
+            Assert.AreEqual("green", heroCard.Buttons[1].Title);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[2].Type);
+            Assert.AreEqual("blue", heroCard.Buttons[2].Value);
+            Assert.AreEqual("blue", heroCard.Buttons[2].Title);
         }
 
         [TestMethod]
@@ -64,13 +91,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual("select from:", activity.Text);
             Assert.IsNotNull(activity.SuggestedActions);
             Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
-            Assert.AreEqual("imBack", activity.SuggestedActions.Actions[0].Type);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
             Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Value);
             Assert.AreEqual("red", activity.SuggestedActions.Actions[0].Title);
-            Assert.AreEqual("imBack", activity.SuggestedActions.Actions[1].Type);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
             Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Value);
             Assert.AreEqual("green", activity.SuggestedActions.Actions[1].Title);
-            Assert.AreEqual("imBack", activity.SuggestedActions.Actions[2].Type);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
             Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Value);
             Assert.AreEqual("blue", activity.SuggestedActions.Actions[2].Title);
         }
@@ -85,13 +112,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var heroCard = (HeroCard)activity.Attachments.First().Content;
 
             Assert.AreEqual(3, heroCard.Buttons.Count);
-            Assert.AreEqual("imBack", heroCard.Buttons[0].Type);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
             Assert.AreEqual("red", heroCard.Buttons[0].Value);
             Assert.AreEqual("red", heroCard.Buttons[0].Title);
-            Assert.AreEqual("imBack", heroCard.Buttons[1].Type);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[1].Type);
             Assert.AreEqual("green", heroCard.Buttons[1].Value);
             Assert.AreEqual("green", heroCard.Buttons[1].Title);
-            Assert.AreEqual("imBack", heroCard.Buttons[2].Type);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[2].Type);
             Assert.AreEqual("blue", heroCard.Buttons[2].Value);
             Assert.AreEqual("blue", heroCard.Buttons[2].Title);
         }
@@ -106,15 +133,54 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var heroCard = (HeroCard)activity.Attachments.First().Content;
 
             Assert.AreEqual(3, heroCard.Buttons.Count);
-            Assert.AreEqual("imBack", heroCard.Buttons[0].Type);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
             Assert.AreEqual("red", heroCard.Buttons[0].Value);
             Assert.AreEqual("red", heroCard.Buttons[0].Title);
-            Assert.AreEqual("imBack", heroCard.Buttons[1].Type);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[1].Type);
             Assert.AreEqual("green", heroCard.Buttons[1].Value);
             Assert.AreEqual("green", heroCard.Buttons[1].Title);
-            Assert.AreEqual("imBack", heroCard.Buttons[2].Type);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[2].Type);
             Assert.AreEqual("blue", heroCard.Buttons[2].Value);
             Assert.AreEqual("blue", heroCard.Buttons[2].Title);
+        }
+
+        [TestMethod]
+        public void ShouldIncludeChoiceActionsInSuggestedActions()
+        {
+            var activity = ChoiceFactory.SuggestedAction(choicesWithActions, "select from:");
+            Assert.AreEqual("select from:", activity.Text);
+            Assert.IsNotNull(activity.SuggestedActions);
+            Assert.AreEqual(3, activity.SuggestedActions.Actions.Count);
+            Assert.AreEqual(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
+            Assert.AreEqual("ImBack Value", activity.SuggestedActions.Actions[0].Value);
+            Assert.AreEqual("ImBack Action", activity.SuggestedActions.Actions[0].Title);
+            Assert.AreEqual(ActionTypes.MessageBack, activity.SuggestedActions.Actions[1].Type);
+            Assert.AreEqual("MessageBack Value", activity.SuggestedActions.Actions[1].Value);
+            Assert.AreEqual("MessageBack Action", activity.SuggestedActions.Actions[1].Title);
+            Assert.AreEqual(ActionTypes.PostBack, activity.SuggestedActions.Actions[2].Type);
+            Assert.AreEqual("PostBack Value", activity.SuggestedActions.Actions[2].Value);
+            Assert.AreEqual("PostBack Action", activity.SuggestedActions.Actions[2].Title);
+        }
+
+        [TestMethod]
+        public void ShouldIncludeChoiceActionsInHeroCards()
+        {
+            var activity = ChoiceFactory.HeroCard(choicesWithActions, "select from:");
+
+            Assert.IsNotNull(activity.Attachments);
+
+            var heroCard = (HeroCard)activity.Attachments.First().Content;
+
+            Assert.AreEqual(3, heroCard.Buttons.Count);
+            Assert.AreEqual(ActionTypes.ImBack, heroCard.Buttons[0].Type);
+            Assert.AreEqual("ImBack Value", heroCard.Buttons[0].Value);
+            Assert.AreEqual("ImBack Action", heroCard.Buttons[0].Title);
+            Assert.AreEqual(ActionTypes.MessageBack, heroCard.Buttons[1].Type);
+            Assert.AreEqual("MessageBack Value", heroCard.Buttons[1].Value);
+            Assert.AreEqual("MessageBack Action", heroCard.Buttons[1].Title);
+            Assert.AreEqual(ActionTypes.PostBack, heroCard.Buttons[2].Type);
+            Assert.AreEqual("PostBack Value", heroCard.Buttons[2].Value);
+            Assert.AreEqual("PostBack Action", heroCard.Buttons[2].Title);
         }
     }
 }


### PR DESCRIPTION
- Modify ChoiceFactory.HeroCard to incorporate each choice's Action property the way ChoiceFactory.SuggestedAction does
- Centralize that functionality in a shared method
- Update the Choice.Action doc comment to reflect that
- Add tests in ChoiceFactoryTests to account for actions in hero cards and suggested actions
- Add basic test for ChoiceFactory.HeroCard that was missing

This is meant to piggyback on garypretty's recent PR since I noticed `Choice.Action` wasn't incorporated into `ChoiceFactory.HeroCard`: https://github.com/Microsoft/botbuilder-dotnet/pull/1339