### PR TITLE
Update LUIS to new (Azure) C# SDK

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.LUIS.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.LUIS.csproj
@@ -23,13 +23,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime" Version="2.0.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime" Version="2.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.13" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TestData/Typed.json
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TestData/Typed.json
@@ -990,6 +990,7 @@
     "sentimentAnalysis": {
       "label": "neutral",
       "score": 0.5
-    }
+    },
+    "connectedServiceResult": null
   }
 }

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TestData/TypedPrebuilt.json
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TestData/TypedPrebuilt.json
@@ -171,6 +171,7 @@
     "sentimentAnalysis": {
       "label": "neutral",
       "score": 0.5
-    }
+    },
+    "connectedServiceResult": null
   }
 }


### PR DESCRIPTION
- Update to new revision of Azure SDK
- New Azure SDK enables downstream feature for Dispatch
- "connectedServiceResult" is a new property that will land in the existing (marshaled) luisResult that lives in properties.
- ConnectedServiceResult is the underlying service-specific Luis result 
- This was requested by Darren for Enterprise and Virtual Assistant features.

In conjunction with nodejs: https://github.com/Microsoft/botbuilder-js/pull/766