### PR TITLE
Added in Max key length checking on Storage Keys

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -771,7 +771,7 @@ namespace Microsoft.Bot.Builder
             }
 
             var connectorClient = turnContext.TurnState.Get<IConnectorClient>();
-            if(connectorClient == null)
+            if (connectorClient == null)
             {
                 throw new InvalidOperationException("An IConnectorClient is required in TurnState for this operation.");
             }

--- a/tests/Microsoft.Bot.Builder.Tests/ConversationStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ConversationStateTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 

--- a/tests/Microsoft.Bot.Builder.Tests/ConversationStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ConversationStateTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    [TestClass]
+    [TestCategory("State Management")]
+    public class ConversationStateTests
+    {
+        private class TestConversationState : ConversationState
+        {
+            public TestConversationState(IStorage storage)
+                : base(storage)
+            {
+            }
+
+            public TestConversationState(IStorage storage, int maxKeyLength)
+                : base(storage, maxKeyLength) 
+            {                
+            }
+
+            // This makes the GetStorageKey method public, so it's easier to test. 
+            public string GetKey(ITurnContext turnContext) =>GetStorageKey(turnContext);
+        }
+
+
+        [TestMethod]        
+        public void KeyLengthValidation()
+        {
+            var dictionary = new Dictionary<string, JObject>();
+            var state = new ConversationState(new MemoryStorage(dictionary));
+            Assert.AreEqual(254, state.MaxKeyLength, "Incorrect default key length");
+
+            var state100 = new ConversationState(new MemoryStorage(dictionary), 100);
+            Assert.AreEqual(100, state100.MaxKeyLength, "Key length must be 100");
+
+            var state500 = new ConversationState(new MemoryStorage(dictionary), 500);
+            Assert.AreEqual(500, state500.MaxKeyLength, "Key length must be 500");
+        }
+
+        [TestMethod]        
+        public void KeyInRange()
+        {
+            var dictionary = new Dictionary<string, JObject>();
+            var state = new TestConversationState(new MemoryStorage(dictionary));
+
+            var context = TestUtilities.CreateEmptyContext();
+            var key1 = state.GetKey(context);
+
+            Assert.AreEqual("EmptyContext/conversations/test", key1, "Incorrect key");
+
+            // Set the conversation Id to a long string
+            context.Activity.Conversation.Id = new string('A', 500);
+            var key2 = state.GetKey(context);
+
+            // The resulting key should be a hash of the ConversationId. 
+            var hashedConversationId = context.Activity.Conversation.Id.GetHashCode().ToString("x");
+            var correctKey = $"{context.Activity.ChannelId}/conversations/{hashedConversationId}";
+            Assert.AreEqual(correctKey, key2, "Incorrect key");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1197 

This code enables a "MaxKeyLength" on ConversationState. If the resulting key is too long, the channelId is hashed to create a shorter key. The MaxKeyLength is defaulted to 254, which is the max length for CosmosDB. It's user settable via a constructor parameter.  

Q: Is the chosen has "complex" enough that hash collisions are unlikely? I wonder if this should be a SHA1 or SHA256 bit hash. 