### PR TITLE
Fixing bug around request buffering

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -16,12 +16,21 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     {
         protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, IAdapterIntegration adapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
+            var requestBody = request.Body;
+
+            // In the case of request buffering being enabled, we could possibly receive a Stream that needs its position reset,
+            // but we can't _blindly_ reset in case buffering hasn't been enabled since we'll be working with a non-seekable Stream
+            // in that case which will throw a NotSupportedException
+            if (requestBody.CanSeek)
+            {
+                requestBody.Position = 0;
+            }
+
             var activity = default(Activity);
 
             // Get the request body and deserialize to the Activity object.
-            // We need to leave the stream open here so others downstream can access it.
-            request.Body.Position = 0;
-            using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)))
+            // NOTE: We explicitly leave the stream open here so others can still access it (in case buffering was enabled); ASP.NET runtime will always dispose of it anyway
+            using (var bodyReader = new JsonTextReader(new StreamReader(requestBody, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)))
             {
                 activity = BotMessageHandlerBase.BotMessageSerializer.Deserialize<Activity>(bodyReader);
             }

--- a/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Integration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
@@ -96,6 +97,14 @@ namespace Microsoft.Bot.Builder.TestBot
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            // NOTE: Uncomment this to force request buffering to test accessing the request body in buffered scenarios (default is always unbuffered)
+            //app.Use(async (httpContext, next) =>
+            //{
+            //    httpContext.Request.EnableBuffering();
+
+            //    await next();
+            //});
 
             app.UseDefaultFiles()
                 .UseStaticFiles()


### PR DESCRIPTION
Fixes #1371

A regression was introduced when support was added in #1352 for a scenario where body stream buffering was enabled. Unfortunately, during that PR, non-buffered streaming scenarios were not regression tested leading to a bug in that (the default) scenario.

The bug was caused by setting `Position = 0` on the body stream when non-buffered because, non-buffered streams are not seekable and thus throw a `NotSupportedException` if you attempt to change their position.