### PR TITLE
Removing SourceLink.Create.CommandLine as a Package Dependency

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.LUIS.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.LUIS.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.13" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.ApplicationInsights/Microsoft.Bot.Builder.ApplicationInsights.csproj
+++ b/libraries/Microsoft.Bot.Builder.ApplicationInsights/Microsoft.Bot.Builder.ApplicationInsights.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />    
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -44,7 +44,7 @@
 		<PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
 		<PackageReference Include="Microsoft.Azure.Storage.Common" Version="9.4.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.1.3" />
 		<PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all"/>
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.csproj
+++ b/libraries/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all"/>
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3"  PrivateAssets="all"/>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3"  PrivateAssets="all"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
+++ b/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
@@ -26,6 +26,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
 	</ItemGroup>
 </Project>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />    
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all"/>    
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
@@ -48,7 +48,7 @@
 		<PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.6" />
 		 <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="2.4.0" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
 		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
 	</ItemGroup>
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
@@ -44,7 +44,7 @@
 		<PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.6" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #1310 
* Setting the SourceLink.Create.CommandLine as a private asset across all projects 
