### PR TITLE
fixed concurrency and added unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,10 +23,9 @@ namespace Microsoft.Bot.Builder.Azure
     /// This class uses a single Azure Storage Blob Container.
     /// Each entity or <see cref="IStoreItem"/> is serialized into a JSON string and stored in an individual text blob.
     /// Each blob is named after the store item key,  which is encoded so that it conforms a valid blob name.
-    /// Concurrency is managed on a per-entity (that is, per-blob) basis. If an entity is an <see cref="IStoreItem"/>,
-    /// the storage object will set the entity's <see cref="IStoreItem.ETag"/> property value to the blob's ETag upon read.
-    /// Afterward, an <see cref="AccessCondition"/> with the ETag value will be generated during Write.
-    /// New entities start with a null ETag.
+    /// If an entity is an <see cref="IStoreItem"/>, the storage object will set the entity's <see cref="IStoreItem.ETag"/>
+    /// property value to the blob's ETag upon read. Afterward, an <see cref="AccessCondition"/> with the ETag value
+    /// will be generated during Write. New entities start with a null ETag.
     /// </remarks>
     public class AzureBlobStorage : IStorage
     {
@@ -39,7 +37,6 @@ namespace Microsoft.Bot.Builder.Azure
 
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;
-        private CloudBlobContainer _container;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobStorage"/> class.
@@ -79,14 +76,14 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            var blobContainer = await GetBlobContainer().ConfigureAwait(false);
-            await Task.WhenAll(
-                keys.Select(key =>
-                {
-                    var blobName = GetBlobName(key);
-                    var blobReference = blobContainer.GetBlobReference(blobName);
-                    return blobReference.DeleteIfExistsAsync();
-                })).ConfigureAwait(false);
+            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobContainer = blobClient.GetContainerReference(_containerName);
+            foreach (var key in keys)
+            {
+                var blobName = GetBlobName(key);
+                var blobReference = blobContainer.GetBlobReference(blobName);
+                await blobReference.DeleteIfExistsAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -103,33 +100,19 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            var blobContainer = await GetBlobContainer().ConfigureAwait(false);
+            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobContainer = blobClient.GetContainerReference(_containerName);
 
-            var readTasks = new List<Task<KeyValuePair<string, object>>>();
+            var items = new Dictionary<string, object>();
 
             foreach (var key in keys)
-            {
-                readTasks.Add(ReadIndividualKey(key));
-            }
-
-            await Task.WhenAll(readTasks).ConfigureAwait(false);
-
-            // Project back the entries that were read, filtering out any entries that were not found.
-            // This gives us a Dictionary(key, value)
-            var items = readTasks.Select(readTask => readTask.Result)
-                .Where(kvp => kvp.Key != null)
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-
-            return items;
-
-            async Task<KeyValuePair<string, object>> ReadIndividualKey(string key)
             {
                 var blobName = GetBlobName(key);
                 var blobReference = blobContainer.GetBlobReference(blobName);
 
                 try
                 {
-                    using (var blobStream = await blobReference.OpenReadAsync().ConfigureAwait(false))
+                    using (var blobStream = await blobReference.OpenReadAsync(cancellationToken).ConfigureAwait(false))
                     using (var jsonReader = new JsonTextReader(new StreamReader(blobStream)))
                     {
                         var obj = JsonSerializer.Deserialize(jsonReader);
@@ -139,21 +122,23 @@ namespace Microsoft.Bot.Builder.Azure
                             storeItem.ETag = blobReference.Properties.ETag;
                         }
 
-                        return new KeyValuePair<string, object>(key, obj);
+                        items.Add(key, obj);
                     }
                 }
                 catch (StorageException ex)
                     when ((HttpStatusCode)ex.RequestInformation.HttpStatusCode == HttpStatusCode.NotFound)
                 {
-                    return new KeyValuePair<string, object>();
+                    continue;
                 }
                 catch (AggregateException ex)
                     when (ex.InnerException is StorageException iex
                     && (HttpStatusCode)iex.RequestInformation.HttpStatusCode == HttpStatusCode.NotFound)
                 {
-                    return new KeyValuePair<string, object>();
+                    continue;
                 }
             }
+
+            return items;
         }
 
         /// <summary>
@@ -170,44 +155,46 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(changes));
             }
 
-            var blobContainer = await GetBlobContainer().ConfigureAwait(false);
+            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobContainer = blobClient.GetContainerReference(_containerName);
+            await blobContainer.CreateIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
+
             var blobRequestOptions = new BlobRequestOptions();
             var operationContext = new OperationContext();
 
-            await Task.WhenAll(
-                changes.Select(async (keyValuePair) =>
+            foreach (var keyValuePair in changes)
+            {
+                var newValue = keyValuePair.Value;
+                var storeItem = newValue as IStoreItem;
+
+                // "*" eTag in IStoreItem converts to null condition for AccessCondition
+                var accessCondition = storeItem?.ETag != "*"
+                    ? AccessCondition.GenerateIfMatchCondition(storeItem?.ETag)
+                    : AccessCondition.GenerateEmptyCondition();
+
+                var blobName = GetBlobName(keyValuePair.Key);
+                var blobReference = blobContainer.GetBlockBlobReference(blobName);
+
+                try
                 {
-                    var newValue = keyValuePair.Value;
-                    var storeItem = newValue as IStoreItem;
-
-                    // "*" eTag in IStoreItem converts to null condition for AccessCondition
-                    var accessCondition = storeItem?.ETag == "*"
-                        ? AccessCondition.GenerateEmptyCondition()
-                        : AccessCondition.GenerateIfMatchCondition(storeItem?.ETag);
-
-                    var blobName = GetBlobName(keyValuePair.Key);
-                    var blobReference = blobContainer.GetBlockBlobReference(blobName);
-
-                    try
+                    using (var memoryStream = new MultiBufferMemoryStream(blobReference.ServiceClient.BufferManager))
+                    using (var streamWriter = new StreamWriter(memoryStream))
                     {
-                        using (var memoryStream = new MultiBufferMemoryStream(blobReference.ServiceClient.BufferManager))
-                        using (var streamWriter = new StreamWriter(memoryStream))
-                        {
-                            JsonSerializer.Serialize(streamWriter, newValue);
-                            streamWriter.Flush();
-                            memoryStream.Seek(0, SeekOrigin.Begin);
-                            await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext).ConfigureAwait(false);
-                        }
+                        JsonSerializer.Serialize(streamWriter, newValue);
+                        streamWriter.Flush();
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+                        await blobReference.UploadFromStreamAsync(memoryStream, accessCondition, blobRequestOptions, operationContext, cancellationToken).ConfigureAwait(false);
                     }
-                    catch (StorageException ex)
-                    when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.BadRequest
-                    && ex.RequestInformation.ErrorCode == BlobErrorCodeStrings.InvalidBlockList)
-                    {
-                        throw new Exception(
-                            $"An error ocurred while trying to write an object. The underlying '{BlobErrorCodeStrings.InvalidBlockList}' error is commonly caused due to concurrently uploading an object larger than 128MB in size.",
-                            ex);
-                    }
-                })).ConfigureAwait(false);
+                }
+                catch (StorageException ex)
+                when (ex.RequestInformation.HttpStatusCode == (int)HttpStatusCode.BadRequest
+                && ex.RequestInformation.ErrorCode == BlobErrorCodeStrings.InvalidBlockList)
+                {
+                    throw new Exception(
+                        $"An error ocurred while trying to write an object. The underlying '{BlobErrorCodeStrings.InvalidBlockList}' error is commonly caused due to concurrently uploading an object larger than 128MB in size.",
+                        ex);
+                }
+            }
         }
 
         private static string GetBlobName(string key)
@@ -220,28 +207,6 @@ namespace Microsoft.Bot.Builder.Azure
             var blobName = HttpUtility.UrlEncode(key);
             NameValidator.ValidateBlobName(blobName);
             return blobName;
-        }
-
-        private ValueTask<CloudBlobContainer> GetBlobContainer()
-        {
-            if (_container != null)
-            {
-                return new ValueTask<CloudBlobContainer>(_container);
-            }
-
-            return new ValueTask<CloudBlobContainer>(EnsureBlobContainerExists());
-
-            async Task<CloudBlobContainer> EnsureBlobContainerExists()
-            {
-                var blobClient = _storageAccount.CreateCloudBlobClient();
-                var container = blobClient.GetContainerReference(_containerName);
-
-                await container.CreateIfNotExistsAsync().ConfigureAwait(false);
-
-                _container = container;
-
-                return _container;
-            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.Azure
 {
     public static class CosmosDbKeyEscape
     {
-        // Per the CosmosDB Docs, there is a max key length of 255. 
+        // Per the CosmosDB Docs, there is a max key length of 255.
         // https://docs.microsoft.com/en-us/azure/cosmos-db/faq#table
         public const int MaxKeyLength = 255;
 
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.Azure
 
             var firstIllegalCharIndex = key.IndexOfAny(_illegalKeys);
 
-            // If there are no illegal characters, and tkey is within length costraints, 
+            // If there are no illegal characters, and tkey is within length costraints,
             // return immediately and avoid any further processing/allocations
             if (firstIllegalCharIndex == -1)
             {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Storage;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    [TestClass]
+    public class AzureBlobStorageTests
+    {
+        private const string ConnectionString = @"AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;";
+
+        // These tests require Azure Storage Emulator v5.7
+        [TestInitialize]
+        public void TestInit()
+        {
+            StorageEmulatorHelper.StartStorageEmulator();
+        }
+
+        [TestMethod]
+        public async Task TestBlobStorageWriteRead()
+        {
+            // Arrange
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var containerName = "test";
+            var storage = new AzureBlobStorage(storageAccount, containerName);
+
+            var changes = new Dictionary<string, object>
+            {
+                { "x", "hello" },
+                { "y", "world" }
+            };
+
+            // Act
+            await storage.WriteAsync(changes);
+            var result = await storage.ReadAsync(new[] { "x", "y" });
+
+            // Assert
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("hello", result["x"]);
+            Assert.AreEqual("world", result["y"]);
+        }
+
+        [TestMethod]
+        public async Task TestBlobStorageWriteDeleteRead()
+        {
+            // Arrange
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var containerName = "test";
+            var storage = new AzureBlobStorage(storageAccount, containerName);
+
+            var changes = new Dictionary<string, object>
+            {
+                { "x", "hello" },
+                { "y", "world" }
+            };
+
+            // Act
+            await storage.WriteAsync(changes);
+            await storage.DeleteAsync(new[] { "x" });
+            var result = await storage.ReadAsync(new[] { "x", "y" });
+
+            // Assert
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("world", result["y"]);
+        }
+
+        [TestMethod]
+        public async Task TestBlobStorageChanges()
+        {
+            // Arrange
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var containerName = "test";
+            var storage = new AzureBlobStorage(storageAccount, containerName);
+
+            // Act
+            await storage.WriteAsync(new Dictionary<string, object> { { "a", "1.0" }, { "b", "2.0" } });
+            await storage.WriteAsync(new Dictionary<string, object> { { "c", "3.0" } });
+            await storage.DeleteAsync(new[] { "b" });
+            await storage.WriteAsync(new Dictionary<string, object> { { "a", "1.1" } });
+            var result = await storage.ReadAsync(new[] { "a", "b", "c", "d", "e" });
+
+            // Assert
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("1.1", result["a"]);
+            Assert.AreEqual("3.0", result["c"]);
+        }
+
+        [TestMethod]
+        public async Task TestConversationStateBlobStorage()
+        {
+            // Arrange
+            var storageAccount = CloudStorageAccount.Parse(ConnectionString);
+            var containerName = "test";
+            var storage = new AzureBlobStorage(storageAccount, containerName);
+            var conversationState = new ConversationState(storage);
+            var propAccessor = conversationState.CreateProperty<Prop>("prop");
+            var adapter = new TestStorageAdapter();
+            var activity = new Activity
+            {
+                ChannelId = "123",
+                Conversation = new ConversationAccount { Id = "abc" }
+            };
+
+            // Act
+            var turnContext1 = new TurnContext(adapter, activity);
+            var propValue1 = await propAccessor.GetAsync(turnContext1, () => new Prop());
+            propValue1.X = "hello";
+            propValue1.Y = "world";
+            await conversationState.SaveChangesAsync(turnContext1, force: true);
+
+            var turnContext2 = new TurnContext(adapter, activity);
+            var propValue2 = await propAccessor.GetAsync(turnContext2);
+
+            // Assert
+            Assert.AreEqual("hello", propValue2.X);
+            Assert.AreEqual("world", propValue2.Y);
+        }
+
+        private class TestStorageAdapter : BotAdapter
+        {
+            public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+            public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class Prop : IStoreItem
+        {
+            public string X { get; set; }
+            public string Y { get; set; }
+            string IStoreItem.ETag { get; set; }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
     public class AzureBlobStorageTests
     {
         private const string ConnectionString = @"AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;";
+        private const string ContainerName = "test";
 
         // These tests require Azure Storage Emulator v5.7
         [TestInitialize]
@@ -23,13 +24,36 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             StorageEmulatorHelper.StartStorageEmulator();
         }
 
+        // These tests require Azure Storage Emulator v5.7
+        [TestCleanup]
+        public void TestCleanUp()
+        {
+            StorageEmulatorHelper.StopStorageEmulator();
+        }
+
+        [TestMethod]
+        public void BlobParamTest()
+        {
+            Assert.ThrowsException<FormatException>(() => new AzureBlobStorage("123", ContainerName));
+
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                new AzureBlobStorage((CloudStorageAccount)null, ContainerName));
+
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                new AzureBlobStorage((string)null, ContainerName));
+
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                new AzureBlobStorage((CloudStorageAccount)null, null));
+
+            Assert.ThrowsException<ArgumentNullException>(() => new AzureBlobStorage((string)null, null));
+        }
+
         [TestMethod]
         public async Task TestBlobStorageWriteRead()
         {
             // Arrange
             var storageAccount = CloudStorageAccount.Parse(ConnectionString);
-            var containerName = "test";
-            var storage = new AzureBlobStorage(storageAccount, containerName);
+            var storage = new AzureBlobStorage(storageAccount, ContainerName);
 
             var changes = new Dictionary<string, object>
             {
@@ -52,8 +76,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             // Arrange
             var storageAccount = CloudStorageAccount.Parse(ConnectionString);
-            var containerName = "test";
-            var storage = new AzureBlobStorage(storageAccount, containerName);
+            var storage = new AzureBlobStorage(storageAccount, ContainerName);
 
             var changes = new Dictionary<string, object>
             {
@@ -76,8 +99,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             // Arrange
             var storageAccount = CloudStorageAccount.Parse(ConnectionString);
-            var containerName = "test";
-            var storage = new AzureBlobStorage(storageAccount, containerName);
+            var storage = new AzureBlobStorage(storageAccount, ContainerName);
 
             // Act
             await storage.WriteAsync(new Dictionary<string, object> { { "a", "1.0" }, { "b", "2.0" } });
@@ -97,8 +119,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             // Arrange
             var storageAccount = CloudStorageAccount.Parse(ConnectionString);
-            var containerName = "test";
-            var storage = new AzureBlobStorage(storageAccount, containerName);
+            var storage = new AzureBlobStorage(storageAccount, ContainerName);
             var conversationState = new ConversationState(storage);
             var propAccessor = conversationState.CreateProperty<Prop>("prop");
             var adapter = new TestStorageAdapter();


### PR DESCRIPTION
fixes #1292 

- removed caching of container handle
- removed concurrency from Delete, Read and Write calls
- simplified code it use straight forward loops instead of Linq and Lambdas
- fixed conditional creation of AccessCondition (the original code was non sense but probably harmless) 
- removed calls to IfExists for container on Delete and Read (which are coded to be conditional anyhow)
- added unit tests

This should most likely fix the non-nonsensical ETag exception because this code was incorrect. _At least this code is now correct_ and that should presumably make the exception go away, at least it's a start. Anyhow I could not reproduce this exact problem either way.

I also made a good start on adding unit tests, I'm sure we could always add more.
