### PR TITLE
additional constructor that takes raw LUIS endpoint

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -76,6 +76,18 @@ namespace Microsoft.Bot.Builder.AI.Luis
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="LuisRecognizer"/> class.
+        /// </summary>
+        /// <param name="applicationEndpoint">The LUIS endpoint as shown in https://luis.ai .</param>
+        /// <param name="predictionOptions">(Optional) The LUIS prediction options to use.</param>
+        /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
+        /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
+        public LuisRecognizer(string applicationEndpoint, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
+            : this(new LuisApplication(applicationEndpoint), predictionOptions, includeApiResults, clientHandler)
+        {
+        }
+
+        /// <summary>
         /// Returns the name of the top scoring intent from a set of LUIS results.
         /// </summary>
         /// <param name="results">Result set to be searched.</param>

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisApplicationTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisApplicationTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         [TestMethod]
         public void LuisApplication_Configuration()
         {
+            // Arrange
             var service = new LuisService
             {
                 AppId = Guid.NewGuid().ToString(),
@@ -54,11 +55,36 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 Region = "westus"
             };
 
+            // Act
             var model = new LuisApplication(service);
 
+            // Assert
             Assert.AreEqual(service.AppId, model.ApplicationId);
             Assert.AreEqual(service.SubscriptionKey, model.EndpointKey);
             Assert.AreEqual(service.GetEndpoint(), model.Endpoint);
+        }
+
+        [TestMethod]
+        public void ListApplicationFromLuisEndpoint()
+        {
+            // Arrange
+            var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
+
+            // Act
+            var app = new LuisApplication(endpoint);
+
+            // Assert
+            Assert.AreEqual("b31aeaf3-3511-495b-a07f-571fc873214b", app.ApplicationId);
+            Assert.AreEqual("048ec46dc58e495482b0c447cfdbd291", app.EndpointKey);
+            Assert.AreEqual("https://westus.api.cognitive.microsoft.com", app.Endpoint);
+        }
+
+        [TestMethod]
+        public void ListApplicationFromLuisEndpointBadArguments()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new LuisApplication("this.is.not.a.uri"));
+            Assert.ThrowsException<ArgumentException>(() => new LuisApplication("https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q="));
+            Assert.ThrowsException<ArgumentException>(() => new LuisApplication("https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q="));
         }
 
         private LuisApplication GetValidModel()

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisApplicationTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisApplicationTests.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         public void ListApplicationFromLuisEndpoint()
         {
             // Arrange
+            // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key
+            // theses are GUIDs edited to look right to the parsing and validation code.
             var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
 
             // Act

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,6 +49,23 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         // Changing this to false will cause running against the actual LUIS service.
         // This is useful in order to see if the oracles for mocking or testing have changed.
         private readonly bool _mock = true;
+
+        [TestMethod]
+        public void LuisRecognizerConstruction()
+        {
+            // Arrange
+            var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
+            var fieldInfo = typeof(LuisRecognizer).GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var recognizer = new LuisRecognizer(endpoint);
+
+            // Assert
+            var app = (LuisApplication)fieldInfo.GetValue(recognizer);
+            Assert.AreEqual("b31aeaf3-3511-495b-a07f-571fc873214b", app.ApplicationId);
+            Assert.AreEqual("048ec46dc58e495482b0c447cfdbd291", app.EndpointKey);
+            Assert.AreEqual("https://westus.api.cognitive.microsoft.com", app.Endpoint);
+        }
 
         [TestMethod]
         public async Task LuisRecognizer_Configuration()

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         public void LuisRecognizerConstruction()
         {
             // Arrange
+            // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key
+            // theses are GUIDs edited to look right to the parsing and validation code.
             var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
             var fieldInfo = typeof(LuisRecognizer).GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
 


### PR DESCRIPTION
This is the C# implementation for https://github.com/Microsoft/BotBuilder/issues/5255

The only thing to note here is that the JavaScript is slightly different because the C# has this additional LuisApplication class. Because the C# has that class I added the extra constructor on that. (Making sure to wire all the constructir overloads through the same code path.)

@stevengum is planning to do the JavaScript.