### PR TITLE
Added optimization around CreateIfNotExists and additional error handling

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Bot.Builder.Azure
         public AzureBlobStorage(string dataConnectionstring, string containerName)
             : this(CloudStorageAccount.Parse(dataConnectionstring), containerName)
         {
-            _checkforContainerExistance = 1;
         }
 
         /// <summary>
@@ -63,6 +62,9 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Checks if a container name is valid
             NameValidator.ValidateContainerName(containerName);
+
+            // Triggers a check for the existance of the container
+            _checkforContainerExistance = 1;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -42,7 +42,6 @@
 		<PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
 		<PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
-		<PackageReference Include="Microsoft.Azure.Storage.Common" Version="9.4.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />


### PR DESCRIPTION
- added optimization so CreateIfNotExists for the container only ever happens once per object - this assumes we have a singleton which is a good assumption
- added retry policy to blob open call - this handles 500 and 408
- added retry for 412 on blob open

Note that this code only uses a single client/container on a single thread. This makes this code safe to edits as there are scenarios where the client/container is not thread safe.

The concurrent handling of a list of objects is not include here as the caller of this code only ever handles a single key at a time. In other words the untested concurrent was actually never used.

The way to understand this module is to see it as a storage plug-in to the BotState class and not as an attempt at a generic wrapper to an otherwise widely used Azure API. In other words the requirement is to satisfy the exclusive needs of BotState with the simplest and safest code. Secondarily it should be reasonably optimal.

Incidentally the two layers of additional error handling within the storage component don't cover all cases - they just make exceptions much much less likely to leak up.

The additional error handling is also only added to Read and not yet Write.


