### PR TITLE
Application Insights config from appsettings.json

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Bot.Builder.ApplicationInsights;
 using Microsoft.Bot.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
@@ -63,6 +64,41 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
 
             return services;
         }
+
+        /// <summary>
+        /// Adds and configures services for Application Insights to the <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> which specifies the contract for a collection of service descriptors.</param>
+        /// <param name="config">Represents a set of key/value application configuration properties.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IServiceCollection AddBotApplicationInsights(this IServiceCollection services, IConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            string instrumentationKey = config.GetValue<string>("ApplicationInsights:instrumentationKey"); 
+
+
+            CreateBotTelemetry(services);
+
+            IBotTelemetryClient telemetryClient = null;
+            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            {
+                services.AddApplicationInsightsTelemetry(instrumentationKey);
+                telemetryClient = new BotTelemetryClient(new TelemetryClient());
+            }
+            else
+            {
+                telemetryClient = NullBotTelemetryClient.Instance;
+            }
+
+            services.AddSingleton(telemetryClient);
+
+            return services;
+        }
+
 
         /// <summary>
         /// Adds and configures services for Application Insights to the <see cref="IServiceCollection" />.

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
@@ -20,6 +21,9 @@
 
   <ItemGroup>
     <None Update="appsettings.json.default">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.json.invalid_instrumentation_key">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="appsettings.json.no_app_insights">

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.AspNetCore.TestHost;
 using System.IO;
 using Microsoft.ApplicationInsights;
+using Microsoft.Bot.Builder.ApplicationInsights;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -16,13 +17,78 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
     {
         public ServiceResolutionTests()
         {
-            // Arrange
-            //_server = new TestServer(new WebHostBuilder()
-                                     //.UseStartup<Startup>());
-            //_client = _server.CreateClient();
         }
+
+
         [TestMethod]
-        public void AppSettings_NoAppSettings()
+        public void AppSettings_NoBot_NoAppSettings()
+        {
+            ArrangeBotFile(null); // No bot file
+            ArrangeAppSettings(null); // No appsettings file
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupAppSettingsOnly>());
+
+            // Telemetry Client should be active, just not configured.
+            // This is not an error condition so samples can degrade.
+            var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsTrue(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
+            // App Insights Telemetry obviously can't work.
+            Assert.IsTrue(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+        }
+
+        [TestMethod]
+        public void AppSettings_NoBot_AppSettings_NoInstrumentation()
+        {
+            ArrangeBotFile(null); // No bot file
+            ArrangeAppSettings("no_instrumentation_key"); // Appsettings file with no instrumentation key
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupAppSettingsOnly>());
+
+            // Telemetry Client should be active, just not configured.
+            // This is not an error condition so samples can degrade.
+            var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsTrue(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
+            // App Insights Telemetry obviously can't work.
+            Assert.IsTrue(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+        }
+
+        [TestMethod]
+        public void AppSettings_NoBot_AppSettings()
+        {
+            ArrangeBotFile(null); // No bot file
+            ArrangeAppSettings("default"); // Appsettings file with instrumentation key
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupAppSettingsOnly>());
+
+            // Telemetry Client should be active
+            var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsFalse(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
+            Assert.IsFalse(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+        }
+
+        [TestMethod]
+        public void AppSettings_NoBot_AppSettings_InvalidKey()
+        {
+            ArrangeBotFile(null); // No bot file
+            ArrangeAppSettings("invalid_instrumentation_key"); // Appsettings file with invalid instrumentation key
+            var server = new TestServer(new WebHostBuilder()
+                .UseStartup<StartupAppSettingsOnly>());
+
+            // Bot Telemetry Client should be active.
+            // This is not an error condition so samples can degrade.
+            var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
+            Assert.IsNotNull(telemetryClient);
+            Assert.IsTrue(typeof(BotTelemetryClient).Equals(telemetryClient.GetType()));
+            // App Insights just rolls with it.  It's technically invalid, but App Insights doesn't (currently) error even when logging.
+            Assert.IsFalse(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+        }
+
+
+        [TestMethod]
+        public void Botfile_NoAppSettings()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings(null); // No appsettings file
@@ -34,8 +100,10 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var telemetryClient = new TelemetryClient();
             Assert.IsTrue(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
         }
+
+
         [TestMethod]
-        public void AppSettings_NoAppInsights()
+        public void Botfile_NoAppInsights()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings("no_app_insights"); // Bad app insights appsettings file
@@ -49,7 +117,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         }
 
         [TestMethod]
-        public void AppSettings_NoAppInsightsKey()
+        public void Botfile_NoAppInsightsKey()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings("no_instrumentation_key"); // Bad app insights appsettings file

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupAppSettingsOnly.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupAppSettingsOnly.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Configuration;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
+{
+    internal class StartupAppSettingsOnly
+    {
+        public StartupAppSettingsOnly(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddBotApplicationInsights(this.Configuration);
+
+            // Adding IConfiguration in sample test server.  Otherwise this appears to be 
+            // registered.
+            services.AddSingleton<IConfiguration>(this.Configuration);
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseBotApplicationInsights();
+        }
+
+    }
+}

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/appsettings.json.default
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/appsettings.json.default
@@ -2,6 +2,6 @@
   "botFilePath": "fake.bot",
   "botFileSecret": "",
   "ApplicationInsights": {
-    "InstrumentationKey": "00000000-0000-0000-0000-000000000000"
+    "InstrumentationKey": "00000000-0000-0000-0000-000000000001"
   }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/appsettings.json.invalid_instrumentation_key
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/appsettings.json.invalid_instrumentation_key
@@ -1,0 +1,7 @@
+{
+  "botFilePath": "fake.bot",
+  "botFileSecret": "",
+  "ApplicationInsights": {
+    "InstrumentationKey": "0000000000"
+  }
+}


### PR DESCRIPTION
John, here's a stab at "no botfile" override.  

Would logically change:
`public void ConfigureServices(IServiceCollection services)`
`{`
`       var botConfig = BotConfiguration.Load("testbot.bot", null);`
`      services.AddBotApplicationInsights(botConfig);`


To something like:
`public IConfiguration Configuration { get; }`

`public void ConfigureServices(IServiceCollection services)`
        `{`
`        services.AddBotApplicationInsights(Configuration);`


