### PR TITLE
Allow TelemetryInitializer properties to be overridden by user

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
@@ -64,13 +64,22 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
                         var telemetryProperties = ((ISupportProperties)telemetry).Properties;
 
                         // Set the activity id https://github.com/Microsoft/botframework-obi/blob/master/botframework-activity/botframework-activity.md#id
-                        telemetryProperties.Add("activityId", (string)body["id"]);
+                        if (!telemetryProperties.ContainsKey("activityId"))
+                        {
+                            telemetryProperties.Add("activityId", (string)body["id"]);
+                        }
 
                         // Set the channel id https://github.com/Microsoft/botframework-obi/blob/master/botframework-activity/botframework-activity.md#channel-id
-                        telemetryProperties.Add("channelId", (string)channelId);
+                        if (!telemetryProperties.ContainsKey("channelId"))
+                        {
+                            telemetryProperties.Add("channelId", (string)channelId);
+                        }
 
                         // Set the activity type https://github.com/Microsoft/botframework-obi/blob/master/botframework-activity/botframework-activity.md#type
-                        telemetryProperties.Add("activityType", (string)body["type"]);
+                        if (!telemetryProperties.ContainsKey("activityType"))
+                        {
+                            telemetryProperties.Add("activityType", (string)body["type"]);
+                        }
                     }
                 }
             }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -69,6 +69,74 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         }
 
         [TestMethod]
+        public void VerifyOverriddenProperties()
+        {
+            var configuration = new TelemetryConfiguration();
+            var sentItems = new List<ITelemetry>();
+            var mockTelemetryChannel = new Mock<ITelemetryChannel>();
+            mockTelemetryChannel.Setup(c => c.Send(It.IsAny<ITelemetry>()))
+                            .Callback<ITelemetry>((telemetry) => sentItems.Add(telemetry))
+                            .Verifiable();
+            configuration.TelemetryChannel = mockTelemetryChannel.Object;
+            configuration.InstrumentationKey = Guid.NewGuid().ToString();
+
+            // Mock http context
+            var httpContext = new Mock<HttpContext>();
+            IDictionary<object, object> items = new Dictionary<object, object>();
+            httpContext.SetupProperty(c => c.Items, items);
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.SetupProperty(c => c.HttpContext, httpContext.Object);
+
+            // Simulate what Middleware does to read body
+            var fromID = "FROMID";
+            var channelID = "CHANNELID";
+            var conversationID = "CONVERSATIONID";
+            var activityID = "ACTIVITYID";
+            var activity = Activity.CreateMessageActivity();
+            activity.From = new ChannelAccount(fromID);
+            activity.ChannelId = channelID;
+            activity.Conversation = new ConversationAccount(false, "CONVOTYPE", conversationID);
+            activity.Id = activityID;
+            var activityBody = JObject.FromObject(activity);
+            items.Add(TelemetryBotIdInitializer.BotActivityKey, activityBody);
+            configuration.TelemetryInitializers.Add(new TelemetryBotIdInitializer(httpContextAccessor.Object));
+            var telemetryClient = new TelemetryClient(configuration);
+            var activityIdValue = "Oh yeah I did it";
+            var channelIdValue = "Hello";
+            var activityTypeValue = "Breaking all the rules";
+
+            // Should not throw.  This implicitly calls the initializer.
+            // Note: We are setting properties that should be populated by the TelemetryInitailizer.
+            // We honor overrides.
+            telemetryClient.TrackEvent("test", new Dictionary<string, string>() {
+                { "activityId", activityIdValue },  // The activityId can be overridden.
+                { "channelId", channelIdValue },
+                { "activityType", activityTypeValue } }, new Dictionary<string, double>() { { "metric", 0.6 } });
+
+            Assert.IsTrue(sentItems.Count == 1);
+            var telem = sentItems[0] as EventTelemetry;
+            Assert.IsTrue(telem != null);
+            
+            
+            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+
+            //
+            // The TelemetryInitializer honors being overridden
+            // What we get out should be what we originally put in, and not what the Initializer
+            // normally does.
+            //
+            Assert.IsFalse(telem.Properties["activityId"] == activityID);
+            Assert.IsTrue(telem.Properties["activityId"] == activityIdValue);
+            Assert.IsTrue(telem.Properties["channelId"] == channelIdValue);
+            Assert.IsFalse(telem.Properties["channelId"] == "CHANNELID");
+            Assert.IsTrue(telem.Properties["activityType"] == activityTypeValue);
+            Assert.IsFalse(telem.Properties["activityType"] == "message");
+            Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+        }
+
+
+        [TestMethod]
         public void VerifyTraceProperties()
         {
 


### PR DESCRIPTION
Fix issue that VA encountered.
Allow users to override telemetry that's logged from the initializer.