### PR TITLE
DialogContext.EndDialogAsync - remove code duplication.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -165,18 +165,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<DialogTurnResult> EndDialogAsync(object result = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Pop active dialog off the stack
-            if (Stack.Any())
-            {
-                var dialogId = Stack[0].Id;
-                var dialog = FindDialog(dialogId);
-                if (dialog != null)
-                {
-                    await dialog.EndDialogAsync(this.Context, Stack[0], DialogReason.EndCalled).ConfigureAwait(false);
-                }
-
-                Stack.RemoveAt(0);
-            }
+            await EndActiveDialogAsync(DialogReason.EndCalled, cancellationToken).ConfigureAwait(false);
 
             // Resume previous dialog
             if (ActiveDialog != null)


### PR DESCRIPTION
In `DialogContext.EndDialogAsync` just call `EndActiveDialogAsync` to pop the active dialog off the stack.