### PR TITLE
Call EndActiveDialog in ReplaceDialogAsync

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -246,11 +246,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<DialogTurnResult> ReplaceDialogAsync(string dialogId, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            // Pop stack
-            if (Stack.Any())
-            {
-                Stack.RemoveAt(0);
-            }
+            // Pop active dialog off the stack
+            await EndActiveDialogAsync(DialogReason.ReplaceCalled, cancellationToken).ConfigureAwait(false);
 
             // Start replacement dialog
             return await BeginDialogAsync(dialogId, options, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
I just think that it's more consistent way of removing the active dialog off the stack.