### PR TITLE
fix for using other serializing formats and converters. 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Bot.Builder.Azure
     /// </summary>
     public class CosmosDbStorage : IStorage
     {
-        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.CreateDefault(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, NullValueHandling = NullValueHandling.Include, ContractResolver = new DefaultContractResolver() });
-
         // When setting up the database, calls are made to CosmosDB. If multiple calls are made, we'll end up setting the
         // collectionLink member variable more than once. The semaphore is for making sure the initialization of the
         // database is done only once.
         private static SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+
+        private readonly JsonSerializer _jsonSerializer;
 
         private readonly string _databaseId;
         private readonly string _collectionId;
@@ -39,11 +39,21 @@ namespace Microsoft.Bot.Builder.Azure
         /// using the provided CosmosDB credentials, database ID, and collection ID.
         /// </summary>
         /// <param name="cosmosDbStorageOptions">Cosmos DB storage configuration options.</param>
-        public CosmosDbStorage(CosmosDbStorageOptions cosmosDbStorageOptions)
+        /// <param name="jsonSerializer">Optional JsonSerializer.</param>
+        public CosmosDbStorage(CosmosDbStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = null)
         {
             if (cosmosDbStorageOptions == null)
             {
                 throw new ArgumentNullException(nameof(cosmosDbStorageOptions));
+            }
+
+            if (jsonSerializer == null)
+            {
+                _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+            }
+            else
+            {
+                _jsonSerializer = jsonSerializer;
             }
 
             if (cosmosDbStorageOptions.CosmosDBEndpoint == null)

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// using the provided CosmosDB credentials, database ID, and collection ID.
         /// </summary>
         /// <param name="cosmosDbStorageOptions">Cosmos DB storage configuration options.</param>
-        /// <param name="jsonSerializer">Optional JsonSerializer. Mind that the TypeNameHandling will be set to TypeNameHandling.All.</param>
+        /// <param name="jsonSerializer">Optional JsonSerializer. Mind that the TypeNameHandling, NullvalueHandling and ContractResolver will be overridden.</param>
         public CosmosDbStorage(CosmosDbStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = null)
         {
             if (cosmosDbStorageOptions == null)
@@ -53,7 +53,10 @@ namespace Microsoft.Bot.Builder.Azure
             }
             else
             {
+                // These need to be overridden til the following values.
                 jsonSerializer.TypeNameHandling = TypeNameHandling.All;
+                jsonSerializer.NullValueHandling = NullValueHandling.Include;
+                jsonSerializer.ContractResolver = new DefaultContractResolver();
                 _jsonSerializer = jsonSerializer;
             }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Azure
     /// </summary>
     public class CosmosDbStorage : IStorage
     {
-        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.CreateDefault(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
 
         // When setting up the database, calls are made to CosmosDB. If multiple calls are made, we'll end up setting the
         // collectionLink member variable more than once. The semaphore is for making sure the initialization of the

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// using the provided CosmosDB credentials, database ID, and collection ID.
         /// </summary>
         /// <param name="cosmosDbStorageOptions">Cosmos DB storage configuration options.</param>
-        /// <param name="jsonSerializer">Optional JsonSerializer.</param>
+        /// <param name="jsonSerializer">Optional JsonSerializer. Mind that the TypeNameHandling will be set to TypeNameHandling.All.</param>
         public CosmosDbStorage(CosmosDbStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = null)
         {
             if (cosmosDbStorageOptions == null)
@@ -53,6 +53,7 @@ namespace Microsoft.Bot.Builder.Azure
             }
             else
             {
+                jsonSerializer.TypeNameHandling = TypeNameHandling.All;
                 _jsonSerializer = jsonSerializer;
             }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Azure
     /// </summary>
     public class CosmosDbStorage : IStorage
     {
-        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.CreateDefault(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.CreateDefault(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, NullValueHandling = NullValueHandling.Include, ContractResolver = new DefaultContractResolver() });
 
         // When setting up the database, calls are made to CosmosDB. If multiple calls are made, we'll end up setting the
         // collectionLink member variable more than once. The semaphore is for making sure the initialization of the

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Azure
             }
             else
             {
-                // These need to be overridden til the following values.
+                // These need to be overridden to the following values.
                 jsonSerializer.TypeNameHandling = TypeNameHandling.All;
                 jsonSerializer.NullValueHandling = NullValueHandling.Include;
                 jsonSerializer.ContractResolver = new DefaultContractResolver();

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// using the provided CosmosDB credentials, database ID, and collection ID.
         /// </summary>
         /// <param name="cosmosDbStorageOptions">Cosmos DB storage configuration options.</param>
-        /// <param name="jsonSerializer">Mind that the TypeNameHandling, NullvalueHandling and ContractResolver may need special TLC: Recommended settings are as follows:
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings: 
         /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.All;</para>
         /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include;</para>
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver();</para>
@@ -93,6 +93,11 @@ namespace Microsoft.Bot.Builder.Azure
         public CosmosDbStorage(CosmosDbStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer)
             : this(cosmosDbStorageOptions)
         {
+            if (jsonSerializer == null)
+            {
+                throw new ArgumentNullException(nameof(jsonSerializer));
+            }
+
             _jsonSerializer = jsonSerializer;
         }
 


### PR DESCRIPTION
if used some serializer setup which are honoured by the dialogs and saved with the accessors they might not be read back if not same settings/converters are set. using f.i. Iso8601TimeSpanConverter this is not globally accessible. the change uses same global JsonConvert.DefaultSettings (AND the additional setting which was set in thie original code) as the rest of the bot.