### PR TITLE
New Telemetry Support for Luis Recognizer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.AI.Luis
+{
+    /// <summary>
+    /// Recognizer with Telemetry support.
+    /// </summary>
+    public interface ITelemetryRecognizer : IRecognizer
+    {
+        /// <summary>
+        /// Gets a value indicating whether determines whether to log personal information that came from the user.
+        /// </summary>
+        /// <value>If true, will log personal information into the IBotTelemetryClient.TrackEvent method; otherwise the properties will be filtered.</value>
+        bool LogPersonalInformation { get; }
+
+        /// <summary>
+        /// Gets the currently configured <see cref="IBotTelemetryClient"/> that logs the LuisResult event.
+        /// </summary>
+        /// <value>The <see cref=IBotTelemetryClient"/> being used to log events.</value>
+        IBotTelemetryClient TelemetryClient { get; }
+
+        /// <summary>
+        /// Return results of the analysis (suggested intents and entities) using the turn context.
+        /// </summary>
+        /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="logProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
+        Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, Dictionary<string, string> logProperties, CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<T> RecognizeAsync<T>(ITurnContext turnContext, Dictionary<string, string> logProperties, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new();
+
+        new Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new();
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
@@ -28,12 +28,13 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// Return results of the analysis (suggested intents and entities) using the turn context.
         /// </summary>
         /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
-        /// <param name="logProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the LuisResult event.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
-        Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, Dictionary<string, string> logProperties, CancellationToken cancellationToken = default(CancellationToken));
+        Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics, CancellationToken cancellationToken = default(CancellationToken));
 
-        Task<T> RecognizeAsync<T>(ITurnContext turnContext, Dictionary<string, string> logProperties, CancellationToken cancellationToken = default(CancellationToken))
+        Task<T> RecognizeAsync<T>(ITurnContext turnContext, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new();
 
         new Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -223,14 +223,18 @@ namespace Microsoft.Bot.Builder.AI.Luis
         {
             var topLuisIntent = recognizerResult.GetTopScoringIntent();
             var intentScore = topLuisIntent.score.ToString("N2");
+            var topTwoIntents = (recognizerResult.Intents.Count > 0) ? recognizerResult.Intents.OrderByDescending(x => x.Value.Score).Take(2).ToArray() : null;
 
             // Add the intent score and conversation id properties
             var properties = new Dictionary<string, string>()
             {
                 { LuisTelemetryConstants.ApplicationIdProperty, _application.ApplicationId },
-                { LuisTelemetryConstants.IntentProperty, topLuisIntent.intent },
-                { LuisTelemetryConstants.IntentScoreProperty, intentScore },
+                { LuisTelemetryConstants.IntentProperty, topTwoIntents?[0].Key ?? string.Empty },
+                { LuisTelemetryConstants.IntentScoreProperty, topTwoIntents?[0].Value.Score?.ToString("N2") ?? "0.00" },
+                { LuisTelemetryConstants.Intent2Property, (topTwoIntents?.Count() > 1) ? topTwoIntents?[1].Key ?? string.Empty : string.Empty },
+                { LuisTelemetryConstants.IntentScore2Property, (topTwoIntents?.Count() > 1) ? topTwoIntents?[1].Value.Score?.ToString("N2") ?? "0.00" : "0.00" },
                 { LuisTelemetryConstants.FromIdProperty, turnContext.Activity.From.Id },
+
             };
 
             if (recognizerResult.Properties.TryGetValue("sentiment", out var sentiment) && sentiment is JObject)

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime;
-using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
@@ -20,7 +19,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
     /// <summary>
     /// A LUIS based implementation of <see cref="IRecognizer"/>.
     /// </summary>
-    public class LuisRecognizer : IRecognizer
+    public class LuisRecognizer : IRecognizer, ITelemetryRecognizer
     {
         /// <summary>
         /// The value type for a LUIS trace activity.
@@ -31,7 +30,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// The context label for a LUIS trace activity.
         /// </summary>
         public const string LuisTraceLabel = "Luis Trace";
-        private const string _metadataKey = "$instance";
+
         private readonly ILUISRuntimeClient _runtime;
         private readonly LuisApplication _application;
         private readonly LuisPredictionOptions _options;
@@ -44,11 +43,15 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <param name="predictionOptions">(Optional) The LUIS prediction options to use.</param>
         /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
         /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
-        public LuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
+        /// <param name="telemetryClient">The IBotTelemetryClient used to log the LuisResult event.</param>
+        public LuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null, IBotTelemetryClient telemetryClient = null)
         {
             _application = application ?? throw new ArgumentNullException(nameof(application));
             _options = predictionOptions ?? new LuisPredictionOptions();
             _includeApiResults = includeApiResults;
+
+            TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
+            LogPersonalInformation = false;
 
             var credentials = new ApiKeyServiceClientCredentials(application.EndpointKey);
             var delegatingHandler = new LuisDelegatingHandler();
@@ -71,7 +74,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
         /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
         public LuisRecognizer(LuisService service, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
-            : this(new LuisApplication(service), predictionOptions, includeApiResults, clientHandler)
+            : this(new LuisApplication(service), predictionOptions, includeApiResults, clientHandler, null)
         {
         }
 
@@ -83,9 +86,35 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
         /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
         public LuisRecognizer(string applicationEndpoint, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
-            : this(new LuisApplication(applicationEndpoint), predictionOptions, includeApiResults, clientHandler)
+            : this(new LuisApplication(applicationEndpoint), predictionOptions, includeApiResults, clientHandler, null)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LuisRecognizer"/> class.
+        /// </summary>
+        /// <param name="telemetryClient">The IBotTelemetryClient used to log the LuisResult event.</param>
+        /// <param name="application">The LUIS application to use to recognize text.</param>
+        /// <param name="predictionOptions">The LUIS prediction options to use.</param>
+        /// <param name="includeApiResults">TRUE to include raw LUIS API response.</param>
+        /// <param name="logPersonalInformation">TRUE to include personally indentifiable information.</param>
+        public LuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+            : this(application, predictionOptions, includeApiResults, null, telemetryClient)
+        {
+            LogPersonalInformation = logPersonalInformation;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
+        /// </summary>
+        /// <value>If true, personal information is logged to Telemetry; otherwise the properties will be filtered.</value>
+        public bool LogPersonalInformation { get; set; }
+
+        /// <summary>
+        /// Gets the currently configured <see cref="IBotTelemetryClient"/> that logs the LuisResult event.
+        /// </summary>
+        /// <value>The <see cref=IBotTelemetryClient"/> being used to log events.</value>
+        public IBotTelemetryClient TelemetryClient { get; }
 
         /// <summary>
         /// Returns the name of the top scoring intent from a set of LUIS results.
@@ -121,300 +150,120 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
         /// <inheritdoc />
         public async Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)
-            => await RecognizeInternalAsync(turnContext, cancellationToken).ConfigureAwait(false);
+            => await RecognizeInternalAsync(turnContext, null, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
         public async Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken)
             where T : IRecognizerConvert, new()
         {
             var result = new T();
-            result.Convert(await RecognizeInternalAsync(turnContext, cancellationToken).ConfigureAwait(false));
+            result.Convert(await RecognizeInternalAsync(turnContext, null, cancellationToken).ConfigureAwait(false));
             return result;
         }
 
-        private static string NormalizedIntent(string intent) => intent.Replace('.', '_').Replace(' ', '_');
-
-        private static IDictionary<string, IntentScore> GetIntents(LuisResult luisResult)
+        /// <summary>
+        /// Return results of the analysis (Suggested actions and intents).
+        /// </summary>
+        /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="logProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
+        public async Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, Dictionary<string, string> logProperties, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (luisResult.Intents != null)
-            {
-                return luisResult.Intents.ToDictionary(
-                    i => NormalizedIntent(i.Intent),
-                    i => new IntentScore { Score = i.Score ?? 0 });
-            }
-            else
-            {
-                return new Dictionary<string, IntentScore>()
-                {
-                    {
-                        NormalizedIntent(luisResult.TopScoringIntent.Intent),
-                        new IntentScore() { Score = luisResult.TopScoringIntent.Score ?? 0 }
-                    },
-                };
-            }
+            return await RecognizeInternalAsync(turnContext, logProperties, cancellationToken).ConfigureAwait(false);
         }
-
-        private static JObject ExtractEntitiesAndMetadata(IList<EntityModel> entities, IList<CompositeEntityModel> compositeEntities, bool verbose)
-        {
-            var entitiesAndMetadata = new JObject();
-            if (verbose)
-            {
-                entitiesAndMetadata[_metadataKey] = new JObject();
-            }
-
-            var compositeEntityTypes = new HashSet<string>();
-
-            // We start by populating composite entities so that entities covered by them are removed from the entities list
-            if (compositeEntities != null && compositeEntities.Any())
-            {
-                compositeEntityTypes = new HashSet<string>(compositeEntities.Select(ce => ce.ParentType));
-                entities = compositeEntities.Aggregate(entities, (current, compositeEntity) => PopulateCompositeEntityModel(compositeEntity, current, entitiesAndMetadata, verbose));
-            }
-
-            foreach (var entity in entities)
-            {
-                // we'll address composite entities separately
-                if (compositeEntityTypes.Contains(entity.Type))
-                {
-                    continue;
-                }
-
-                AddProperty(entitiesAndMetadata, ExtractNormalizedEntityName(entity), ExtractEntityValue(entity));
-
-                if (verbose)
-                {
-                    AddProperty((JObject)entitiesAndMetadata[_metadataKey], ExtractNormalizedEntityName(entity), ExtractEntityMetadata(entity));
-                }
-            }
-
-            return entitiesAndMetadata;
-        }
-
-        private static JToken Number(dynamic value)
-        {
-            if (value == null)
-            {
-                return null;
-            }
-
-            return long.TryParse((string)value, out var longVal) ?
-                            new JValue(longVal) :
-                            new JValue(double.Parse((string)value));
-        }
-
-        private static JToken ExtractEntityValue(EntityModel entity)
-        {
-#pragma warning disable IDE0007 // Use implicit type
-            if (entity.AdditionalProperties == null || !entity.AdditionalProperties.TryGetValue("resolution", out dynamic resolution))
-#pragma warning restore IDE0007 // Use implicit type
-            {
-                return entity.Entity;
-            }
-
-            if (entity.Type.StartsWith("builtin.datetime."))
-            {
-                return JObject.FromObject(resolution);
-            }
-            else if (entity.Type.StartsWith("builtin.datetimeV2."))
-            {
-                if (resolution.values == null || resolution.values.Count == 0)
-                {
-                    return JArray.FromObject(resolution);
-                }
-
-                var resolutionValues = (IEnumerable<dynamic>)resolution.values;
-                var type = resolution.values[0].type;
-                var timexes = resolutionValues.Select(val => val.timex);
-                var distinctTimexes = timexes.Distinct();
-                return new JObject(new JProperty("type", type), new JProperty("timex", JArray.FromObject(distinctTimexes)));
-            }
-            else
-            {
-                switch (entity.Type)
-                {
-                    case "builtin.number":
-                    case "builtin.ordinal": return Number(resolution.value);
-                    case "builtin.percentage":
-                        {
-                            var svalue = (string)resolution.value;
-                            if (svalue.EndsWith("%"))
-                            {
-                                svalue = svalue.Substring(0, svalue.Length - 1);
-                            }
-
-                            return Number(svalue);
-                        }
-
-                    case "builtin.age":
-                    case "builtin.dimension":
-                    case "builtin.currency":
-                    case "builtin.temperature":
-                        {
-                            var units = (string)resolution.unit;
-                            var val = Number(resolution.value);
-                            var obj = new JObject();
-                            if (val != null)
-                            {
-                                obj.Add("number", val);
-                            }
-
-                            obj.Add("units", units);
-                            return obj;
-                        }
-
-                    default:
-                        return resolution.value ?? JArray.FromObject(resolution.values);
-                }
-            }
-        }
-
-        private static JObject ExtractEntityMetadata(EntityModel entity)
-        {
-            dynamic obj = JObject.FromObject(new
-            {
-                startIndex = (int)entity.StartIndex,
-                endIndex = (int)entity.EndIndex + 1,
-                text = entity.Entity,
-                type = entity.Type,
-            });
-            if (entity.AdditionalProperties != null)
-            {
-                if (entity.AdditionalProperties.TryGetValue("score", out var score))
-                {
-                    obj.score = (double)score;
-                }
-
-#pragma warning disable IDE0007 // Use implicit type
-                if (entity.AdditionalProperties.TryGetValue("resolution", out dynamic resolution) && resolution.subtype != null)
-#pragma warning restore IDE0007 // Use implicit type
-                {
-                    obj.subtype = resolution.subtype;
-                }
-            }
-
-            return obj;
-        }
-
-        private static string ExtractNormalizedEntityName(EntityModel entity)
-        {
-            // Type::Role -> Role
-            var type = entity.Type.Split(':').Last();
-            if (type.StartsWith("builtin.datetimeV2."))
-            {
-                type = "datetime";
-            }
-
-            if (type.StartsWith("builtin.currency"))
-            {
-                type = "money";
-            }
-
-            if (type.StartsWith("builtin."))
-            {
-                type = type.Substring(8);
-            }
-
-            var role = entity.AdditionalProperties != null && entity.AdditionalProperties.ContainsKey("role") ? (string)entity.AdditionalProperties["role"] : string.Empty;
-            if (!string.IsNullOrWhiteSpace(role))
-            {
-                type = role;
-            }
-
-            return type.Replace('.', '_').Replace(' ', '_');
-        }
-
-        private static IList<EntityModel> PopulateCompositeEntityModel(CompositeEntityModel compositeEntity, IList<EntityModel> entities, JObject entitiesAndMetadata, bool verbose)
-        {
-            var childrenEntites = new JObject();
-            var childrenEntitiesMetadata = new JObject();
-            if (verbose)
-            {
-                childrenEntites[_metadataKey] = new JObject();
-            }
-
-            // This is now implemented as O(n^2) search and can be reduced to O(2n) using a map as an optimization if n grows
-            var compositeEntityMetadata = entities.FirstOrDefault(e => e.Type == compositeEntity.ParentType && e.Entity == compositeEntity.Value);
-
-            // This is an error case and should not happen in theory
-            if (compositeEntityMetadata == null)
-            {
-                return entities;
-            }
-
-            if (verbose)
-            {
-                childrenEntitiesMetadata = ExtractEntityMetadata(compositeEntityMetadata);
-                childrenEntites[_metadataKey] = new JObject();
-            }
-
-            var coveredSet = new HashSet<EntityModel>();
-            foreach (var child in compositeEntity.Children)
-            {
-                foreach (var entity in entities)
-                {
-                    // We already covered this entity
-                    if (coveredSet.Contains(entity))
-                    {
-                        continue;
-                    }
-
-                    // This entity doesn't belong to this composite entity
-                    if (child.Type != entity.Type || !CompositeContainsEntity(compositeEntityMetadata, entity))
-                    {
-                        continue;
-                    }
-
-                    // Add to the set to ensure that we don't consider the same child entity more than once per composite
-                    coveredSet.Add(entity);
-                    AddProperty(childrenEntites, ExtractNormalizedEntityName(entity), ExtractEntityValue(entity));
-
-                    if (verbose)
-                    {
-                        AddProperty((JObject)childrenEntites[_metadataKey], ExtractNormalizedEntityName(entity), ExtractEntityMetadata(entity));
-                    }
-                }
-            }
-
-            AddProperty(entitiesAndMetadata, ExtractNormalizedEntityName(compositeEntityMetadata), childrenEntites);
-            if (verbose)
-            {
-                AddProperty((JObject)entitiesAndMetadata[_metadataKey], ExtractNormalizedEntityName(compositeEntityMetadata), childrenEntitiesMetadata);
-            }
-
-            // filter entities that were covered by this composite entity
-            return entities.Except(coveredSet).ToList();
-        }
-
-        private static bool CompositeContainsEntity(EntityModel compositeEntityMetadata, EntityModel entity)
-            => entity.StartIndex >= compositeEntityMetadata.StartIndex &&
-                   entity.EndIndex <= compositeEntityMetadata.EndIndex;
 
         /// <summary>
-        /// If a property doesn't exist add it to a new array, otherwise append it to the existing array.
+        /// Return results of the analysis (Suggested actions and intents).
         /// </summary>
-        private static void AddProperty(JObject obj, string key, JToken value)
+        /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="logProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
+        public async Task<T> RecognizeAsync<T>(ITurnContext turnContext, Dictionary<string, string> logProperties, CancellationToken cancellationToken = default(CancellationToken))
+            where T : IRecognizerConvert, new()
         {
-            if (((IDictionary<string, JToken>)obj).ContainsKey(key))
-            {
-                ((JArray)obj[key]).Add(value);
-            }
-            else
-            {
-                obj[key] = new JArray(value);
-            }
+            var result = new T();
+            result.Convert(await RecognizeInternalAsync(turnContext, logProperties, cancellationToken).ConfigureAwait(false));
+            return result;
         }
 
-        private static void AddProperties(LuisResult luis, RecognizerResult result)
+        /// <summary>
+        /// Invoked prior to a LuisResult being logged.
+        /// </summary>
+        /// <param name="recognizerResult">The Luis Results for the call.</param>
+        /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="additionalProperties">Additional properties to be logged with the LuisResult event.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns><see cref="Task"/>.</returns>
+        protected virtual async Task OnRecognizerResultAsync(RecognizerResult recognizerResult, ITurnContext turnContext, Dictionary<string, string> additionalProperties = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (luis.SentimentAnalysis != null)
-            {
-                result.Properties.Add("sentiment", new JObject(
-                    new JProperty("label", luis.SentimentAnalysis.Label),
-                    new JProperty("score", luis.SentimentAnalysis.Score)));
-            }
+            var properties = await FillLuisEventPropertiesAsync(recognizerResult, turnContext, additionalProperties, cancellationToken).ConfigureAwait(false);
+
+            // Track the event
+            TelemetryClient.TrackEvent(LuisTelemetryConstants.LuisResult, properties, null);
+
+            return;
         }
 
-        private async Task<RecognizerResult> RecognizeInternalAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        /// <summary>
+        /// Fills the event properties for LuisResult event for telemetry.
+        /// These properties are logged when the recognizer is called.
+        /// </summary>
+        /// <param name="recognizerResult">Last activity sent from user.</param>
+        /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="additionalProperties">Additional properties to add to the event.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// additionalProperties
+        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageSend event.</returns>
+        protected Task<Dictionary<string, string>> FillLuisEventPropertiesAsync(RecognizerResult recognizerResult, ITurnContext turnContext, Dictionary<string, string> additionalProperties = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var topLuisIntent = recognizerResult.GetTopScoringIntent();
+            var intentScore = topLuisIntent.score.ToString("N2");
+
+            // Add the intent score and conversation id properties
+            var properties = new Dictionary<string, string>()
+            {
+                { LuisTelemetryConstants.ApplicationIdProperty, _application.ApplicationId },
+                { LuisTelemetryConstants.IntentProperty, topLuisIntent.intent },
+                { LuisTelemetryConstants.IntentScoreProperty, intentScore },
+                { LuisTelemetryConstants.FromIdProperty, turnContext.Activity.From.Id },
+            };
+
+            if (recognizerResult.Properties.TryGetValue("sentiment", out var sentiment) && sentiment is JObject)
+            {
+                if (((JObject)sentiment).TryGetValue("label", out var label))
+                {
+                    properties.Add(LuisTelemetryConstants.SentimentLabelProperty, label.Value<string>());
+                }
+
+                if (((JObject)sentiment).TryGetValue("score", out var score))
+                {
+                    properties.Add(LuisTelemetryConstants.SentimentScoreProperty, score.Value<string>());
+                }
+            }
+
+            var entities = recognizerResult.Entities?.ToString();
+            properties.Add(LuisTelemetryConstants.EntitiesProperty, entities);
+
+            // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example
+            if (LogPersonalInformation && !string.IsNullOrEmpty(turnContext.Activity.Text))
+            {
+                properties.Add(LuisTelemetryConstants.QuestionProperty, turnContext.Activity.Text);
+            }
+
+            // Additional Properties can override "stock" properties.
+            if (additionalProperties != null)
+            {
+                return Task.FromResult(additionalProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value));
+            }
+
+            return Task.FromResult(properties);
+        }
+
+        private async Task<RecognizerResult> RecognizeInternalAsync(ITurnContext turnContext, Dictionary<string, string> additionalProperties, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(turnContext);
 
@@ -445,14 +294,17 @@ namespace Microsoft.Bot.Builder.AI.Luis
             {
                 Text = utterance,
                 AlteredText = luisResult.AlteredQuery,
-                Intents = GetIntents(luisResult),
-                Entities = ExtractEntitiesAndMetadata(luisResult.Entities, luisResult.CompositeEntities, _options.IncludeInstanceData ?? true),
+                Intents = LuisUtil.GetIntents(luisResult),
+                Entities = LuisUtil.ExtractEntitiesAndMetadata(luisResult.Entities, luisResult.CompositeEntities, _options.IncludeInstanceData ?? true),
             };
-            AddProperties(luisResult, recognizerResult);
+            LuisUtil.AddProperties(luisResult, recognizerResult);
             if (_includeApiResults)
             {
                 recognizerResult.Properties.Add("luisResult", luisResult);
             }
+
+            // Log telemetry
+            await OnRecognizerResultAsync(recognizerResult, turnContext, additionalProperties, cancellationToken).ConfigureAwait(false);
 
             var traceInfo = JObject.FromObject(
                 new

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisTelemetryConstants.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisTelemetryConstants.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.AI.Luis
+{
+    /// <summary>
+    /// The IBotTelemetryClient event and property names that logged by default.
+    /// </summary>
+    public static class LuisTelemetryConstants
+    {
+        public const string LuisResult = "LuisResult";  // Event name
+        public const string ApplicationIdProperty = "applicationId";
+        public const string IntentProperty = "intent";
+        public const string IntentScoreProperty = "intentScore";
+        public const string EntitiesProperty = "entities";
+        public const string QuestionProperty = "question";
+        public const string ActivityIdProperty = "activityId";
+        public const string SentimentLabelProperty = "sentimentLabel";
+        public const string SentimentScoreProperty = "sentimentScore";
+        public const string FromIdProperty = "fromId";
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisTelemetryConstants.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisTelemetryConstants.cs
@@ -8,15 +8,17 @@ namespace Microsoft.Bot.Builder.AI.Luis
     /// </summary>
     public static class LuisTelemetryConstants
     {
-        public const string LuisResult = "LuisResult";  // Event name
-        public const string ApplicationIdProperty = "applicationId";
-        public const string IntentProperty = "intent";
-        public const string IntentScoreProperty = "intentScore";
-        public const string EntitiesProperty = "entities";
-        public const string QuestionProperty = "question";
-        public const string ActivityIdProperty = "activityId";
-        public const string SentimentLabelProperty = "sentimentLabel";
-        public const string SentimentScoreProperty = "sentimentScore";
-        public const string FromIdProperty = "fromId";
+        public static readonly string LuisResult = "LuisResult";  // Event name
+        public static readonly string ApplicationIdProperty = "applicationId";
+        public static readonly string IntentProperty = "intent";
+        public static readonly string IntentScoreProperty = "intentScore";
+        public static readonly string Intent2Property = "intent2";
+        public static readonly string IntentScore2Property = "intentScore2";
+        public static readonly string EntitiesProperty = "entities";
+        public static readonly string QuestionProperty = "question";
+        public static readonly string ActivityIdProperty = "activityId";
+        public static readonly string SentimentLabelProperty = "sentimentLabel";
+        public static readonly string SentimentScoreProperty = "sentimentScore";
+        public static readonly string FromIdProperty = "fromId";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisUtil.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisUtil.cs
@@ -1,0 +1,298 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.AI.Luis
+{
+    // Utility functions used to extract and transform data from Luis SDK
+    internal static class LuisUtil
+    {
+        internal const string _metadataKey = "$instance";
+
+        internal static string NormalizedIntent(string intent) => intent.Replace('.', '_').Replace(' ', '_');
+
+        internal static IDictionary<string, IntentScore> GetIntents(LuisResult luisResult)
+        {
+            if (luisResult.Intents != null)
+            {
+                return luisResult.Intents.ToDictionary(
+                    i => NormalizedIntent(i.Intent),
+                    i => new IntentScore { Score = i.Score ?? 0 });
+            }
+            else
+            {
+                return new Dictionary<string, IntentScore>()
+                {
+                    {
+                        NormalizedIntent(luisResult.TopScoringIntent.Intent),
+                        new IntentScore() { Score = luisResult.TopScoringIntent.Score ?? 0 }
+                    },
+                };
+            }
+        }
+
+        internal static JObject ExtractEntitiesAndMetadata(IList<EntityModel> entities, IList<CompositeEntityModel> compositeEntities, bool verbose)
+        {
+            var entitiesAndMetadata = new JObject();
+            if (verbose)
+            {
+                entitiesAndMetadata[_metadataKey] = new JObject();
+            }
+
+            var compositeEntityTypes = new HashSet<string>();
+
+            // We start by populating composite entities so that entities covered by them are removed from the entities list
+            if (compositeEntities != null && compositeEntities.Any())
+            {
+                compositeEntityTypes = new HashSet<string>(compositeEntities.Select(ce => ce.ParentType));
+                entities = compositeEntities.Aggregate(entities, (current, compositeEntity) => PopulateCompositeEntityModel(compositeEntity, current, entitiesAndMetadata, verbose));
+            }
+
+            foreach (var entity in entities)
+            {
+                // we'll address composite entities separately
+                if (compositeEntityTypes.Contains(entity.Type))
+                {
+                    continue;
+                }
+
+                AddProperty(entitiesAndMetadata, ExtractNormalizedEntityName(entity), ExtractEntityValue(entity));
+
+                if (verbose)
+                {
+                    AddProperty((JObject)entitiesAndMetadata[_metadataKey], ExtractNormalizedEntityName(entity), ExtractEntityMetadata(entity));
+                }
+            }
+
+            return entitiesAndMetadata;
+        }
+
+        internal static JToken Number(dynamic value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return long.TryParse((string)value, out var longVal) ?
+                            new JValue(longVal) :
+                            new JValue(double.Parse((string)value));
+        }
+
+        internal static JToken ExtractEntityValue(EntityModel entity)
+        {
+#pragma warning disable IDE0007 // Use implicit type
+            if (entity.AdditionalProperties == null || !entity.AdditionalProperties.TryGetValue("resolution", out dynamic resolution))
+#pragma warning restore IDE0007 // Use implicit type
+            {
+                return entity.Entity;
+            }
+
+            if (entity.Type.StartsWith("builtin.datetime."))
+            {
+                return JObject.FromObject(resolution);
+            }
+            else if (entity.Type.StartsWith("builtin.datetimeV2."))
+            {
+                if (resolution.values == null || resolution.values.Count == 0)
+                {
+                    return JArray.FromObject(resolution);
+                }
+
+                var resolutionValues = (IEnumerable<dynamic>)resolution.values;
+                var type = resolution.values[0].type;
+                var timexes = resolutionValues.Select(val => val.timex);
+                var distinctTimexes = timexes.Distinct();
+                return new JObject(new JProperty("type", type), new JProperty("timex", JArray.FromObject(distinctTimexes)));
+            }
+            else
+            {
+                switch (entity.Type)
+                {
+                    case "builtin.number":
+                    case "builtin.ordinal": return Number(resolution.value);
+                    case "builtin.percentage":
+                        {
+                            var svalue = (string)resolution.value;
+                            if (svalue.EndsWith("%"))
+                            {
+                                svalue = svalue.Substring(0, svalue.Length - 1);
+                            }
+
+                            return Number(svalue);
+                        }
+
+                    case "builtin.age":
+                    case "builtin.dimension":
+                    case "builtin.currency":
+                    case "builtin.temperature":
+                        {
+                            var units = (string)resolution.unit;
+                            var val = Number(resolution.value);
+                            var obj = new JObject();
+                            if (val != null)
+                            {
+                                obj.Add("number", val);
+                            }
+
+                            obj.Add("units", units);
+                            return obj;
+                        }
+
+                    default:
+                        return resolution.value ?? JArray.FromObject(resolution.values);
+                }
+            }
+        }
+
+        internal static JObject ExtractEntityMetadata(EntityModel entity)
+        {
+            dynamic obj = JObject.FromObject(new
+            {
+                startIndex = (int)entity.StartIndex,
+                endIndex = (int)entity.EndIndex + 1,
+                text = entity.Entity,
+                type = entity.Type,
+            });
+            if (entity.AdditionalProperties != null)
+            {
+                if (entity.AdditionalProperties.TryGetValue("score", out var score))
+                {
+                    obj.score = (double)score;
+                }
+
+#pragma warning disable IDE0007 // Use implicit type
+                if (entity.AdditionalProperties.TryGetValue("resolution", out dynamic resolution) && resolution.subtype != null)
+#pragma warning restore IDE0007 // Use implicit type
+                {
+                    obj.subtype = resolution.subtype;
+                }
+            }
+
+            return obj;
+        }
+
+        internal static string ExtractNormalizedEntityName(EntityModel entity)
+        {
+            // Type::Role -> Role
+            var type = entity.Type.Split(':').Last();
+            if (type.StartsWith("builtin.datetimeV2."))
+            {
+                type = "datetime";
+            }
+
+            if (type.StartsWith("builtin.currency"))
+            {
+                type = "money";
+            }
+
+            if (type.StartsWith("builtin."))
+            {
+                type = type.Substring(8);
+            }
+
+            var role = entity.AdditionalProperties != null && entity.AdditionalProperties.ContainsKey("role") ? (string)entity.AdditionalProperties["role"] : string.Empty;
+            if (!string.IsNullOrWhiteSpace(role))
+            {
+                type = role;
+            }
+
+            return type.Replace('.', '_').Replace(' ', '_');
+        }
+
+        internal static IList<EntityModel> PopulateCompositeEntityModel(CompositeEntityModel compositeEntity, IList<EntityModel> entities, JObject entitiesAndMetadata, bool verbose)
+        {
+            var childrenEntites = new JObject();
+            var childrenEntitiesMetadata = new JObject();
+            if (verbose)
+            {
+                childrenEntites[_metadataKey] = new JObject();
+            }
+
+            // This is now implemented as O(n^2) search and can be reduced to O(2n) using a map as an optimization if n grows
+            var compositeEntityMetadata = entities.FirstOrDefault(e => e.Type == compositeEntity.ParentType && e.Entity == compositeEntity.Value);
+
+            // This is an error case and should not happen in theory
+            if (compositeEntityMetadata == null)
+            {
+                return entities;
+            }
+
+            if (verbose)
+            {
+                childrenEntitiesMetadata = ExtractEntityMetadata(compositeEntityMetadata);
+                childrenEntites[_metadataKey] = new JObject();
+            }
+
+            var coveredSet = new HashSet<EntityModel>();
+            foreach (var child in compositeEntity.Children)
+            {
+                foreach (var entity in entities)
+                {
+                    // We already covered this entity
+                    if (coveredSet.Contains(entity))
+                    {
+                        continue;
+                    }
+
+                    // This entity doesn't belong to this composite entity
+                    if (child.Type != entity.Type || !CompositeContainsEntity(compositeEntityMetadata, entity))
+                    {
+                        continue;
+                    }
+
+                    // Add to the set to ensure that we don't consider the same child entity more than once per composite
+                    coveredSet.Add(entity);
+                    AddProperty(childrenEntites, ExtractNormalizedEntityName(entity), ExtractEntityValue(entity));
+
+                    if (verbose)
+                    {
+                        AddProperty((JObject)childrenEntites[_metadataKey], ExtractNormalizedEntityName(entity), ExtractEntityMetadata(entity));
+                    }
+                }
+            }
+
+            AddProperty(entitiesAndMetadata, ExtractNormalizedEntityName(compositeEntityMetadata), childrenEntites);
+            if (verbose)
+            {
+                AddProperty((JObject)entitiesAndMetadata[_metadataKey], ExtractNormalizedEntityName(compositeEntityMetadata), childrenEntitiesMetadata);
+            }
+
+            // filter entities that were covered by this composite entity
+            return entities.Except(coveredSet).ToList();
+        }
+
+        internal static bool CompositeContainsEntity(EntityModel compositeEntityMetadata, EntityModel entity)
+            => entity.StartIndex >= compositeEntityMetadata.StartIndex &&
+                   entity.EndIndex <= compositeEntityMetadata.EndIndex;
+
+        /// <summary>
+        /// If a property doesn't exist add it to a new array, otherwise append it to the existing array.
+        /// </summary>
+        internal static void AddProperty(JObject obj, string key, JToken value)
+        {
+            if (((IDictionary<string, JToken>)obj).ContainsKey(key))
+            {
+                ((JArray)obj[key]).Add(value);
+            }
+            else
+            {
+                obj[key] = new JArray(value);
+            }
+        }
+
+        internal static void AddProperties(LuisResult luis, RecognizerResult result)
+        {
+            if (luis.SentimentAnalysis != null)
+            {
+                result.Properties.Add("sentiment", new JObject(
+                    new JProperty("label", luis.SentimentAnalysis.Label),
+                    new JProperty("score", luis.SentimentAnalysis.Score)));
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/TelemetryConstants.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryConstants.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder
+{
+    public static class TelemetryConstants
+    {
+        public const string ChannelIdProperty = "channelId";
+        public const string ConversationIdProperty = "conversationId";
+        public const string ConversationNameProperty = "conversationName";
+        public const string DialogIdProperty = "DialogId";
+        public const string FromIdProperty = "fromId";
+        public const string FromNameProperty = "fromName";
+        public const string LocaleProperty = "locale";
+        public const string RecipientIdProperty = "recipientId";
+        public const string RecipientNameProperty = "recipientName";
+        public const string ReplyActivityIDProperty = "replyActivityId";
+        public const string TextProperty = "text";
+        public const string SpeakProperty = "speak";
+        public const string UserIdProperty = "userId";
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerConstants.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerConstants.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    /// The Telemetry Logger Event names.
+    /// </summary>
+    public static class TelemetryLoggerConstants
+    {
+        // The name of the event when when new message is received from the user.
+        public const string BotMsgReceiveEvent = "BotMessageReceived";
+
+        // The name of the event when logged when a message is sent from the bot to the user.
+        public const string BotMsgSendEvent = "BotMessageSend";
+
+        // The name of the event when a message is updated by the bot.
+        public const string BotMsgUpdateEvent = "BotMessageUpdate";
+
+        // The name of the event when a message is deleted by the bot.
+        public const string BotMsgDeleteEvent = "BotMessageDelete";
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -1,0 +1,345 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    /// Middleware for logging incoming, outgoing, updated or deleted Activity messages using IBotTelemetryClient.
+    /// </summary>
+    public class TelemetryLoggerMiddleware : IMiddleware
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryLoggerMiddleware"/> class.
+        /// </summary>
+        /// <param name="telemetryClient">The IBotTelemetryClient implementation used for registering telemetry events.</param>
+        /// <param name="logPersonalInformation"> (Optional) TRUE to include personally indentifiable information.</param>
+        public TelemetryLoggerMiddleware(IBotTelemetryClient telemetryClient, bool logPersonalInformation = false)
+        {
+            TelemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+            LogPersonalInformation = logPersonalInformation;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether indicates whether to log personal information into events.
+        /// By default, the following properties will not be logged if this is set to false:
+        ///   Activity.From.Name
+        ///   Activity.Text
+        ///   Activity.Speak
+        /// </summary>
+        /// <value>
+        /// A value indicating whether indicates whether to log personal information into events.
+        /// </value>
+        public bool LogPersonalInformation { get; }
+
+        /// <summary>
+        /// Gets the IBotTelemetryClient.
+        /// </summary>
+        /// <value>
+        /// The IBotTelemetryClient.
+        /// </value>
+        public IBotTelemetryClient TelemetryClient { get; }
+
+        /// <summary>
+        /// Invoked when a message is received from the user.
+        /// Performs logging of telemetry data using the IBotTelemetryClient.TrackEvent() method.
+        /// This event name used is "BotMessageReceived".
+        /// </summary>
+        /// <param name="activity">Current activity sent from user.</param>
+        /// <param name="cancellation"> cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        public Task OnReceiveActivityAsync(Activity activity, CancellationToken cancellation)
+        {
+            TelemetryClient.TrackEvent(TelemetryLoggerConstants.BotMsgReceiveEvent, FillReceiveEventProperties(activity));
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when the bot sends a message to the user.
+        /// Performs logging of telemetry data using the IBotTelemetryClient.TrackEvent() method.
+        /// This event name used is "BotMessageSend".
+        /// </summary>
+        /// <param name="activity">Current activity sent from user.</param>
+        /// <param name="cancellation"> cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        public Task OnSendActivityAsync(Activity activity, CancellationToken cancellation)
+        {
+            TelemetryClient.TrackEvent(TelemetryLoggerConstants.BotMsgSendEvent, FillSendEvendProperties(activity));
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when the bot updates a message.
+        /// Performs logging of telemetry data using the IBotTelemetryClient.TrackEvent() method.
+        /// This event name used is "BotMessageUpdate".
+        /// </summary>
+        /// <param name="activity">Current activity sent from user.</param>
+        /// <param name="cancellation"> cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        public Task OnUpdateActivityAsync(Activity activity, CancellationToken cancellation)
+        {
+            TelemetryClient.TrackEvent(TelemetryLoggerConstants.BotMsgUpdateEvent, FillUpdateEventProperties(activity));
+
+            return Task.CompletedTask;
+
+        }
+
+        /// <summary>
+        /// Invoked when the bot deletes a message.
+        /// Performs logging of telemetry data using the IBotTelemetryClient.TrackEvent() method.
+        /// This event name used is "BotMessageDelete".
+        /// </summary>
+        /// <param name="activity">Current activity sent from user.</param>
+        /// <param name="cancellation"> cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        public Task OnDeleteActivityAsync(Activity activity, CancellationToken cancellation)
+        {
+            TelemetryClient.TrackEvent(TelemetryLoggerConstants.BotMsgDeleteEvent, FillDeleteEventProperties(activity));
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Logs events based on incoming and outgoing activities using the IBotTelemetryClient interface.
+        /// </summary>
+        /// <param name="context">The context object for this turn.</param>
+        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <seealso cref="ITurnContext"/>
+        /// <seealso cref="Bot.Schema.IActivity"/>
+        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        {
+            BotAssert.ContextNotNull(context);
+
+            // log incoming activity at beginning of turn
+            if (context.Activity != null)
+            {
+                var activity = context.Activity;
+
+                // Log Bot Message Received
+                await OnReceiveActivityAsync(activity, cancellationToken).ConfigureAwait(false);
+            }
+
+            // hook up onSend pipeline
+            context.OnSendActivities(async (ctx, activities, nextSend) =>
+            {
+                // run full pipeline
+                var responses = await nextSend().ConfigureAwait(false);
+
+                foreach (var activity in activities)
+                {
+                    await OnSendActivityAsync(activity, cancellationToken).ConfigureAwait(false);
+                }
+
+                return responses;
+            });
+
+            // hook up update activity pipeline
+            context.OnUpdateActivity(async (ctx, activity, nextUpdate) =>
+            {
+                // run full pipeline
+                var response = await nextUpdate().ConfigureAwait(false);
+
+                await OnUpdateActivityAsync(activity, cancellationToken).ConfigureAwait(false);
+
+                return response;
+            });
+
+            // hook up delete activity pipeline
+            context.OnDeleteActivity(async (ctx, reference, nextDelete) =>
+            {
+                // run full pipeline
+                await nextDelete().ConfigureAwait(false);
+
+                var deleteActivity = new Activity
+                {
+                    Type = ActivityTypes.MessageDelete,
+                    Id = reference.ActivityId,
+                }
+                .ApplyConversationReference(reference, isIncoming: false)
+                .AsMessageDeleteActivity();
+
+                await OnDeleteActivityAsync((Activity)deleteActivity, cancellationToken).ConfigureAwait(false);
+            });
+
+            if (nextTurn != null)
+            {
+                await nextTurn(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Fills the Event properties for BotMessageReceived.
+        /// These properties are logged in the IBotTelemetryClient.TrackEvent method when a message is received from the user.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <param name="additionalProperties">Additional properties to add to the event.</param>
+        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageReceived event.</returns>
+        protected Dictionary<string, string> FillReceiveEventProperties(Activity activity, Dictionary<string, string> additionalProperties = null)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.FromIdProperty, activity.From.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                    { TelemetryConstants.LocaleProperty, activity.Locale },
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.RecipientNameProperty, activity.Recipient.Name },
+                };
+
+            // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
+            if (LogPersonalInformation)
+            {
+                if (!string.IsNullOrWhiteSpace(activity.From.Name))
+                {
+                    properties.Add(TelemetryConstants.FromNameProperty, activity.From.Name);
+                }
+
+                if (!string.IsNullOrWhiteSpace(activity.Text))
+                {
+                    properties.Add(TelemetryConstants.TextProperty, activity.Text);
+                }
+
+                if (!string.IsNullOrWhiteSpace(activity.Speak))
+                {
+                    properties.Add(TelemetryConstants.SpeakProperty, activity.Speak);
+                }
+            }
+
+            // Additional Properties can override "stock" properties.
+            if (additionalProperties != null)
+            {
+                return additionalProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value);
+            }
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Fills the event properties for BotMessageSend.
+        /// These properties are logged when an activity message is sent by the Bot to the user.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <param name="additionalProperties">Additional properties to add to the event.</param>
+        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageSend event.</returns>
+        protected Dictionary<string, string> FillSendEvendProperties(Activity activity, Dictionary<string, string> additionalProperties = null)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.ReplyActivityIDProperty, activity.ReplyToId },
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                    { TelemetryConstants.LocaleProperty, activity.Locale },
+                };
+
+            // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
+            if (LogPersonalInformation)
+            {
+                if (!string.IsNullOrWhiteSpace(activity.Recipient.Name))
+                {
+                    properties.Add(TelemetryConstants.RecipientNameProperty, activity.Recipient.Name);
+                }
+
+                if (!string.IsNullOrWhiteSpace(activity.Text))
+                {
+                    properties.Add(TelemetryConstants.TextProperty, activity.Text);
+                }
+
+                if (!string.IsNullOrWhiteSpace(activity.Speak))
+                {
+                    properties.Add(TelemetryConstants.SpeakProperty, activity.Speak);
+                }
+            }
+
+            // Additional Properties can override "stock" properties.
+            if (additionalProperties != null)
+            {
+                return additionalProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value);
+            }
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Fills the event properties for BotMessageUpdate.
+        /// These properties are logged when an activity message is updated by the Bot.
+        /// For example, if a card is interacted with by the use, and the card needs to be updated to reflect
+        /// some interaction.
+        /// </summary>
+        /// <param name="activity">Last activity sent from user.</param>
+        /// <param name="additionalProperties">Additional properties to add to the event.</param>
+        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageUpdate event.</returns>
+        protected Dictionary<string, string> FillUpdateEventProperties(Activity activity, Dictionary<string, string> additionalProperties = null)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.ConversationIdProperty, activity.Conversation.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                    { TelemetryConstants.LocaleProperty, activity.Locale },
+                };
+
+            // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example
+            if (LogPersonalInformation && !string.IsNullOrWhiteSpace(activity.Text))
+            {
+                properties.Add(TelemetryConstants.TextProperty, activity.Text);
+            }
+
+            // Additional Properties can override "stock" properties.
+            if (additionalProperties != null)
+            {
+                return additionalProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value);
+            }
+
+            return properties;
+
+            return properties;
+        }
+
+        /// <summary>
+        /// Fills the event properties for BotMessageDelete.
+        /// These properties are logged when an activity message is deleted by the Bot.
+        /// </summary>
+        /// <param name="activity">The Activity object deleted by bot.</param>
+        /// <param name="additionalProperties">Additional properties to add to the event.</param>
+        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageDelete event.</returns>
+        protected Dictionary<string, string> FillDeleteEventProperties(IMessageDeleteActivity activity, Dictionary<string, string> additionalProperties = null)
+        {
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
+                    { TelemetryConstants.ConversationIdProperty, activity.Conversation.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
+                };
+
+            // Additional Properties can override "stock" properties.
+            if (additionalProperties != null)
+            {
+                return additionalProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value);
+            }
+
+            return properties;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
@@ -1,0 +1,167 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    [TestClass]
+    public class TelemetryMiddlewareTests
+    {
+        [TestMethod]
+        [TestCategory("Telemetry")]
+        public async Task Telemetry_LogActivities()
+        {
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
+            TestAdapter adapter = new TestAdapter()
+                .Use(new TelemetryLoggerMiddleware(mockTelemetryClient.Object, logPersonalInformation: true));
+            string conversationId = null;
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                conversationId = context.Activity.Conversation.Id;
+                var typingActivity = new Activity
+                {
+                    Type = ActivityTypes.Typing,
+                    RelatesTo = context.Activity.RelatesTo
+                };
+                await context.SendActivityAsync(typingActivity);
+                await Task.Delay(500);
+                await context.SendActivityAsync("echo:" + context.Activity.Text);
+            })
+                .Send("foo")
+                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:foo")
+                .Send("bar")
+                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:bar")
+                .StartTestAsync();
+
+            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 6);
+            Assert.AreEqual(mockTelemetryClient.Invocations[0].Arguments[0], "BotMessageReceived"); // Check initial message
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).Count == 7);
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("fromId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("conversationName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("locale"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("recipientId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("recipientName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("fromName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("text"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1])["text"] == "foo");
+
+            Assert.AreEqual(mockTelemetryClient.Invocations[1].Arguments[0], "BotMessageSend"); // Check Typing message
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[1].Arguments[1]).Count == 5);
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[1].Arguments[1]).ContainsKey("replyActivityId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[1].Arguments[1]).ContainsKey("recipientId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[1].Arguments[1]).ContainsKey("conversationName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[1].Arguments[1]).ContainsKey("locale"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[1].Arguments[1]).ContainsKey("recipientName"));
+
+            Assert.AreEqual(mockTelemetryClient.Invocations[2].Arguments[0], "BotMessageSend"); // Check message reply
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).Count == 6);
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).ContainsKey("replyActivityId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).ContainsKey("recipientId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).ContainsKey("conversationName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).ContainsKey("locale"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).ContainsKey("recipientName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1]).ContainsKey("text"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[2].Arguments[1])["text"] == "echo:foo");
+
+            Assert.AreEqual(mockTelemetryClient.Invocations[3].Arguments[0], "BotMessageReceived"); // Check bar message
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).Count == 7);
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("fromId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("conversationName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("locale"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("recipientId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("recipientName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("fromName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("text"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1])["text"] == "bar");
+        }
+
+        [TestMethod]
+        [TestCategory("Telemetry")]
+        public async Task Transcript_LogUpdateActivities()
+        {
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
+            TestAdapter adapter = new TestAdapter()
+                .Use(new TelemetryLoggerMiddleware(mockTelemetryClient.Object, logPersonalInformation: true));
+            string conversationId = null;
+            Activity activityToUpdate = null;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                conversationId = context.Activity.Conversation.Id;
+                if (context.Activity.Text == "update")
+                {
+                    activityToUpdate.Text = "new response";
+                    await context.UpdateActivityAsync(activityToUpdate);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("response");
+                    var response = await context.SendActivityAsync(activity);
+                    activity.Id = response.Id;
+
+                    // clone the activity, so we can use it to do an update
+                    activityToUpdate = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+                }
+            })
+                .Send("foo")
+                .Send("update")
+                    .AssertReply("new response")
+                .StartTestAsync();
+
+            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 4);
+            Assert.AreEqual(mockTelemetryClient.Invocations[3].Arguments[0], "BotMessageUpdate"); // Check update message
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).Count == 5);
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("recipientId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("conversationId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("conversationName"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("locale"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("text"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1])["text"] == "new response");
+        }
+
+
+        [TestMethod]
+        [TestCategory("Middleware")]
+        public async Task Transcript_LogDeleteActivities()
+        {
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
+            TestAdapter adapter = new TestAdapter()
+                .Use(new TelemetryLoggerMiddleware(mockTelemetryClient.Object, logPersonalInformation: true));
+            string conversationId = null;
+            string activityId = null;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                conversationId = context.Activity.Conversation.Id;
+                if (context.Activity.Text == "deleteIt")
+                {
+                    await context.DeleteActivityAsync(activityId);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("response");
+                    var response = await context.SendActivityAsync(activity);
+                    activityId = response.Id;
+                }
+            })
+                .Send("foo")
+                    .AssertReply("response")
+                .Send("deleteIt")
+                .StartTestAsync();
+            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 4);
+            Assert.AreEqual(mockTelemetryClient.Invocations[3].Arguments[0], "BotMessageDelete"); // Check delete message
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).Count == 3);
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("recipientId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("conversationId"));
+            Assert.IsTrue(((Dictionary<string, string>)mockTelemetryClient.Invocations[3].Arguments[1]).ContainsKey("conversationName"));
+        }
+    }
+}


### PR DESCRIPTION
Adds support for IBotTelemetryClient (no new dependencies) within the Luis Recognizer.

https://github.com/daveta/analytics/blob/master/telemetry_enhancements/TelemetryEnhancements.md#telemetry-support-luis
- Properties can be added to the telemetry event per invocation 
- Class can be derived to override default behavior
- Exposed methods to help populate events when deriving

