### PR TITLE
QnA Telemetry Support

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/ITelemetryQnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/ITelemetryQnAMaker.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.AI.QnA
+{
+    public interface ITelemetryQnAMaker
+    {
+        /// <summary>
+        /// Gets a value indicating whether determines whether to log personal information that came from the user.
+        /// </summary>
+        /// <value>If true, will log personal information into the IBotTelemetryClient.TrackEvent method; otherwise the properties will be filtered.</value>
+        bool LogPersonalInformation { get; }
+
+        /// <summary>
+        /// Gets the currently configured <see cref="IBotTelemetryClient"/> that logs the QnaMessage event.
+        /// </summary>
+        /// <value>The <see cref=IBotTelemetryClient"/> being used to log events.</value>
+        IBotTelemetryClient TelemetryClient { get; }
+
+        /// <summary>
+        /// Generates an answer from the knowledge base.
+        /// </summary>
+        /// <param name="turnContext">The Turn Context that contains the user question to be queried against your knowledge base.</param>
+        /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
+        /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the QnaMessage event.</param>
+        /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the QnaMessage event.</param>
+        /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
+        Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics = null);
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             {
                 if (!string.IsNullOrWhiteSpace(text))
                 {
-                    properties.Add(QnATelemetryConstants.OriginalQuestionProperty, text);
+                    properties.Add(QnATelemetryConstants.QuestionProperty, text);
                 }
 
                 if (!string.IsNullOrWhiteSpace(userName))
@@ -200,7 +200,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             if (queryResults.Length > 0)
             {
                 var queryResult = queryResults[0];
-                properties.Add(QnATelemetryConstants.QuestionProperty, JsonConvert.SerializeObject(queryResult.Questions));
+                properties.Add(QnATelemetryConstants.MatchedQuestionProperty, JsonConvert.SerializeObject(queryResult.Questions));
                 properties.Add(QnATelemetryConstants.QuestionIdProperty, queryResult.Id.ToString());
                 properties.Add(QnATelemetryConstants.AnswerProperty, queryResult.Answer);
                 metrics.Add(QnATelemetryConstants.ScoreProperty, queryResult.Score);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -162,16 +162,16 @@ namespace Microsoft.Bot.Builder.AI.QnA
         }
 
         /// <summary>
-        /// Fills the event properties andmetrics for the QnaMessage event for telemetry.
+        /// Fills the event properties and metrics for the QnaMessage event for telemetry.
         /// These properties are logged when the QnA GetAnswers method is called.
         /// </summary>
         /// <param name="queryResults">QnA service results.</param>
         /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
-        /// <param name="telemetryProperties">Additional properties to add to the event.</param>
-        /// <param name="telemetryMetrics">Additional metrics to add to the event.</param>
+        /// <param name="telemetryProperties">Properties to add/override for the event.</param>
+        /// <param name="telemetryMetrics">Metrics to add/override for the event.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// additionalProperties
-        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageSend event.</returns>
+        /// <returns>A tuple of Properties and Metrics that will be sent to the IBotTelemetryClient.TrackEvent method for the QnAMessage event.  The properties and metrics returned the standard properties logged with any properties passed from the GetAnswersAsync method.</returns>
         protected Task<(Dictionary<string, string> Properties, Dictionary<string, double> Metrics)> FillQnAEventAsync(QueryResult[] queryResults, ITurnContext turnContext, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var properties = new Dictionary<string, string>();

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.Versioning;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Configuration;
@@ -18,7 +20,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
     /// <summary>
     /// Provides access to a QnA Maker knowledge base.
     /// </summary>
-    public class QnAMaker
+    public class QnAMaker : ITelemetryQnAMaker
     {
         public const string QnAMakerName = nameof(QnAMaker);
         public const string QnAMakerTraceType = "https://www.qnamaker.ai/schemas/trace";
@@ -39,7 +41,9 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="options">The options for the QnA Maker knowledge base.</param>
         /// <param name="httpClient">An alternate client with which to talk to QnAMaker.
         /// If null, a default client is used for this instance.</param>
-        public QnAMaker(QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null)
+        /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
+        /// <param name="logPersonalInformation">Set to true to include personally indentifiable information in telemetry events.</param>
+        public QnAMaker(QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
         {
             _httpClient = httpClient ?? DefaultHttpClient;
 
@@ -68,29 +72,48 @@ namespace Microsoft.Bot.Builder.AI.QnA
             _isLegacyProtocol = _endpoint.Host.EndsWith("v3.0");
 
             _options = options ?? new QnAMakerOptions();
-
             ValidateOptions(_options);
+
+            TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
+            LogPersonalInformation = logPersonalInformation;
         }
 
-        /// <summary>
         /// Initializes a new instance of the <see cref="QnAMaker"/> class.
         /// </summary>
         /// <param name="service">QnA service details from configuration.</param>
         /// <param name="options">The options for the QnA Maker knowledge base.</param>
         /// <param name="httpClient">An alternate client with which to talk to QnAMaker.
         /// If null, a default client is used for this instance.</param>
-        public QnAMaker(QnAMakerService service, QnAMakerOptions options = null, HttpClient httpClient = null)
-            : this(new QnAMakerEndpoint(service), options, httpClient)
+        public QnAMaker(QnAMakerService service, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+            : this(new QnAMakerEndpoint(service), options, httpClient, telemetryClient, logPersonalInformation)
         {
         }
+
+        /// <summary>
+        /// Gets a value indicating whether determines whether to log personal information that came from the user.
+        /// </summary>
+        /// <value>If true, will log personal information into the IBotTelemetryClient.TrackEvent method; otherwise the properties will be filtered.</value>
+        public bool LogPersonalInformation { get; }
+
+        /// <summary>
+        /// Gets the currently configured <see cref="IBotTelemetryClient"/> that logs the QnaMessage event.
+        /// </summary>
+        /// <value>The <see cref=IBotTelemetryClient"/> being used to log events.</value>
+        public IBotTelemetryClient TelemetryClient { get; }
 
         /// <summary>
         /// Generates an answer from the knowledge base.
         /// </summary>
         /// <param name="turnContext">The Turn Context that contains the user question to be queried against your knowledge base.</param>
         /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
+        /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the QnaMessage event.</param>
+        /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the QnaMessage event.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
-        public async Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options = null)
+        public async Task<QueryResult[]> GetAnswersAsync(
+                                        ITurnContext turnContext,
+                                        QnAMakerOptions options = null,
+                                        Dictionary<string, string> telemetryProperties = null,
+                                        Dictionary<string, double> telemetryMetrics = null)
         {
             if (turnContext == null)
             {
@@ -120,7 +143,94 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
             await EmitTraceInfoAsync(turnContext, (Activity)messageActivity, result, hydratedOptions).ConfigureAwait(false);
 
+            await OnQnaResultsAsync(result, turnContext, telemetryProperties, telemetryMetrics, CancellationToken.None).ConfigureAwait(false);
+
             return result;
+        }
+
+        protected virtual async Task OnQnaResultsAsync(
+                   QueryResult[] queryResults,
+                   ITurnContext turnContext,
+                   Dictionary<string, string> telemetryProperties = null,
+                   Dictionary<string, double> telemetryMetrics = null,
+                   CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var eventData = await FillQnAEventAsync(queryResults, turnContext, telemetryProperties, telemetryMetrics, cancellationToken).ConfigureAwait(false);
+
+            // Track the event
+            TelemetryClient.TrackEvent(QnATelemetryConstants.QnaMsgEvent, eventData.Properties, eventData.Metrics);
+        }
+
+        /// <summary>
+        /// Fills the event properties andmetrics for the QnaMessage event for telemetry.
+        /// These properties are logged when the QnA GetAnswers method is called.
+        /// </summary>
+        /// <param name="queryResults">QnA service results.</param>
+        /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="telemetryProperties">Additional properties to add to the event.</param>
+        /// <param name="telemetryMetrics">Additional metrics to add to the event.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// additionalProperties
+        /// <returns>A dictionary that is sent as "Properties" to IBotTelemetryClient.TrackEvent method for the BotMessageSend event.</returns>
+        protected Task<(Dictionary<string, string> Properties, Dictionary<string, double> Metrics)> FillQnAEventAsync(QueryResult[] queryResults, ITurnContext turnContext, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var properties = new Dictionary<string, string>();
+            var metrics = new Dictionary<string, double>();
+
+            properties.Add(QnATelemetryConstants.KnowledgeBaseIdProperty, _endpoint.KnowledgeBaseId);
+
+            var text = turnContext.Activity.Text;
+            var userName = turnContext.Activity.From.Name;
+
+            // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
+            if (LogPersonalInformation)
+            {
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    properties.Add(QnATelemetryConstants.OriginalQuestionProperty, text);
+                }
+
+                if (!string.IsNullOrWhiteSpace(userName))
+                {
+                    properties.Add(QnATelemetryConstants.UsernameProperty, userName);
+                }
+            }
+
+            // Fill in Qna Results (found or not)
+            if (queryResults.Length > 0)
+            {
+                var queryResult = queryResults[0];
+                properties.Add(QnATelemetryConstants.QuestionProperty, JsonConvert.SerializeObject(queryResult.Questions));
+                properties.Add(QnATelemetryConstants.QuestionIdProperty, queryResult.Id.ToString());
+                properties.Add(QnATelemetryConstants.AnswerProperty, queryResult.Answer);
+                metrics.Add(QnATelemetryConstants.ScoreProperty, queryResult.Score);
+                properties.Add(QnATelemetryConstants.ArticleFoundProperty, "true");
+            }
+            else
+            {
+                properties.Add(QnATelemetryConstants.QuestionProperty, "No Qna Question matched");
+                properties.Add(QnATelemetryConstants.QuestionIdProperty, "No QnA Question Id matched");
+                properties.Add(QnATelemetryConstants.AnswerProperty, "No Qna Answer matched");
+                properties.Add(QnATelemetryConstants.ArticleFoundProperty, "false");
+            }
+
+            // Additional Properties can override "stock" properties.
+            if (telemetryProperties != null)
+            {
+                telemetryProperties = telemetryProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value);
+            }
+
+            // Additional Metrics can override "stock" metrics.
+            if (telemetryMetrics != null)
+            {
+                telemetryMetrics = telemetryMetrics.Concat(metrics)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value);
+            }
+
+            return Task.FromResult((Properties: telemetryProperties ?? properties, Metrics: telemetryMetrics ?? metrics));
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnATelemetryConstants.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnATelemetryConstants.cs
@@ -8,15 +8,15 @@ namespace Microsoft.Bot.Builder.AI.QnA
     /// </summary>
     public static class QnATelemetryConstants
     {
-        public const string QnaMsgEvent = "QnaMessage"; // Event name
-        public const string KnowledgeBaseIdProperty = "knowledgeBaseId";
-        public const string AnswerProperty = "answer";
-        public const string ArticleFoundProperty = "articleFound";
-        public const string ChannelIdProperty = "channelId";
-        public const string OriginalQuestionProperty = "originalQuestion";
-        public const string QuestionProperty = "question";
-        public const string QuestionIdProperty = "questionId";
-        public const string ScoreProperty = "score";
-        public const string UsernameProperty = "username";
+        public static readonly string QnaMsgEvent = "QnaMessage"; // Event name
+        public static readonly string KnowledgeBaseIdProperty = "knowledgeBaseId";
+        public static readonly string AnswerProperty = "answer";
+        public static readonly string ArticleFoundProperty = "articleFound";
+        public static readonly string ChannelIdProperty = "channelId";
+        public static readonly string MatchedQuestionProperty = "matchedQuestion";
+        public static readonly string QuestionProperty = "question";
+        public static readonly string QuestionIdProperty = "questionId";
+        public static readonly string ScoreProperty = "score";
+        public static readonly string UsernameProperty = "username";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnATelemetryConstants.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnATelemetryConstants.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.AI.QnA
+{
+    /// <summary>
+    /// Default QnA event and property names logged using IBotTelemetryClient.
+    /// </summary>
+    public static class QnATelemetryConstants
+    {
+        public const string QnaMsgEvent = "QnaMessage"; // Event name
+        public const string KnowledgeBaseIdProperty = "knowledgeBaseId";
+        public const string AnswerProperty = "answer";
+        public const string ArticleFoundProperty = "articleFound";
+        public const string ChannelIdProperty = "channelId";
+        public const string OriginalQuestionProperty = "originalQuestion";
+        public const string QuestionProperty = "question";
+        public const string QuestionIdProperty = "questionId";
+        public const string ScoreProperty = "score";
+        public const string UsernameProperty = "username";
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments.Count, 3);
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("originalQuestion"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("matchedQuestion"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("questionId"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("answer"));
@@ -773,8 +773,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments.Count, 3);
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
-            Assert.IsFalse(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("originalQuestion"));
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("matchedQuestion"));
+            Assert.IsFalse(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("questionId"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("answer"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["answer"], "BaseCamp: You can use a damp rag to clean around the Power Pack");
@@ -884,11 +884,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.AreEqual(telemetryClient.Invocations.Count, 1);
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments.Count, 3);
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
-            Assert.IsFalse(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("originalQuestion"));
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("questionId"));
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("answer"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.KnowledgeBaseIdProperty));
+            Assert.IsFalse(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.QuestionProperty));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.MatchedQuestionProperty));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.QuestionIdProperty));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.AnswerProperty));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["answer"], "BaseCamp: You can use a damp rag to clean around the Power Pack");
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("MyImportantProperty"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["MyImportantProperty"], "myImportantValue");
@@ -953,9 +953,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["knowledgeBaseId"], "myImportantValue");
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("originalQuestion"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("matchedQuestion"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["originalQuestion"], "myImportantValue2");
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
+            Assert.IsFalse(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("questionId"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("answer"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["answer"], "BaseCamp: You can use a damp rag to clean around the Power Pack");
@@ -1004,7 +1004,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var telemetryProperties = new Dictionary<string, string>
             {
                 { "knowledgeBaseId", "myImportantValue" },
-                { "originalQuestion", "myImportantValue2" },
+                { "matchedQuestion", "myImportantValue2" },
             };
             var telemetryMetrics = new Dictionary<string, double>
             {
@@ -1017,12 +1017,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.AreEqual(telemetryClient.Invocations.Count, 2);
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments.Count, 3);
             Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
-            Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count, 7);
+            Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count, 6);
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["knowledgeBaseId"], "myImportantValue");
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("originalQuestion"));
-            Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["originalQuestion"], "myImportantValue2");
-            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("matchedQuestion"));
+            Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["matchedQuestion"], "myImportantValue2");
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("questionId"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("answer"));
             Assert.AreEqual(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["answer"], "BaseCamp: You can use a damp rag to clean around the Power Pack");


### PR DESCRIPTION
Adds Telemetry support to QnAMaker

Shares same pattern as Luis and TelemetryMiddleware.
- Enables setting properties during GetAnswersAsync
- Enables deriving from class and adding properties

https://github.com/daveta/analytics/blob/master/telemetry_enhancements/TelemetryEnhancements.md#telemetry-qna-recognizer
