### PR TITLE
Disable the "Live" token refresh tests

### DIFF
--- a/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Microsoft.Bot.Connector.Authentication;
 
-namespace Microsoft.Bot.Builder.Tests
+namespace Microsoft.Bot.Connector.Tests
 {
     /// <summary>
     /// Summary description for UnitTest1
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
         }
 
-        [Fact]
+        //[Fact]
         public async Task TokenTests_GetCredentialsWorks()
         {
             MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("645cd89f-a83e-4af9-abb5-a454e917cbc4", "jvoMWRBA67:zjgePZ359_-_");
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
 
-        [Fact]
+        //[Fact]
         public async Task TokenTests_RefreshTokenWorks()
         {
             MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("12604f0f-bc92-4318-a6dd-aed704445ba4", "H_k}}7b75BEl+KY1");
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.NotEqual(result2, result3);
         }
 
-        [Fact]
+        //[Fact]
         public async Task TokenTests_RefreshTestLoad()
         {
             MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("12604f0f-bc92-4318-a6dd-aed704445ba4", "H_k}}7b75BEl+KY1");


### PR DESCRIPTION
This PR disables the Token Refresh tests, as they're all failing with what looks like a recent configuration error on the AAD side. 

Related to #1480 