### PR TITLE
Token Refresh: fix failing tests due to deleted app id

### DIFF
--- a/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Connector.Tests
         {
         }
 
-        //[Fact]
+        [Fact]
         public async Task TokenTests_GetCredentialsWorks()
         {
             MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("645cd89f-a83e-4af9-abb5-a454e917cbc4", "jvoMWRBA67:zjgePZ359_-_");
@@ -26,10 +26,10 @@ namespace Microsoft.Bot.Connector.Tests
         }
 
 
-        //[Fact]
+        [Fact]
         public async Task TokenTests_RefreshTokenWorks()
         {
-            MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("12604f0f-bc92-4318-a6dd-aed704445ba4", "H_k}}7b75BEl+KY1");
+            MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("645cd89f-a83e-4af9-abb5-a454e917cbc4", "jvoMWRBA67:zjgePZ359_-_");
             var result = await credentials.GetTokenAsync();
             Assert.NotNull(result);
             var result2 = await credentials.GetTokenAsync();
@@ -39,10 +39,10 @@ namespace Microsoft.Bot.Connector.Tests
             Assert.NotEqual(result2, result3);
         }
 
-        //[Fact]
+        [Fact]
         public async Task TokenTests_RefreshTestLoad()
         {
-            MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("12604f0f-bc92-4318-a6dd-aed704445ba4", "H_k}}7b75BEl+KY1");
+            MicrosoftAppCredentials credentials = new MicrosoftAppCredentials("645cd89f-a83e-4af9-abb5-a454e917cbc4", "jvoMWRBA67:zjgePZ359_-_");
             List<Task<string>> tasks = new List<Task<string>>();
             for (int i = 0; i < 1000; i++)
             {


### PR DESCRIPTION
Fixes #1480 