### PR TITLE
[StyleCop] Fix all warnings in BotBuilder.Configuration.Test

### DIFF
--- a/tests/Microsoft.Bot.Configuration.Tests/ConfigurationLoadAndSaveTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ConfigurationLoadAndSaveTests.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Configuration.Tests
 {
     [TestClass]
-    public class ConfingurationLoadAndSaveTests
+    public class ConfigurationLoadAndSaveTests
     {
         private const string TestBotFileName = @"..\..\..\test.bot";
         private const string OutputBotFileName = "save.bot";
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Configuration.Tests
             var config = await BotConfiguration.LoadAsync(TestBotFileName);
             Assert.AreEqual("test", config.Name);
             Assert.AreEqual("test description", config.Description);
-            Assert.AreEqual("", config.Padlock);
+            Assert.AreEqual(string.Empty, config.Padlock);
             Assert.AreEqual(12, config.Services.Count);
             dynamic properties = config.Properties;
             Assert.AreEqual(true, (bool)properties.extra, "extra property should round trip");
@@ -68,7 +68,6 @@ namespace Microsoft.Bot.Configuration.Tests
             }
         }
 
-
         [TestMethod]
         public async Task LoadAndSaveUnencryptedBotFile()
         {
@@ -102,7 +101,9 @@ namespace Microsoft.Bot.Configuration.Tests
                 await BotConfiguration.LoadAsync(OutputBotFileName);
                 Assert.Fail("Load should have thrown due to no secret");
             }
-            catch { }
+            catch
+            {
+            }
         }
 
         [TestMethod]
@@ -190,7 +191,10 @@ namespace Microsoft.Bot.Configuration.Tests
                 await config2.SaveAsAsync(OutputBotFileName);
                 Assert.Fail("Save() should have thrown due to no secret");
             }
-            catch { }
+            catch
+            {
+            }
+
             config2.ClearSecret();
             await config2.SaveAsAsync(OutputBotFileName, secret);
         }
@@ -200,7 +204,7 @@ namespace Microsoft.Bot.Configuration.Tests
         {
             string secret = BotConfiguration.GenerateKey();
             var config = await BotConfiguration.LoadAsync(TestBotFileName);
-            Assert.AreEqual("", config.Padlock, "There should be no padlock");
+            Assert.AreEqual(string.Empty, config.Padlock, "There should be no padlock");
 
             // save with secret
             await config.SaveAsAsync("savesecret.bot", secret);
@@ -229,6 +233,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreEqual(appInsights.ApiKeys["key1"], "testKey1", "failed to decrypt key1");
                             Assert.AreEqual(appInsights.ApiKeys["key2"], "testKey2", "failed to decrypt key2");
                         }
+
                         break;
 
                     case ServiceTypes.BlobStorage:
@@ -237,6 +242,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreEqual("UseDevelopmentStorage=true;", blobStorage.ConnectionString, "failed to decrypt connectionString");
                             Assert.AreEqual("testContainer", blobStorage.Container, "failed to decrypt Container");
                         }
+
                         break;
 
                     case ServiceTypes.CosmosDB:
@@ -246,8 +252,8 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreEqual("C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==", cosmosDb.Key, "failed to decrypt key");
                             Assert.AreEqual("testDatabase", cosmosDb.Database, "failed to decrypt database");
                             Assert.AreEqual("testCollection", cosmosDb.Collection, "failed to decrypt collection");
-
                         }
+
                         break;
 
                     case ServiceTypes.Dispatch:
@@ -256,6 +262,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsTrue(dispatch.AuthoringKey.Contains("0000"), "failed to decrypt authoringkey");
                             Assert.IsTrue(dispatch.SubscriptionKey.Contains("0000"), "failed to decrypt subscriptionKey");
                         }
+
                         break;
 
                     case ServiceTypes.Endpoint:
@@ -263,6 +270,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             var endpoint = (EndpointService)config2.Services[i];
                             Assert.AreEqual("testpassword", endpoint.AppPassword, "failed to decrypt appPassword");
                         }
+
                         break;
 
                     case ServiceTypes.File:
@@ -274,6 +282,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsTrue(luis.AuthoringKey.Contains("0000"), "failed to decrypt authoringkey");
                             Assert.IsTrue(luis.SubscriptionKey.Contains("0000"), "failed to decrypt subscriptionKey");
                         }
+
                         break;
 
                     case ServiceTypes.QnA:
@@ -283,6 +292,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsTrue(qna.EndpointKey.Contains("0000"), "failed to decrypt EndpointKey");
                             Assert.IsTrue(qna.SubscriptionKey.Contains("0000"), "failed to decrypt SubscriptionKey");
                         }
+
                         break;
 
                     case ServiceTypes.Generic:
@@ -292,6 +302,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreEqual(generic.Configuration["key1"], "testKey1", "failed to decrypt key1");
                             Assert.AreEqual(generic.Configuration["key2"], "testKey2", "failed to decrypt key2");
                         }
+
                         break;
 
                     default:
@@ -315,6 +326,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreNotEqual(appInsights.ApiKeys["key1"], "testKey1", "failed to encrypt key1");
                             Assert.AreNotEqual(appInsights.ApiKeys["key2"], "testKey2", "failed to encrypt key2");
                         }
+
                         break;
 
                     case ServiceTypes.BlobStorage:
@@ -323,6 +335,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreNotEqual("UseDevelopmentStorage=true;", azureStorage.ConnectionString, "failed to encrypt connectionString");
                             Assert.AreEqual("testContainer", azureStorage.Container, "should not change container");
                         }
+
                         break;
 
                     case ServiceTypes.CosmosDB:
@@ -333,6 +346,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreEqual("testDatabase", cosmosdb.Database, "should not change database");
                             Assert.AreEqual("testCollection", cosmosdb.Collection, "should not change collection");
                         }
+
                         break;
 
                     case ServiceTypes.Bot:
@@ -346,6 +360,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsFalse(dispatch.AuthoringKey.Contains("0000"), "failed to encrypt authoringkey");
                             Assert.IsFalse(dispatch.SubscriptionKey.Contains("0000"), "failed to encrypt subscriptionKey");
                         }
+
                         break;
 
                     case ServiceTypes.Endpoint:
@@ -355,6 +370,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsTrue(endpoint.AppId.Contains("0000"), "appId should not be changed");
                             Assert.IsFalse(endpoint.AppPassword.Contains("testpassword"), "failed to encrypt appPassword");
                         }
+
                         break;
 
                     case ServiceTypes.File:
@@ -368,6 +384,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsFalse(luis.AuthoringKey.Contains("0000"), "failed to encrypt authoringkey");
                             Assert.IsFalse(luis.SubscriptionKey.Contains("0000"), "failed to encrypt subscriptionKey");
                         }
+
                         break;
 
                     case ServiceTypes.QnA:
@@ -378,6 +395,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.IsFalse(qna.EndpointKey.Contains("0000"), "failed to encrypt EndpointKey");
                             Assert.IsFalse(qna.SubscriptionKey.Contains("0000"), "failed to encrypt SubscriptionKey");
                         }
+
                         break;
                     case ServiceTypes.Generic:
                         {
@@ -386,6 +404,7 @@ namespace Microsoft.Bot.Configuration.Tests
                             Assert.AreNotEqual(generic.Configuration["key1"], "testKey1", "failed to encrypt key1");
                             Assert.AreNotEqual(generic.Configuration["key2"], "testKey2", "failed to encrypt key2");
                         }
+
                         break;
                     default:
                         // ignore unknown service type
@@ -400,13 +419,13 @@ namespace Microsoft.Bot.Configuration.Tests
             var secretKey = "d+Mhts8yQIJIj9P/l1pO7n1fQExss7vvE8t9rg8qXsc=";
             var config = await BotConfiguration.LoadAsync(@"..\..\..\legacy.bot", secretKey);
             Assert.AreEqual("xyzpdq", ((EndpointService)config.Services[0]).AppPassword, "value should be unencrypted");
-            Assert.IsTrue(!String.IsNullOrEmpty(config.Padlock), "padlock should exist");
+            Assert.IsTrue(!string.IsNullOrEmpty(config.Padlock), "padlock should exist");
             Assert.IsNull(config.Properties["secretKey"], "secretKey should not exist");
 
             await config.SaveAsAsync(OutputBotFileName, secretKey);
             config = await BotConfiguration.LoadAsync(OutputBotFileName, secretKey);
             File.Delete(OutputBotFileName);
-            Assert.IsTrue(!String.IsNullOrEmpty(config.Padlock), "padlock should exist");
+            Assert.IsTrue(!string.IsNullOrEmpty(config.Padlock), "padlock should exist");
             Assert.IsNull(config.Properties["secretKey"], "secretKey should not exist");
         }
 
@@ -417,7 +436,7 @@ namespace Microsoft.Bot.Configuration.Tests
             var endpointSvc = publicConfig.Services.Single(x => x.Type == ServiceTypes.Endpoint) as EndpointService;
             Assert.IsNotNull(endpointSvc);
             Assert.IsNull(endpointSvc.ChannelService);
-            
+
             var govConfig = BotConfiguration.Load(@"..\..\..\govTest.bot");
             endpointSvc = govConfig.Services.Single(x => x.Type == ServiceTypes.Endpoint) as EndpointService;
             Assert.IsNotNull(endpointSvc);

--- a/tests/Microsoft.Bot.Configuration.Tests/ConnectionTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ConnectionTests.cs
@@ -43,7 +43,8 @@ namespace Microsoft.Bot.Configuration.Tests
             Assert.IsNotNull(service, "Should find a service with this type and name.");
             Assert.IsTrue(service.Id.Equals("12"), "Should find the correct service.");
 
-            Assert.IsNull(config.FindServiceByNameOrId<CosmosDbService>("testAbs"),
+            Assert.IsNull(
+                config.FindServiceByNameOrId<CosmosDbService>("testAbs"),
                 "Should not find a service of this type and name.");
         }
 
@@ -63,6 +64,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 config2.DisconnectService(key);
             }
+
             Assert.AreEqual(config2.Services.Count, 0, "didn't remove all services");
         }
 
@@ -75,12 +77,14 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 config2.ConnectService(service);
             }
+
             var servicesIds = config2.Services.Select(s => s.Id).ToArray();
 
             foreach (var id in servicesIds)
             {
                 config2.DisconnectServiceByNameOrId(id);
             }
+
             Assert.AreEqual(config2.Services.Count, 0, "didn't remove all services");
         }
 
@@ -93,12 +97,14 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 config2.ConnectService(service);
             }
+
             var serviceNames = config2.Services.Select(s => s.Name).ToArray();
 
             foreach (var name in serviceNames)
             {
                 config2.DisconnectServiceByNameOrId(name);
             }
+
             Assert.AreEqual(config2.Services.Count, 0, "didn't remove all services");
         }
 
@@ -116,8 +122,7 @@ namespace Microsoft.Bot.Configuration.Tests
             // We should have at least an ABS and generic service with the name "testAbs".
             const string name = "testAbs";
             var duplicateServices = config2.Services.Where(s => s.Name.Equals(name)).ToArray();
-            Assert.IsTrue(duplicateServices.Length > 1,
-                "Should have at least two services with this name.");
+            Assert.IsTrue(duplicateServices.Length > 1, "Should have at least two services with this name.");
 
             var botService = config2.DisconnectServiceByNameOrId<BotService>(name);
             Assert.IsNotNull(botService, "Should have removed an ABS service.");
@@ -149,18 +154,19 @@ namespace Microsoft.Bot.Configuration.Tests
                     uniqueNames.Add(name);
                 }
             }
-            Assert.IsTrue(duplicatedNames.Count > 0,
-                "The config file should have at least one duplicated service name.");
+
+            Assert.IsTrue(duplicatedNames.Count > 0, "The config file should have at least one duplicated service name.");
             foreach (var name in uniqueNames)
             {
                 config2.DisconnectServiceByNameOrId(name);
             }
-            Assert.AreEqual(config2.Services.Count, duplicatedNames.Count,
-                "Extra services (with a duplicated name) should still be connected.");
+
+            Assert.AreEqual(config2.Services.Count, duplicatedNames.Count, "Extra services (with a duplicated name) should still be connected.");
             foreach (var name in duplicatedNames)
             {
                 config2.DisconnectServiceByNameOrId(name);
             }
+
             Assert.AreEqual(config2.Services.Count, 0, "Didn't remove remaining services.");
         }
 
@@ -279,7 +285,6 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 Assert.Fail("endpoint failed with empty values");
             }
-
         }
 
         [TestMethod]
@@ -304,7 +309,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var file = new FileService
                 {
-                    Path = string.Empty
+                    Path = string.Empty,
                 };
                 file.Encrypt(secret);
                 file.Decrypt(secret);
@@ -318,7 +323,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var luis = new LuisService
                 {
-                    SubscriptionKey = string.Empty
+                    SubscriptionKey = string.Empty,
                 };
                 luis.Encrypt(secret);
                 luis.Decrypt(secret);
@@ -332,7 +337,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var dispatch = new DispatchService
                 {
-                    SubscriptionKey = string.Empty
+                    SubscriptionKey = string.Empty,
                 };
                 dispatch.Encrypt(secret);
                 dispatch.Decrypt(secret);
@@ -346,7 +351,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var insights = new AppInsightsService
                 {
-                    InstrumentationKey = string.Empty
+                    InstrumentationKey = string.Empty,
                 };
                 insights.Encrypt(secret);
                 insights.Decrypt(secret);
@@ -371,7 +376,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var cosmos = new CosmosDbService
                 {
-                    Key = string.Empty
+                    Key = string.Empty,
                 };
                 cosmos.Encrypt(secret);
                 cosmos.Decrypt(secret);
@@ -385,7 +390,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var qna = new QnAMakerService
                 {
-                    SubscriptionKey = string.Empty
+                    SubscriptionKey = string.Empty,
                 };
                 qna.Encrypt(secret);
                 qna.Decrypt(secret);
@@ -399,7 +404,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var blob = new BlobStorageService
                 {
-                    ConnectionString = string.Empty
+                    ConnectionString = string.Empty,
                 };
                 blob.Encrypt(secret);
                 blob.Decrypt(secret);
@@ -413,7 +418,7 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 var endpoint = new EndpointService
                 {
-                    AppPassword = string.Empty
+                    AppPassword = string.Empty,
                 };
                 endpoint.Encrypt(secret);
                 endpoint.Decrypt(secret);
@@ -422,7 +427,6 @@ namespace Microsoft.Bot.Configuration.Tests
             {
                 Assert.Fail("endpoint failed with empty values");
             }
-
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Configuration.Tests/EncryptionTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/EncryptionTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Configuration.Encryption;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Configuration.Tests
 {
@@ -58,7 +58,6 @@ namespace Microsoft.Bot.Configuration.Tests
             Assert.AreEqual(value, decrypted, "decryption failed");
         }
 
-
         [TestMethod]
         public void EncryptWithNullKeyThrows()
         {
@@ -71,10 +70,8 @@ namespace Microsoft.Bot.Configuration.Tests
             }
             catch (Exception)
             {
-
             }
         }
-
 
         [TestMethod]
         public void DecryptWithNullKeyThrows()
@@ -90,7 +87,6 @@ namespace Microsoft.Bot.Configuration.Tests
             }
             catch (Exception)
             {
-
             }
         }
 
@@ -108,7 +104,6 @@ namespace Microsoft.Bot.Configuration.Tests
             }
             catch (Exception)
             {
-
             }
 
             try
@@ -122,9 +117,7 @@ namespace Microsoft.Bot.Configuration.Tests
             }
             catch (Exception)
             {
-
             }
-
         }
     }
 }

--- a/tests/Microsoft.Bot.Configuration.Tests/ServiceTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ServiceTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Bot.Configuration.Tests
             Assert.AreEqual(luis.GetEndpoint(), "https://usgoviowa.api.cognitive.microsoft.us");
         }
 
-
         [TestMethod]
         public void QnaMakerSuffixTest()
         {


### PR DESCRIPTION
- Reorder using directives
- Remove empty blank lines
- Add trailing comma in multi-line initializers
- Fix typo in a class name