### PR TITLE
Fix null Action.Title check in ChoiceFactory

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             var maxTitleLength = 0;
             foreach (var choice in list)
             {
-                var l = choice.Action != null && string.IsNullOrEmpty(choice.Action.Title) ? choice.Action.Title.Length : choice.Value.Length;
+                var l = choice.Action != null && !string.IsNullOrEmpty(choice.Action.Title) ? choice.Action.Title.Length : choice.Value.Length;
                 if (l > maxTitleLength)
                 {
                     maxTitleLength = l;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -100,6 +100,50 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        public async Task ChoicePromptWithCardActionAndNoValueShouldNotFail()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var choice = new Choice()
+                    {
+                        Action = new CardAction()
+                        {
+                            Type = "imBack",
+                            Value = "value",
+                            Title = "title"
+                        }
+                    };
+
+                    var options = new PromptOptions()
+                    {
+                        Choices = new List<Choice> { choice }
+                    };
+                    await dc.PromptAsync("ChoicePrompt",
+                        options,
+                        cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(StartsWithValidator(" (1) title"))
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task ShouldSendPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());


### PR DESCRIPTION
Fixes #1485 

Per issue, if a Choice uses something like:

```
new Choice()
{
    Action = new CardAction()
    {
        Type = "messageBack",
        Value = "myValue",
        Title = "myTitle,
    }
}
```

instead of simply:

```
new Choice()
{
    Value = "myValue"
}
```
...it creates a `Object reference not set to an instance of an object` exception.

This is because if `choice.Action.Title` is `null`, this line:

```
var l = choice.Action != null && string.IsNullOrEmpty(choice.Action.Title) ? choice.Action.Title.Length : choice.Value.Length;
```

evaluates to:

```
var l = true && true = choice.Action.Title.Length
```

...so it checks for `choice.Action.Title.Length` when `choice.Action.Title` is `null`
