### PR TITLE
[StyleCop] Fix warnings in Bot.Connetor.Test project

### DIFF
--- a/tests/Microsoft.Bot.Connector.Tests/AttachmentsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/AttachmentsTests.cs
@@ -14,7 +14,7 @@ namespace Connector.Tests
 {
     public class AttachmentsTests : BaseTest
     {
-        protected const string conversationId = "B21UTEF8S:T03CWQ0QB:D2369CT7C";
+        protected const string ConversationId = "B21UTEF8S:T03CWQ0QB:D2369CT7C";
 
         [Fact]
         public async Task UploadAttachmentAndGetAttachment()
@@ -22,7 +22,7 @@ namespace Connector.Tests
             await UseClientFor(async client =>
             {
                 var attachment = new AttachmentData("image/png", "Bot.png", ReadFile("bot.png"), ReadFile("bot_icon.png"));
-                var response = await client.Conversations.UploadAttachmentAsync(conversationId, attachment);
+                var response = await client.Conversations.UploadAttachmentAsync(ConversationId, attachment);
                 var attachmentId = response.Id;
                 var attachmentInfo = await client.Attachments.GetAttachmentInfoAsync(attachmentId);
 
@@ -45,10 +45,10 @@ namespace Connector.Tests
                 var attachment = new AttachmentData()
                 {
                     Name = "Bot.png",
-                    Type = "image/png"
+                    Type = "image/png",
                 };
 
-                var ex = await Assert.ThrowsAsync<ErrorResponseException>(() => client.Conversations.UploadAttachmentAsync(conversationId, attachment));
+                var ex = await Assert.ThrowsAsync<ErrorResponseException>(() => client.Conversations.UploadAttachmentAsync(ConversationId, attachment));
                 Assert.Equal("MissingProperty", ex.Body.Error.Code);
                 Assert.Contains("original", ex.Body.Error.Message);
             });
@@ -75,7 +75,7 @@ namespace Connector.Tests
         {
             await UseClientFor(async client =>
             {
-                var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Conversations.UploadAttachmentAsync(conversationId, null));
+                var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Conversations.UploadAttachmentAsync(ConversationId, null));
                 Assert.Contains("cannot be null", ex.Message);
             });
         }
@@ -85,11 +85,12 @@ namespace Connector.Tests
         {
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
-            await AssertTracingFor(async () =>
+            await AssertTracingFor(
+                async () =>
                 await UseClientFor(async client =>
                 {
                     var attachment = new AttachmentData("image/png", "Bot.png", ReadFile("bot.png"), ReadFile("bot_icon.png"));
-                    var response = await client.Conversations.UploadAttachmentWithHttpMessagesAsync(conversationId, attachment, customHeaders);
+                    var response = await client.Conversations.UploadAttachmentWithHttpMessagesAsync(ConversationId, attachment, customHeaders);
                     Assert.NotNull(response.Body);
                     Assert.NotNull(response.Body.Id);
                 }),
@@ -128,7 +129,7 @@ namespace Connector.Tests
             await UseClientFor(async client =>
             {
                 var attachment = new AttachmentData("image/png", "Bot.png", ReadFile("bot.png"), ReadFile("bot_icon.png"));
-                var response = await client.Conversations.UploadAttachmentAsync(conversationId, attachment);
+                var response = await client.Conversations.UploadAttachmentAsync(ConversationId, attachment);
                 var attachmentId = response.Id;
                 var stream = await client.Attachments.GetAttachmentAsync(attachmentId, "original");
 
@@ -162,7 +163,6 @@ namespace Connector.Tests
         [Fact]
         public async Task GetAttachmentViewWithNullAttachmentIdFails()
         {
-
             await UseClientFor(async client =>
             {
                 var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Attachments.GetAttachmentAsync(null, "original"));
@@ -173,11 +173,10 @@ namespace Connector.Tests
         [Fact]
         public async Task GetAttachmentViewWithInvalidViewIdFails()
         {
-
             await UseClientFor(async client =>
             {
                 var attachment = new AttachmentData("image/png", "Bot.png", ReadFile("bot.png"), ReadFile("bot_icon.png"));
-                var response = await client.Conversations.UploadAttachmentAsync(conversationId, attachment);
+                var response = await client.Conversations.UploadAttachmentAsync(ConversationId, attachment);
 
                 var ex = await Assert.ThrowsAsync<ErrorResponseException>(() => client.Attachments.GetAttachmentAsync(response.Id, "invalid"));
 
@@ -192,11 +191,10 @@ namespace Connector.Tests
         [Fact]
         public async Task GetAttachmentViewWithNullViewIdFails()
         {
-
             await UseClientFor(async client =>
             {
                 var attachment = new AttachmentData("image/png", "Bot.png", ReadFile("bot.png"), ReadFile("bot_icon.png"));
-                var response = await client.Conversations.UploadAttachmentAsync(conversationId, attachment);
+                var response = await client.Conversations.UploadAttachmentAsync(ConversationId, attachment);
 
                 var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Attachments.GetAttachmentAsync(response.Id, null));
 

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
@@ -2,15 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Moq;
-using Xunit;
-using RichardSzalay.MockHttp;
-using System.Net.Http;
 using Microsoft.IdentityModel.Protocols;
-using System.Threading;
-using System.Net;
+using Moq;
+using RichardSzalay.MockHttp;
+using Xunit;
 
 namespace Microsoft.Bot.Connector.Authentication.Tests
 {
@@ -186,7 +186,7 @@ namespace Microsoft.Bot.Connector.Authentication.Tests
                 _mockHttpMessageHandler.When(FakeKeysAddressUrl)
                     .Respond(HttpStatusCode.NotFound);
 
-                Func <Task> action = async () => await _endorsementsRetriever.GetDocumentAsync(FakeDocumentAddress, CancellationToken.None);
+                Func<Task> action = async () => await _endorsementsRetriever.GetDocumentAsync(FakeDocumentAddress, CancellationToken.None);
 
                 action.Should().Throw<Exception>();
             }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsValidatorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsValidatorTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         [Fact]
         public void EndorsedChannelIdShouldPassWithTwoEndorsements()
         {
-            var isEndorsed = EndorsementsValidator.Validate("right", new HashSet<string>(new [] { "right", "wrong" }));
+            var isEndorsed = EndorsementsValidator.Validate("right", new HashSet<string>(new[] { "right", "wrong" }));
             isEndorsed.Should().BeTrue();
         }
 

--- a/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
@@ -5,12 +5,9 @@ namespace Connector.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Runtime.CompilerServices;
-    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Test.HttpRecorder;
     using Microsoft.Bot.Connector;

--- a/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
@@ -5,6 +5,7 @@ namespace Connector.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -21,29 +22,15 @@ namespace Connector.Tests
 
     public class BaseTest
     {
-        private const HttpRecorderMode mode = HttpRecorderMode.Playback;
-
-        protected const string clientId = "[MSAPP_ID]";
-        protected const string clientSecret = "[MSAPP_PASSWORD]";
-        protected const string userId = "U19KH8EHJ:T03CWQ0QB";
-        protected const string botId = "B21UTEF8S:T03CWQ0QB";
-        protected static Uri hostUri = new Uri("https://slack.botframework.com", UriKind.Absolute);
+        private readonly HttpRecorderMode mode = HttpRecorderMode.Playback;
 
         private readonly string token;
-
-        public ChannelAccount Bot { get; private set; }
-
-        public ChannelAccount User { get; private set; }
-
-        private string ClassName => GetType().FullName;
-
-#pragma warning disable 162
 
         public BaseTest()
         {
             if (mode == HttpRecorderMode.Record)
             {
-                var credentials = new MicrosoftAppCredentials(clientId, clientSecret);
+                var credentials = new MicrosoftAppCredentials(ClientId, ClientSecret);
                 var task = credentials.GetTokenAsync();
                 task.Wait();
                 this.token = task.Result;
@@ -53,12 +40,33 @@ namespace Connector.Tests
                 this.token = "STUB_TOKEN";
             }
 
-            Bot = new ChannelAccount() { Id = botId };
-            User = new ChannelAccount() { Id = userId };
+            Bot = new ChannelAccount() { Id = BotId };
+            User = new ChannelAccount() { Id = UserId };
         }
 
-        public async Task AssertTracingFor(Func<Task> doTest, string tracedMethodName,
-            bool isSuccesful = true, Func<HttpRequestMessage, bool> assertHttpRequestMessage = null)
+        public ChannelAccount Bot { get; private set; }
+
+        public ChannelAccount User { get; private set; }
+
+        protected static Uri HostUri { get; set; } = new Uri("https://slack.botframework.com", UriKind.Absolute);
+
+        protected string ClientId { get; private set; } = "[MSAPP_ID]";
+
+        protected string ClientSecret { get; private set; } = "[MSAPP_PASSWORD]";
+
+        protected string UserId { get; private set; } = "U19KH8EHJ:T03CWQ0QB";
+
+        protected string BotId { get; private set; } = "B21UTEF8S:T03CWQ0QB";
+
+        private string ClassName => GetType().FullName;
+
+#pragma warning disable 162
+
+        public async Task AssertTracingFor(
+            Func<Task> doTest,
+            string tracedMethodName,
+            bool isSuccesful = true,
+            Func<HttpRequestMessage, bool> assertHttpRequestMessage = null)
         {
             tracedMethodName = tracedMethodName.EndsWith("Async") ? tracedMethodName.Remove(tracedMethodName.LastIndexOf("Async")) : tracedMethodName;
 
@@ -108,7 +116,7 @@ namespace Connector.Tests
             {
                 HttpMockServer.Initialize(className ?? ClassName, methodName, mode);
 
-                using (var client = new ConnectorClient(hostUri, new BotAccessTokenStub(token), handlers: HttpMockServer.CreateInstance()))
+                using (var client = new ConnectorClient(HostUri, new BotAccessTokenStub(token), handlers: HttpMockServer.CreateInstance()))
                 {
                     await doTest(client);
                 }
@@ -132,26 +140,9 @@ namespace Connector.Tests
                     HttpMockServer.FileSystemUtilsObject = new FileSystemUtils();
                     HttpMockServer.Flush();
                 }
+
                 context.Stop();
             }
-        }
-    }
-
-#pragma warning restore 162
-
-    public class BotAccessTokenStub : ServiceClientCredentials
-    {
-        private readonly string token;
-
-        public BotAccessTokenStub(string token)
-        {
-            this.token = token;
-        }
-
-        public override async Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.token);
-            await base.ProcessHttpRequestAsync(request, cancellationToken);
         }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BaseTest.cs
@@ -12,6 +12,7 @@ namespace Connector.Tests
     using Microsoft.Azure.Test.HttpRecorder;
     using Microsoft.Bot.Connector;
     using Microsoft.Bot.Connector.Authentication;
+    using Microsoft.Bot.Connector.Tests;
     using Microsoft.Bot.Schema;
     using Microsoft.Rest;
     using Microsoft.Rest.ClientRuntime.Azure.TestFramework;

--- a/tests/Microsoft.Bot.Connector.Tests/BotAccessTokenStub.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BotAccessTokenStub.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Rest;
+
+namespace Connector.Tests
+{
+#pragma warning restore 162
+
+    public class BotAccessTokenStub : ServiceClientCredentials
+    {
+        private readonly string token;
+
+        public BotAccessTokenStub(string token)
+        {
+            this.token = token;
+        }
+
+        public override async Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", this.token);
+            await base.ProcessHttpRequestAsync(request, cancellationToken);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/BotAccessTokenStub.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/BotAccessTokenStub.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Rest;
 
-namespace Connector.Tests
+namespace Microsoft.Bot.Connector.Tests
 {
 #pragma warning restore 162
 

--- a/tests/Microsoft.Bot.Connector.Tests/ConnectorClientTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConnectorClientTest.cs
@@ -4,15 +4,10 @@
 namespace Connector.Tests
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Net.Http;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Microsoft.Bot.Connector;
     using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Schema;
-    using Microsoft.Rest;
     using Xunit;
 
     public class ConnectorClientTest : BaseTest

--- a/tests/Microsoft.Bot.Connector.Tests/ConversationsTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConversationsTest.cs
@@ -34,14 +34,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Create Conversation"
+                Text = "TEST Create Conversation",
             };
 
             var param = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -63,14 +63,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Create Conversation with invalid Bot"
+                Text = "TEST Create Conversation with invalid Bot",
             };
 
             var param = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = new ChannelAccount() { Id = "invalid-id" },
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -93,14 +93,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Create Conversation without members"
+                Text = "TEST Create Conversation without members",
             };
 
             var param = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -123,14 +123,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Create Conversation with Bot member"
+                Text = "TEST Create Conversation with Bot member",
             };
 
             var param = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { Bot },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -162,27 +162,28 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Create Conversation"
+                Text = "TEST Create Conversation",
             };
 
             var param = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
-            await AssertTracingFor(async () =>
+            await AssertTracingFor(
+                async () =>
                 await UseClientFor(async client =>
                 {
                     var result = await client.Conversations.CreateConversationWithHttpMessagesAsync(param, customHeaders, default(CancellationToken));
                     Assert.NotNull(result.Body);
                     Assert.NotNull(result.Body.ActivityId);
                 }),
-            nameof(ConversationsExtensions.CreateConversationAsync),
-            assertHttpRequestMessage:
+                nameof(ConversationsExtensions.CreateConversationAsync),
+                assertHttpRequestMessage:
                 (h) => h.Headers.Contains("customHeader") && h.Headers.GetValues("customHeader").Contains("customValue"));
         }
 
@@ -192,7 +193,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -205,7 +206,10 @@ namespace Connector.Tests
                 foreach (var member in members)
                 {
                     hasUser = member.Id == User.Id;
-                    if (hasUser) break;
+                    if (hasUser)
+                    {
+                        break;
+                    }
                 }
 
                 Assert.True(hasUser);
@@ -219,11 +223,10 @@ namespace Connector.Tests
         [Fact]
         public async Task GetConversationMembersWithInvalidConversationId()
         {
-
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -242,7 +245,6 @@ namespace Connector.Tests
         [Fact]
         public async Task GetConversationMembersWithNullConversationId()
         {
-
             await UseClientFor(async client =>
             {
                 var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Conversations.GetConversationMembersAsync(null));
@@ -256,7 +258,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
@@ -273,7 +275,10 @@ namespace Connector.Tests
                                     foreach (var member in members.Body)
                                     {
                                         hasUser = member.Id == User.Id;
-                                        if (hasUser) break;
+                                        if (hasUser)
+                                        {
+                                            break;
+                                        }
                                     }
 
                                     Assert.True(hasUser);
@@ -289,7 +294,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -302,7 +307,10 @@ namespace Connector.Tests
                 foreach (var member in membersResult.Members)
                 {
                     hasUser = member.Id == User.Id;
-                    if (hasUser) break;
+                    if (hasUser)
+                    {
+                        break;
+                    }
                 }
 
                 Assert.True(hasUser);
@@ -319,7 +327,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -340,7 +348,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -353,7 +361,10 @@ namespace Connector.Tests
                 foreach (var member in membersResult.Members)
                 {
                     hasUser = member.Id == User.Id;
-                    if (hasUser) break;
+                    if (hasUser)
+                    {
+                        break;
+                    }
                 }
 
                 Assert.True(hasUser);
@@ -370,12 +381,13 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
-            await AssertTracingFor(async () =>
+            await AssertTracingFor(
+                async () =>
                 await UseClientFor(async client =>
                 {
                     var conversation = await client.Conversations.CreateConversationAsync(createMessage);
@@ -387,7 +399,10 @@ namespace Connector.Tests
                     foreach (var member in members.Body.Members)
                     {
                         hasUser = member.Id == User.Id;
-                        if (hasUser) break;
+                        if (hasUser)
+                        {
+                            break;
+                        }
                     }
 
                     Assert.True(hasUser);
@@ -406,14 +421,14 @@ namespace Connector.Tests
                 Recipient = User,
                 From = Bot,
                 Name = "acticity",
-                Text = "TEST Send to Conversation"
+                Text = "TEST Send to Conversation",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -422,7 +437,6 @@ namespace Connector.Tests
                 var response = await client.Conversations.SendToConversationAsync(conversation.Id, activity);
                 Assert.NotNull(response.Id);
             });
-
         }
 
         [Fact]
@@ -432,21 +446,20 @@ namespace Connector.Tests
         [Fact]
         public async Task SendToConversationWithInvalidConversationId()
         {
-
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
                 Name = "acticity",
-                Text = "TEST Send to Conversation with invalid conversation id"
+                Text = "TEST Send to Conversation with invalid conversation id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -468,7 +481,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -480,7 +493,7 @@ namespace Connector.Tests
                     Recipient = User,
                     From = new ChannelAccount() { Id = "B21S8SG7K:T03CWQ0QB" },
                     Name = "acticity",
-                    Text = "TEST Send to Conversation"
+                    Text = "TEST Send to Conversation",
                 };
                 var ex = await Assert.ThrowsAsync<ErrorResponseException>(() => client.Conversations.SendToConversationAsync(conversationId: string.Concat(conversation.Id, "M"), activity: activity));
                 Assert.Equal("MissingProperty", ex.Body.Error.Code);
@@ -501,14 +514,14 @@ namespace Connector.Tests
                 Recipient = User,
                 From = Bot,
                 Name = "acticity",
-                Text = "TEST Send to Conversation with null conversation id"
+                Text = "TEST Send to Conversation with null conversation id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -524,7 +537,7 @@ namespace Connector.Tests
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -554,8 +567,8 @@ namespace Connector.Tests
                         {
                             Title = "A static image",
                             Subtitle = "JPEG image",
-                            Images = new CardImage[] { new CardImage() { Url = "https://docs.microsoft.com/bot-framework/media/designing-bots/core/dialogs-screens.png" } }
-                        }
+                            Images = new CardImage[] { new CardImage() { Url = "https://docs.microsoft.com/bot-framework/media/designing-bots/core/dialogs-screens.png" } },
+                        },
                     },
                     new Attachment()
                     {
@@ -564,17 +577,16 @@ namespace Connector.Tests
                         {
                             Title = "An animation",
                             Subtitle = "GIF image",
-                            Images = new CardImage[] { new CardImage() { Url = "http://i.giphy.com/Ki55RUbOV5njy.gif" } }
-                        }
+                            Images = new CardImage[] { new CardImage() { Url = "http://i.giphy.com/Ki55RUbOV5njy.gif" } },
+                        },
                     },
-                }
-
+                },
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -598,19 +610,20 @@ namespace Connector.Tests
                 Recipient = User,
                 From = Bot,
                 Name = "acticity",
-                Text = "TEST Send to Conversation"
+                Text = "TEST Send to Conversation",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
-            await AssertTracingFor(async () =>
+            await AssertTracingFor(
+                async () =>
                 await UseClientFor(async client =>
                 {
                     var conversation = await client.Conversations.CreateConversationAsync(createMessage);
@@ -630,14 +643,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Get Activity Members"
+                Text = "TEST Get Activity Members",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -650,7 +663,10 @@ namespace Connector.Tests
                 foreach (var member in members)
                 {
                     hasUser = member.Id == User.Id;
-                    if (hasUser) break;
+                    if (hasUser)
+                    {
+                        break;
+                    }
                 }
 
                 Assert.True(hasUser);
@@ -669,14 +685,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Get Activity Members with invalid conversation id"
+                Text = "TEST Get Activity Members with invalid conversation id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -700,14 +716,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Get Activity Members with null conversation id"
+                Text = "TEST Get Activity Members with null conversation id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -726,14 +742,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Get Activity Members with null activity id"
+                Text = "TEST Get Activity Members with null activity id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -752,14 +768,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Get Activity Members"
+                Text = "TEST Get Activity Members",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
@@ -777,13 +793,16 @@ namespace Connector.Tests
                         foreach (var member in members.Body)
                         {
                             hasUser = member.Id == User.Id;
-                            if (hasUser) break;
+                            if (hasUser)
+                            {
+                                break;
+                            }
                         }
 
                         Assert.True(hasUser);
                     }),
-                    nameof(ConversationsExtensions.GetActivityMembersAsync),
-                    assertHttpRequestMessage:
+                nameof(ConversationsExtensions.GetActivityMembersAsync),
+                assertHttpRequestMessage:
                         (h) => h.Headers.Contains("customHeader") && h.Headers.GetValues("customHeader").Contains("customValue"));
         }
 
@@ -795,7 +814,7 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity gets a reply"
+                Text = "TEST Activity gets a reply",
             };
 
             var reply = new Activity()
@@ -803,13 +822,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply to Activity"
+                Text = "TEST Reply to Activity",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -829,13 +848,12 @@ namespace Connector.Tests
         [Fact]
         public async Task ReplyToActivityWithInvalidConversationId()
         {
-
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply activity with invalid conversation id"
+                Text = "TEST Reply activity with invalid conversation id",
             };
 
             var reply = new Activity()
@@ -843,13 +861,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply mustn't shown"
+                Text = "TEST Reply mustn't shown",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -869,13 +887,12 @@ namespace Connector.Tests
         [Fact]
         public async Task ReplyToActivityWithNullConversationId()
         {
-
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply activity with null conversation id"
+                Text = "TEST Reply activity with null conversation id",
             };
 
             var reply = new Activity()
@@ -883,13 +900,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply mustn't shown"
+                Text = "TEST Reply mustn't shown",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -904,13 +921,12 @@ namespace Connector.Tests
         [Fact]
         public async Task ReplyToActivityWithNullActivityId()
         {
-
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply activity with null activity id"
+                Text = "TEST Reply activity with null activity id",
             };
 
             var reply = new Activity()
@@ -918,13 +934,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply mustn't shown"
+                Text = "TEST Reply mustn't shown",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -939,19 +955,18 @@ namespace Connector.Tests
         [Fact]
         public async Task ReplyToActivityWithNullReply()
         {
-
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply activity with null reply"
+                Text = "TEST Reply activity with null reply",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -971,7 +986,7 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity gets a reply"
+                Text = "TEST Activity gets a reply",
             };
 
             var reply = new Activity()
@@ -979,18 +994,19 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Reply to Activity"
+                Text = "TEST Reply to Activity",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
-            await AssertTracingFor(async () =>
+            await AssertTracingFor(
+                async () =>
                 await UseClientFor(async client =>
                 {
                     var conversation = await client.Conversations.CreateConversationAsync(createMessage);
@@ -1013,14 +1029,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be deleted"
+                Text = "TEST Activity to be deleted",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -1043,14 +1059,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be deleted with invalid conversation Id"
+                Text = "TEST Activity to be deleted with invalid conversation Id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -1074,14 +1090,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be deleted with null conversation Id"
+                Text = "TEST Activity to be deleted with null conversation Id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -1100,14 +1116,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be deleted with null activity Id"
+                Text = "TEST Activity to be deleted with null activity Id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             await UseClientFor(async client =>
@@ -1126,14 +1142,14 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be deleted"
+                Text = "TEST Activity to be deleted",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
                 Bot = Bot,
-                Activity = activity
+                Activity = activity,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
@@ -1147,8 +1163,8 @@ namespace Connector.Tests
                             conversation.Id, conversation.ActivityId, customHeaders, default(CancellationToken));
                         Assert.NotNull(conversation.ActivityId);
                     }),
-                    nameof(ConversationsExtensions.DeleteActivityAsync),
-                    assertHttpRequestMessage:
+                nameof(ConversationsExtensions.DeleteActivityAsync),
+                assertHttpRequestMessage:
                         (h) => h.Headers.Contains("customHeader") && h.Headers.GetValues("customHeader").Contains("customValue"));
         }
 
@@ -1160,13 +1176,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be updated"
+                Text = "TEST Activity to be updated",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -1179,12 +1195,11 @@ namespace Connector.Tests
                     Type = ActivityTypes.Message,
                     Recipient = User,
                     From = Bot,
-                    Text = "TEST Successfully activity updated"
+                    Text = "TEST Successfully activity updated",
                 };
                 var updateResponse = await client.Conversations.UpdateActivityAsync(conversation.Id, response.Id, update);
                 Assert.NotNull(updateResponse.Id);
             });
-
         }
 
         [Fact]
@@ -1199,13 +1214,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be updated with invalid conversation Id"
+                Text = "TEST Activity to be updated with invalid conversation Id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -1218,7 +1233,7 @@ namespace Connector.Tests
                     Type = ActivityTypes.Message,
                     Recipient = User,
                     From = Bot,
-                    Text = "TEST Activity mustn't be updated"
+                    Text = "TEST Activity mustn't be updated",
                 };
                 var ex = await Assert.ThrowsAsync<ErrorResponseException>(() => client.Conversations.UpdateActivityAsync("B21S8SG7K:T03CWQ0QB", response.Id, update));
                 Assert.Equal("ServiceError", ex.Body.Error.Code);
@@ -1238,13 +1253,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be updated with null conversation Id"
+                Text = "TEST Activity to be updated with null conversation Id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -1257,7 +1272,7 @@ namespace Connector.Tests
                     Type = ActivityTypes.Message,
                     Recipient = User,
                     From = Bot,
-                    Text = "TEST Activity mustn't be updated"
+                    Text = "TEST Activity mustn't be updated",
                 };
                 var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Conversations.UpdateActivityAsync(null, response.Id, update));
                 Assert.Contains("cannot be null", ex.Message);
@@ -1272,13 +1287,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be updated with null activity Id"
+                Text = "TEST Activity to be updated with null activity Id",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -1291,7 +1306,7 @@ namespace Connector.Tests
                     Type = ActivityTypes.Message,
                     Recipient = User,
                     From = Bot,
-                    Text = "TEST Activity mustn't be updated"
+                    Text = "TEST Activity mustn't be updated",
                 };
                 var ex = await Assert.ThrowsAsync<ValidationException>(() => client.Conversations.UpdateActivityAsync(conversation.Id, null, update));
                 Assert.Contains("cannot be null", ex.Message);
@@ -1306,13 +1321,13 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be updated with null activity"
+                Text = "TEST Activity to be updated with null activity",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             await UseClientFor(async client =>
@@ -1323,6 +1338,7 @@ namespace Connector.Tests
                 Assert.Contains("cannot be null", ex.Message);
             });
         }
+
         [Fact]
         public async Task UpdateActivityWithCustomHeaders()
         {
@@ -1331,18 +1347,19 @@ namespace Connector.Tests
                 Type = ActivityTypes.Message,
                 Recipient = User,
                 From = Bot,
-                Text = "TEST Activity to be updated"
+                Text = "TEST Activity to be updated",
             };
 
             var createMessage = new ConversationParameters()
             {
                 Members = new ChannelAccount[] { User },
-                Bot = Bot
+                Bot = Bot,
             };
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
-            await AssertTracingFor(async () =>
+            await AssertTracingFor(
+                async () =>
                 await UseClientFor(async client =>
                 {
                     var conversation = await client.Conversations.CreateConversationAsync(createMessage);
@@ -1353,7 +1370,7 @@ namespace Connector.Tests
                         Type = ActivityTypes.Message,
                         Recipient = User,
                         From = Bot,
-                        Text = "TEST Successfully activity updated"
+                        Text = "TEST Successfully activity updated",
                     };
                     var updateResponse = await client.Conversations.UpdateActivityWithHttpMessagesAsync(
                         conversation.Id, response.Id, update, customHeaders, default(CancellationToken));

--- a/tests/Microsoft.Bot.Connector.Tests/FaultyClass.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/FaultyClass.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 

--- a/tests/Microsoft.Bot.Connector.Tests/FaultyClass.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/FaultyClass.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+
+namespace Microsoft.Bot.Connector.Tests
+{
+    public class FaultyClass
+    {
+        public Exception ExceptionToThrow { get; set; }
+
+        public Exception ExceptionReceived { get; set; } = null;
+
+        public int LatestRetryCount { get; set; }
+
+        public int CallCount { get; set; } = 0;
+
+        public int TriesUntilSuccess { get; set; } = 0;
+
+        public async Task<string> FaultyTask()
+        {
+            CallCount++;
+
+            if (CallCount < TriesUntilSuccess && ExceptionToThrow != null)
+            {
+                throw ExceptionToThrow;
+            }
+
+            return await Task.FromResult(string.Empty);
+        }
+
+        public RetryParams ExceptionHandler(Exception ex, int currentRetryCount)
+        {
+            ExceptionReceived = ex;
+            LatestRetryCount = currentRetryCount;
+
+            return RetryParams.DefaultBackOff(currentRetryCount);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Xunit;
 

--- a/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/GetTokenRefreshTests.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.Text;
 using System.Collections.Generic;
-using Microsoft.Bot.Connector;
+using System.Text;
 using System.Threading.Tasks;
-using Xunit;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
+using Xunit;
 
 namespace Microsoft.Bot.Connector.Tests
 {
     /// <summary>
-    /// Summary description for UnitTest1
+    /// Description for UnitTest1.
     /// </summary>
     public class GetTokenRefreshTests
     {
@@ -24,7 +24,6 @@ namespace Microsoft.Bot.Connector.Tests
             var result = await credentials.GetTokenAsync();
             Assert.NotNull(result);
         }
-
 
         //[Fact]
         public async Task TokenTests_RefreshTokenWorks()
@@ -55,7 +54,10 @@ namespace Microsoft.Bot.Connector.Tests
                 string result = await item;
                 Assert.NotNull(result);
                 if (prevResult != null)
+                {
                     Assert.Equal(prevResult, result);
+                }
+
                 prevResult = result;
             }
 
@@ -63,17 +65,24 @@ namespace Microsoft.Bot.Connector.Tests
             for (int i = 0; i < 1000; i++)
             {
                 if (i % 100 == 50)
+                {
                     tasks.Add(credentials.GetTokenAsync(true));
+                }
                 else
+                {
                     tasks.Add(credentials.GetTokenAsync());
+                }
             }
 
             HashSet<string> results = new HashSet<string>();
-            for(int i=0; i < 1000; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 string result = await tasks[i];
                 if (i == 0)
+                {
                     results.Add(result);
+                }
+
                 Assert.NotNull(result);
                 if (prevResult != null)
                 {
@@ -83,10 +92,11 @@ namespace Microsoft.Bot.Connector.Tests
                         results.Add(result);
                     }
                     else
+                    {
                         Assert.Contains(result, results);
+                    }
                 }
             }
-
         }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/JwtTokenValidationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Connector.Tests
             ChannelValidation.ToBotFromChannelTokenValidationParameters.ValidateLifetime = false;
             client = new HttpClient
             {
-                BaseAddress = new Uri("https://webchat.botframework.com/")
+                BaseAddress = new Uri("https://webchat.botframework.com/"),
             };
             emptyClient = new HttpClient();
         }
@@ -64,7 +64,6 @@ namespace Microsoft.Bot.Connector.Tests
             var header = string.Empty;
             var credentials = new SimpleCredentialProvider(string.Empty, string.Empty);
 
-
             await Assert.ThrowsAsync<ArgumentNullException>(
                 async () => await JwtTokenValidation.ValidateAuthHeader(header, credentials, new SimpleChannelProvider(), string.Empty, null, emptyClient));
         }
@@ -85,7 +84,7 @@ namespace Microsoft.Bot.Connector.Tests
             string header = $"Bearer {await new MicrosoftAppCredentials("2cd87869-38a0-4182-9251-d056e8f0ac24", "2.30Vs3VQLKt974F").GetTokenAsync()}";
             var credentials = new SimpleCredentialProvider("00000000-0000-0000-0000-000000000000", string.Empty);
             await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await JwtTokenValidation.ValidateAuthHeader(header, credentials, new SimpleChannelProvider(), string.Empty, null, emptyClient));            
+                async () => await JwtTokenValidation.ValidateAuthHeader(header, credentials, new SimpleChannelProvider(), string.Empty, null, emptyClient));
         }
 
         /// <summary>
@@ -164,7 +163,7 @@ namespace Microsoft.Bot.Connector.Tests
 
             Assert.False(MicrosoftAppCredentials.IsTrustedServiceUrl("https://webchat.botframework.com/"));
         }
-        
+
         [Fact]
         public async void Emulator_AuthHeader_CorrectAppIdAndServiceUrl_WithGovChannelService_ShouldValidate()
         {
@@ -197,8 +196,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
@@ -210,8 +211,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, false);
@@ -225,22 +228,26 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
 
             await Assert.ThrowsAsync<UnauthorizedAccessException>(
                 async () => await GovernmentChannelValidation.ValidateIdentity(identity, credentials, serviceUrl));
         }
-        
+
         [Fact]
         public async void GovernmentChannelValidation_WrongAudienceClaim_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, "abc", null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
@@ -248,14 +255,16 @@ namespace Microsoft.Bot.Connector.Tests
             await Assert.ThrowsAsync<UnauthorizedAccessException>(
                 async () => await GovernmentChannelValidation.ValidateIdentity(identity, credentials, serviceUrl));
         }
-        
+
         [Fact]
         public async void GovernmentChannelValidation_WrongAudienceClaimIssuer_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, "wrongissuer"),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
@@ -269,9 +278,11 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
-                new Claim(AuthenticationConstants.AudienceClaim, "", null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
+                new Claim(AuthenticationConstants.AudienceClaim, string.Empty, null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
 
@@ -284,10 +295,12 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
-                new Claim(AuthenticationConstants.ServiceUrlClaim, "", null),
+                new Claim(AuthenticationConstants.ServiceUrlClaim, string.Empty, null),
             }, true);
 
             await Assert.ThrowsAsync<UnauthorizedAccessException>(
@@ -299,8 +312,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, GovernmentAuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, "other", null),
             }, true);
@@ -314,8 +329,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
@@ -327,8 +344,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, false);
@@ -342,8 +361,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
 
@@ -356,8 +377,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, "abc", null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
@@ -371,8 +394,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, "wrongissuer"),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
@@ -386,9 +411,11 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
-                new Claim(AuthenticationConstants.AudienceClaim, "", null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
+                new Claim(AuthenticationConstants.AudienceClaim, string.Empty, null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, serviceUrl, null),
             }, true);
 
@@ -401,10 +428,12 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
-                new Claim(AuthenticationConstants.ServiceUrlClaim, "", null),
+                new Claim(AuthenticationConstants.ServiceUrlClaim, string.Empty, null),
             }, true);
 
             await Assert.ThrowsAsync<UnauthorizedAccessException>(
@@ -416,8 +445,10 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
-            var credentials = new SimpleCredentialProvider(appId, String.Empty);
-            var identity = new SimpleClaimsIdentity(new List<Claim>() {
+            var credentials = new SimpleCredentialProvider(appId, string.Empty);
+            var identity = new SimpleClaimsIdentity(
+                new List<Claim>()
+                {
                 new Claim(AuthenticationConstants.AudienceClaim, appId, null, AuthenticationConstants.ToBotFromChannelTokenIssuer),
                 new Claim(AuthenticationConstants.ServiceUrlClaim, "other", null),
             }, true);
@@ -440,6 +471,7 @@ namespace Microsoft.Bot.Connector.Tests
 
             Assert.True(result.IsAuthenticated);
         }
+
         private async Task JwtTokenValidation_ValidateAuthHeader_WithChannelService_Throws(string appId, string pwd, string channelService)
         {
             string header = $"Bearer {await new MicrosoftAppCredentials(appId, pwd).GetTokenAsync()}";
@@ -465,12 +497,16 @@ namespace Microsoft.Bot.Connector.Tests
         {
             private bool _isAuthenticated;
 
-            public SimpleClaimsIdentity(IEnumerable<Claim> claims, bool isAuthenticated) : base(claims)
+            public SimpleClaimsIdentity(IEnumerable<Claim> claims, bool isAuthenticated)
+                : base(claims)
             {
                 _isAuthenticated = isAuthenticated;
             }
 
-            public override bool IsAuthenticated { get { return _isAuthenticated; } }
+            public override bool IsAuthenticated
+            {
+                get { return _isAuthenticated; }
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/JwtTokenValidationTests.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;

--- a/tests/Microsoft.Bot.Connector.Tests/MicrosoftGovernmentAppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/MicrosoftGovernmentAppCredentialsTests.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Xunit;

--- a/tests/Microsoft.Bot.Connector.Tests/MicrosoftGovernmentAppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/MicrosoftGovernmentAppCredentialsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Connector.Tests
 
             Assert.Contains("login.microsoftonline.us", cred.OAuthEndpoint);
         }
-        
+
         [Fact]
         public void MicrosoftGovernmentAppCredentials_Uses_Gov_Scope()
         {

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -60,24 +60,6 @@ namespace Connector.Tests
              });
         }
 
-        // [Fact] - Disabled due to bug in service
-        //public async Task GetSignInLinkAsync_ShouldReturnValidUrl()
-        //{
-        //    var activity = new Activity()
-        //    {
-        //        Id = "myid",
-        //        From = new ChannelAccount() { Id = "fromId" },
-        //        ServiceUrl = "https://localhost"
-        //    };
-        //    await UseOAuthClientFor(async client =>
-        //     {
-        //         var uri = await client.GetSignInLinkAsync(activity, "mygithubconnection");
-        //         Assert.False(string.IsNullOrEmpty(uri));
-        //         Uri uriResult;
-        //         Assert.True(Uri.TryCreate(uri, UriKind.Absolute, out uriResult) && uriResult.Scheme == Uri.UriSchemeHttps);
-        //     });
-        //}
-
         [Fact]
         public async Task SignOutUser_ShouldThrowOnEmptyUserId()
         {
@@ -119,5 +101,23 @@ namespace Connector.Tests
             var client = new OAuthClient(new Uri("http://localhost"), new BotAccessTokenStub("token"));
             await Assert.ThrowsAsync<ValidationException>(() => client.UserToken.GetAadTokensAsync("user", "connection", null));
         }
+
+        // [Fact] - Disabled due to bug in service
+        // public async Task GetSignInLinkAsync_ShouldReturnValidUrl()
+        // {
+        //    var activity = new Activity()
+        //    {
+        //        Id = "myid",
+        //        From = new ChannelAccount() { Id = "fromId" },
+        //        ServiceUrl = "https://localhost"
+        //    };
+        //    await UseOAuthClientFor(async client =>
+        //     {
+        //         var uri = await client.GetSignInLinkAsync(activity, "mygithubconnection");
+        //         Assert.False(string.IsNullOrEmpty(uri));
+        //         Uri uriResult;
+        //         Assert.True(Uri.TryCreate(uri, UriKind.Absolute, out uriResult) && uriResult.Scheme == Uri.UriSchemeHttps);
+        //     });
+        // }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
+using Microsoft.Bot.Connector.Tests;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest;
 using Xunit;

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading.Tasks;
-using Connector.Tests;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest;

--- a/tests/Microsoft.Bot.Connector.Tests/RetryParamsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/RetryParamsTests.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Microsoft.Bot.Connector.Authentication;
 using Xunit;
 

--- a/tests/Microsoft.Bot.Connector.Tests/RetryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/RetryTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Xunit;

--- a/tests/Microsoft.Bot.Connector.Tests/RetryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/RetryTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Bot.Connector.Tests
         {
             FaultyClass faultyClass = new FaultyClass()
             {
-                ExceptionToThrow = null
+                ExceptionToThrow = null,
             };
 
             var result = await Retry.Run(
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Connector.Tests
             FaultyClass faultyClass = new FaultyClass()
             {
                 ExceptionToThrow = new ArgumentNullException(),
-                TriesUntilSuccess = 3
+                TriesUntilSuccess = 3,
             };
 
             var result = await Retry.Run(
@@ -48,43 +48,13 @@ namespace Microsoft.Bot.Connector.Tests
             FaultyClass faultyClass = new FaultyClass()
             {
                 ExceptionToThrow = new ArgumentNullException(),
-                TriesUntilSuccess = 12
+                TriesUntilSuccess = 12,
             };
 
-            await Assert.ThrowsAsync<AggregateException>(async () => 
+            await Assert.ThrowsAsync<AggregateException>(async () =>
                 await Retry.Run(
                     task: () => faultyClass.FaultyTask(),
                     retryExceptionHandler: (ex, ct) => faultyClass.ExceptionHandler(ex, ct)));
-        }
-    }
-
-    public class FaultyClass
-    {
-        public Exception ExceptionToThrow { get; set; }
-        public Exception ExceptionReceived { get; set; } = null;
-        public int LatestRetryCount { get; set; }
-        public int CallCount { get; set; } = 0;
-        public int TriesUntilSuccess { get; set; } = 0;
-
-
-        public async Task<string> FaultyTask()
-        {
-            CallCount++;
-
-            if (CallCount < TriesUntilSuccess && ExceptionToThrow != null)
-            {
-                throw ExceptionToThrow;
-            }
-
-            return string.Empty;
-        }
-
-        public RetryParams ExceptionHandler(Exception ex, int currentRetryCount)
-        {
-            ExceptionReceived = ex;
-            LatestRetryCount = currentRetryCount;
-
-            return RetryParams.DefaultBackOff(currentRetryCount);
         }
     }
 }


### PR DESCRIPTION
- Reorder using directives
- Remove empty blank lines
- Add trailing comma in multi-line initializers
- Remove trailing white spaces
- Update protected const fields to be protected property with private set.
- Update private const field to be private read-only to avoid unreachable code in BaseTest class.