### PR TITLE
ContinueConversationAsync get AppId from Adapter's credentials

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -127,9 +127,7 @@ namespace Microsoft.Bot.Builder
         {
             if (string.IsNullOrWhiteSpace(botAppId))
             {
-                var credentials = (SimpleCredentialProvider)this._credentialProvider;
-
-                botAppId = credentials.AppId;
+                botAppId = this._credentialProvider.AppId;
 
                 if (string.IsNullOrWhiteSpace(botAppId))
                 {

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -944,25 +944,16 @@ namespace Microsoft.Bot.Builder
         {
             try
             {
-                var interfaces = this._credentialProvider.GetType().GetInterfaces();
+                var asAppId = this._credentialProvider as IAppId;
 
-                if (!interfaces.Any(x => x.Name == "IAppId"))
+                if (asAppId == null)
                 {
-                    throw new ArgumentNullException("BotFrameworkAdapter.ContinueConversationAsync(): Interface IAppId is missing");
+                    throw new InvalidOperationException("BotFrameworkAdapter.ContinueConversationAsync(): Interface IAppId is missing");
                 }
 
-                var interf = this._credentialProvider.GetType().GetInterface("IAppId");
+                string appId = asAppId.AppId;
 
-                var property = interf.GetProperty("AppId");
-
-                if (property is null)
-                {
-                    return string.Empty;
-                }
-
-                var value = property.GetValue(this._credentialProvider);
-
-                return value != null ? value.ToString() : string.Empty;
+                return appId;
             }
             catch (Exception ex)
             {

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Builder
         {
             if (string.IsNullOrWhiteSpace(botAppId))
             {
-                botAppId = this._credentialProvider.AppId;
+                botAppId = HasAppId(this._credentialProvider);
 
                 if (string.IsNullOrWhiteSpace(botAppId))
                 {
@@ -934,6 +934,25 @@ namespace Microsoft.Bot.Builder
                 new MicrosoftAppCredentials(appId, appPassword, _httpClient);
             _appCredentialMap[appId] = appCredentials;
             return appCredentials;
+        }
+
+        /// <summary>
+        /// Looks for the AppId property in the Credential Provider.
+        /// </summary>
+        /// <param name="credentialProvider">The Adapter's Credential Provider.</param>
+        /// <returns>AppId in case it exists.</returns>
+        private string HasAppId(ICredentialProvider credentialProvider)
+        {
+            var property = credentialProvider.GetType().GetProperty("AppId");
+
+            if (property is null)
+            {
+                return string.Empty;
+            }
+
+            var value = property.GetValue(credentialProvider);
+
+            return value != null ? value.ToString() : string.Empty;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -127,7 +127,14 @@ namespace Microsoft.Bot.Builder
         {
             if (string.IsNullOrWhiteSpace(botAppId))
             {
-                throw new ArgumentNullException(nameof(botAppId));
+                var credentials = (SimpleCredentialProvider)this._credentialProvider;
+
+                botAppId = credentials.AppId;
+
+                if (string.IsNullOrWhiteSpace(botAppId))
+                {
+                    throw new ArgumentNullException(nameof(botAppId));
+                }
             }
 
             if (reference == null)
@@ -817,6 +824,7 @@ namespace Microsoft.Bot.Builder
             }
 
             var connectorClient = turnContext.TurnState.Get<IConnectorClient>();
+
             if (connectorClient == null)
             {
                 throw new InvalidOperationException("An IConnectorClient is required in TurnState for this operation.");

--- a/libraries/Microsoft.Bot.Connector/Authentication/CredentialProviders/TestCredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CredentialProviders/TestCredentialProvider.cs
@@ -1,30 +1,27 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+﻿using System.Threading.Tasks;
 
-using System.Threading.Tasks;
-
-namespace Microsoft.Bot.Connector.Authentication
+namespace Microsoft.Bot.Connector.Authentication.CredentialProviders
 {
     /// <summary>
-    /// A simple implementation of the <see cref="ICredentialProvider"/> interface.
+    /// A test implementation of the <see cref="ICredentialProvider"/> interface that doesn't implements IAppId interface.
     /// </summary>
-    public class SimpleCredentialProvider : ICredentialProvider, IAppId
+    public class TestCredentialProvider : ICredentialProvider
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SimpleCredentialProvider"/> class.
+        /// Initializes a new instance of the <see cref="TestCredentialProvider"/> class.
         /// with empty credentials.
         /// </summary>
-        public SimpleCredentialProvider()
+        public TestCredentialProvider()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SimpleCredentialProvider"/> class.
+        /// Initializes a new instance of the <see cref="TestCredentialProvider"/> class.
         /// with the provided credentials.
         /// </summary>
         /// <param name="appId">The app ID.</param>
         /// <param name="password">The app password.</param>
-        public SimpleCredentialProvider(string appId, string password)
+        public TestCredentialProvider(string appId, string password)
         {
             this.AppId = appId;
             this.Password = password;

--- a/libraries/Microsoft.Bot.Connector/Authentication/CredentialProviders/TestCredentialProviderNoAppId.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CredentialProviders/TestCredentialProviderNoAppId.cs
@@ -5,23 +5,23 @@ namespace Microsoft.Bot.Connector.Authentication.CredentialProviders
     /// <summary>
     /// A test implementation of the <see cref="ICredentialProvider"/> interface that doesn't implements IAppId interface.
     /// </summary>
-    public class TestCredentialProvider : ICredentialProvider
+    public class TestCredentialProviderNoAppId : ICredentialProvider
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="TestCredentialProvider"/> class.
+        /// Initializes a new instance of the <see cref="TestCredentialProviderNoAppId"/> class.
         /// with empty credentials.
         /// </summary>
-        public TestCredentialProvider()
+        public TestCredentialProviderNoAppId()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TestCredentialProvider"/> class.
+        /// Initializes a new instance of the <see cref="TestCredentialProviderNoAppId"/> class.
         /// with the provided credentials.
         /// </summary>
         /// <param name="appId">The app ID.</param>
         /// <param name="password">The app password.</param>
-        public TestCredentialProvider(string appId, string password)
+        public TestCredentialProviderNoAppId(string appId, string password)
         {
             this.AppId = appId;
             this.Password = password;

--- a/libraries/Microsoft.Bot.Connector/Authentication/IAppId.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/IAppId.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// Represents the Id of a bot for a credential provider.
+    /// </summary>
+    public interface IAppId
+    {
+        /// <summary>
+        /// Gets or sets the app ID for a credential provider.
+        /// </summary>
+        /// <value>
+        /// The app ID for the credential.
+        /// </value>
+        string AppId { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
@@ -18,6 +18,22 @@ namespace Microsoft.Bot.Connector.Authentication
     public interface ICredentialProvider
     {
         /// <summary>
+        /// Gets or sets the app ID for this credential.
+        /// </summary>
+        /// <value>
+        /// The app ID for this credential.
+        /// </value>
+        string AppId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the app password for this credential.
+        /// </summary>
+        /// <value>
+        /// The app password for this credential.
+        /// </value>
+        string Password { get; set; }
+
+        /// <summary>
         /// Validates an app ID.
         /// </summary>
         /// <param name="appId">The app ID to validate.</param>

--- a/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
@@ -18,22 +18,6 @@ namespace Microsoft.Bot.Connector.Authentication
     public interface ICredentialProvider
     {
         /// <summary>
-        /// Gets or sets the app ID for this credential.
-        /// </summary>
-        /// <value>
-        /// The app ID for this credential.
-        /// </value>
-        string AppId { get; set; }
-
-        /// <summary>
-        /// Gets or sets the app password for this credential.
-        /// </summary>
-        /// <value>
-        /// The app password for this credential.
-        /// </value>
-        string Password { get; set; }
-
-        /// <summary>
         /// Validates an app ID.
         /// </summary>
         /// <param name="appId">The app ID to validate.</param>

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -79,11 +79,12 @@ namespace Microsoft.Bot.Builder.Tests
                     Role = "bot",
                 },
             };
-            Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
+
             await adapter.ContinueConversationAsync("MyBot", cr, continueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
@@ -106,7 +107,7 @@ namespace Microsoft.Bot.Builder.Tests
                 ServiceUrl = "https://test.com",
                 Conversation = new ConversationAccount
                 {
-                    ConversationType = "",
+                    ConversationType = string.Empty,
                     Id = "testConversationId",
                     IsGroup = false,
                     Name = "testConversationName",
@@ -124,6 +125,7 @@ namespace Microsoft.Bot.Builder.Tests
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
+
             await adapter.ContinueConversationAsync(null, cr, continueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
@@ -146,7 +148,7 @@ namespace Microsoft.Bot.Builder.Tests
                 ServiceUrl = "https://test.com",
                 Conversation = new ConversationAccount
                 {
-                    ConversationType = "",
+                    ConversationType = string.Empty,
                     Id = "testConversationId",
                     IsGroup = false,
                     Name = "testConversationName",
@@ -164,12 +166,14 @@ namespace Microsoft.Bot.Builder.Tests
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
+
             await adapter.ContinueConversationAsync("AppId", cr, continueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
 
     [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException),
+        [ExpectedException(
+            typeof(ArgumentNullException),
             "An AppId of null was inappropriately allowed.")]
         public async Task ContinueConversation_AppIdNullAsync()
         {
@@ -188,7 +192,7 @@ namespace Microsoft.Bot.Builder.Tests
                 ServiceUrl = "https://test.com",
                 Conversation = new ConversationAccount
                 {
-                    ConversationType = "",
+                    ConversationType = string.Empty,
                     Id = "testConversationId",
                     IsGroup = false,
                     Name = "testConversationName",
@@ -206,6 +210,7 @@ namespace Microsoft.Bot.Builder.Tests
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
+
             await adapter.ContinueConversationAsync(null, cr, continueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.IsTrue(callbackInvoked);
         }
 
-    [TestMethod]
+        [TestMethod]
         [ExpectedException(
             typeof(ArgumentNullException),
             "An AppId of null was inappropriately allowed.")]

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Connector.Authentication.CredentialProviders;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -179,6 +180,50 @@ namespace Microsoft.Bot.Builder.Tests
         {
             bool callbackInvoked = false;
             var adapter = new BotFrameworkAdapter(new SimpleCredentialProvider());
+            ConversationReference cr = new ConversationReference
+            {
+                ActivityId = "activityId",
+                Bot = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+                ChannelId = "testChannel",
+                ServiceUrl = "https://test.com",
+                Conversation = new ConversationAccount
+                {
+                    ConversationType = string.Empty,
+                    Id = "testConversationId",
+                    IsGroup = false,
+                    Name = "testConversationName",
+                    Role = "user",
+                },
+                User = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+            };
+            Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            }
+
+            await adapter.ContinueConversationAsync(null, cr, ContinueCallback, default(CancellationToken));
+            Assert.IsTrue(callbackInvoked);
+        }
+
+        [TestMethod]
+        [ExpectedException(
+            typeof(ArgumentNullException),
+            "An AppId of null was inappropriately allowed.")]
+        public async Task ContinueConversation_IAppIdMissing()
+        {
+            bool callbackInvoked = false;
+            var adapter = new BotFrameworkAdapter(new TestCredentialProvider("AppId", "AppSecret"));
             ConversationReference cr = new ConversationReference
             {
                 ActivityId = "activityId",

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -218,12 +218,12 @@ namespace Microsoft.Bot.Builder.Tests
 
         [TestMethod]
         [ExpectedException(
-            typeof(ArgumentNullException),
-            "An AppId of null was inappropriately allowed.")]
+            typeof(InvalidOperationException),
+            "The credentialProvider does not implements IAppId interface.")]
         public async Task ContinueConversation_IAppIdMissing()
         {
             bool callbackInvoked = false;
-            var adapter = new BotFrameworkAdapter(new TestCredentialProvider("AppId", "AppSecret"));
+            var adapter = new BotFrameworkAdapter(new TestCredentialProviderNoAppId("AppId", "AppSecret"));
             ConversationReference cr = new ConversationReference
             {
                 ActivityId = "activityId",

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -79,13 +79,13 @@ namespace Microsoft.Bot.Builder.Tests
                     Role = "bot",
                 },
             };
-            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
 
-            await adapter.ContinueConversationAsync("MyBot", cr, continueCallback, default(CancellationToken));
+            await adapter.ContinueConversationAsync("MyBot", cr, ContinueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
 
@@ -120,13 +120,13 @@ namespace Microsoft.Bot.Builder.Tests
                     Role = "bot",
                 },
             };
-            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
 
-            await adapter.ContinueConversationAsync(null, cr, continueCallback, default(CancellationToken));
+            await adapter.ContinueConversationAsync(null, cr, ContinueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
 
@@ -161,13 +161,13 @@ namespace Microsoft.Bot.Builder.Tests
                     Role = "bot",
                 },
             };
-            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
 
-            await adapter.ContinueConversationAsync("AppId", cr, continueCallback, default(CancellationToken));
+            await adapter.ContinueConversationAsync("AppId", cr, ContinueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
 
@@ -205,13 +205,13 @@ namespace Microsoft.Bot.Builder.Tests
                     Role = "bot",
                 },
             };
-            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
 
-            await adapter.ContinueConversationAsync(null, cr, continueCallback, default(CancellationToken));
+            await adapter.ContinueConversationAsync(null, cr, ContinueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -83,8 +84,87 @@ namespace Microsoft.Bot.Builder.Tests
                 callbackInvoked = true;
                 return Task.CompletedTask;
             }
+            await adapter.ContinueConversationAsync("MyBot", cr, continueCallback, default(CancellationToken));
+            Assert.IsTrue(callbackInvoked);
+        }
 
-            await adapter.ContinueConversationAsync("MyBot", cr, ContinueCallback, default(CancellationToken));
+        [TestMethod]
+        public async Task ContinueConversation_AppIdNotInformedAsync()
+        {
+            bool callbackInvoked = false;
+            var adapter = new BotFrameworkAdapter(new SimpleCredentialProvider("AppId", "AppSecret"));
+            ConversationReference cr = new ConversationReference
+            {
+                ActivityId = "activityId",
+                Bot = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+                ChannelId = "testChannel",
+                ServiceUrl = "https://test.com",
+                Conversation = new ConversationAccount
+                {
+                    ConversationType = "",
+                    Id = "testConversationId",
+                    IsGroup = false,
+                    Name = "testConversationName",
+                    Role = "user",
+                },
+                User = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+            };
+            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            }
+            await adapter.ContinueConversationAsync(null, cr, continueCallback, default(CancellationToken));
+            Assert.IsTrue(callbackInvoked);
+        }
+
+        [TestMethod]
+        public async Task ContinueConversation_AppIdInformedAsync()
+        {
+            bool callbackInvoked = false;
+            var adapter = new BotFrameworkAdapter(new SimpleCredentialProvider("AppId", "AppSecret"));
+            ConversationReference cr = new ConversationReference
+            {
+                ActivityId = "activityId",
+                Bot = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+                ChannelId = "testChannel",
+                ServiceUrl = "https://test.com",
+                Conversation = new ConversationAccount
+                {
+                    ConversationType = "",
+                    Id = "testConversationId",
+                    IsGroup = false,
+                    Name = "testConversationName",
+                    Role = "user",
+                },
+                User = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+            };
+            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            }
+            await adapter.ContinueConversationAsync("AppId", cr, continueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotAdapterTests.cs
@@ -167,5 +167,47 @@ namespace Microsoft.Bot.Builder.Tests
             await adapter.ContinueConversationAsync("AppId", cr, continueCallback, default(CancellationToken));
             Assert.IsTrue(callbackInvoked);
         }
+
+    [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException),
+            "An AppId of null was inappropriately allowed.")]
+        public async Task ContinueConversation_AppIdNullAsync()
+        {
+            bool callbackInvoked = false;
+            var adapter = new BotFrameworkAdapter(new SimpleCredentialProvider());
+            ConversationReference cr = new ConversationReference
+            {
+                ActivityId = "activityId",
+                Bot = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+                ChannelId = "testChannel",
+                ServiceUrl = "https://test.com",
+                Conversation = new ConversationAccount
+                {
+                    ConversationType = "",
+                    Id = "testConversationId",
+                    IsGroup = false,
+                    Name = "testConversationName",
+                    Role = "user",
+                },
+                User = new ChannelAccount
+                {
+                    Id = "channelId",
+                    Name = "testChannelAccount",
+                    Role = "bot",
+                },
+            };
+            Task continueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            }
+            await adapter.ContinueConversationAsync(null, cr, continueCallback, default(CancellationToken));
+            Assert.IsTrue(callbackInvoked);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #1401 

## Proposed Changes

- In _ICredentialProvider_ interface, we added two properties (getters and setters), AppId and Password.

- In _ContinueConversationAsync_ method, we get the AppId from the Adapter's credentials in case it's not informed, so, this parameter is not required anymore.

![image](https://user-images.githubusercontent.com/44245136/55105005-44c60000-50aa-11e9-8c5b-0789f5a4ca2a.png)

This fix doesn't introduce breaking changes because the [SimpleCredentialprovider](https://github.com/Microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Connector/Authentication/SimpleCredentialProvider.cs) class is the only one that implements _ICredentialProvider_ interface.
