### PR TITLE
Retain binary compatibility for LUIS recognizer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisPredictionOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisPredictionOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 
+using Newtonsoft.Json;
+
 namespace Microsoft.Bot.Builder.AI.Luis
 {
     /// <summary>
@@ -63,5 +65,20 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// The time zone offset.
         /// </value>
         public double? TimezoneOffset { get; set; }
+
+        /// <summary>
+        /// Gets or sets the IBotTelemetryClient used to log the LuisResult event.
+        /// </summary>
+        /// <value>
+        /// The client used to log telemetry events.
+        /// </value>
+        [JsonIgnore]
+        public IBotTelemetryClient TelemetryClient { get; set; } = new NullBotTelemetryClient();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
+        /// </summary>
+        /// <value>If true, personal information is logged to Telemetry; otherwise the properties will be filtered.</value>
+        public bool LogPersonalInformation { get; set; } = false;
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -90,19 +90,6 @@ namespace Microsoft.Bot.Builder.AI.Luis
         {
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LuisRecognizer"/> class.
-        /// </summary>
-        /// <param name="telemetryClient">The IBotTelemetryClient used to log the LuisResult event.</param>
-        /// <param name="application">The LUIS application to use to recognize text.</param>
-        /// <param name="predictionOptions">The LUIS prediction options to use.</param>
-        /// <param name="includeApiResults">TRUE to include raw LUIS API response.</param>
-        /// <param name="logPersonalInformation">TRUE to include personally indentifiable information.</param>
-        public LuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
-            : this(application, predictionOptions, includeApiResults, null, telemetryClient)
-        {
-            LogPersonalInformation = logPersonalInformation;
-        }
 
         /// <summary>
         /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -43,15 +43,14 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <param name="predictionOptions">(Optional) The LUIS prediction options to use.</param>
         /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
         /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
-        /// <param name="telemetryClient">The IBotTelemetryClient used to log the LuisResult event.</param>
-        public LuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+        public LuisRecognizer(LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
         {
             _application = application ?? throw new ArgumentNullException(nameof(application));
             _options = predictionOptions ?? new LuisPredictionOptions();
             _includeApiResults = includeApiResults;
 
-            TelemetryClient = telemetryClient ?? new NullBotTelemetryClient();
-            LogPersonalInformation = logPersonalInformation;
+            TelemetryClient = _options.TelemetryClient;
+            LogPersonalInformation = _options.LogPersonalInformation;
 
             var credentials = new ApiKeyServiceClientCredentials(application.EndpointKey);
             var delegatingHandler = new LuisDelegatingHandler();
@@ -74,7 +73,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
         /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
         public LuisRecognizer(LuisService service, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
-            : this(new LuisApplication(service), predictionOptions, includeApiResults, clientHandler, null)
+            : this(new LuisApplication(service), predictionOptions, includeApiResults, clientHandler)
         {
         }
 
@@ -86,7 +85,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <param name="includeApiResults">(Optional) TRUE to include raw LUIS API response.</param>
         /// <param name="clientHandler">(Optional) Custom handler for LUIS API calls to allow mocking.</param>
         public LuisRecognizer(string applicationEndpoint, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, HttpClientHandler clientHandler = null)
-            : this(new LuisApplication(applicationEndpoint), predictionOptions, includeApiResults, clientHandler, null)
+            : this(new LuisApplication(applicationEndpoint), predictionOptions, includeApiResults, clientHandler)
         {
         }
 

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -546,17 +546,23 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var luisApp = new LuisApplication(endpoint);
             var telemetryClient = new Mock<IBotTelemetryClient>();
             var adapter = new NullAdapter();
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+
             var activity = new Activity
             {
                 Type = ActivityTypes.Message,
                 Text = "please book from May 5 to June 6",
                 Recipient = new ChannelAccount(),           // to no where
                 From = new ChannelAccount(),                // from no one
-                Conversation = new ConversationAccount()    // on no conversation
+                Conversation = new ConversationAccount(),   // on no conversation
             };
 
             var turnContext = new TurnContext(adapter, activity);
-            var recognizer = new LuisRecognizer(luisApp, null, false, clientHandler, telemetryClient.Object);
+            var recognizer = new LuisRecognizer(luisApp, options, false, clientHandler);
 
             // Act
             var additionalProperties = new Dictionary<string, string>
@@ -583,6 +589,98 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
         [TestMethod]
         [TestCategory("Telemetry")]
+        public async Task Telemetry_PiiLoggedAsync()
+        {
+            // Arrange
+            // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key
+            // theses are GUIDs edited to look right to the parsing and validation code.
+            var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
+            var clientHandler = new EmptyLuisResponseClientHandler();
+            var luisApp = new LuisApplication(endpoint);
+            var telemetryClient = new Mock<IBotTelemetryClient>();
+            var adapter = new NullAdapter();
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = "please book from May 5 to June 6",
+                Recipient = new ChannelAccount(),           // to no where
+                From = new ChannelAccount(),                // from no one
+                Conversation = new ConversationAccount(),   // on no conversation
+            };
+
+            var turnContext = new TurnContext(adapter, activity);
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = true,
+            };
+            var recognizer = new LuisRecognizer(luisApp, options, false, clientHandler);
+
+            // Act
+            var result = await recognizer.RecognizeAsync(turnContext, null).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(telemetryClient.Invocations.Count, 1);
+            Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0].ToString(), "LuisResult");
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count == 8);
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intentScore"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent2"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intentScore2"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("fromId"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("entities"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
+        }
+
+        [TestMethod]
+        [TestCategory("Telemetry")]
+        public async Task Telemetry_NoPiiLoggedAsync()
+        {
+            // Arrange
+            // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key
+            // theses are GUIDs edited to look right to the parsing and validation code.
+            var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
+            var clientHandler = new EmptyLuisResponseClientHandler();
+            var luisApp = new LuisApplication(endpoint);
+            var telemetryClient = new Mock<IBotTelemetryClient>();
+            var adapter = new NullAdapter();
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = "please book from May 5 to June 6",
+                Recipient = new ChannelAccount(),           // to no where
+                From = new ChannelAccount(),                // from no one
+                Conversation = new ConversationAccount(),   // on no conversation
+            };
+
+            var turnContext = new TurnContext(adapter, activity);
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+            var recognizer = new LuisRecognizer(luisApp, options, false, clientHandler);
+
+            // Act
+            var result = await recognizer.RecognizeAsync(turnContext, null).ConfigureAwait(false);
+
+            // Assert
+            Assert.AreEqual(telemetryClient.Invocations.Count, 1);
+            Assert.AreEqual(telemetryClient.Invocations[0].Arguments[0].ToString(), "LuisResult");
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count == 7);
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intentScore"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent2"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intentScore2"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("fromId"));
+            Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("entities"));
+            Assert.IsFalse(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("question"));
+        }
+
+        [TestMethod]
+        [TestCategory("Telemetry")]
         public async Task Telemetry_OverrideOnDeriveAsync()
         {
             // Arrange
@@ -603,7 +701,13 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             };
 
             var turnContext = new TurnContext(adapter, activity);
-            var recognizer = new TelemetryOverrideRecognizer(telemetryClient.Object, luisApp, null, false, false, clientHandler);
+
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+            var recognizer = new TelemetryOverrideRecognizer(telemetryClient.Object, luisApp, options, false, false, clientHandler);
 
             var additionalProperties = new Dictionary<string, string>
             {
@@ -648,7 +752,13 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             };
 
             var turnContext = new TurnContext(adapter, activity);
-            var recognizer = new OverrideFillRecognizer(telemetryClient.Object, luisApp, null, false, false, clientHandler);
+
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+            var recognizer = new OverrideFillRecognizer(telemetryClient.Object, luisApp, options, false, false, clientHandler);
 
             var additionalProperties = new Dictionary<string, string>
             {
@@ -704,7 +814,13 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             };
 
             var turnContext = new TurnContext(adapter, activity);
-            var recognizer = new LuisRecognizer(luisApp, null, false, clientHandler, telemetryClient.Object);
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+
+            var recognizer = new LuisRecognizer(luisApp, options, false, clientHandler);
 
             // Act
             var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
@@ -741,7 +857,12 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             };
 
             var turnContext = new TurnContext(adapter, activity);
-            var recognizer = new LuisRecognizer(luisApp, null, false, clientHandler, telemetryClient.Object);
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+            var recognizer = new LuisRecognizer(luisApp, options, false, clientHandler);
 
             // Act
             // Use a class the converts the Recognizer Result..
@@ -756,8 +877,6 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("fromId"));
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("entities"));
         }
-
-
 
         [TestMethod]
         [TestCategory("Telemetry")]
@@ -781,7 +900,13 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             };
 
             var turnContext = new TurnContext(adapter, activity);
-            var recognizer = new LuisRecognizer(luisApp, null, false, clientHandler, telemetryClient.Object);
+
+            var options = new LuisPredictionOptions
+            {
+                TelemetryClient = telemetryClient.Object,
+                LogPersonalInformation = false,
+            };
+            var recognizer = new LuisRecognizer(luisApp, options, false, clientHandler);
 
             // Act
             var additionalProperties = new Dictionary<string, string>
@@ -956,7 +1081,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
     public class TelemetryOverrideRecognizer : LuisRecognizer
     {
         public TelemetryOverrideRecognizer(IBotTelemetryClient telemetryClient, LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logPersonalInformation = false, HttpClientHandler clientHandler = null)
-           : base(application, predictionOptions, includeApiResults, clientHandler, telemetryClient)
+           : base(application, predictionOptions, includeApiResults, clientHandler)
         {
             LogPersonalInformation = logPersonalInformation;
         }
@@ -983,7 +1108,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
     public class OverrideFillRecognizer : LuisRecognizer
     {
         public OverrideFillRecognizer(IBotTelemetryClient telemetryClient, LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logPersonalInformation = false, HttpClientHandler clientHandler = null)
-           : base(application, predictionOptions, includeApiResults, clientHandler, telemetryClient)
+           : base(application, predictionOptions, includeApiResults, clientHandler)
         {
             LogPersonalInformation = logPersonalInformation;
         }

--- a/tests/Microsoft.Bot.Builder.TestBot/LuisHelper.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/LuisHelper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.BotBuilderSamples
                     "https://" + configuration["LuisAPIHostName"]);
 
                 // TODO: fix the ambiguity introduced in 4.4.n
-                var recognizer = new LuisRecognizer(luisApplication, null, false, null, null, false);
+                var recognizer = new LuisRecognizer(luisApplication, null, false, null);
 
                 // The actual call to LUIS
                 var recognizerResult = await recognizer.RecognizeAsync(turnContext, cancellationToken);


### PR DESCRIPTION
Change construction of the LUIS recognizer to maintain binary compatibility.  This effectively reverts back to original constructor and pushes new options in the `LuisPredictionOptions` class.
Also add a few more tests.

I'll update nodejs side if we're good with this..

@Zerryth : We can follow this pattern for timeout.