### PR TITLE
[Azure] Fix 'PartitionKey value must be supplied for this operation' error

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -131,6 +131,8 @@ namespace Microsoft.Bot.Builder.Azure
         /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
         public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken)
         {
+            RequestOptions options = null;
+
             if (keys == null)
             {
                 throw new ArgumentNullException(nameof(keys));
@@ -143,12 +145,19 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Ensure Initialization has been run
             await InitializeAsync().ConfigureAwait(false);
-            var options = new RequestOptions() { PartitionKey = new PartitionKey(this._partitionKey) };
+
+            if (!string.IsNullOrEmpty(this._partitionKey))
+            {
+                options = new RequestOptions() { PartitionKey = new PartitionKey(this._partitionKey) };
+            }
 
             // Parallelize deletion
             var tasks = keys.Select(key =>
                 _client.DeleteDocumentAsync(
-                    UriFactory.CreateDocumentUri(_databaseId, _collectionId, CosmosDbKeyEscape.EscapeKey(key)),
+                    UriFactory.CreateDocumentUri(
+                        _databaseId,
+                        _collectionId,
+                        CosmosDbKeyEscape.EscapeKey(key)),
                     options,
                     cancellationToken: cancellationToken));
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Bot.Builder.Azure
         private readonly RequestOptions _documentCollectionCreationRequestOptions = null;
         private readonly RequestOptions _databaseCreationRequestOptions = null;
         private readonly IDocumentClient _client;
-        private readonly object cosmosDbStorageOptions;
         private string _collectionLink = null;
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -143,8 +143,7 @@ namespace Microsoft.Bot.Builder.Azure
 
             // Ensure Initialization has been run
             await InitializeAsync().ConfigureAwait(false);
-            var options = new RequestOptions();
-            options.PartitionKey = new PartitionKey(this._partitionKey);
+            var options = new RequestOptions() { PartitionKey = new PartitionKey(this._partitionKey) };
 
             // Parallelize deletion
             var tasks = keys.Select(key =>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
@@ -13,6 +13,14 @@ namespace Microsoft.Bot.Builder.Azure
     public class CosmosDbStorageOptions
     {
         /// <summary>
+        /// Gets or sets the partitionKey value.
+        /// </summary>
+        /// <value>
+        /// The Partition Key.
+        /// </value>
+        public string PartitionKey { get; set; }
+
+        /// <summary>
         /// Gets or sets the CosmosDB endpoint.
         /// </summary>
         /// <value>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -392,61 +392,72 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     .StartTestAsync();
             }
         }
-
+        
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
         public async Task DeleteAsyncFromSingleCollection()
         {
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-            var changes = new Dictionary<string, object>();
-            changes.Add(DocumentId, ItemToTest);
+            if (CheckEmulator())
+            {
+                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
+                var changes = new Dictionary<string, object>();
+                changes.Add(DocumentId, ItemToTest);
 
-            await storage.WriteAsync(changes, CancellationToken.None);
+                await storage.WriteAsync(changes, CancellationToken.None);
 
-            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
-            Assert.IsTrue(result.IsCompletedSuccessfully);
+                var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
+                Assert.IsTrue(result.IsCompletedSuccessfully);
+            }
         }
 
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
         public async Task DeleteAsyncFromPartitionedCollection()
         {
-            /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-            /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-            /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-            string partitionKeyPath = "document/city";
+            if (CheckEmulator())
+            {
+                /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+                /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+                /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+                string partitionKeyPath = "document/city";
 
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+                await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
 
-            // Connect to the comosDb created before
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
-            var item = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
-            var changes = new Dictionary<string, object>();
-            changes.Add(DocumentId, ItemToTest);
+                // Connect to the comosDb created before
+                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
+                var changes = new Dictionary<string, object>();
+                changes.Add(DocumentId, ItemToTest);
 
-            await storage.WriteAsync(changes, CancellationToken.None);
+                await storage.WriteAsync(changes, CancellationToken.None);
 
-            var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
-            Assert.IsTrue(result.IsCompletedSuccessfully);
+                var result = await Task.WhenAny(storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None)).ConfigureAwait(false);
+                Assert.IsTrue(result.IsCompletedSuccessfully);
+            }
         }
 
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
         public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
         {
-            /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
-            /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
-            /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
-            string partitionKeyPath = "document/city";
+            if (CheckEmulator())
+            {
+                /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
+                /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
+                /// <seealso cref="WriteAsync(IDictionary{string, object}, CancellationToken)"/>
+                string partitionKeyPath = "document/city";
 
-            await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
+                await CreateCosmosDbWithPartitionedCollection(partitionKeyPath);
 
-            // Connect to the comosDb created before
-            var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
-            var changes = new Dictionary<string, object>();
-            changes.Add(DocumentId, ItemToTest);
+                // Connect to the comosDb created before
+                var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
+                var changes = new Dictionary<string, object>();
+                changes.Add(DocumentId, ItemToTest);
 
-            await storage.WriteAsync(changes, CancellationToken.None);
+                await storage.WriteAsync(changes, CancellationToken.None);
 
-            // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None));
+                // Should throw InvalidOperationException: PartitionKey value must be supplied for this operation.
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () => await storage.DeleteAsync(new string[] { DocumentId }, CancellationToken.None));
+            }
         }
 
         public bool CheckEmulator()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -511,8 +511,6 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-
-
         public bool CheckEmulator()
         {
             if (!_hasEmulator.Value)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
@@ -16,7 +17,6 @@ using Microsoft.Bot.Builder.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json;
-using System.Linq;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
@@ -30,13 +30,10 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         private const string CosmosDatabaseName = "test-db";
         private const string CosmosCollectionName = "bot-storage";
-
-        // Variables used to test delete cases
         private const string DocumentId = "UtteranceLog-001";
-        private readonly StoreItem ItemToTest = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
 
-        private static string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
+        private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private static Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
         {
             if (File.Exists(_emulatorPath))
@@ -53,6 +50,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             return false;
         });
+
+        // Item used to test delete cases
+        private readonly StoreItem itemToTest = new StoreItem { MessageList = new string[] { "hi", "how are u" }, City = "Contoso" };
 
         private IStorage _storage;
 
@@ -402,7 +402,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             {
                 var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
                 var changes = new Dictionary<string, object>();
-                changes.Add(DocumentId, ItemToTest);
+                changes.Add(DocumentId, itemToTest);
 
                 await storage.WriteAsync(changes, CancellationToken.None);
 
@@ -427,7 +427,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 // Connect to the comosDb created before with "Contoso" as partitionKey
                 var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
                 var changes = new Dictionary<string, object>();
-                changes.Add(DocumentId, ItemToTest);
+                changes.Add(DocumentId, itemToTest);
 
                 await storage.WriteAsync(changes, CancellationToken.None);
 
@@ -452,7 +452,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 // Connect to the comosDb created before
                 var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
                 var changes = new Dictionary<string, object>();
-                changes.Add(DocumentId, ItemToTest);
+                changes.Add(DocumentId, itemToTest);
 
                 await storage.WriteAsync(changes, CancellationToken.None);
 
@@ -477,12 +477,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 // Connect to the comosDb created before with "Contoso" as partitionKey
                 var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions("Contoso"));
                 var changes = new Dictionary<string, object>();
-                changes.Add(DocumentId, ItemToTest);
+                changes.Add(DocumentId, itemToTest);
 
                 await storage.WriteAsync(changes, CancellationToken.None);
 
-                var result = await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);                
-                Assert.AreEqual(ItemToTest.City, result[DocumentId].City);
+                var result = await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None);
+                Assert.AreEqual(itemToTest.City, result[DocumentId].City);
             }
         }
 
@@ -502,12 +502,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 // Connect to the comosDb created before without partitionKey
                 var storage = new CosmosDbStorage(CreateCosmosDbStorageOptions());
                 var changes = new Dictionary<string, object>();
-                changes.Add(DocumentId, ItemToTest);
+                changes.Add(DocumentId, itemToTest);
 
                 await storage.WriteAsync(changes, CancellationToken.None);
 
                 // Should throw DocumentClientException: Cross partition query is required but disabled
-                await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));                               
+                await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -387,6 +387,39 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
+        [TestMethod]
+        public async Task DeleteFromCosmosStorageWithPartitionKey()
+        {
+            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
+            {
+                PartitionKey = string.Empty,
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+            });
+
+            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task DeleteFromCosmosStorageWithoutPartitionKey()
+        {
+            var storage = new CosmosDbStorage(new CosmosDbStorageOptions()
+            {
+                PartitionKey = string.Empty,
+                AuthKey = CosmosAuthKey,
+                CollectionId = CosmosCollectionName,
+                CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
+                DatabaseId = CosmosDatabaseName,
+            });
+
+            string extStr = "PartitionKey value must be supplied for this operation";
+            Assert.ThrowsException<InvalidOperationException>(() => extStr);
+
+            await storage.DeleteAsync(new string[] { "foo" }, CancellationToken.None);
+        }
+
         public bool CheckEmulator()
         {
             if (!_hasEmulator.Value)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public async Task DeleteDocumentFromSingleCollection()
+        public async Task DeleteAsyncFromSingleCollection()
         {
             string DocumentId = "UtteranceLog-001";
             string[] keys = { DocumentId };
@@ -414,7 +414,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public async Task DeleteDocumentFromPartitionedCollection()
+        public async Task DeleteAsyncFromPartitionedCollection()
         {
             /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey
@@ -445,8 +445,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             Assert.IsTrue(result.IsCompletedSuccessfully);
         }
       
-        [TestMethod]
-        public async Task DeleteFromCosmosStorageWithoutPartitionKey()
+        [TestMethod] 
+        public async Task DeleteAsyncFromPartitionedCollectionWithoutPartitionKey()
         {
             /// The WriteAsync method receive a object as a parameter then encapsulate it in a object named "document"
             /// The partitionKeyPath must have the "document" value to properly route the values as partitionKey


### PR DESCRIPTION
### Description
This PR will fix the Issue #1407.

### Changes made

- Add `PartitionKey` field to the `CosmosDbStorageOptions`
- Modify the `DeleteAsync` method to generate the `RequestOptions `with the `PartitionKey `provided by the `CosmosDbStorageOptions`
- Pass the `options` optional parameter to the `DeleteDocumentAsync` method.
### Testing

1. [ Connect your bot to a CosmosDB](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-howto-v4-storage?view=azure-bot-service-4.0&tabs=csharp)

1.  Add the following on the main bot class:
```
private const string CosmosServiceEndpoint = "Endpoint";
private const string CosmosDBKey = "YourDBKey";
private const string CosmosDBDatabaseName = "bot-cosmos-sql-db";
private const string CosmosDBCollectionName = "bot-storage";
private const string CosmosDBPartitionKey = "YourPartitionKey";

// Replaces Memory Storage with reference to Cosmos DB.
private static readonly CosmosDbStorage _myStorage = new CosmosDbStorage(new CosmosDbStorageOptions
{
    PartitionKey = CosmosDBPartitionKey,
    AuthKey = CosmosDBKey,
    CollectionId = CosmosDBCollectionName,
    CosmosDBEndpoint = new Uri(CosmosServiceEndpoint),
    DatabaseId = CosmosDBDatabaseName,
});
```
and

```
string[] utteranceList = { "id-to-delete" };
await _myStorage.DeleteAsync(utteranceList, cancellationToken);
```

On the EmptyBot, it should look something like [this](https://gist.github.com/Aliandi/483f7141550ceb8d2205545fbf25b46c).