### PR TITLE
Add FindChoiceOptions.NoIndex

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
@@ -30,23 +30,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             var matched = Find.FindChoices(utterance, list, options);
             if (matched.Count == 0)
             {
-                // Next try finding by ordinal
-                var matches = RecognizeOrdinal(utterance, locale);
-                if (matches.Any())
+                var opt = options ?? new FindChoicesOptions();
+                if (!opt.NoIndex)
                 {
-                    foreach (var match in matches)
+                    // Next try finding by ordinal
+                    var matches = RecognizeOrdinal(utterance, locale);
+                    if (matches.Any())
                     {
-                        MatchChoiceByIndex(list, matched, match);
+                        foreach (var match in matches)
+                        {
+                            MatchChoiceByIndex(list, matched, match);
+                        }
                     }
-                }
-                else
-                {
-                    // Finally try by numerical index
-                    matches = RecognizeNumber(utterance, locale);
-
-                    foreach (var match in matches)
+                    else
                     {
-                        MatchChoiceByIndex(list, matched, match);
+                        // Finally try by numerical index
+                        matches = RecognizeNumber(utterance, locale);
+
+                        foreach (var match in matches)
+                        {
+                            MatchChoiceByIndex(list, matched, match);
+                        }
                     }
                 }
 
@@ -58,6 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
             return matched;
         }
+
 
         private static void MatchChoiceByIndex(IList<Choice> list, List<ModelResult<FoundChoice>> matched, ModelResult<FoundChoice> match)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/FindChoicesOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/FindChoicesOptions.cs
@@ -22,5 +22,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// A <c>true</c> if the title of the choices action will NOT be searched over; otherwise <c>false</c>.
         /// </value>
         public bool NoAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the choices will NOT be recognized by their index.
+        /// The default is <c>false</c>. This is optional.
+        /// </summary>
+        /// <value>
+        /// A <c>true</c> if the choices will NOT be recognized by their index; otherwise <c>false</c>.
+        /// </value>
+        public bool NoIndex { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -138,19 +138,19 @@ namespace Microsoft.Bot.Builder.Dialogs
                     // First check whether the prompt was sent to the user with numbers - if it was we should recognize numbers
                     var defaults = ChoiceDefaults[culture];
                     var choiceOptions = ChoiceOptions ?? defaults.Item3;
-
-                    // This logic reflects the fact that IncludeNumbers is nullable and True is the default set in Inline style
-                    if (!choiceOptions.IncludeNumbers.HasValue || choiceOptions.IncludeNumbers.Value)
+                    var findChoiceOptions = new FindChoicesOptions
                     {
-                        // The text may be a number in which case we will interpret that as a choice.
-                        var confirmChoices = ConfirmChoices ?? Tuple.Create(defaults.Item1, defaults.Item2);
-                        var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
-                        var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(message.Text, choices);
-                        if (secondAttemptResults.Count > 0)
-                        {
-                            result.Succeeded = true;
-                            result.Value = secondAttemptResults[0].Resolution.Index == 0;
-                        }
+                        Locale = culture,
+                        NoIndex = !choiceOptions.IncludeNumbers.GetValueOrDefault(true)
+                    };
+
+                    var confirmChoices = ConfirmChoices ?? Tuple.Create(defaults.Item1, defaults.Item2);
+                    var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
+                    var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(message.Text, choices, findChoiceOptions);
+                    if (secondAttemptResults.Count > 0)
+                    {
+                        result.Succeeded = true;
+                        result.Value = secondAttemptResults[0].Resolution.Index == 0;
                     }
                 }
             }


### PR DESCRIPTION
1. At the moment in `ConfimrPrompt` the second attempt (based on `ChoiceRecognizers`) is made only if ChoiceOptions's `IncludeNumber` is `true`. So if it's `false` there won't be a chance to recognize the choice based on its synonyms.
2. I think this option (`NoIndex`) naturally complement the existing `NoValue` and `NoAction` options.