### PR TITLE
Fix binary compat for QnAMaker

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// If null, a default client is used for this instance.</param>
         /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
         /// <param name="logPersonalInformation">Set to true to include personally indentifiable information in telemetry events.</param>
-        public QnAMaker(QnAMakerService service, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+        public QnAMaker(QnAMakerService service, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation = false)
             : this(new QnAMakerEndpoint(service), options, httpClient, telemetryClient, logPersonalInformation)
         {
         }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// If null, a default client is used for this instance.</param>
         /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
         /// <param name="logPersonalInformation">Set to true to include personally indentifiable information in telemetry events.</param>
-        public QnAMaker(QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
+        public QnAMaker(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation = false)
         {
             _httpClient = httpClient ?? DefaultHttpClient;
 
@@ -78,14 +78,39 @@ namespace Microsoft.Bot.Builder.AI.QnA
             LogPersonalInformation = logPersonalInformation;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QnAMaker"/> class.
+        /// </summary>
+        /// <param name="endpoint">The endpoint of the knowledge base to query.</param>
+        /// <param name="options">The options for the QnA Maker knowledge base.</param>
+        /// <param name="httpClient">An alternate client with which to talk to QnAMaker.
+        /// If null, a default client is used for this instance.</param>
+        public QnAMaker(QnAMakerEndpoint endpoint, QnAMakerOptions options = null, HttpClient httpClient = null)
+            : this(endpoint, options, httpClient, null)
+        {
+        }
+
         /// Initializes a new instance of the <see cref="QnAMaker"/> class.
         /// </summary>
         /// <param name="service">QnA service details from configuration.</param>
         /// <param name="options">The options for the QnA Maker knowledge base.</param>
         /// <param name="httpClient">An alternate client with which to talk to QnAMaker.
         /// If null, a default client is used for this instance.</param>
+        /// <param name="telemetryClient">The IBotTelemetryClient used for logging telemetry events.</param>
+        /// <param name="logPersonalInformation">Set to true to include personally indentifiable information in telemetry events.</param>
         public QnAMaker(QnAMakerService service, QnAMakerOptions options = null, HttpClient httpClient = null, IBotTelemetryClient telemetryClient = null, bool logPersonalInformation = false)
             : this(new QnAMakerEndpoint(service), options, httpClient, telemetryClient, logPersonalInformation)
+        {
+        }
+
+        /// Initializes a new instance of the <see cref="QnAMaker"/> class.
+        /// </summary>
+        /// <param name="service">QnA service details from configuration.</param>
+        /// <param name="options">The options for the QnA Maker knowledge base.</param>
+        /// <param name="httpClient">An alternate client with which to talk to QnAMaker.
+        /// If null, a default client is used for this instance.</param>
+        public QnAMaker(QnAMakerService service, QnAMakerOptions options = null, HttpClient httpClient = null)
+            : this(new QnAMakerEndpoint(service), options, httpClient, null)
         {
         }
 
@@ -106,13 +131,24 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// </summary>
         /// <param name="turnContext">The Turn Context that contains the user question to be queried against your knowledge base.</param>
         /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
+        /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
+        public Task<QueryResult[]> GetAnswersAsync(ITurnContext turnContext, QnAMakerOptions options = null)
+        {
+            return GetAnswersAsync(turnContext, options, null);
+        }
+
+        /// <summary>
+        /// Generates an answer from the knowledge base.
+        /// </summary>
+        /// <param name="turnContext">The Turn Context that contains the user question to be queried against your knowledge base.</param>
+        /// <param name="options">The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.</param>
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the QnaMessage event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the QnaMessage event.</param>
         /// <returns>A list of answers for the user query, sorted in decreasing order of ranking score.</returns>
         public async Task<QueryResult[]> GetAnswersAsync(
                                         ITurnContext turnContext,
-                                        QnAMakerOptions options = null,
-                                        Dictionary<string, string> telemetryProperties = null,
+                                        QnAMakerOptions options,
+                                        Dictionary<string, string> telemetryProperties,
                                         Dictionary<string, double> telemetryMetrics = null)
         {
             if (turnContext == null)

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -646,20 +646,6 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"));
         }
 
-        private static TurnContext GetContext(string utterance)
-        {
-            var b = new TestAdapter();
-            var a = new Activity
-            {
-                Type = ActivityTypes.Message,
-                Text = utterance,
-                Conversation = new ConversationAccount(),
-                Recipient = new ChannelAccount(),
-                From = new ChannelAccount(),
-            };
-            return new TurnContext(b, a);
-        }
-
         [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
@@ -677,17 +663,15 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
 
             // Act (Null Telemetry client)
-            //
             //    This will default to the NullTelemetryClient which no-ops all calls.
-            //
             var qna = new QnAMaker(endpoint, options, client, null, true);
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"));
 
@@ -715,11 +699,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
             var telemetryClient = new Mock<IBotTelemetryClient>();
 
@@ -740,6 +724,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("articleFound"));
             Assert.AreEqual(((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2]).Count, 1);
             Assert.IsTrue(((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2]).ContainsKey("score"));
+
             // Assert - Validate we didn't break QnA functionality.
             Assert.IsNotNull(results);
             Assert.AreEqual(results.Length, 1, "should get one result");
@@ -764,11 +749,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
             var telemetryClient = new Mock<IBotTelemetryClient>();
 
@@ -789,6 +774,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("articleFound"));
             Assert.AreEqual(((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2]).Count, 1);
             Assert.IsTrue(((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2]).ContainsKey("score"));
+
             // Assert - Validate we didn't break QnA functionality.
             Assert.IsNotNull(results);
             Assert.AreEqual(results.Length, 1, "should get one result");
@@ -813,11 +799,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
             var telemetryClient = new Mock<IBotTelemetryClient>();
 
@@ -867,11 +853,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
             var telemetryClient = new Mock<IBotTelemetryClient>();
 
@@ -930,18 +916,16 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
             var telemetryClient = new Mock<IBotTelemetryClient>();
 
             // Act - Pass in properties during QnA invocation that override default properties
-            //
             //  NOTE: We are invoking this with PII turned OFF, and passing a PII property (originalQuestion).
-            //
             var qna = new QnAMaker(endpoint, options, client, telemetryClient.Object, false);
             var telemetryProperties = new Dictionary<string, string>
             {
@@ -991,11 +975,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             {
                 KnowledgeBaseId = _knowlegeBaseId,
                 EndpointKey = _endpointKey,
-                Host = _hostname
+                Host = _hostname,
             };
             var options = new QnAMakerOptions
             {
-                Top = 1
+                Top = 1,
             };
             var telemetryClient = new Mock<IBotTelemetryClient>();
 
@@ -1007,7 +991,6 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             //           - Set in GetAnswersAsync
             //       Logically, the GetAnswersAync should win.  But ultimately OnQnaResultsAsync decides since it is the last
             //       code to touch the properties before logging (since it actually logs the event).
-            //
             var qna = new OverrideFillTelemetry(endpoint, options, client, telemetryClient.Object, false);
             var telemetryProperties = new Dictionary<string, string>
             {
@@ -1042,9 +1025,19 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             Assert.AreEqual(((Dictionary<string, double>)telemetryClient.Invocations[0].Arguments[2])["score"], 3.14159);
         }
 
-
-
-
+        private static TurnContext GetContext(string utterance)
+        {
+            var b = new TestAdapter();
+            var a = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = utterance,
+                Conversation = new ConversationAccount(),
+                Recipient = new ChannelAccount(),
+                From = new ChannelAccount(),
+            };
+            return new TurnContext(b, a);
+        }
 
         private string GetV2LegacyRequestUrl() => $"{_hostname}/v2.0/knowledgebases/{_knowlegeBaseId}/generateanswer";
 
@@ -1092,75 +1085,72 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             return new QnAMaker(endpoint, options, client);
         }
 
-    public class OverrideTelemetry : QnAMaker
-    {
-        public OverrideTelemetry(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation)
-            : base(endpoint, options, httpClient, telemetryClient, logPersonalInformation)
+        public class OverrideTelemetry : QnAMaker
         {
+            public OverrideTelemetry(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation)
+                : base(endpoint, options, httpClient, telemetryClient, logPersonalInformation)
+            {
+            }
+
+            protected override Task OnQnaResultsAsync(
+                                        QueryResult[] queryResults,
+                                        ITurnContext turnContext,
+                                        Dictionary<string, string> telemetryProperties = null,
+                                        Dictionary<string, double> telemetryMetrics = null,
+                                        CancellationToken cancellationToken = default(CancellationToken))
+            {
+                var properties = telemetryProperties ?? new Dictionary<string, string>();
+
+                // GetAnswerAsync overrides derived class.
+                properties.TryAdd("MyImportantProperty", "myImportantValue");
+
+                // Log event
+                TelemetryClient.TrackEvent(
+                                QnATelemetryConstants.QnaMsgEvent,
+                                properties);
+
+                // Create second event.
+                var secondEventProperties = new Dictionary<string, string>();
+                secondEventProperties.Add("MyImportantProperty2", "myImportantValue2");
+                TelemetryClient.TrackEvent(
+                                "MySecondEvent",
+                                secondEventProperties);
+                return Task.CompletedTask;
+            }
         }
 
-        protected override Task OnQnaResultsAsync(
-                                    QueryResult[] queryResults, 
-                                    ITurnContext turnContext, 
-                                    Dictionary<string, string> telemetryProperties = null, 
-                                    Dictionary<string, double> telemetryMetrics = null, 
-                                    CancellationToken cancellationToken = default(CancellationToken))
+        public class OverrideFillTelemetry : QnAMaker
         {
-            var properties = telemetryProperties ?? new Dictionary<string, string>();
-            // GetAnswerAsync overrides derived class.
-            properties.TryAdd("MyImportantProperty", "myImportantValue");
+            public OverrideFillTelemetry(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation)
+                : base(endpoint, options, httpClient, telemetryClient, logPersonalInformation)
+            {
+            }
 
-            // Log event
-            TelemetryClient.TrackEvent(
-                            QnATelemetryConstants.QnaMsgEvent,
-                            properties);
+            protected override async Task OnQnaResultsAsync(
+                                        QueryResult[] queryResults,
+                                        ITurnContext turnContext,
+                                        Dictionary<string, string> telemetryProperties = null,
+                                        Dictionary<string, double> telemetryMetrics = null,
+                                        CancellationToken cancellationToken = default(CancellationToken))
+            {
+                var eventData = await FillQnAEventAsync(queryResults, turnContext, telemetryProperties, telemetryMetrics, cancellationToken).ConfigureAwait(false);
 
-            // Create second event.
-            var secondEventProperties = new Dictionary<string, string>();
-            secondEventProperties.Add("MyImportantProperty2",
-                                       "myImportantValue2");
-            TelemetryClient.TrackEvent(
-                            "MySecondEvent",
-                            secondEventProperties);
-            return Task.CompletedTask;
+                // Add my property
+                eventData.Properties.Add("MyImportantProperty", "myImportantValue");
+
+                // Log QnaMessage event
+                TelemetryClient.TrackEvent(
+                                QnATelemetryConstants.QnaMsgEvent,
+                                eventData.Properties,
+                                eventData.Metrics);
+
+                // Create second event.
+                var secondEventProperties = new Dictionary<string, string>();
+                secondEventProperties.Add("MyImportantProperty2", "myImportantValue2");
+                TelemetryClient.TrackEvent(
+                                "MySecondEvent",
+                                secondEventProperties);
+            }
         }
-    }
-
-    public class OverrideFillTelemetry : QnAMaker
-    {
-        public OverrideFillTelemetry(QnAMakerEndpoint endpoint, QnAMakerOptions options, HttpClient httpClient, IBotTelemetryClient telemetryClient, bool logPersonalInformation)
-            : base(endpoint, options, httpClient, telemetryClient, logPersonalInformation)
-        {
-        }
-
-        protected override async Task OnQnaResultsAsync(
-                                    QueryResult[] queryResults,
-                                    ITurnContext turnContext,
-                                    Dictionary<string, string> telemetryProperties = null,
-                                    Dictionary<string, double> telemetryMetrics = null,
-                                    CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var eventData = await FillQnAEventAsync(queryResults, turnContext, telemetryProperties, telemetryMetrics, cancellationToken).ConfigureAwait(false);
-
-            // Add my property
-            eventData.Properties.Add("MyImportantProperty", "myImportantValue");
-
-            // Log QnaMessage event
-            TelemetryClient.TrackEvent(
-                            QnATelemetryConstants.QnaMsgEvent,
-                            eventData.Properties,
-                            eventData.Metrics
-                            );
-
-            // Create second event.
-            var secondEventProperties = new Dictionary<string, string>();
-            secondEventProperties.Add("MyImportantProperty2",
-                                       "myImportantValue2");
-            TelemetryClient.TrackEvent(
-                            "MySecondEvent",
-                            secondEventProperties);
-        }
-    }
-
     }
 }


### PR DESCRIPTION
Addresses [binary compatibility issue with QnA](https://github.com/Microsoft/botbuilder-dotnet/issues/1560).

Refactor constructors to preserve binary compat, Cleanup warnings on QnA tests.
