### PR TITLE
OAuth card with Signin action for Microsoft Teams client

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -247,6 +247,16 @@ namespace Microsoft.Bot.Builder.Dialogs
                 if (!prompt.Attachments.Any(a => a.Content is SigninCard))
                 {
                     var link = await adapter.GetOauthSignInLinkAsync(turnContext, _settings.ConnectionName, cancellationToken).ConfigureAwait(false);
+                    
+                    if (turnContext.Activity.ChannelId == "msteams")
+                    {
+                        // The fallbackUrl specifies the page to be opened on mobile, until they support automatically passing the
+                        // verification code via notifySuccess().
+                        // This flow gracefully falls back to asking the user to enter the verification code manually, so we use the same
+                        // signin URL as the fallback URL.
+                        link += $"&fallbackUrl={Uri.EscapeDataString(link)}";
+                    }
+                    
                     prompt.Attachments.Add(new Attachment
                     {
                         ContentType = SigninCard.ContentType,
@@ -259,7 +269,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                                 {
                                     Title = _settings.Title,
                                     Value = link,
-                                    Type = turnContext.Activity.ChannelId == "msteams" ? ActionTypes.OpenUrl : ActionTypes.Signin,
+                                    Type = ActionTypes.Signin,
                                 },
                             },
                         },


### PR DESCRIPTION
Return back Signin action type for Microsoft Teams and add a fallback for mobile client.
It simplifies auth flow and we can automate the process of magic number verification if Microsoft Teams desktop client is used. More details https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/authentication/auth-flow-bot