### PR TITLE
Assigns a default endpoing to westus if no endpoint is supplied

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
             if (string.IsNullOrWhiteSpace(endpoint))
             {
-                throw new ArgumentException($"\"{endpoint}\" is not a valid LUIS endpoint.");
+                endpoint = "https://westus.api.cognitive.microsoft.com";
             }
 
             if (!Uri.IsWellFormedUriString(endpoint, UriKind.Absolute))


### PR DESCRIPTION
Updates the luisApplication.cs file to set a default endpoint of 'https://westus.api.cognitive.microsoft.com' when no endpoint is supplied.