### PR TITLE
Update OAuthPrompt.cs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                                 {
                                     Title = _settings.Title,
                                     Value = link,
-                                    Type = turnContext.Activity.ChannelId == "msteams" ? ActionTypes.OpenUrl : ActionTypes.Signin,
+                                    Type = turnContext.Activity.ChannelId == "msteams" ? ActionTypes.Signin : ActionTypes.OpenUrl,
                                 },
                             },
                         },


### PR DESCRIPTION
When using OAuthPrompt within Teams- the authentication is opening within a browser.

It should use signin action.