### PR TITLE
Allow null Recipient field for CreateTrace and CreateReply

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Bot.Schema
             {
                 Type = ActivityTypes.Message,
                 Timestamp = DateTime.UtcNow,
-                From = new ChannelAccount(id: this.Recipient.Id, name: this.Recipient.Name),
+                From = new ChannelAccount(id: this.Recipient?.Id, name: this.Recipient?.Name),
                 Recipient = new ChannelAccount(id: this.From.Id, name: this.From.Name),
                 ReplyToId = this.Id,
                 ServiceUrl = this.ServiceUrl,
@@ -191,7 +191,7 @@ namespace Microsoft.Bot.Schema
             {
                 Type = ActivityTypes.Trace,
                 Timestamp = DateTime.UtcNow,
-                From = new ChannelAccount(id: this.Recipient.Id, name: this.Recipient.Name),
+                From = new ChannelAccount(id: this.Recipient?.Id, name: this.Recipient?.Name),
                 Recipient = new ChannelAccount(id: this.From.Id, name: this.From.Name),
                 ReplyToId = this.Id,
                 ServiceUrl = this.ServiceUrl,

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -114,6 +114,18 @@ namespace Microsoft.Bot.Schema.Tests
             Assert.AreEqual(conversationReference.ActivityId, activity.ReplyToId);
         }
 
+        [TestMethod]
+        public void CreateTraceAllowsNullRecipient()
+        {
+            // https://github.com/Microsoft/botbuilder-dotnet/issues/1580
+            var activity = CreateActivity();
+            activity.Recipient = null;
+            var trace = activity.CreateTrace("test");
+
+            // CreateTrace flips Recipient and From
+            Assert.IsNull(trace.From.Id);
+        }
+
         private Activity CreateActivity()
         {
             var account1 = new ChannelAccount


### PR DESCRIPTION
Fixes https://github.com/Microsoft/botbuilder-dotnet/issues/1580

Seems odd that Recipient and From are flipped in CreateTrace.