### PR TITLE
Add ChoiceInput

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 {
@@ -44,10 +46,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
                 if (!string.IsNullOrEmpty(this.ChoicesProperty))
                 {
-                    var choiceValue = dc.State.GetValue<List<Choice>>(this.ChoicesProperty);
+                    var choiceValue = dc.State.GetValue<object>(this.ChoicesProperty);
                     if (choiceValue != null)
                     {
-                        choices = choiceValue;
+                        try
+                        {
+                            if (choiceValue is string)
+                            {
+                                choices = JsonConvert.DeserializeObject<List<Choice>>(choiceValue.ToString());
+                            }
+                            else if (choiceValue is List<Choice>)
+                            {
+                                choices = (List<Choice>)choiceValue;
+                            }
+                        }
+                        catch
+                        {
+
+                        }
                     }
                 }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -1,0 +1,48 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
+{
+    /// <summary>
+    /// Declarative text input to gather choices from users
+    /// </summary>
+    public class ChoiceInput : InputWrapper<ChoicePrompt, FoundChoice>
+    {
+        public List<Choice> choices { get; set; }
+
+        protected override async Task<DialogTurnResult> OnRunCommandAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Check value in state and only call if missing or required by AlwaysPrompt
+            var value = dc.State.GetValue<FoundChoice>(Property);
+
+            if (value == null || AlwaysPrompt)
+            {
+                if (Prompt == null)
+                {
+                    throw new ArgumentNullException(nameof(Activity));
+                }
+
+                var prompt = await Prompt.BindToData(dc.Context, dc.State).ConfigureAwait(false);
+                var retryPrompt = RetryPrompt == null ? prompt : await RetryPrompt.BindToData(dc.Context, dc.State).ConfigureAwait(false);
+
+                return await dc.PromptAsync(nameof(ChoicePrompt), new ChoicePromptOptions() { Prompt = prompt, RetryPrompt = retryPrompt, Choices = this.choices}, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken);
+            }
+        }
+        protected override string OnComputeId()
+        {
+            return $"ChoiceInput[{BindingPath()}]";
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     {
         public List<Choice> Choices { get; set; }
 
+        public string ChoicesProperty { get; set; }
+
         public ListStyle Style { get; set; }
 
         // Override the base method since we need to pass choices to the prompt options
@@ -38,7 +40,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
                 this.prompt.Style = this.Style;
 
-                return await dc.PromptAsync(this.prompt.Id, new ChoicePromptOptions() { Prompt = prompt, RetryPrompt = retryPrompt, Choices = this.Choices}, cancellationToken).ConfigureAwait(false);
+                var choices = this.Choices ?? new List<Choice>();
+
+                if (!string.IsNullOrEmpty(this.ChoicesProperty))
+                {
+                    var choiceValue = dc.State.GetValue<List<Choice>>(this.ChoicesProperty);
+                    if (choiceValue != null)
+                    {
+                        choices = choiceValue;
+                    }
+                }
+
+                return await dc.PromptAsync(this.prompt.Id, new ChoicePromptOptions() { Prompt = prompt, RetryPrompt = retryPrompt, Choices = choices}, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -18,6 +18,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     {
         public List<Choice> choices { get; set; }
 
+        protected override ChoicePrompt CreatePrompt()
+        {
+            return new ChoicePrompt()
+            { };
+
+        }
         protected override async Task<DialogTurnResult> OnRunCommandAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Check value in state and only call if missing or required by AlwaysPrompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -16,14 +16,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// </summary>
     public class ChoiceInput : InputWrapper<ChoicePrompt, FoundChoice>
     {
-        public List<Choice> choices { get; set; }
+        public List<Choice> Choices { get; set; }
 
-        protected override ChoicePrompt CreatePrompt()
-        {
-            return new ChoicePrompt()
-            { };
+        public ListStyle Style { get; set; }
 
-        }
+        // Override the base method since we need to pass choices to the prompt options
         protected override async Task<DialogTurnResult> OnRunCommandAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Check value in state and only call if missing or required by AlwaysPrompt
@@ -39,7 +36,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 var prompt = await Prompt.BindToData(dc.Context, dc.State).ConfigureAwait(false);
                 var retryPrompt = RetryPrompt == null ? prompt : await RetryPrompt.BindToData(dc.Context, dc.State).ConfigureAwait(false);
 
-                return await dc.PromptAsync(nameof(ChoicePrompt), new ChoicePromptOptions() { Prompt = prompt, RetryPrompt = retryPrompt, Choices = this.choices}, cancellationToken).ConfigureAwait(false);
+                this.prompt.Style = this.Style;
+
+                return await dc.PromptAsync(this.prompt.Id, new ChoicePromptOptions() { Prompt = prompt, RetryPrompt = retryPrompt, Choices = this.Choices}, cancellationToken).ConfigureAwait(false);
             }
             else
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputWrapper.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputWrapper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// <typeparam name="TValue">Type of the value that the prompt will store and get to and from memory</typeparam>
     public class InputWrapper<TPrompt, TValue> : DialogCommand, IDialogDependencies where TPrompt : IDialog, new()
     {
-        private TPrompt prompt;
+        protected TPrompt prompt;
 
         /// <summary>
         /// Activity to send to the user

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Types/Factory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Types/Factory.cs
@@ -133,6 +133,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Types
             Register("Microsoft.IntegerInput", typeof(IntegerInput));
             Register("Microsoft.FloatInput", typeof(FloatInput));
             Register("Microsoft.BoolInput", typeof(ConfirmInput));
+            Register("Microsoft.ChoiceInput", typeof(ChoiceInput));
 
             // Recognizers
             Register("Microsoft.LuisRecognizer", typeof(LuisRecognizer), new LuisRecognizerLoader(TypeFactory.Configuration));

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
         }
 
-        public ChoicePrompt(string dialogId, PromptValidator<FoundChoice> validator = null, string defaultLocale = null)
+        public ChoicePrompt(string dialogId = nameof(ChoicePrompt), PromptValidator<FoundChoice> validator = null, string defaultLocale = null)
             : base(dialogId, validator)
         {
             Style = ListStyle.Auto;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             { Chinese, new ChoiceFactoryOptions { InlineSeparator = "， ", InlineOr = " 要么 ", InlineOrMore = "， 要么 ", IncludeNumbers = true } },
         };
 
+        public ChoicePrompt()
+            : base()
+        {
+        }
+
         public ChoicePrompt(string dialogId, PromptValidator<FoundChoice> validator = null, string defaultLocale = null)
             : base(dialogId, validator)
         {

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 10 - ChoiceInput/ChoiceInput.main.dialog
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 10 - ChoiceInput/ChoiceInput.main.dialog
@@ -2,31 +2,32 @@
    "$schema": "../../app.schema",
    "$type": "Microsoft.AdaptiveDialog",
    "rules": [
-      {
-         "$type": "Microsoft.NoMatchRule",
-        "steps": [
-          {
-            "$type": "Microsoft.SendActivity",
-            "activity": "Test Choice Input"
-          },
-          {
-            "$type": "Microsoft.ChoiceInput",
-            "property": "user.choice",
-            "choices": [
-              {
-              "value": "Add1"
-              },
-              {
-              "value": "Add2"
-              }
-            ],
-            "prompt": "please select a choice from below:"
-          },
-          {
-            "$type": "Microsoft.SendActivity",
-            "activity": "{user.choice}"
-          }
-        ]
-      },
+    {
+      "$type": "Microsoft.NoMatchRule",
+      "steps": [
+        {
+          "$type": "Microsoft.ChoiceInput",
+          "property": "user.style",
+          "choices": [
+            {
+              "value": "Test1"
+            },
+            {
+              "value": "Test2"
+            },
+            {
+              "value": "Test3"
+            }
+          ],
+          "prompt": "Please select a value from below",
+          "style": "HeroCard",
+          "alwaysPrompt": true
+        },
+        {
+          "$type": "Microsoft.SendActivity",
+          "activity": "You select: {user.style.Value}"
+        }
+      ]
+    }          
    ]
 }

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 10 - ChoiceInput/ChoiceInput.main.dialog
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 10 - ChoiceInput/ChoiceInput.main.dialog
@@ -1,0 +1,32 @@
+{
+   "$schema": "../../app.schema",
+   "$type": "Microsoft.AdaptiveDialog",
+   "rules": [
+      {
+         "$type": "Microsoft.NoMatchRule",
+        "steps": [
+          {
+            "$type": "Microsoft.SendActivity",
+            "activity": "Test Choice Input"
+          },
+          {
+            "$type": "Microsoft.ChoiceInput",
+            "property": "user.choice",
+            "choices": [
+              {
+              "value": "Add1"
+              },
+              {
+              "value": "Add2"
+              }
+            ],
+            "prompt": "please select a choice from below:"
+          },
+          {
+            "$type": "Microsoft.SendActivity",
+            "activity": "{user.choice}"
+          }
+        ]
+      },
+   ]
+}

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 10 - ChoiceInput/ChoiceInput.main.dialog
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 10 - ChoiceInput/ChoiceInput.main.dialog
@@ -19,8 +19,8 @@
               "value": "Test3"
             }
           ],
-          "prompt": "Please select a value from below",
-          "style": "HeroCard",
+          "prompt": "Please select a value from below:",
+          "style": "List",
           "alwaysPrompt": true
         },
         {

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 12 - GithubIssueBot/show.lg
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/Planning 12 - GithubIssueBot/show.lg
@@ -14,7 +14,7 @@
                     "type": "TextBlock",
                     "size": "Medium",
                     "weight": "Bolder",
-                    "text": "Test"
+                    "text": "${x.title}"
                 },
                 {
                     "type": "ColumnSet",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -146,6 +146,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         }
 
         [TestMethod]
+        public async Task JsonDialogLoad_ChoiceInputDialog()
+        {
+            string path = Path.Combine(samplesDirectory, @"Planning 10 - ChoiceInput\ChoiceInput.main.dialog");
+
+            await BuildTestFlow(path)
+            .Send(new Activity(ActivityTypes.ConversationUpdate, membersAdded: new List<ChannelAccount>() { new ChannelAccount("bot", "Bot") }))
+            .Send("hello")
+            .AssertReply("Please select a value from below:\n\n   1. Test1\n   2. Test2\n   3. Test3")
+            .Send("Test1")
+            .AssertReply("You select: Test1")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task JsonDialogLoad_ExternalLanguage()
         {
             string path = Path.Combine(samplesDirectory, @"Planning 8 - ExternalLanguage\ExternalLanguage.main.dialog");


### PR DESCRIPTION
Add Choice Input and related sample.

![image](https://user-images.githubusercontent.com/9328933/55388190-6836f200-5565-11e9-98a6-70e87ea37916.png)


Supported Type in ChoicePrompt:


    public enum ListStyle
    {
        /// <summary>
        /// Don't include any choices for prompt.
        /// </summary>
        None,

        /// <summary>
        /// Automatically select the appropriate style for the current channel.
        /// </summary>
        Auto,

        /// <summary>
        /// Add choices to prompt as an inline list.
        /// </summary>
        Inline,

        /// <summary>
        /// Add choices to prompt as a numbered list.
        /// </summary>
        List,

        /// <summary>
        /// Add choices to prompt as suggested actions.
        /// </summary>
        SuggestedAction,

        /// <summary>
        /// Add choices to prompt as a HeroCard with buttons.
        /// </summary>
        HeroCard,
    }