### PR TITLE
Adds ChoiceStyle propery to PromptOptions so the developer can overr…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -64,13 +64,14 @@ namespace Microsoft.Bot.Builder.Dialogs
             var choices = options.Choices ?? new List<Choice>();
             var channelId = turnContext.Activity.ChannelId;
             var choiceOptions = ChoiceOptions ?? DefaultChoiceOptions[culture];
+            var choiceStyle = options.ChoiceStyle ?? Style;
             if (isRetry && options.RetryPrompt != null)
             {
-                prompt = AppendChoices(options.RetryPrompt, channelId, choices, Style, choiceOptions);
+                prompt = AppendChoices(options.RetryPrompt, channelId, choices, choiceStyle, choiceOptions);
             }
             else
             {
-                prompt = AppendChoices(options.Prompt, channelId, choices, Style, choiceOptions);
+                prompt = AppendChoices(options.Prompt, channelId, choices, choiceStyle, choiceOptions);
             }
 
             // Send prompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             var choices = options.Choices ?? new List<Choice>();
             var channelId = turnContext.Activity.ChannelId;
             var choiceOptions = ChoiceOptions ?? DefaultChoiceOptions[culture];
-            var choiceStyle = options.ChoiceStyle ?? Style;
+            var choiceStyle = options.Style ?? Style;
             if (isRetry && options.RetryPrompt != null)
             {
                 prompt = AppendChoices(options.RetryPrompt, channelId, choices, choiceStyle, choiceOptions);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// This property can be used to override or set the value of <see cref="ChoicePrompt.Style"/> property
         /// when the prompt is being executed using <see cref="DialogContext.PromptAsync"/>.
         /// </value>
-        public ListStyle? ChoiceStyle { get; set; }
+        public ListStyle? Style { get; set; }
 
         public object Validations { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -10,22 +10,31 @@ namespace Microsoft.Bot.Builder.Dialogs
     public class PromptOptions
     {
         /// <summary>
-        /// Gets or sets the initial prompt to send the user as <seealso cref="Activity"/>Activity.
+        /// Gets or sets the initial prompt to send the user as <seealso cref="Activity"/>.
         /// </summary>
         /// <value>
-        /// The initial prompt to send the user as <seealso cref="Activity"/>Activity.
+        /// The initial prompt to send the user as <seealso cref="Activity"/>.
         /// </value>
         public Activity Prompt { get; set; }
 
         /// <summary>
-        /// Gets or sets the retry prompt to send the user as <seealso cref="Activity"/>Activity.
+        /// Gets or sets the retry prompt to send the user as <seealso cref="Activity"/>.
         /// </summary>
         /// <value>
-        /// The retry prompt to send the user as <seealso cref="Activity"/>Activity.
+        /// The retry prompt to send the user as <seealso cref="Activity"/>.
         /// </value>
         public Activity RetryPrompt { get; set; }
 
         public IList<Choice> Choices { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ListStyle"/> for a <see cref="ChoicePrompt"/>.
+        /// </summary>
+        /// <value>
+        /// This property can be used to override or set the value of <see cref="ChoicePrompt.Style"/> property
+        /// when the prompt is being executed using <see cref="DialogContext.PromptAsync"/>.
+        /// </value>
+        public ListStyle? ChoiceStyle { get; set; }
 
         public object Validations { get; set; }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -529,7 +529,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                             {
                                 Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
                                 Choices = _colorChoices,
-                                ChoiceStyle = ListStyle.SuggestedAction,
+                                Style = ListStyle.SuggestedAction,
                             },
                             cancellationToken);
                     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -18,28 +18,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     [TestCategory("Choice Prompts")]
     public class ChoicePromptTests
     {
-        private List<Choice> colorChoices = new List<Choice>
+        private readonly List<Choice> _colorChoices = new List<Choice>
         {
-            new Choice { Value = "red" },
-            new Choice { Value = "green" },
-            new Choice { Value = "blue" },
+            new Choice {Value = "red"},
+            new Choice {Value = "green"},
+            new Choice {Value = "blue"},
         };
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ChoicePromptWithEmptyIdShouldFail()
         {
-            var emptyId = string.Empty;
-            var choicePrompt = new ChoicePrompt(emptyId);
+            var choicePrompt = new ChoicePrompt(string.Empty);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ChoicePromptWithNullIdShouldFail()
         {
-            var nullId = string.Empty;
-            nullId = null;
-            var choicePrompt = new ChoicePrompt(nullId);
+            var choicePrompt = new ChoicePrompt(null);
         }
 
         [TestMethod]
@@ -56,34 +53,35 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    var choice = new Choice()
-                    {
-                        Action = new CardAction()
-                        {
-                            Type = "imBack",
-                            Value = "value",
-                            Title = "title"
-                        }
-                    };
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
 
-                    var options = new PromptOptions()
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
                     {
-                        Choices = new List<Choice> { choice }
-                    };
-                    await dc.PromptAsync("ChoicePrompt",
-                        options,
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator(" (1) title"))
-            .StartTestAsync();
+                        var choice = new Choice()
+                        {
+                            Action = new CardAction()
+                            {
+                                Type = "imBack",
+                                Value = "value",
+                                Title = "title",
+                            },
+                        };
+
+                        var options = new PromptOptions()
+                        {
+                            Choices = new List<Choice> {choice},
+                        };
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            options,
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(StartsWithValidator(" (1) title"))
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -100,25 +98,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(StartsWithValidator("favorite color?"))
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -134,25 +132,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync();
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("favorite color? (1) red, (2) green, or (3) blue")
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply("favorite color? (1) red, (2) green, or (3) blue")
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -167,90 +165,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var dialogs = new DialogSet(dialogState);
 
             // Create ChoicePrompt and change style to ListStyle.List which affects how choices are presented.
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.List;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
             {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("favorite color?\n\n   1. red\n   2. green\n   3. blue")
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptUsingSuggestedActions()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.SuggestedAction;
-            dialogs.Add(listPrompt);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(SuggestedActionsValidator(
-                "favorite color?",
-                new SuggestedActions
-                {
-                    Actions = new List<CardAction>
-                    {
-                        new CardAction { Type = "imBack", Value = "red", Title = "red" },
-                        new CardAction { Type = "imBack", Value = "green", Title = "green" },
-                        new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
-                    },
-                }))
-            .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task ShouldSendPromptUsingHeroCard()
-        {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            var dialogs = new DialogSet(dialogState);
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.HeroCard;
+                Style = ListStyle.List,
+            };
             dialogs.Add(listPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
@@ -264,23 +182,109 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                             "ChoicePrompt",
                             new PromptOptions
                             {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = colorChoices,
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply("favorite color?\n\n   1. red\n   2. green\n   3. blue")
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptUsingSuggestedActions()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
+            {
+                Style = ListStyle.SuggestedAction,
+            };
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(SuggestedActionsValidator(
+                    "favorite color?",
+                    new SuggestedActions
+                    {
+                        Actions = new List<CardAction>
+                        {
+                            new CardAction {Type = "imBack", Value = "red", Title = "red"},
+                            new CardAction {Type = "imBack", Value = "green", Title = "green"},
+                            new CardAction {Type = "imBack", Value = "blue", Title = "blue"},
+                        },
+                    }))
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSendPromptUsingHeroCard()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
+            {
+                Style = ListStyle.HeroCard,
+            };
+            dialogs.Add(listPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
                             },
                             cancellationToken);
                     }
                 })
                 .Send("hello")
                 .AssertReply(HeroCardValidator(new HeroCard
+                {
+                    Text = "favorite color?",
+                    Buttons = new List<CardAction>
                     {
-                        Text = "favorite color?",
-                        Buttons = new List<CardAction>
-                        {
-                            new CardAction { Type = "imBack", Value = "red", Title = "red" },
-                            new CardAction { Type = "imBack", Value = "green", Title = "green" },
-                            new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
-                        },
-                    }))
+                        new CardAction {Type = "imBack", Value = "red", Title = "red"},
+                        new CardAction {Type = "imBack", Value = "green", Title = "green"},
+                        new CardAction {Type = "imBack", Value = "blue", Title = "blue"},
+                    },
+                }))
                 .StartTestAsync();
         }
 
@@ -295,30 +299,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
 
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
+            {
+                Style = ListStyle.None,
+            };
             dialogs.Add(listPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("favorite color?")
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply("favorite color?")
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -332,35 +338,37 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
 
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
+            {
+                Style = ListStyle.None,
+            };
             dialogs.Add(listPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
                             {
-                                Type = ActivityTypes.Message,
-                                Text = "favorite color?",
-                                Speak = "spoken prompt",
+                                Prompt = new Activity
+                                {
+                                    Type = ActivityTypes.Message,
+                                    Text = "favorite color?",
+                                    Speak = "spoken prompt",
+                                },
+                                Choices = _colorChoices,
                             },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(SpeakValidator("favorite color?", "spoken prompt"))
-            .StartTestAsync();
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(SpeakValidator("favorite color?", "spoken prompt"))
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -374,41 +382,43 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
 
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
+            {
+                Style = ListStyle.None,
+            };
             dialogs.Add(listPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
 
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
-                {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-                else if (results.Status == DialogTurnStatus.Complete)
-                {
-                    var choiceResult = (FoundChoice)results.Result;
-                    await turnContext.SendActivityAsync(MessageFactory.Text($"{choiceResult.Value}"), cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("red")
-            .AssertReply("red")
-            .StartTestAsync();
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                    else if (results.Status == DialogTurnStatus.Complete)
+                    {
+                        var choiceResult = (FoundChoice)results.Result;
+                        await turnContext.SendActivityAsync(MessageFactory.Text($"{choiceResult.Value}"), cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(StartsWithValidator("favorite color?"))
+                .Send("red")
+                .AssertReply("red")
+                .StartTestAsync();
         }
 
         [TestMethod]
-        public async Task ShouldNOTrecognizeOtherText()
+        public async Task ShouldNotRecognizeOtherText()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
@@ -417,33 +427,35 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .Use(new AutoSaveStateMiddleware(convoState));
 
             var dialogs = new DialogSet(dialogState);
-            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English);
-            listPrompt.Style = ListStyle.None;
+            var listPrompt = new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English)
+            {
+                Style = ListStyle.None,
+            };
             dialogs.Add(listPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "your favorite color, please?" },
-                            Choices = colorChoices,
-                        },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("what was that?")
-            .AssertReply("your favorite color, please?")
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                RetryPrompt = new Activity {Type = ActivityTypes.Message, Text = "your favorite color, please?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(StartsWithValidator("favorite color?"))
+                .Send("what was that?")
+                .AssertReply("your favorite color, please?")
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -462,32 +474,79 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 await promptContext.Context.SendActivityAsync(MessageFactory.Text("validator called"), cancellationToken);
                 return true;
             };
-            var listPrompt = new ChoicePrompt("ChoicePrompt", validator, Culture.English);
-            listPrompt.Style = ListStyle.None;
+            var listPrompt = new ChoicePrompt("ChoicePrompt", validator, Culture.English)
+            {
+                Style = ListStyle.None,
+            };
             dialogs.Add(listPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-
-                var results = await dc.ContinueDialogAsync(cancellationToken);
-                if (results.Status == DialogTurnStatus.Empty)
                 {
-                    await dc.PromptAsync(
-                        "ChoicePrompt",
-                        new PromptOptions
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity {Type = ActivityTypes.Message, Text = "favorite color?"},
+                                Choices = _colorChoices,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(StartsWithValidator("favorite color?"))
+                .Send("I'll take the red please.")
+                .AssertReply("validator called")
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldUseChoiceStyleIfPresent()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English) { Style = ListStyle.HeroCard });
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    var results = await dc.ContinueDialogAsync(cancellationToken);
+                    if (results.Status == DialogTurnStatus.Empty)
+                    {
+                        await dc.PromptAsync(
+                            "ChoicePrompt",
+                            new PromptOptions
+                            {
+                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                Choices = _colorChoices,
+                                ChoiceStyle = ListStyle.SuggestedAction,
+                            },
+                            cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply(SuggestedActionsValidator(
+                    "favorite color?",
+                    new SuggestedActions
+                    {
+                        Actions = new List<CardAction>
                         {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                            Choices = colorChoices,
+                            new CardAction {Type = "imBack", Value = "red", Title = "red"},
+                            new CardAction {Type = "imBack", Value = "green", Title = "green"},
+                            new CardAction {Type = "imBack", Value = "blue", Title = "blue"},
                         },
-                        cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply(StartsWithValidator("favorite color?"))
-            .Send("I'll take the red please.")
-            .AssertReply("validator called")
-            .StartTestAsync();
+                    }))
+                .StartTestAsync();
         }
 
         /*


### PR DESCRIPTION
**Problem**
As a developer, I would like to be able to change the PromptChoice style when calling PromptAsync so I can alter the style based on the channel where my bot is running.

Ref issue #1433 

Currently, OnPromptAsync uses the Style property to set the ChoicePrompt style, in many implementations, Prompts and Dialogs are created as singletons and I can't alter this property without impacting other sessions using the same instance of the dialog.

**Fix**
Added a nullable ChoiceStyle property to PromptOptions so the developer can invoke PromptAsync and alter the ListStyle if needed. The code will look as follows:

    await dc.PromptAsync(
        "ChoicePrompt",
        new PromptOptions
        {
            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
            Choices = _colorChoices,
            ChoiceStyle = ListStyle.SuggestedAction,
        },
        cancellationToken);


**Additional notes**
This PR also fixes to StyleCop issues in the ChoicePromptTests.

**Other solutions considered**

- Creating a different ChoicePrompt with the desired Style property for each channel in my dialog constructor and then picking the right one during PromptAsync but didn't look that elegant. 
- Creating my own choice prompt derived from Prompt<FoundChoice> but couldn't inject a new value for Style in the OnPromptAsync override that is invoked by StepContect.PromptAsync (I also need to duplicate a bunch of code in ChoicePrompt that I don't want to lose).
- Creating my own ChoicePrompt that takes a Func<ITurnContext, ListStyle> in the constructor and overrides OnPrompAsync to evaluate the delegate and set the style there but can't access the private DefaultChoiceOptions dictionary defined in the base and I will end up losing functionality (and will also duplicate a bunch of code in the base OnPromptAsync.