### PR TITLE
Fix Cosmos DB tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -295,24 +295,21 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task ReadingNullKeysReturnsEmptyDictionary()
+        public async Task ReadingNullKeysThrowException()
         {
             if (CheckEmulator())
             {
-                string[] nullKeys = null;
-                var state = await _storage.ReadAsync(nullKeys);
-                Assert.IsInstanceOfType(state, typeof(Dictionary<string, object>));
-                Assert.AreEqual(state.Count, 0);
+                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
             }
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
         [TestMethod]
-        public async Task WritingNullStoreItemsDoesntThrow()
+        public async Task WritingNullStoreItemsThrowException()
         {
             if (CheckEmulator())
             {
-                await _storage.WriteAsync(null);
+                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
             }
         }
 


### PR DESCRIPTION
WriteAsync and ReadAsync CosmosDbStorage.cs implementations throw ArgumentNullException when passing null as object to store or keys to look for.
Test were broken since both were asserting a different behavior.