### PR TITLE
[StyleCop] Fix all the warnings on Bot.Builder.AI.LUIS.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -949,8 +949,8 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
         private static TurnContext GetContext(string utterance)
         {
-            var b = new TestAdapter();
-            var a = new Activity
+            var testAdapter = new TestAdapter();
+            var activity = new Activity
             {
                 Type = ActivityTypes.Message,
                 Text = utterance,
@@ -958,7 +958,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 Recipient = new ChannelAccount(),
                 From = new ChannelAccount(),
             };
-            return new TurnContext(b, a);
+            return new TurnContext(testAdapter, activity);
         }
 
         // Compare two JSON structures and ensure entity and intent scores are within delta

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/OverrideFillRecognizer.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/OverrideFillRecognizer.cs
@@ -21,7 +21,6 @@ using RichardSzalay.MockHttp;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Tests
 {
-
     public class OverrideFillRecognizer : LuisRecognizer
     {
         public OverrideFillRecognizer(IBotTelemetryClient telemetryClient, LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logPersonalInformation = false, HttpClientHandler clientHandler = null)

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/OverrideFillRecognizer.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/OverrideFillRecognizer.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RichardSzalay.MockHttp;
+
+namespace Microsoft.Bot.Builder.AI.Luis.Tests
+{
+
+    public class OverrideFillRecognizer : LuisRecognizer
+    {
+        public OverrideFillRecognizer(IBotTelemetryClient telemetryClient, LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logPersonalInformation = false, HttpClientHandler clientHandler = null)
+           : base(application, predictionOptions, includeApiResults, clientHandler)
+        {
+            LogPersonalInformation = logPersonalInformation;
+        }
+
+        protected override async Task OnRecognizerResultAsync(RecognizerResult recognizerResult, ITurnContext turnContext, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var properties = await FillLuisEventPropertiesAsync(recognizerResult, turnContext, telemetryProperties, cancellationToken).ConfigureAwait(false);
+
+            properties.TryAdd("MyImportantProperty", "myImportantValue");
+
+            // Log event
+            TelemetryClient.TrackEvent(
+                            LuisTelemetryConstants.LuisResult,
+                            properties,
+                            telemetryMetrics);
+
+            // Create second event.
+            var secondEventProperties = new Dictionary<string, string>();
+            secondEventProperties.Add(
+                "MyImportantProperty2",
+                "myImportantValue2");
+            TelemetryClient.TrackEvent(
+                            "MySecondEvent",
+                            secondEventProperties);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryConvertResult.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryConvertResult.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RichardSzalay.MockHttp;
+
+namespace Microsoft.Bot.Builder.AI.Luis.Tests
+{
+
+    public class TelemetryConvertResult : IRecognizerConvert
+    {
+        private RecognizerResult _result;
+
+        public TelemetryConvertResult()
+        {
+        }
+
+        /// <summary>
+        /// Convert recognizer result.
+        /// </summary>
+        /// <param name="result">Result to convert.</param>
+        public void Convert(dynamic result)
+        {
+            _result = result as RecognizerResult;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryConvertResult.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryConvertResult.cs
@@ -21,7 +21,6 @@ using RichardSzalay.MockHttp;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Tests
 {
-
     public class TelemetryConvertResult : IRecognizerConvert
     {
         private RecognizerResult _result;

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryOverrideRecognizer.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryOverrideRecognizer.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RichardSzalay.MockHttp;
+
+namespace Microsoft.Bot.Builder.AI.Luis.Tests
+{
+
+    public class TelemetryOverrideRecognizer : LuisRecognizer
+    {
+        public TelemetryOverrideRecognizer(IBotTelemetryClient telemetryClient, LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logPersonalInformation = false, HttpClientHandler clientHandler = null)
+           : base(application, predictionOptions, includeApiResults, clientHandler)
+        {
+            LogPersonalInformation = logPersonalInformation;
+        }
+
+        protected override Task OnRecognizerResultAsync(RecognizerResult recognizerResult, ITurnContext turnContext, Dictionary<string, string> properties = null, Dictionary<string, double> metrics = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            properties.TryAdd("MyImportantProperty", "myImportantValue");
+
+            // Log event
+            TelemetryClient.TrackEvent(
+                            LuisTelemetryConstants.LuisResult,
+                            properties,
+                            metrics);
+
+            // Create second event.
+            var secondEventProperties = new Dictionary<string, string>();
+            secondEventProperties.Add(
+                "MyImportantProperty2",
+                "myImportantValue2");
+            TelemetryClient.TrackEvent(
+                            "MySecondEvent",
+                            secondEventProperties);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryOverrideRecognizer.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/TelemetryOverrideRecognizer.cs
@@ -21,7 +21,6 @@ using RichardSzalay.MockHttp;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Tests
 {
-
     public class TelemetryOverrideRecognizer : LuisRecognizer
     {
         public TelemetryOverrideRecognizer(IBotTelemetryClient telemetryClient, LuisApplication application, LuisPredictionOptions predictionOptions = null, bool includeApiResults = false, bool logPersonalInformation = false, HttpClientHandler clientHandler = null)


### PR DESCRIPTION
**Changes made**:
 
•	'public' members before 'private' members
•	A closing brace not preceded by a blank line
•	Add trailing comma in multi-line initializers
•	The 'protected' before 'override'
•	Single-line comment preceded by a blank line
•	Element '_result' declare an access modifier
•	Files only contain a single type