### PR TITLE
Share HttpClient to OIDC metadata document retriever

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             _openIdMetadata = _openIdMetadataCache.GetOrAdd(metadataUrl, key =>
             {
-                return new ConfigurationManager<OpenIdConnectConfiguration>(metadataUrl, new OpenIdConnectConfigurationRetriever());
+                return new ConfigurationManager<OpenIdConnectConfiguration>(metadataUrl, new OpenIdConnectConfigurationRetriever(), httpClient);
             });
 
             _endorsementsData = _endorsementsCache.GetOrAdd(metadataUrl, key =>


### PR DESCRIPTION
The `HttpClient` was not being shared with the `ConfigurationManager<OpenIdConnectConfiguration>`. Needed to pass the instance into the constructor overload so that it is used by the `OpenIdConnectConfiguration` when fetching the document.

Fixes #1595.