### PR TITLE
[nodejs parity] Allow LUIS endpoint to be null or empty 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
             if (string.IsNullOrWhiteSpace(endpoint))
             {
-                throw new ArgumentException($"\"{endpoint}\" is not a valid LUIS endpoint.");
+                endpoint = "https://westus.api.cognitive.microsoft.com";
             }
 
             if (!Uri.IsWellFormedUriString(endpoint, UriKind.Absolute))

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisApplicationTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisApplicationTests.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.ThrowsException<ArgumentException>(() => new LuisApplication(Guid.NewGuid().ToString(), null, Endpoint));
             Assert.ThrowsException<ArgumentException>(() => new LuisApplication(Guid.NewGuid().ToString(), string.Empty, Endpoint));
             Assert.ThrowsException<ArgumentException>(() => new LuisApplication(Guid.NewGuid().ToString(), "0000", Endpoint));
-            Assert.ThrowsException<ArgumentException>(() => new LuisApplication(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), null));
 
             var luisApp = new LuisApplication(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), Endpoint);
             Assert.AreEqual(Endpoint, luisApp.Endpoint);

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -76,6 +76,36 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [TestMethod]
+        public void NullEndpoint()
+        {
+            // Arrange
+            var fieldInfo = typeof(LuisRecognizer).GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var myappNull = new LuisApplication(_luisAppId, _subscriptionKey, null);
+            var recognizerNull = new LuisRecognizer(myappNull, null);
+
+            // Assert
+            var app = (LuisApplication)fieldInfo.GetValue(recognizerNull);
+            Assert.AreEqual("https://westus.api.cognitive.microsoft.com", app.Endpoint);
+        }
+
+        [TestMethod]
+        public void EmptyEndpoint()
+        {
+            // Arrange
+            var fieldInfo = typeof(LuisRecognizer).GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var myappEmpty = new LuisApplication(_luisAppId, _subscriptionKey, string.Empty);
+            var recognizerEmpty = new LuisRecognizer(myappEmpty, null);
+
+            // Assert
+            var app = (LuisApplication)fieldInfo.GetValue(recognizerEmpty);
+            Assert.AreEqual("https://westus.api.cognitive.microsoft.com", app.Endpoint);
+        }
+
+        [TestMethod]
         public async Task LuisRecognizer_Configuration()
         {
             var service = new LuisService


### PR DESCRIPTION
Fixes https://github.com/Microsoft/botbuilder-dotnet/issues/1387

Enable empty endpoint (just like nodejs)!