### PR TITLE
added timeout options for qna & luis for dotnet

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <summary>
         /// Gets the currently configured <see cref="IBotTelemetryClient"/> that logs the LuisResult event.
         /// </summary>
-        /// <value>The <see cref=IBotTelemetryClient"/> being used to log events.</value>
+        /// <value>The <see cref="IBotTelemetryClient"/> being used to log events.</value>
         IBotTelemetryClient TelemetryClient { get; }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisPredictionOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisPredictionOptions.cs
@@ -59,6 +59,14 @@ namespace Microsoft.Bot.Builder.AI.Luis
         public bool? Staging { get; set; }
 
         /// <summary>
+        /// Gets or sets the time in milliseconds to wait before the request times out.
+        /// </summary>
+        /// <value>
+        /// The time in milliseconds to wait before the request times out. Default is 100000 milliseconds.
+        /// </value>
+        public double Timeout { get; set; } = 100000;
+
+        /// <summary>
         /// Gets or sets the time zone offset.
         /// </summary>
         /// <value>

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Configuration;
 using Microsoft.Bot.Schema;
+using Microsoft.Rest;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.AI.Luis
@@ -36,6 +37,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         private readonly LuisApplication _application;
         private readonly LuisPredictionOptions _options;
         private readonly bool _includeApiResults;
+        private readonly HttpClient _httpClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LuisRecognizer"/> class.
@@ -55,15 +57,22 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
             var credentials = new ApiKeyServiceClientCredentials(application.EndpointKey);
             var delegatingHandler = new LuisDelegatingHandler();
+            var httpClientHandler = clientHandler ?? CreateRootHandler();
+            var currentHandler = CreateHttpHandlerPipeline(httpClientHandler, delegatingHandler);
 
-            // LUISRuntimeClient requires that we explicitly bind to the appropriate constructor.
-            _runtime = clientHandler == null
-                    ?
-                new LUISRuntimeClient(credentials, delegatingHandler)
-                    :
-                new LUISRuntimeClient(credentials, clientHandler, delegatingHandler);
+            DefaultHttpClient = new HttpClient(currentHandler, false)
+            {
+                Timeout = TimeSpan.FromMilliseconds(_options.Timeout),
+            };
 
-            _runtime.Endpoint = application.Endpoint;
+            // assign DefaultHttpClient to _httpClient to expose Timeout in unit tests
+            // and keep HttpClient usage as a singleton
+            _httpClient = DefaultHttpClient;
+
+            _runtime = new LUISRuntimeClient(credentials, _httpClient, false)
+            {
+                Endpoint = application.Endpoint,
+            };
         }
 
         /// <summary>
@@ -90,6 +99,8 @@ namespace Microsoft.Bot.Builder.AI.Luis
         {
         }
 
+        public static HttpClient DefaultHttpClient { get; private set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
         /// </summary>
@@ -99,7 +110,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <summary>
         /// Gets the currently configured <see cref="IBotTelemetryClient"/> that logs the LuisResult event.
         /// </summary>
-        /// <value>The <see cref=IBotTelemetryClient"/> being used to log events.</value>
+        /// <value>The <see cref="IBotTelemetryClient"/> being used to log events.</value>
         public IBotTelemetryClient TelemetryClient { get; }
 
         /// <summary>
@@ -323,5 +334,42 @@ namespace Microsoft.Bot.Builder.AI.Luis
             await turnContext.TraceActivityAsync("LuisRecognizer", traceInfo, LuisTraceType, LuisTraceLabel, cancellationToken).ConfigureAwait(false);
             return recognizerResult;
         }
+
+        private DelegatingHandler CreateHttpHandlerPipeline(HttpClientHandler httpClientHandler, params DelegatingHandler[] handlers)
+        {
+            // Now, the RetryAfterDelegatingHandler should be the absoulte outermost handler
+            // because it's extremely lightweight and non-interfering
+            DelegatingHandler currentHandler =
+                new RetryDelegatingHandler(new RetryAfterDelegatingHandler { InnerHandler = httpClientHandler });
+
+            if (handlers != null)
+            {
+                for (var i = handlers.Length - 1; i >= 0; --i)
+                {
+                    var handler = handlers[i];
+
+                    // Non-delegating handlers are ignored since we always
+                    // have RetryDelegatingHandler as the outer-most handler
+                    while (handler.InnerHandler is DelegatingHandler)
+                    {
+                        handler = handler.InnerHandler as DelegatingHandler;
+                    }
+
+                    handler.InnerHandler = currentHandler;
+                    currentHandler = handlers[i];
+                }
+            }
+
+            return currentHandler;
+        }
+
+        private HttpClientHandler CreateRootHandler() =>
+
+            // Create our root handler
+#if FullNetFx
+            return new WebRequestHandler();
+#else
+            new HttpClientHandler();
+#endif
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
@@ -24,6 +24,18 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public float ScoreThreshold { get; set; }
 
         /// <summary>
+        /// Gets or sets the time in milliseconds to wait before the request times out.
+        /// </summary>
+        /// <value>
+        /// The time in milliseconds to wait before the request times out. Default is 100000 milliseconds.
+        /// </value>
+        /// <remarks>
+        /// This property allows users to set Timeout without having to pass in a custom HttpClient to QnAMaker class constructor.
+        /// If using custom HttpClient, then set Timeout value in HttpClient instead of QnAMakerOptions.Timeout.
+        /// </remarks>
+        public double Timeout { get; set; }
+
+        /// <summary>
         /// Gets or sets the number of ranked results you want in the output.
         /// </summary>
         /// <value>

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -76,6 +76,22 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [TestMethod]
+        public void LuisRecognizer_Timeout()
+        {
+            var endpoint = "https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=";
+            var fieldInfo = typeof(LuisRecognizer).GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
+            var optionsWithTimeout = new LuisPredictionOptions()
+            {
+                Timeout = 300,
+            };
+            var expectedTimeout = 300;
+
+            var recognizerWithTimeout = new LuisRecognizer(endpoint, optionsWithTimeout);
+
+            Assert.AreEqual(expectedTimeout, LuisRecognizer.DefaultHttpClient.Timeout.Milliseconds);
+        }
+
+        [TestMethod]
         public async Task LuisRecognizer_Configuration()
         {
             var service = new LuisService
@@ -111,6 +127,13 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.AreEqual(11, (int)result.Entities["$instance"]["Name"].First["startIndex"]);
             Assert.AreEqual(15, (int)result.Entities["$instance"]["Name"].First["endIndex"]);
             AssertScore(result.Entities["$instance"]["Name"].First["score"]);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void LuisRecognizer_NullLuisAppArg()
+        {
+            var recognizerWithNullLuisApplication = new LuisRecognizer(application: null);
         }
 
         [TestMethod]
@@ -1085,6 +1108,20 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 .Respond("application/json", response);
 
             return new MockedHttpClientHandler(mockMessageHandler.ToHttpClient());
+        }
+
+        private static TurnContext GetNonMessageContext(string utterance)
+        {
+            var b = new TestAdapter();
+            var a = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                Text = utterance,
+                Conversation = new ConversationAccount(),
+                Recipient = new ChannelAccount(),
+                From = new ChannelAccount(),
+            };
+            return new TurnContext(b, a);
         }
 
         private string GetRequestUrl() => $"{_endpoint}/luis/v2.0/apps/{_luisAppId}";


### PR DESCRIPTION
Part 2 of 2 PRs to fix https://github.com/Microsoft/BotBuilder/issues/5196

## Description
* Added timeout option (in milliseconds) in `LuisRecognizer` and `QnAMaker` - **dotnet**
* As in C# `HttpClient`, set timeout default to 100000 milliseconds
* fixed missing `"` in docs of `IBotTelemetryClient`

## Specific Changes

**LuisRecognizer**
  - added `Timeout` property to `LuisPredictionOptions`
  - `LuisRecognizer` now exposes a `DefaultHttpClient` property to set a default HttpClient for requests, as well as to expose for testing
  - in order to pass `ServiceClientCredentials`, `HttpClient`, `HttpClientHandler`, and `LuisDelegatingHandler` changes to `LUISRuntimeClient`, used MsRest's `CreateRootHandler()` and `CreateHttpHandlerPipeline()` to create `HttpClient` to send to `LUISRuntimeClient` constructor inside `LuisRecognizer` cosntructor
 
**QnAMaker**
  - `QnAMakerOptions` now has optional `Timeout` property
  - `QnAMaker` class constructor will now assign `DefaultHttpClient` to `_httpClient` field if no `HttpClient` arg is provided
    - This will allow the user to set `Timeout` without having to pass in their custom `HttpClient`
  - If user _does_ pass in `HttpClient` into `QnAMaker` constructor, then it will take the timeout value set in `HttpClient`
 - `DefaultHttpClient` is public to expose for testing
