### PR TITLE
LG Tests were broken by recent refactoring of ResourceExplorer

### DIFF
--- a/tests/Microsoft.Bot.Builder.AI.LanguageGeneration.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LanguageGeneration.Tests/LGGeneratorTests.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         [TestMethod]
         public async Task TestExactLanguageLookup()
         {
-            var resourceManager = ResourceExplorer.LoadProject(GetFallbackFolder());
+            var resourceManager = new ResourceExplorer();
+            resourceManager.AddFolder(GetFallbackFolder());
             var lg = new LGLanguageGenerator(resourceManager);
 
             Assert.AreEqual("english-us", await lg.Generate("en-us", id: "test"));
@@ -44,7 +45,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             string[] yTypes = new string[] { "y", "x" };
             string[] xTypes = new string[] { "x" };
 
-            var resourceManager = ResourceExplorer.LoadProject(GetFallbackFolder());
+            var resourceManager = new ResourceExplorer();
+            resourceManager.AddFolder(GetFallbackFolder());
             var lg = new LGLanguageGenerator(resourceManager);
 
             // property is defined at each point in the hierarchy
@@ -66,7 +68,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             string[] tags2 = new string[] { "tag2" };
             string[] oddTags = new string[] { "foo", "bar" };
 
-            var resourceManager = ResourceExplorer.LoadProject(GetFallbackFolder());
+            var resourceManager = new ResourceExplorer();
+            resourceManager.AddFolder(GetFallbackFolder());
             var lg = new LGLanguageGenerator(resourceManager);
 
             Assert.AreEqual("english", await lg.Generate("en", id: "test", tags: notags));
@@ -87,7 +90,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             string[] tags2 = new string[] { "tag2" };
             string[] oddTags = new string[] { "foo", "bar" };
 
-            var resourceManager = ResourceExplorer.LoadProject(GetFallbackFolder());
+            var resourceManager = new ResourceExplorer();
+            resourceManager.AddFolder(GetFallbackFolder());
             var lg = new LGLanguageGenerator(resourceManager);
 
             Assert.AreEqual("test x", await lg.Generate("en", id: "property", tags: notags, types: xTypes));


### PR DESCRIPTION
Fixed tests to correctly point resource explorer to fallback folder