### PR TITLE
Remove references to FuseBox keys from Unit Tests

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -65,10 +65,13 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="appId">The Microsoft app ID.</param>
         /// <param name="password">The Microsoft app password.</param>
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
-        public MicrosoftAppCredentials(string appId, string password, HttpClient customHttpClient) : this(appId, password, null, customHttpClient) { }
+        public MicrosoftAppCredentials(string appId, string password, HttpClient customHttpClient)
+            : this(appId, password, null, customHttpClient)
+        {
+        }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="MicrosoftAppCredentials"/> class.
+        /// Initializes a new instance of the <see cref="MicrosoftAppCredentials"/> class.
         /// </summary>
         /// <param name="appId">The Microsoft app ID.</param>
         /// <param name="password">The Microsoft app password.</param>

--- a/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
@@ -5,14 +5,13 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
-
     public static class TimeSpanExtensions
     {
         private static Random random = new Random();
 
         public static TimeSpan WithJitter(this TimeSpan delay, double multiplier = 0.1)
         {
-            // Generate an uniform distribution between zero and 10% of the proposed delay and add it as 
+            // Generate an uniform distribution between zero and 10% of the proposed delay and add it as
             // random noise. The reason for this is that if there are multiple threads about to retry
             // at the same time, it can overload the server again and trigger throttling again.
             // By adding a bit of random noise, we distribute requests a across time.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestUtilities.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 
@@ -13,22 +8,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
     public class TestUtilities
     {
-        private static Lazy<Dictionary<string, string>> environmentKeys = new Lazy<Dictionary<string, string>>(() =>
-        {
-            try
-            {
-                return File.ReadAllLines(@"\\fusebox\private\sdk\UnitTestKeys-new.cmd")
-                    .Where(l => l.StartsWith("@set", StringComparison.OrdinalIgnoreCase))
-                    .Select(l => l.Replace("@set ", string.Empty, StringComparison.OrdinalIgnoreCase).Split('='))
-                    .ToDictionary(pairs => pairs[0], pairs => pairs[1]);
-            }
-            catch (Exception err)
-            {
-                System.Diagnostics.Debug.WriteLine(err.Message);
-                return new Dictionary<string, string>();
-            }
-        });
-
         public static TurnContext CreateEmptyContext()
         {
             var b = new TestAdapter();
@@ -49,21 +28,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var bc = new TurnContext(b, a);
 
             return bc;
-        }
-
-        public static string GetKey(string key)
-        {
-            if (!environmentKeys.Value.TryGetValue(key, out var value))
-            {
-                // fallback to environment variables
-                value = Environment.GetEnvironmentVariable(key);
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    value = null;
-                }
-            }
-
-            return value;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TestUtilities.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 
@@ -12,22 +8,6 @@ namespace Microsoft.Bot.Builder.Tests
 {
     public class TestUtilities
     {
-        private static Lazy<Dictionary<string, string>> environmentKeys = new Lazy<Dictionary<string, string>>(() =>
-        {
-            try
-            {
-                return File.ReadAllLines(@"\\fusebox\private\sdk\UnitTestKeys-new.cmd")
-                    .Where(l => l.StartsWith("@set", StringComparison.OrdinalIgnoreCase))
-                    .Select(l => l.Replace("@set ", string.Empty, StringComparison.OrdinalIgnoreCase).Split('='))
-                    .ToDictionary(pairs => pairs[0], pairs => pairs[1]);
-            }
-            catch (Exception err)
-            {
-                System.Diagnostics.Debug.WriteLine(err.Message);
-                return new Dictionary<string, string>();
-            }
-        });
-
         public static TurnContext CreateEmptyContext()
         {
             var b = new TestAdapter();
@@ -47,36 +27,6 @@ namespace Microsoft.Bot.Builder.Tests
             var bc = new TurnContext(b, a);
 
             return bc;
-        }
-
-        /*
-        public static T CreateEmptyContext<T>() where T:ITurnContext
-        {
-            TestAdapter b = new TestAdapter();
-            Activity a = new Activity();
-            if (typeof(T).IsAssignableFrom(typeof(ITurnContext)))
-            {
-                ITurnContext bc = new TurnContext(b, a);
-                return (T)bc;
-            }
-            else
-                throw new ArgumentException($"Unknown Type {typeof(T).Name}");
-        }
-        */
-
-        public static string GetKey(string key)
-        {
-            if (!environmentKeys.Value.TryGetValue(key, out var value))
-            {
-                // fallback to environment variables
-                value = Environment.GetEnvironmentVariable(key);
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    value = null;
-                }
-            }
-
-            return value;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Tests
                 return TranscriptsLocalPath;
             }
 
-            var transcriptsLocation = TestUtilities.GetKey(BotBuilderTranscriptsLocationKey) ?? DefaultTranscriptRepositoryZipLocation;
+            var transcriptsLocation = DefaultTranscriptRepositoryZipLocation;
 
             var tempPath = Path.GetTempPath();
             var zipFilePath = Path.Combine(tempPath, Path.GetFileName(transcriptsLocation));


### PR DESCRIPTION
Unit Tests had references to Fusebox cmd files. With the migration to Functional tests, and a dedicated functional test build with proper secret management, these references need to be removed. 

Cleaned up some stylecop warnings while I was in there. 