### PR TITLE
Ignore Stylecop warnings in TestBot.WebApi project

### DIFF
--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Bots/DialogBot.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Bots/DialogBot.cs
@@ -18,12 +18,10 @@ namespace Microsoft.BotBuilderSamples
     public class DialogBot<T> : ActivityHandler
         where T : Dialog
     {
-#pragma warning disable SA1401 // Fields should be private
         protected readonly Dialog _dialog;
         protected readonly BotState _conversationState;
         protected readonly BotState _userState;
         protected readonly ILogger _logger;
-#pragma warning restore SA1401 // Fields should be private
 
         public DialogBot(ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
         {

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Dialogs/BookingDialog.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Dialogs/BookingDialog.cs
@@ -17,15 +17,14 @@ namespace Microsoft.BotBuilderSamples
             AddDialog(new TextPrompt(nameof(TextPrompt)));
             AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
             AddDialog(new DateResolverDialog());
-            var steps = new WaterfallStep[]
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 DestinationStepAsync,
                 OriginStepAsync,
                 TravelDateStepAsync,
                 ConfirmStepAsync,
                 FinalStepAsync,
-            };
-            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), steps));
+            }));
 
             // The initial child Dialog to run.
             InitialDialogId = nameof(WaterfallDialog);

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Dialogs/DateResolverDialog.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Dialogs/DateResolverDialog.cs
@@ -26,26 +26,6 @@ namespace Microsoft.BotBuilderSamples
             InitialDialogId = nameof(WaterfallDialog);
         }
 
-        private static Task<bool> DateTimePromptValidator(PromptValidatorContext<IList<DateTimeResolution>> promptContext, CancellationToken cancellationToken)
-        {
-            if (promptContext.Recognized.Succeeded)
-            {
-                // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
-                // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
-                var timex = promptContext.Recognized.Value[0].Timex.Split('T')[0];
-
-                // If this is a definite Date including year, month and day we are good otherwise reprompt.
-                // A better solution might be to let the user know what part is actually missing.
-                var isDefinite = new TimexProperty(timex).Types.Contains(Constants.TimexTypes.Definite);
-
-                return Task.FromResult(isDefinite);
-            }
-            else
-            {
-                return Task.FromResult(false);
-            }
-        }
-
         private async Task<DialogTurnResult> InitialStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var timex = (string)stepContext.Options;
@@ -89,6 +69,26 @@ namespace Microsoft.BotBuilderSamples
         {
             var timex = ((List<DateTimeResolution>)stepContext.Result)[0].Timex;
             return await stepContext.EndDialogAsync(timex);
+        }
+
+        private static Task<bool> DateTimePromptValidator(PromptValidatorContext<IList<DateTimeResolution>> promptContext, CancellationToken cancellationToken)
+        {
+            if (promptContext.Recognized.Succeeded)
+            {
+                // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
+                // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
+                var timex = promptContext.Recognized.Value[0].Timex.Split('T')[0];
+
+                // If this is a definite Date including year, month and day we are good otherwise reprompt.
+                // A better solution might be to let the user know what part is actually missing.
+                var isDefinite = new TimexProperty(timex).Types.Contains(Constants.TimexTypes.Definite);
+
+                return Task.FromResult(isDefinite);
+            }
+            else
+            {
+                return Task.FromResult(false);
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Dialogs/DateResolverDialog.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Dialogs/DateResolverDialog.cs
@@ -16,12 +16,11 @@ namespace Microsoft.BotBuilderSamples
             : base(id ?? nameof(DateResolverDialog))
         {
             AddDialog(new DateTimePrompt(nameof(DateTimePrompt), DateTimePromptValidator));
-            var steps = new WaterfallStep[]
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[]
             {
                 InitialStepAsync,
                 FinalStepAsync,
-            };
-            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), steps));
+           }));
 
             // The initial child Dialog to run.
             InitialDialogId = nameof(WaterfallDialog);

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/DisableAllRuleSet-DotNet.ruleset
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/DisableAllRuleSet-DotNet.ruleset
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for StyleCop.Analyzers.csproj." ToolsVersion="15.0">
+  <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
+    <Rule Id="AvoidAsyncVoid" Action="None" />
+    <Rule Id="UseConfigureAwait" Action="None" />
+  </Rules>
+
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">    
+    <Rule Id="CS1573" Action="None" />
+    <Rule Id="CS1591" Action="None" />  
+    <Rule Id="CS1712" Action="None" />
+  </Rules>
+
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0003" Action="None" />
+    <Rule Id="IDE0043" Action="None" />
+  </Rules>  
+
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.VisualBasic.Features" RuleNamespace="Microsoft.CodeAnalysis.VisualBasic.Features">
+    <Rule Id="IDE0043" Action="None" />
+  </Rules>
+
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" /> <!-- XML documentation comments --> 
+    <Rule Id="SA1101" Action="None" /> <!-- local calls prefixed with this -->  
+    <Rule Id="SA1118" Action="None" />     
+    <Rule Id="SA1129" Action="None" /> <!-- don't use value type constructor-->
+    <Rule Id="SA1200" Action="None" />
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1214" Action="None"/>  <!-- encapsalate field in property-->
+    <Rule Id="SA1305" Action="None" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1401" Action="None" />
+    <Rule Id="SA1412" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1609" Action="None" />
+    <Rule Id="SA1633" Action="None" /> 
+    <Rule Id="SA1652" Action="None" /> <!-- XML documentation comments -->
+  </Rules>
+
+</RuleSet>

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
@@ -1,6 +1,9 @@
 ﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <CodeAnalysisRuleSet>DisableAllRuleSet-DotNet.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>


### PR DESCRIPTION
**Changes made**:

- Revert fixes made on PR #1642
- Create a new ruleset file on Bot.Builder.TestBot.WebApi & customize it for ignoring rules (Action="None")
- Edit the .csproj file on Bot.Builder.TestBot.WebApi and add the CodeAnalysisRuleSet