### PR TITLE
Expression: Add string index support in access element function

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -583,7 +583,7 @@ namespace Microsoft.Bot.Builder.Expressions
                         }
                         else
                         {
-                            error = $"type of ({instance}, {idx}) should be (object, string) or (collection, int)";
+                            error = $"{instance} is not a collection.";
                         }
                     }
                     else if(idxValue is string idxStr)

--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -515,23 +515,7 @@ namespace Microsoft.Bot.Builder.Expressions
                         }
                         else if (jtoken is JValue jvalue)
                         {
-                            value = jvalue.Value;
-                            if (jvalue.Type == JTokenType.Integer)
-                            {
-                                value = jvalue.ToObject<int>();
-                            }
-                            else if (jvalue.Type == JTokenType.String)
-                            {
-                                value = jvalue.ToObject<string>();
-                            }
-                            else if (jvalue.Type == JTokenType.Boolean)
-                            {
-                                value = jvalue.ToObject<bool>();
-                            }
-                            else if (jvalue.Type == JTokenType.Float)
-                            {
-                                value = jvalue.ToObject<double>();
-                            }
+                            value = GetSpecificTypeFromJValue(jvalue);
                         }
                         else value = jtoken;
                     }
@@ -589,23 +573,7 @@ namespace Microsoft.Bot.Builder.Expressions
                                 }
                                 else if (value is JValue jvalue)
                                 {
-                                    value = jvalue.Value;
-                                    if (jvalue.Type == JTokenType.Integer)
-                                    {
-                                        value = jvalue.ToObject<int>();
-                                    }
-                                    else if (jvalue.Type == JTokenType.String)
-                                    {
-                                        value = jvalue.ToObject<string>();
-                                    }
-                                    else if (jvalue.Type == JTokenType.Boolean)
-                                    {
-                                        value = jvalue.ToObject<bool>();
-                                    }
-                                    else if (jvalue.Type == JTokenType.Float)
-                                    {
-                                        value = jvalue.ToObject<double>();
-                                    }
+                                    value = GetSpecificTypeFromJValue(jvalue);
                                 }
                             }
                             else
@@ -618,6 +586,10 @@ namespace Microsoft.Bot.Builder.Expressions
                             error = $"{instance} is not a collection.";
                         }
                     }
+                    else if(idxValue is string idxStr)
+                    {
+                        (value, error) = AccessProperty(inst, idxStr);
+                    }
                     else
                     {
                         error = $"Could not coerce {index} to an int.";
@@ -625,6 +597,28 @@ namespace Microsoft.Bot.Builder.Expressions
                 }
             }
             return (value, error);
+        }
+
+        private static object GetSpecificTypeFromJValue(JValue jvalue)
+        {
+            var value = jvalue.Value;
+            if (jvalue.Type == JTokenType.Integer)
+            {
+                value = jvalue.ToObject<int>();
+            }
+            else if (jvalue.Type == JTokenType.String)
+            {
+                value = jvalue.ToObject<string>();
+            }
+            else if (jvalue.Type == JTokenType.Boolean)
+            {
+                value = jvalue.ToObject<bool>();
+            }
+            else if (jvalue.Type == JTokenType.Float)
+            {
+                value = jvalue.ToObject<double>();
+            }
+            return value;
         }
 
         private static (object value, string error) And(Expression expression, object state)
@@ -880,8 +874,7 @@ namespace Microsoft.Bot.Builder.Expressions
             var functions = new Dictionary<string, ExpressionEvaluator>
             {
                 // Math
-                { ExpressionType.Element, new ExpressionEvaluator(ExtractElement, ReturnType.Object,
-                    (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.Number)) },
+                { ExpressionType.Element, new ExpressionEvaluator(ExtractElement, ReturnType.Object,ValidateBinary) },
                 { ExpressionType.Add, Numeric(args => args[0] + args[1]) },
                 { ExpressionType.Subtract, Numeric(args => args[0] - args[1]) },
                 { ExpressionType.Multiply, Numeric(args => args[0] * args[1]) },

--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -515,7 +515,23 @@ namespace Microsoft.Bot.Builder.Expressions
                         }
                         else if (jtoken is JValue jvalue)
                         {
-                            value = GetSpecificTypeFromJValue(jvalue);
+                            value = jvalue.Value;
+                            if (jvalue.Type == JTokenType.Integer)
+                            {
+                                value = jvalue.ToObject<int>();
+                            }
+                            else if (jvalue.Type == JTokenType.String)
+                            {
+                                value = jvalue.ToObject<string>();
+                            }
+                            else if (jvalue.Type == JTokenType.Boolean)
+                            {
+                                value = jvalue.ToObject<bool>();
+                            }
+                            else if (jvalue.Type == JTokenType.Float)
+                            {
+                                value = jvalue.ToObject<double>();
+                            }
                         }
                         else value = jtoken;
                     }
@@ -573,7 +589,23 @@ namespace Microsoft.Bot.Builder.Expressions
                                 }
                                 else if (value is JValue jvalue)
                                 {
-                                    value = GetSpecificTypeFromJValue(jvalue);
+                                    value = jvalue.Value;
+                                    if (jvalue.Type == JTokenType.Integer)
+                                    {
+                                        value = jvalue.ToObject<int>();
+                                    }
+                                    else if (jvalue.Type == JTokenType.String)
+                                    {
+                                        value = jvalue.ToObject<string>();
+                                    }
+                                    else if (jvalue.Type == JTokenType.Boolean)
+                                    {
+                                        value = jvalue.ToObject<bool>();
+                                    }
+                                    else if (jvalue.Type == JTokenType.Float)
+                                    {
+                                        value = jvalue.ToObject<double>();
+                                    }
                                 }
                             }
                             else
@@ -597,28 +629,6 @@ namespace Microsoft.Bot.Builder.Expressions
                 }
             }
             return (value, error);
-        }
-
-        private static object GetSpecificTypeFromJValue(JValue jvalue)
-        {
-            var value = jvalue.Value;
-            if (jvalue.Type == JTokenType.Integer)
-            {
-                value = jvalue.ToObject<int>();
-            }
-            else if (jvalue.Type == JTokenType.String)
-            {
-                value = jvalue.ToObject<string>();
-            }
-            else if (jvalue.Type == JTokenType.Boolean)
-            {
-                value = jvalue.ToObject<bool>();
-            }
-            else if (jvalue.Type == JTokenType.Float)
-            {
-                value = jvalue.ToObject<double>();
-            }
-            return value;
         }
 
         private static (object value, string error) And(Expression expression, object state)

--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -583,7 +583,7 @@ namespace Microsoft.Bot.Builder.Expressions
                         }
                         else
                         {
-                            error = $"{instance} is not a collection.";
+                            error = $"type of ({instance}, {idx}) should be (object, string) or (collection, int)";
                         }
                     }
                     else if(idxValue is string idxStr)
@@ -592,7 +592,7 @@ namespace Microsoft.Bot.Builder.Expressions
                     }
                     else
                     {
-                        error = $"Could not coerce {index} to an int.";
+                        error = $"Could not coerce {index} to an int or string";
                     }
                 }
             }

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -263,7 +263,6 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("items[2]", "two", new HashSet<string> { "items[2]" }),
             Test("bag.list[bag.index - 2]", "blue", new HashSet<string> {"bag.list", "bag.index" }),
             # endregion
-
         };
 
         [DataTestMethod]

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -262,6 +262,8 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("property(bag, concat('na','me'))","mybag"),
             Test("items[2]", "two", new HashSet<string> { "items[2]" }),
             Test("bag.list[bag.index - 2]", "blue", new HashSet<string> {"bag.list", "bag.index" }),
+            Test("bag['name']","mybag"),
+            Test("bag[substring(concat('na','me','more'), 0, length('name'))]","mybag"),
             # endregion
         };
 

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -264,6 +264,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("bag.list[bag.index - 2]", "blue", new HashSet<string> {"bag.list", "bag.index" }),
             Test("bag['name']","mybag"),
             Test("bag[substring(concat('na','me','more'), 0, length('name'))]","mybag"),
+            Test("items[1+1]","two"),
             # endregion
         };
 

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -266,6 +266,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("bag[substring(concat('na','me','more'), 0, length('name'))]","mybag"),
             Test("items[1+1]","two"),
             # endregion
+
         };
 
         [DataTestMethod]


### PR DESCRIPTION
Originally we support such format: A[0]
Modify this to support string format index: A['name'], in this way developper can access an element by dynamic variable, such an example:
we have such scope:
```
'weather' : {
    'today' : 'sunny',
    'tomorrow' : 'cloudy'
}
```
The variable string 'day' is obtained from user‘s input, may be 'today' or maybe 'tomorrow'.

Original we can use such functions: `weather.(Accessor(day))`, but it looks unfriendly.

In PR #1658 a new function was added: `Property`,  now `property(weather, day)` works well.


In this PR, developper can also access the weather in such way -> `weather[day]`

