### PR TITLE
LG: add context to parsing error

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
@@ -10,14 +10,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     {
         public override void SyntaxError([NotNull] Antlr4.Runtime.IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e)
         {
-            var lineStrArray = offendingSymbol.InputStream.GetText(new Interval(0, int.MaxValue)).Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var lineStrArray = offendingSymbol.InputStream.GetText(new Interval(0, int.MaxValue)).Split('\n');
             var lineStr = lineStrArray[line - 1];
 
             var errorbuilder = new StringBuilder();
             errorbuilder.Append("[ERROR]:\r\n");
             errorbuilder.Append(lineStr + "\r\n");
             errorbuilder.Append(new string(' ', charPositionInLine));
-            errorbuilder.Append("\r\n");
 
             var length = offendingSymbol.StopIndex - offendingSymbol.StartIndex + 1;
             errorbuilder.Append(new string('^', length));

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 
@@ -9,7 +10,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     {
         public override void SyntaxError([NotNull] Antlr4.Runtime.IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e)
         {
-            throw new Exception($"[ERROR]: syntax error at line {line}:{charPositionInLine} {msg}");
+            var lineStrArray = offendingSymbol.InputStream.GetText(new Interval(0, int.MaxValue)).Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var lineStr = lineStrArray[line - 1];
+
+            var errorbuilder = new StringBuilder();
+            errorbuilder.Append("[ERROR]:\r\n");
+            errorbuilder.Append(lineStr + "\r\n");
+            errorbuilder.Append(new string(' ', charPositionInLine));
+            errorbuilder.Append("\r\n");
+
+            var length = offendingSymbol.StopIndex - offendingSymbol.StartIndex + 1;
+            errorbuilder.Append(new string('^', length));
+            errorbuilder.Append("\r\n");
+            errorbuilder.Append($"{msg}\r\n");
+            throw new Exception(errorbuilder.ToString());
         }
     }
 }


### PR DESCRIPTION
for Antlr error, we use such error format: 
```
[Error]:
my template body(params. invalid)
                       ^^
invalid parameters format
```
