### PR TITLE
InputWrapper: If no property is provided we simply don't bind to memory but let the prompt go through.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputWrapper.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputWrapper.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
             }
 
-            // Check value in state and only call if missing or required by AlwaysPrompt
-            var value = dc.State.GetValue<TValue>(Property);
+            // Check value in state and only call if missing and Property specified, or if required by AlwaysPrompt
+            var value = Property == null ? default(TValue) : dc.State.GetValue<TValue>(Property);
 
             if (value == null || AlwaysPrompt)
             {

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/04 - TextInput/TextInput.WithoutProperty.main.dialog
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/04 - TextInput/TextInput.WithoutProperty.main.dialog
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../app.schema",
+    "$type": "Microsoft.AdaptiveDialog",
+    "steps": [
+        {
+            "$type": "Microsoft.TextInput",
+            "prompt": "Hello, I'm Zoidberg. What is your name?"
+        },
+        {
+            "$type": "Microsoft.SendActivity",
+            "activity": "Hello, nice to talk to you!"
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -69,10 +69,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
 
         [TestMethod]
         public async Task JsonDialogLoad_TextInputWithoutProperty()
-        {
-            string path = Path.Combine(samplesDirectory, @"04 - TextInput\TextInput.WithoutProperty.main.dialog");
-
-            await BuildTestFlow(path)
+        {   
+            await BuildTestFlow("TextInput.WithoutProperty.main.dialog")
             .SendConversationUpdate()
                 .AssertReply("Hello, I'm Zoidberg. What is your name?")
             .Send("Carlos")

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -68,6 +68,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         }
 
         [TestMethod]
+        public async Task JsonDialogLoad_TextInputWithoutProperty()
+        {
+            string path = Path.Combine(samplesDirectory, @"04 - TextInput\TextInput.WithoutProperty.main.dialog");
+
+            await BuildTestFlow(path)
+            .SendConversationUpdate()
+                .AssertReply("Hello, I'm Zoidberg. What is your name?")
+            .Send("Carlos")
+                .AssertReply("Hello, nice to talk to you!")
+                .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task JsonDialogLoad_TextInput()
         {
             await BuildTestFlow("TextInput.main.dialog")


### PR DESCRIPTION
…

Fixes #1701 + tests + sample