### PR TITLE
Add DirectLineClientTests to FunctionalTest project using ARM

### DIFF
--- a/FunctionalTests/ExportedTemplate/DeploymentHelper.cs
+++ b/FunctionalTests/ExportedTemplate/DeploymentHelper.cs
@@ -1,0 +1,115 @@
+// Requires the following Azure NuGet packages and related dependencies:
+// package id="Microsoft.Azure.Management.Authorization" version="2.0.0"
+// package id="Microsoft.Azure.Management.ResourceManager" version="1.4.0-preview"
+// package id="Microsoft.Rest.ClientRuntime.Azure.Authentication" version="2.2.8-preview"
+  
+using Microsoft.Azure.Management.ResourceManager;
+using Microsoft.Azure.Management.ResourceManager.Models;
+using Microsoft.Rest.Azure.Authentication;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+
+namespace PortalGenerated
+{
+    /// <summary>
+    /// This is a helper class for deploying an Azure Resource Manager template
+    /// More info about template deployments can be found here https://go.microsoft.com/fwLink/?LinkID=733371
+    /// </summary>
+    class DeploymentHelper
+    {
+        string subscriptionId = "your-subscription-id";
+        string clientId = "your-service-principal-clientId";
+        string clientSecret = "your-service-principal-client-secret";
+        string resourceGroupName = "resource-group-name";
+        string deploymentName = "deployment-name";
+        string resourceGroupLocation = "resource-group-location"; // must be specified for creating a new resource group
+        string pathToTemplateFile = "path-to-template.json-on-disk";
+        string pathToParameterFile = "path-to-parameters.json-on-disk";
+        string tenantId = "tenant-id";
+
+        public async void Run()
+        {
+            // Try to obtain the service credentials
+            var serviceCreds = await ApplicationTokenProvider.LoginSilentAsync(tenantId, clientId, clientSecret);
+
+            // Read the template and parameter file contents
+            JObject templateFileContents = GetJsonFileContents(pathToTemplateFile);
+            JObject parameterFileContents = GetJsonFileContents(pathToParameterFile);
+
+            // Create the resource manager client
+            var resourceManagementClient = new ResourceManagementClient(serviceCreds);
+            resourceManagementClient.SubscriptionId = subscriptionId;
+
+            // Create or check that resource group exists
+            EnsureResourceGroupExists(resourceManagementClient, resourceGroupName, resourceGroupLocation);
+
+            // Start a deployment
+            DeployTemplate(resourceManagementClient, resourceGroupName, deploymentName, templateFileContents, parameterFileContents);
+        }
+
+        /// <summary>
+        /// Reads a JSON file from the specified path
+        /// </summary>
+        /// <param name="pathToJson">The full path to the JSON file</param>
+        /// <returns>The JSON file contents</returns>
+        private JObject GetJsonFileContents(string pathToJson)
+        {
+            JObject templatefileContent = new JObject();
+            using (StreamReader file = File.OpenText(pathToJson))
+            {
+                using (JsonTextReader reader = new JsonTextReader(file))
+                {
+                    templatefileContent = (JObject)JToken.ReadFrom(reader);
+                    return templatefileContent;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ensures that a resource group with the specified name exists. If it does not, will attempt to create one.
+        /// </summary>
+        /// <param name="resourceManagementClient">The resource manager client.</param>
+        /// <param name="resourceGroupName">The name of the resource group.</param>
+        /// <param name="resourceGroupLocation">The resource group location. Required when creating a new resource group.</param>
+        private static void EnsureResourceGroupExists(ResourceManagementClient resourceManagementClient, string resourceGroupName, string resourceGroupLocation)
+        {
+            if (resourceManagementClient.ResourceGroups.CheckExistence(resourceGroupName) != true)
+            {
+                Console.WriteLine(string.Format("Creating resource group '{0}' in location '{1}'", resourceGroupName, resourceGroupLocation));
+                var resourceGroup = new ResourceGroup();
+                resourceGroup.Location = resourceGroupLocation;
+                resourceManagementClient.ResourceGroups.CreateOrUpdate(resourceGroupName, resourceGroup);
+            }
+            else
+            {
+                Console.WriteLine(string.Format("Using existing resource group '{0}'", resourceGroupName));
+            }
+        }
+
+        /// <summary>
+        /// Starts a template deployment.
+        /// </summary>
+        /// <param name="resourceManagementClient">The resource manager client.</param>
+        /// <param name="resourceGroupName">The name of the resource group.</param>
+        /// <param name="deploymentName">The name of the deployment.</param>
+        /// <param name="templateFileContents">The template file contents.</param>
+        /// <param name="parameterFileContents">The parameter file contents.</param>
+        private static void DeployTemplate(ResourceManagementClient resourceManagementClient, string resourceGroupName, string deploymentName, JObject templateFileContents, JObject parameterFileContents)
+        {
+            Console.WriteLine(string.Format("Starting template deployment '{0}' in resource group '{1}'", deploymentName, resourceGroupName));
+            var deployment = new Deployment();
+
+            deployment.Properties = new DeploymentProperties
+            {
+                Mode = DeploymentMode.Incremental,
+                Template = templateFileContents,
+                Parameters = parameterFileContents["parameters"].ToObject<JObject>()
+            };
+
+            var deploymentResult = resourceManagementClient.Deployments.CreateOrUpdate(resourceGroupName, deploymentName, deployment);
+            Console.WriteLine(string.Format("Deployment status: {0}", deploymentResult.Properties.ProvisioningState));
+        }
+    }
+}

--- a/FunctionalTests/ExportedTemplate/deploy.ps1
+++ b/FunctionalTests/ExportedTemplate/deploy.ps1
@@ -1,0 +1,107 @@
+<#
+ .SYNOPSIS
+    Deploys a template to Azure
+
+ .DESCRIPTION
+    Deploys an Azure Resource Manager template
+
+ .PARAMETER subscriptionId
+    The subscription id where the template will be deployed.
+
+ .PARAMETER resourceGroupName
+    The resource group where the template will be deployed. Can be the name of an existing or a new resource group.
+
+ .PARAMETER resourceGroupLocation
+    Optional, a resource group location. If specified, will try to create a new resource group in this location. If not specified, assumes resource group is existing.
+
+ .PARAMETER deploymentName
+    The deployment name.
+
+ .PARAMETER templateFilePath
+    Optional, path to the template file. Defaults to template.json.
+
+ .PARAMETER parametersFilePath
+    Optional, path to the parameters file. Defaults to parameters.json. If file is not found, will prompt for parameter values based on template.
+#>
+
+param(
+ [Parameter(Mandatory=$True)]
+ [string]
+ $subscriptionId,
+
+ [Parameter(Mandatory=$True)]
+ [string]
+ $resourceGroupName,
+
+ [string]
+ $resourceGroupLocation,
+
+ [Parameter(Mandatory=$True)]
+ [string]
+ $deploymentName,
+
+ [string]
+ $templateFilePath = "template.json",
+
+ [string]
+ $parametersFilePath = "parameters.json"
+)
+
+<#
+.SYNOPSIS
+    Registers RPs
+#>
+Function RegisterRP {
+    Param(
+        [string]$ResourceProviderNamespace
+    )
+
+    Write-Host "Registering resource provider '$ResourceProviderNamespace'";
+    Register-AzureRmResourceProvider -ProviderNamespace $ResourceProviderNamespace;
+}
+
+#******************************************************************************
+# Script body
+# Execution begins here
+#******************************************************************************
+$ErrorActionPreference = "Stop"
+
+# sign in
+Write-Host "Logging in...";
+Login-AzureRmAccount;
+
+# select subscription
+Write-Host "Selecting subscription '$subscriptionId'";
+Select-AzureRmSubscription -SubscriptionID $subscriptionId;
+
+# Register RPs
+$resourceProviders = @("microsoft.cognitiveservices","microsoft.storage","microsoft.web","microsoft.insights","microsoft.botservice");
+if($resourceProviders.length) {
+    Write-Host "Registering resource providers"
+    foreach($resourceProvider in $resourceProviders) {
+        RegisterRP($resourceProvider);
+    }
+}
+
+#Create or check for existing resource group
+$resourceGroup = Get-AzureRmResourceGroup -Name $resourceGroupName -ErrorAction SilentlyContinue
+if(!$resourceGroup)
+{
+    Write-Host "Resource group '$resourceGroupName' does not exist. To create a new resource group, please enter a location.";
+    if(!$resourceGroupLocation) {
+        $resourceGroupLocation = Read-Host "resourceGroupLocation";
+    }
+    Write-Host "Creating resource group '$resourceGroupName' in location '$resourceGroupLocation'";
+    New-AzureRmResourceGroup -Name $resourceGroupName -Location $resourceGroupLocation
+}
+else{
+    Write-Host "Using existing resource group '$resourceGroupName'";
+}
+
+# Start the deployment
+Write-Host "Starting deployment...";
+if(Test-Path $parametersFilePath) {
+    New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -Name $deploymentName -TemplateFile $templateFilePath -TemplateParameterFile $parametersFilePath;
+} else {
+    New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -Name $deploymentName -TemplateFile $templateFilePath;
+}

--- a/FunctionalTests/ExportedTemplate/deploy.sh
+++ b/FunctionalTests/ExportedTemplate/deploy.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# -e: immediately exit if any command has a non-zero exit status
+# -o: prevents errors in a pipeline from being masked
+# IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
+
+usage() { echo "Usage: $0 -i <subscriptionId> -g <resourceGroupName> -n <deploymentName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+
+declare subscriptionId=""
+declare resourceGroupName=""
+declare deploymentName=""
+declare resourceGroupLocation=""
+
+# Initialize parameters specified from command line
+while getopts ":i:g:n:l:" arg; do
+	case "${arg}" in
+		i)
+			subscriptionId=${OPTARG}
+			;;
+		g)
+			resourceGroupName=${OPTARG}
+			;;
+		n)
+			deploymentName=${OPTARG}
+			;;
+		l)
+			resourceGroupLocation=${OPTARG}
+			;;
+		esac
+done
+shift $((OPTIND-1))
+
+#Prompt for parameters is some required parameters are missing
+if [[ -z "$subscriptionId" ]]; then
+	echo "Your subscription ID can be looked up with the CLI using: az account show --out json "
+	echo "Enter your subscription ID:"
+	read subscriptionId
+	[[ "${subscriptionId:?}" ]]
+fi
+
+if [[ -z "$resourceGroupName" ]]; then
+	echo "This script will look for an existing resource group, otherwise a new one will be created "
+	echo "You can create new resource groups with the CLI using: az group create "
+	echo "Enter a resource group name"
+	read resourceGroupName
+	[[ "${resourceGroupName:?}" ]]
+fi
+
+if [[ -z "$deploymentName" ]]; then
+	echo "Enter a name for this deployment:"
+	read deploymentName
+fi
+
+if [[ -z "$resourceGroupLocation" ]]; then
+	echo "If creating a *new* resource group, you need to set a location "
+	echo "You can lookup locations with the CLI using: az account list-locations "
+	
+	echo "Enter resource group location:"
+	read resourceGroupLocation
+fi
+
+#templateFile Path - template file to be used
+templateFilePath="template.json"
+
+if [ ! -f "$templateFilePath" ]; then
+	echo "$templateFilePath not found"
+	exit 1
+fi
+
+#parameter file path
+parametersFilePath="parameters.json"
+
+if [ ! -f "$parametersFilePath" ]; then
+	echo "$parametersFilePath not found"
+	exit 1
+fi
+
+if [ -z "$subscriptionId" ] || [ -z "$resourceGroupName" ] || [ -z "$deploymentName" ]; then
+	echo "Either one of subscriptionId, resourceGroupName, deploymentName is empty"
+	usage
+fi
+
+#login to azure using your credentials
+az account show 1> /dev/null
+
+if [ $? != 0 ];
+then
+	az login
+fi
+
+#set the default subscription id
+az account set --subscription $subscriptionId
+
+set +e
+
+#Check for existing RG
+az group show --name $resourceGroupName 1> /dev/null
+
+if [ $? != 0 ]; then
+	echo "Resource group with name" $resourceGroupName "could not be found. Creating new resource group.."
+	set -e
+	(
+		set -x
+		az group create --name $resourceGroupName --location $resourceGroupLocation 1> /dev/null
+	)
+	else
+	echo "Using existing resource group..."
+fi
+
+#Start deployment
+echo "Starting deployment..."
+(
+	set -x
+	az group deployment create --name "$deploymentName" --resource-group "$resourceGroupName" --template-file "$templateFilePath" --parameters "@${parametersFilePath}"
+)
+
+if [ $?  == 0 ];
+ then
+	echo "Template has been successfully deployed"
+fi

--- a/FunctionalTests/ExportedTemplate/deployer.rb
+++ b/FunctionalTests/ExportedTemplate/deployer.rb
@@ -1,0 +1,71 @@
+require 'azure_mgmt_resources'
+
+class Deployer
+
+  # Initialize the deployer class with subscription, resource group and resource group location. The class will raise an
+  # ArgumentError if there are empty values for Tenant Id, Client Id or Client Secret environment variables.
+  #
+  # @param [String] subscription_id the subscription to deploy the template
+  # @param [String] resource_group the resource group to create or update and then deploy the template
+  # @param [String] resource_group_location the location of the resource group
+  def initialize(subscription_id, resource_group, resource_group_location)
+    raise ArgumentError.new("Missing template file 'template.json' in current directory.") unless File.exist?('template.json')
+    raise ArgumentError.new("Missing parameters file 'parameters.json' in current directory.") unless File.exist?('parameters.json')
+    @resource_group = resource_group
+    @subscription_id = subscription_id
+	@resource_group_location = resource_group_location
+    provider = MsRestAzure::ApplicationTokenProvider.new(
+        ENV['AZURE_TENANT_ID'],
+        ENV['AZURE_CLIENT_ID'],
+        ENV['AZURE_CLIENT_SECRET'])
+    credentials = MsRest::TokenCredentials.new(provider)
+    @client = Azure::ARM::Resources::ResourceManagementClient.new(credentials)
+    @client.subscription_id = @subscription_id
+  end
+
+  # Deploy the template to a resource group
+  def deploy
+    # ensure the resource group is created
+    params = Azure::ARM::Resources::Models::ResourceGroup.new.tap do |rg|
+      rg.location = @resource_group_location
+    end
+    @client.resource_groups.create_or_update(@resource_group, params).value!
+
+    # build the deployment from a json file template from parameters
+    template = File.read(File.expand_path(File.join(__dir__, 'template.json')))
+    deployment = Azure::ARM::Resources::Models::Deployment.new
+    deployment.properties = Azure::ARM::Resources::Models::DeploymentProperties.new
+    deployment.properties.template = JSON.parse(template)
+    deployment.properties.mode = Azure::ARM::Resources::Models::DeploymentMode::Incremental
+
+    # build the deployment template parameters from Hash to {key: {value: value}} format
+    deploy_params = File.read(File.expand_path(File.join(__dir__, 'parameters.json')))
+    deployment.properties.parameters = JSON.parse(deploy_params)["parameters"]
+
+    # put the deployment to the resource group
+    @client.deployments.create_or_update(@resource_group, 'azure-sample', deployment)
+  end
+end
+
+# Get user inputs and execute the script
+if(ARGV.empty?)
+  puts "Please specify subscriptionId resourceGroupName resourceGroupLocation as command line arguments"
+  exit
+end
+
+subscription_id = ARGV[0]             # Azure Subscription Id
+resource_group = ARGV[1]              # The resource group for deployment
+resource_group_location = ARGV[2]     # The resource group location
+
+msg = "\nInitializing the Deployer class with subscription id: #{subscription_id}, resource group: #{resource_group}"
+msg += "\nand resource group location: #{resource_group_location}...\n\n"
+puts msg
+
+# Initialize the deployer class
+deployer = Deployer.new(subscription_id, resource_group, resource_group_location)
+
+puts "Beginning the deployment... \n\n"
+# Deploy the template
+deployment = deployer.deploy
+
+puts "Done deploying!!"

--- a/FunctionalTests/ExportedTemplate/parameters.json
+++ b/FunctionalTests/ExportedTemplate/parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "botId": {
+            "value": ""
+        },
+        "appId": {
+            "value": ""
+        },
+        "appSecret": {
+            "value": ""
+        }
+    }
+}

--- a/FunctionalTests/ExportedTemplate/template.json
+++ b/FunctionalTests/ExportedTemplate/template.json
@@ -1,0 +1,183 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "groupLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the location of the Resource Group."
+            }
+        },
+        "groupName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the name of the Resource Group."
+            }
+        },
+        "appId": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+            }
+        },
+        "appSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+            }
+        },
+        "botId": {
+            "type": "string",
+            "metadata": {
+                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+            }
+        },
+        "botSku": {
+            "type": "string",
+            "metadata": {
+                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+            }
+        },
+        "newAppServicePlanName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the App Service Plan."
+            }
+        },
+        "newAppServicePlanSku": {
+            "type": "object",
+            "defaultValue": {
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
+                "capacity": 1
+            },
+            "metadata": {
+                "description": "The SKU of the App Service Plan. Defaults to Standard values."
+            }
+        },
+        "newAppServicePlanLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "The location of the App Service Plan. Defaults to \"westus\"."
+            }
+        },
+        "newWebAppName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[parameters('newAppServicePlanName')]",
+        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    },
+    "resources": [
+        {
+            "name": "[parameters('groupName')]",
+            "type": "Microsoft.Resources/resourceGroups",
+            "apiVersion": "2018-05-01",
+            "location": "[parameters('groupLocation')]",
+            "properties": {
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "storageDeployment",
+            "resourceGroup": "[parameters('groupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "comments": "Create a new App Service Plan",
+                            "type": "Microsoft.Web/serverfarms",
+                            "name": "[variables('appServicePlanName')]",
+                            "apiVersion": "2018-02-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "sku": "[parameters('newAppServicePlanSku')]",
+                            "properties": {
+                                "name": "[variables('appServicePlanName')]"
+                            }
+                        },
+                        {
+                            "comments": "Create a Web App using the new App Service Plan",
+                            "type": "Microsoft.Web/sites",
+                            "apiVersion": "2015-08-01",
+                            "location": "[variables('resourcesLocation')]",
+                            "kind": "app",
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            ],
+                            "name": "[variables('webAppName')]",
+                            "properties": {
+                                "name": "[variables('webAppName')]",
+                                "serverFarmId": "[variables('appServicePlanName')]",
+                                "siteConfig": {
+                                    "appSettings": [
+                                        {
+                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                                            "value": "10.14.1"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppId",
+                                            "value": "[parameters('appId')]"
+                                        },
+                                        {
+                                            "name": "MicrosoftAppPassword",
+                                            "value": "[parameters('appSecret')]"
+                                        }
+                                    ],
+                                    "cors": {
+                                        "allowedOrigins": [
+                                            "https://botservice.hosting.portal.azure.net",
+                                            "https://hosting.onecloud.azure-test.net/"
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "apiVersion": "2017-12-01",
+                            "type": "Microsoft.BotService/botServices",
+                            "name": "[parameters('botId')]",
+                            "location": "global",
+                            "kind": "bot",
+                            "sku": {
+                                "name": "[parameters('botSku')]"
+                            },
+                            "properties": {
+                                "name": "[parameters('botId')]",
+                                "displayName": "[parameters('botId')]",
+                                "endpoint": "[variables('botEndpoint')]",
+                                "msaAppId": "[parameters('appId')]",
+                                "developerAppInsightsApplicationId": null,
+                                "developerAppInsightKey": null,
+                                "publishingCredentials": null,
+                                "storageResourceId": null
+                            },
+                            "dependsOn": [
+                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                            ]
+                        }
+                    ],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 
             var botAnswer = await StartBotConversationAsync();
 
-            Assert.AreEqual($"Turn 1: You sent '{input}'\n", botAnswer);
+            Assert.AreEqual($"Echo: {input}", botAnswer);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                 // Analyze each activity in the activity set.
                 foreach (Activity activity in activities)
                 {
-                    if (activity.Type == ActivityTypes.Message && activity.Text != "conversationUpdate event detected")
+                    if (activity.Type == ActivityTypes.Message && activity.Text != "Welcome to Echo Bot.")
                     {
                         answer = activity.Text;
                     }

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.DirectLine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.DirectLine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.FunctionalTests
+{
+    [TestClass]
+    #if !FUNCTIONALTESTS
+    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
+    #endif
+
+    public class DirectLineClientTests
+    {
+        private static string directLineSecret = null;
+        private static string botId = null;
+        private static string fromUser = "DirectLineClientTestUser";
+        private static string echoGuid = string.Empty;
+        private static string input = $"Testing Azure Bot GUID: ";
+
+        [TestMethod]
+        public async Task SendDirectLineMessage()
+        {
+            GetEnvironmentVars();
+
+            echoGuid = Guid.NewGuid().ToString();
+            input = input + echoGuid;
+
+            var botAnswer = await StartBotConversationAsync();
+
+            Assert.AreEqual($"Turn 1: You sent '{input}'\n", botAnswer);
+        }
+
+        /// <summary>
+        /// Starts a conversation with a bot. Sends a message and waits for the response.
+        /// </summary>
+        /// <returns>Returns the bot's answer.</returns>
+        private static async Task<string> StartBotConversationAsync()
+        {
+            // Create a new Direct Line client.
+            DirectLineClient client = new DirectLineClient(directLineSecret);
+
+            // Start the conversation.
+            var conversation = await client.Conversations.StartConversationAsync();
+
+            // Create a message activity with the input text.
+            Activity userMessage = new Activity
+            {
+                From = new ChannelAccount(fromUser),
+                Text = input,
+                Type = ActivityTypes.Message,
+            };
+
+            // Send the message activity to the bot.
+            await client.Conversations.PostActivityAsync(conversation.ConversationId, userMessage);
+
+            // Read the bot's message.
+            var botAnswer = await ReadBotMessagesAsync(client, conversation.ConversationId);
+
+            return botAnswer;
+        }
+
+        /// <summary>
+        /// Polls the bot continuously until it gets a response.
+        /// </summary>
+        /// <param name="client">The Direct Line client.</param>
+        /// <param name="conversationId">The conversation ID.</param>
+        /// <returns>Returns the bot's answer.</returns>
+        private static async Task<string> ReadBotMessagesAsync(DirectLineClient client, string conversationId)
+        {
+            string watermark = null;
+            string answer = string.Empty;
+
+            // Poll the bot for replies once per second.
+            while (answer.Equals(string.Empty))
+            {
+                // Retrieve the activity sent from the bot.
+                var activitySet = await client.Conversations.GetActivitiesAsync(conversationId, watermark);
+                watermark = activitySet?.Watermark;
+
+                // Extract the activies sent from the bot.
+                var activities = from x in activitySet.Activities
+                                 where x.From.Id == botId
+                                 select x;
+
+                // Analyze each activity in the activity set.
+                foreach (Activity activity in activities)
+                {
+                    if (activity.Type == ActivityTypes.Message && activity.Text != "conversationUpdate event detected")
+                    {
+                        answer = activity.Text;
+                    }
+                }
+
+                // Wait for one second before polling the bot again.
+                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+
+                return answer;
+            }
+
+            return answer;
+        }
+
+        /// <summary>
+        /// Get the values for the environment variables.
+        /// </summary>
+        private void GetEnvironmentVars()
+        {
+            if (string.IsNullOrWhiteSpace(directLineSecret) || string.IsNullOrWhiteSpace(botId))
+            {
+                directLineSecret = Environment.GetEnvironmentVariable("DIRECTLINE");
+                if (string.IsNullOrWhiteSpace(directLineSecret))
+                {
+                    throw new Exception("Environment variable 'DIRECTLINE' not found.");
+                }
+
+                botId = Environment.GetEnvironmentVariable("BOTID");
+                if (string.IsNullOrWhiteSpace(botId))
+                {
+                    throw new Exception("Environment variable 'BOTID' not found.");
+                }
+            }
+        }
+    }
+}

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
   </ItemGroup>
 

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -11,9 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Proposed Changes

Add new **DirectLineClientTests** to _FunctionalTests_ project to test sending a message to an echo bot deployed in Azure with ARM Templates and check its response.
![image](https://user-images.githubusercontent.com/44245136/56241601-aacff280-606c-11e9-89a6-cc726d8b740a.png)
## Steps to configure the Pipeline:
1- Define three environment variables: **AppId**, **AppSecret** and **BotName** and mark the first two as Secrets.
![image](https://user-images.githubusercontent.com/44245136/56324093-454f3500-6144-11e9-8a70-197378003c4e.png)
![image](https://user-images.githubusercontent.com/44245136/56241788-20d45980-606d-11e9-9a2e-6a502575452a.png)
2- Add a **_PowerShell Script Task_** to download the .zip that contains the latest version of the EchoBot Sample.

![image](https://user-images.githubusercontent.com/42191764/56601611-fa18a480-65d1-11e9-8b92-f56dd06ee47c.png)

The script is:
```powershell
$url = "https://dev.botframework.com/api/misc/bottemplateroot"
$output = "$(System.DefaultWorkingDirectory)\FunctionalTests\echoBot.zip"

$partialUrl = Invoke-WebRequest -Uri $url

$cleanUrl = $partialUrl -replace'["]'

$completeUrl = "$($cleanUrl)csharp-abs-webapp-v4_echobot_precompiled.zip"

$wc = New-Object System.Net.WebClient
$wc.DownloadFile($completeUrl, $output)

Expand-Archive $output -DestinationPath $(System.DefaultWorkingDirectory)\FunctionalTests\echoBot\

$slnPath = Get-ChildItem -Path $(System.DefaultWorkingDirectory)\FunctionalTests\echoBot\ -Filter EchoBot.sln -Recurse -Force -ErrorAction SilentlyContinue| select FullName

$folder = Split-Path $slnPath.FullName

Compress-Archive -Path $folder\* -DestinationPath $(System.DefaultWorkingDirectory)\FunctionalTests\SampleEchoBot.zip
```
3- Configure one **_Azure CLI Task_** to:
- Run _az deployment create_ command to **create the resources** in Azure.
- Run _az webapp deployment_ command to **deploy the EchoBot** sample.
- Run _az bot direcline create_ command to **connect the bot to the DirectLine** channel

![image](https://user-images.githubusercontent.com/42191764/56601631-07359380-65d2-11e9-9cb8-f024b07c51e0.png)

The output goes into a json file from where we will recover the channel key later.

The script is:
```powershell
call az deployment create --name "nightly-test-bot" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="nightly-test-bot" groupLocation="westus" newAppServicePlanLocation="westus"

call az webapp deployment source config-zip --resource-group "nightly-test-bot" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\FunctionalTests\SampleEchoBot.zip" 

call az bot directline create -n "$(BotName)" -g "nightly-test-bot" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"
```
4- Add a new **_PowerShell Script Task_** to read the json file generated in the previous step and get the secret key to connect to the bot. It also sets an environment variable with this value.

![image](https://user-images.githubusercontent.com/42191764/56601560-dbb2a900-65d1-11e9-9607-5fedaff7a110.png)

The script is:
```powershell
$json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json

$key = $json.properties.properties.sites.key
$botName = $(BotName)

echo "##vso[task.setvariable variable=DIRECTLINE;]$key"
echo "##vso[task.setvariable variable=BOTID;]$botName"
```
5- After the Tests run, add a new **_Azure CLI Task_** to delete the resource group we've created in the first step.
![image](https://user-images.githubusercontent.com/44245136/56602512-0b62b080-65d4-11e9-8090-d2e0b7e83983.png)
The script is:
```powershell
call az group delete -n "nightly-test-bot" --yes
```

We strongly recommend setting this task to run _Even if a previous task has failed, even if the build was canceled_. With this setting, we will assure that the resources will be deleted from Azure even if the build fails at any step.

After running these steps, the Bot is deployed, tested and deleted.
![image](https://user-images.githubusercontent.com/44245136/56602818-afe4f280-65d4-11e9-8bbd-364734f77635.png)
![image](https://user-images.githubusercontent.com/44245136/56242017-b374f880-606d-11e9-8a55-242d9cbb0f2b.png)