### PR TITLE
Expression: add truthiness feature

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Expressions
             {
                 foreach (var child in expression.Children)
                 {
-                    if (child.ReturnType != ReturnType.Object && !types.Contains(child.ReturnType) && !types.Contains(ReturnType.Object))
+                    if (child.ReturnType != ReturnType.Object && !types.Contains(child.ReturnType))
                     {
                         if (types.Count() == 1)
                         {
@@ -1193,7 +1193,7 @@ namespace Microsoft.Bot.Builder.Expressions
                 new ExpressionEvaluator(ExpressionType.If,
                     Apply(args => IsLogicTrue(args[0]) ? args[1] : args[2]),
                     ReturnType.Object,
-                    (expression) => ValidateArityAndAnyType(expression, 3, 3, ReturnType.Object)),
+                    (expression) => ValidateArityAndAnyType(expression, 3, 3)),
                 new ExpressionEvaluator(ExpressionType.Rand, Apply(args => Randomizer.Next(args[0], args[1]), VerifyInteger),
                     ReturnType.Number, ValidateBinaryNumber),
                 new ExpressionEvaluator(ExpressionType.CreateArray, Apply(args => new List<object>(args)), ReturnType.Object),

--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Expressions
             {
                 foreach (var child in expression.Children)
                 {
-                    if (child.ReturnType != ReturnType.Object && !types.Contains(child.ReturnType))
+                    if (child.ReturnType != ReturnType.Object && !types.Contains(child.ReturnType) && !types.Contains(ReturnType.Object))
                     {
                         if (types.Count() == 1)
                         {
@@ -136,13 +136,6 @@ namespace Microsoft.Bot.Builder.Expressions
         /// <param name="expression">Expression to validate.</param>
         public static void ValidateNumber(Expression expression)
             => ValidateArityAndAnyType(expression, 1, int.MaxValue, ReturnType.Number);
-
-        /// <summary>
-        /// Validate 1 or more boolean arguments.
-        /// </summary>
-        /// <param name="expression">Expression to validate.</param>
-        public static void ValidateBoolean(Expression expression)
-            => ValidateArityAndAnyType(expression, 1, int.MaxValue, ReturnType.Boolean);
 
         /// <summary>
         /// Validate 1 or more string arguments.
@@ -718,6 +711,31 @@ namespace Microsoft.Bot.Builder.Expressions
             return result;
         }
 
+        
+        private static bool IsEmpty(object instance)
+        {
+            if (instance == null) return true;
+            if (instance is string string0) return string.IsNullOrEmpty(string0);
+            if (TryParseList(instance, out IList list)) return list.Count == 0;
+            return instance.GetType().GetProperties().Length == 0;
+        }
+
+        /// <summary>
+        /// Logic True in Logical comparison functions
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <returns></returns>
+        private static bool IsLogicTrue(object instance)
+        {
+            if (instance is bool instanceBool)
+                return instanceBool;
+
+            if (instance.IsNumber())
+                return !(Convert.ToSingle(instance) == 0.0);
+
+            return !IsEmpty(instance);
+        }
+
         private static (object value, string error) And(Expression expression, object state)
         {
             object result = true;
@@ -727,14 +745,13 @@ namespace Microsoft.Bot.Builder.Expressions
                 (result, error) = child.TryEvaluate(state);
                 if (error == null)
                 {
-                    if (!(result is bool bresult))
+                    if (IsLogicTrue(result))
                     {
-                        error = $"{child} is not boolean";
-                        break;
+                        result = true;
                     }
-                    else if (!bresult)
+                    else
                     {
-                        // Hit a false so stop
+                        result = false;
                         break;
                     }
                 }
@@ -755,14 +772,13 @@ namespace Microsoft.Bot.Builder.Expressions
                 (result, error) = child.TryEvaluate(state);
                 if (error == null)
                 {
-                    if (!(result is bool bresult))
+                    if (!IsLogicTrue(result))
                     {
-                        error = $"{child} is not boolean";
-                        break;
+                        result = false;
                     }
-                    else if (bresult)
+                    else
                     {
-                        // Hit a true so stop
+                        result = true;
                         break;
                     }
                 }
@@ -1011,9 +1027,9 @@ namespace Microsoft.Bot.Builder.Expressions
                 Comparison(ExpressionType.GreaterThan, args => args[0] > args[1]),
                 Comparison(ExpressionType.GreaterThanOrEqual, args => args[0] >= args[1]),
                 new ExpressionEvaluator(ExpressionType.Exists, Apply(args => args[0] != null), ReturnType.Boolean, ValidateUnary),
-                new ExpressionEvaluator(ExpressionType.And, (expression, state) => And(expression, state), ReturnType.Boolean, ValidateBoolean),
-                new ExpressionEvaluator(ExpressionType.Or, (expression, state) => Or(expression, state), ReturnType.Boolean, ValidateBoolean),
-                new ExpressionEvaluator(ExpressionType.Not, Apply(args => !args[0], VerifyBoolean), ReturnType.Boolean, ValidateUnaryBoolean),
+                new ExpressionEvaluator(ExpressionType.And, (expression, state) => And(expression, state), ReturnType.Boolean),
+                new ExpressionEvaluator(ExpressionType.Or, (expression, state) => Or(expression, state), ReturnType.Boolean),
+                new ExpressionEvaluator(ExpressionType.Not, Apply(args => !IsLogicTrue(args[0])), ReturnType.Boolean, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Contains, Apply(args =>
                     {
                         if (args[0] is string string0 && args[1] is string string1)
@@ -1036,13 +1052,7 @@ namespace Microsoft.Bot.Builder.Expressions
 
                         return false;
                     }), ReturnType.Boolean, ValidateBinary),
-                new ExpressionEvaluator(ExpressionType.Empty, Apply(args =>
-                    {
-                        if (args[0] == null) return true;
-                        if (args[0] is string string0) return string.IsNullOrEmpty(string0);
-                        if (TryParseList(args[0], out IList list)) return list.Count == 0;
-                        return args[0].GetType().GetProperties().Length == 0;
-                    }), ReturnType.Boolean, ValidateUnary), 
+                new ExpressionEvaluator(ExpressionType.Empty, Apply(args => IsEmpty(args[0])), ReturnType.Boolean, ValidateUnary), 
 
                 // String
                 new ExpressionEvaluator(ExpressionType.Concat, Apply(args =>
@@ -1175,15 +1185,15 @@ namespace Microsoft.Bot.Builder.Expressions
                 new ExpressionEvaluator(ExpressionType.Int, Apply(args => (float)Convert.ToSingle(args[0])), ReturnType.Number, ValidateUnary),
                 // TODO: Is this really the best way?
                 new ExpressionEvaluator(ExpressionType.String, Apply(args => JsonConvert.SerializeObject(args[0]).TrimStart('"').TrimEnd('"')), ReturnType.String, ValidateUnary),
-                new ExpressionEvaluator(ExpressionType.Bool, Apply(args => Convert.ToBoolean(args[0])), ReturnType.Boolean, ValidateUnary),
+                new ExpressionEvaluator(ExpressionType.Bool, Apply(args => IsLogicTrue(args[0])), ReturnType.Boolean, ValidateUnary),
             
                 // Misc
                 new ExpressionEvaluator(ExpressionType.Accessor, Accessor, ReturnType.Object, ValidateAccessor),
                 new ExpressionEvaluator(ExpressionType.Property, Property, ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
                 new ExpressionEvaluator(ExpressionType.If,
-                    Apply(args => args[0] ? args[1] : args[2]),
+                    Apply(args => IsLogicTrue(args[0]) ? args[1] : args[2]),
                     ReturnType.Object,
-                    (expr) => ValidateOrder(expr, null, ReturnType.Boolean, ReturnType.Object, ReturnType.Object)),
+                    (expression) => ValidateArityAndAnyType(expression, 3, 3, ReturnType.Object)),
                 new ExpressionEvaluator(ExpressionType.Rand, Apply(args => Randomizer.Next(args[0], args[1]), VerifyInteger),
                     ReturnType.Number, ValidateBinaryNumber),
                 new ExpressionEvaluator(ExpressionType.CreateArray, Apply(args => new List<object>(args)), ReturnType.Object),

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/BadExpressionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/BadExpressionTests.cs
@@ -69,9 +69,6 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("'1' / 2"), // params should be number
             Test("'1' % 2"), // params should be number
             Test("'1' ^ 2"), // params should be number
-            Test("'1' && true"), // params should be boolean
-            Test("'1' || true"), // params should be boolean
-            Test("!'1'"), // params should be boolean
             Test("items >= 1"), // params should be number or string
             Test("items <= 1"), // params should be number or string
             Test("'string'&one"), // $ can only accept string parameter
@@ -105,7 +102,6 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             # endregion
 
             # region Logical comparison functions test
-            Test("and(one, hello, one < two)"), //one and hello are not bool type
             Test("greater(one, hello)"), // string and integer are not comparable
             Test("greater(one)"), // greater need two parameters
             Test("greaterOrEquals(one, hello)"), // string and integer are not comparable
@@ -114,15 +110,10 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("less(one)"), // function need two parameters
             Test("lessOrEquals(one, hello)"), // string and integer are not comparable
             Test("lessOrEquals(one)"), // function need two parameters
-            Test("not(hello)"), // not can only accept bool parameter
             Test("equals(one)"), // equals must accept two parameters
             Test("exists(1, 2)"), // function need one parameter
-            Test("if(hello, 'r1', 'r2')"), // the first parameter of the if must be bool
             //Test("if(!exists(one), one, hello)"), // the second and third parameters of if must the same type
-            //Test("or(hello == 'hello')"), // or function needs two parameters
-            Test("or(hello, one)"), // or function only accept bool parameters
             Test("not(false, one)"), // function need one parameter
-            Test("not(1)"), //accept boolean param
             # endregion
 
             # region Conversion functions test
@@ -131,7 +122,6 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("int(hello)"), // param shoud be int format string
             Test("int(1, 1)"), // shold have 1 param
             Test("string(hello, 1)"), // shold have 1 param
-            Test("bool(hello)"), // param shoud be float format string
             Test("bool(false, 1)"), // shold have 1 param
             # endregion
 

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -123,6 +123,13 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("'string'&'builder'","stringbuilder"),
             Test("\"string\"&\"builder\"","stringbuilder"),
             Test("one > 0.5 && two < 2.5", true, oneTwo),
+            Test("float(5.5) && float(0.0)", false),
+            Test("hello && \"hello\"", true),
+            Test("items || ((2 + 2) <= (4 - 1))", true), // true || false
+            Test("0 || false", false), // false || false
+            Test("!(hello)", false), // false
+            Test("!(10)", false),
+            Test("!(0)", true),
             Test("one > 0.5 || two < 1.5", true, oneTwo),
             Test("0/3", 0),
             # endregion
@@ -203,6 +210,17 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("not(one == 1.0)", false, new HashSet<string> {"one" }),
             Test("not(not(one == 1.0))", true, new HashSet<string> {"one" }),
             Test("not(false)", true),
+            Test("and(one > 0.5, two < 2.5)", true, oneTwo),
+            Test("and(float(5.5), float(0.0))", false),
+            Test("and(hello, \"hello\")", true),
+            Test("or(items, (2 + 2) <= (4 - 1))", true), // true || false
+            Test("or(0, false)", false), // false || false
+            Test("not(hello)", false), // false
+            Test("not(10)", false),
+            Test("not(0)", true),
+            Test("if(hello, 'r1', 'r2')", "r1"),
+            Test("if(0, 'r1', 'r2')", "r2"),
+            Test("if(10, 'r1', 'r2')", "r1"),
             # endregion
 
             # region  Conversion functions test
@@ -215,10 +233,10 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("string(bag.set)", "{\"four\":4.0}"),
             Test("bool(1)", true),
             Test("bool(0)", false),
-            Test("bool('false')", false),
-            Test("bool('true')", true),
+            Test("bool('false')", true), // we make it true, because it is not empty
+            Test("bool('hi')", true),
             Test("createArray('h', 'e', 'l', 'l', 'o')", new List<object>{"h", "e", "l", "l", "o" }),
-            Test("createArray(1, bool('false'), string(bool(1)), float('10'))", new List<object>{1, false, "true", 10.0f }),
+            Test("createArray(1, bool(0), string(bool(1)), float('10'))", new List<object>{1, false, "true", 10.0f }),
             # endregion
 
             # region  Math functions test


### PR DESCRIPTION
support such expression:
'a' || 'b' -> true
'a'&& 'b' -> true
not('hi') -> false
if('a', 1, 2) -> 1

In logical comparison functions(or, and, not, if) and operators(||, &&, !) , to support non boolean type.
for below case, false will return:

original value for boolean
0 for number,
null or empty for string,
0 count for list,
0 property for other format(JObject, dynamic)