### PR TITLE
cleanup startup.cs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebugAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebugAdapter.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             this.model = model ?? new DataModel(coercion ?? new Coercion());
             this.registry = registry ?? throw new ArgumentNullException(nameof(registry));
             this.breakpoints = breakpoints ?? throw new ArgumentNullException(nameof(breakpoints));
-            this.terminate = terminate ?? throw new ArgumentNullException(nameof(terminate));
+            this.terminate = terminate ?? new Action(() => Environment.Exit(0));
             this.task = ListenAsync(new IPEndPoint(IPAddress.Any, port), cancellationToken.Token);
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingAdapterExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging
+{
+    public static class DebbugingBotAdapterExtensions
+    {
+        /// <summary>
+        /// Enable Debug Adapter Protocol for the running adapter.
+        /// </summary>
+        /// <param name="botAdapter">BotAdapter to enable</param>
+        /// <param name="port">port to listen on</param>
+        /// <param name="registry">IRegistry to use (default will be SourceMap())</param>
+        /// <param name="breakpoints">IBreakpoints to use (default will be SourceMap())</param>
+        /// <param name="terminate">Termination function (Default is Environment.Exit()</param>
+        /// <param name="logger">ILogger to use (Default is NullLogger)</param>
+        /// <param name="model">IDataModel to use (default is internal implmentation)</param>
+        /// <param name="coercion">ICoercion to use (default is internal implmentation)</param>
+        /// <returns></returns>
+        public static BotAdapter UseDebugger(this BotAdapter botAdapter, int port, Source.IRegistry registry = null, IBreakpoints breakpoints = null, Action terminate = null, IDataModel model = null, ILogger logger = null, ICoercion coercion = null)
+        {
+            var sourceMap = new SourceMap();
+            DebugSupport.SourceRegistry = registry ?? sourceMap;
+            return botAdapter.Use(new DebugAdapter(port: port, 
+                registry: registry ?? sourceMap, 
+                breakpoints: breakpoints ?? registry as IBreakpoints ?? sourceMap, 
+                terminate: terminate, 
+                model: model, 
+                logger: logger));
+        }
+
+
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/DeclarativeAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/DeclarativeAdapterExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
+
+namespace Microsoft.Bot.Builder.Dialogs.Declarative
+{
+    public static class DeclarativeAdapterExtensions
+    {
+        /// <summary>
+        /// Register ResourceExplorer and optionally register more types
+        /// </summary>
+        /// <param name="botAdapter">BotAdapter to add middleware to</param>
+        /// <param name="resourceExplorer">resourceExplorer to use</param>
+        /// <param name="registerCustomTypes">function to add custom types</param>
+        /// <returns></returns>
+        public static BotAdapter UseResourceExplorer(this BotAdapter botAdapter, ResourceExplorer resourceExplorer, Action registerCustomTypes = null)
+        {
+            TypeFactory.RegisterAdaptiveTypes();
+
+            if (resourceExplorer == null)
+            {
+                throw new ArgumentNullException(nameof(resourceExplorer));
+            }
+
+            if (registerCustomTypes != null)
+            {
+                registerCustomTypes();
+            }
+
+            return botAdapter.Use(new RegisterClassMiddleware<ResourceExplorer>(resourceExplorer));
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/LGAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/LGAdapterExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    public static class LGAdapterExtensions
+    {
+        /// <summary>
+        /// Register ILanguageGenerator (and optional IMessageActivityGenerator) will be used by all template binding classes
+        /// </summary>
+        /// <param name="botAdapter">BotAdapter</param>
+        /// <param name="languageGenerator">ILanguageGenerator implementation</param>
+        /// <param name="messageGenerator">IMessageActivityGenerator implementation (default is TextMessageActivityGenerator(languageGenerator)</param>
+        /// <returns></returns>
+        public static BotAdapter UseLanguageGenerator(this BotAdapter botAdapter, ILanguageGenerator languageGenerator, IMessageActivityGenerator messageGenerator = null)
+        {
+            return botAdapter.Use(new RegisterClassMiddleware<ILanguageGenerator>(languageGenerator))
+                    .Use(new RegisterClassMiddleware<IMessageActivityGenerator>(new TextMessageActivityGenerator(languageGenerator)));
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/AdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/AdapterExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="conversationState">ConversationState to use (default is new ConversationState (registered storage))</param>
         /// <param name="auto">automatically manage state (default is true), if set to false, it is your responsibility to load and save state</param>
         /// <returns>Botadapter</returns>
-        public static BotAdapter UseState(this BotAdapter botAdapter, UserState userState = null, ConversationState conversationState = null, bool auto=true)
+        public static BotAdapter UseState(this BotAdapter botAdapter, UserState userState, ConversationState conversationState, bool auto = true)
         {
             if (botAdapter == null)
             {

--- a/libraries/Microsoft.Bot.Builder/AdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/AdapterExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Bot.Builder
+{
+    public static class AdapterExtensions
+    {
+        /// <summary>
+        /// Register storage with the adapter so that is available via TurnContext.Get&lt;IStorage&gt;().
+        /// </summary>
+        /// <param name="botAdapter">bot adapter to register storage with</param>
+        /// <param name="storage">IStorage implementation to register</param>
+        /// <returns>bot adapter</returns>
+        public static BotAdapter UseStorage(this BotAdapter botAdapter, IStorage storage)
+        {
+            return botAdapter.Use(new RegisterClassMiddleware<IStorage>(storage));
+        }
+
+        /// <summary>
+        /// Register UserState and ConversationState objects so they are accessible via TurnContext.Get&lt;UserState&gt() and add auto save middleware.
+        /// </summary>
+        /// <param name="botAdapter">bot adapater to add save state to</param>
+        /// <param name="userState">UserState to use (default is new UserState(registered storage))</param>
+        /// <param name="conversationState">ConversationState to use (default is new ConversationState (registered storage))</param>
+        /// <param name="auto">automatically manage state (default is true), if set to false, it is your responsibility to load and save state</param>
+        /// <returns>Botadapter</returns>
+        public static BotAdapter UseState(this BotAdapter botAdapter, UserState userState = null, ConversationState conversationState = null, bool auto=true)
+        {
+            if (botAdapter == null)
+            {
+                throw new ArgumentNullException(nameof(botAdapter));
+            }
+
+            if (userState == null || conversationState == null)
+            {
+                var storageMiddleware = botAdapter.MiddlewareSet.Where(mw => mw is RegisterClassMiddleware<IStorage>).Cast<RegisterClassMiddleware<IStorage>>().FirstOrDefault();
+                if (storageMiddleware == null)
+                {
+                    throw new ArgumentNullException("There is no IStorage registered in the middleware");
+                }
+
+                if (userState == null)
+                {
+                    var userStateMiddleware = botAdapter.MiddlewareSet.Where(mw => mw is RegisterClassMiddleware<UserState>).Cast<RegisterClassMiddleware<UserState>>().FirstOrDefault();
+                    if (userStateMiddleware != null)
+                    {
+                        userState = userStateMiddleware.Service;
+                    }
+                    else
+                    {
+                        userState = new UserState(storageMiddleware.Service);
+                        botAdapter.Use(new RegisterClassMiddleware<UserState>(userState));
+                    }
+                }
+
+                if (conversationState == null)
+                {
+                    var conversationStateMiddleware = botAdapter.MiddlewareSet.Where(mw => mw is RegisterClassMiddleware<ConversationState>).Cast<RegisterClassMiddleware<ConversationState>>().FirstOrDefault();
+                    if (conversationStateMiddleware != null)
+                    {
+                        conversationState = conversationStateMiddleware.Service;
+                    }
+                    else
+                    {
+                        conversationState = new ConversationState(storageMiddleware.Service);
+                        botAdapter.Use(new RegisterClassMiddleware<ConversationState>(conversationState));
+                    }
+                }
+            }
+
+            if (auto)
+            {
+                return botAdapter.Use(new AutoSaveStateMiddleware(userState, conversationState));
+            }
+
+            return botAdapter;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotAdapter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder
         /// Gets the collection of middleware in the adapter's pipeline.
         /// </summary>
         /// <value>The middleware collection for the pipeline.</value>
-        protected MiddlewareSet MiddlewareSet { get; } = new MiddlewareSet();
+        public MiddlewareSet MiddlewareSet { get; } = new MiddlewareSet();
 
         /// <summary>
         /// Adds middleware to the adapter's pipeline.

--- a/libraries/Microsoft.Bot.Builder/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder/MiddlewareSet.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +12,7 @@ namespace Microsoft.Bot.Builder
     /// <summary>
     /// Contains an ordered set of <see cref="IMiddleware"/>.
     /// </summary>
-    public class MiddlewareSet : IMiddleware
+    public class MiddlewareSet : IMiddleware, IEnumerable<IMiddleware>
     {
         private readonly IList<IMiddleware> _middleware = new List<IMiddleware>();
 
@@ -81,6 +82,16 @@ namespace Microsoft.Bot.Builder
                 turnContext,
                 (ct) => ReceiveActivityInternalAsync(turnContext, callback, nextMiddlewareIndex + 1, ct),
                 cancellationToken);
+        }
+
+        public IEnumerator<IMiddleware> GetEnumerator()
+        {
+            return this._middleware.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this._middleware.GetEnumerator();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/RegisterClassMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/RegisterClassMiddleware.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder
     public class RegisterClassMiddleware<T> : IMiddleware
         where T : class
     {
-        private T service;
+        public T Service { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegisterClassMiddleware{T}"/> class.
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="service">The service instance to register.</param>
         public RegisterClassMiddleware(T service)
         {
-            this.service = service;
+            this.Service = service;
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             // Register service
-            turnContext.TurnState.Add(this.service);
+            turnContext.TurnState.Add(this.Service);
             await nextTurn(cancellationToken).ConfigureAwait(false);
         }
     }

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Controllers/BotController.cs
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Controllers/BotController.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// Generated with Bot Builder V4 SDK Template for Visual Studio EchoBot v4.3.0
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace Microsoft.Bot.Builder.TestBot.Json
+{
+    // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
+    // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
+    // achieved by specifying a more specific type for the bot constructor argument.
+    [Route("api/messages")]
+    [ApiController]
+    public class BotController : ControllerBase
+    {
+        private readonly IBotFrameworkHttpAdapter Adapter;
+        private readonly IBot Bot;
+
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        {
+            Adapter = adapter;
+            Bot = bot;
+        }
+
+        [HttpPost]
+        public async Task PostAsync()
+        {
+            // Delegate the processing of the HTTP POST to the adapter.
+            // The adapter will invoke the bot.
+            await Adapter.ProcessAsync(Request, Response, Bot);
+        }
+    }
+}

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -1,64 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>ade3d9c2-1633-4922-89e5-a4a50ccb3bc8</UserSecretsId>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="CustomSteps\Testbot.CalculateDogYears.schema" />
-    <None Remove="CustomSteps\Testbot.CSharpStep.schema" />
-    <None Remove="CustomSteps\Testbot.JavascriptStep.schema" />
-    <None Remove="en-us.lg" />
-    <None Remove="main.dialog" />
-    <None Remove="Samples\02 - EndTurn\EndTurn.main.dialog" />
-    <None Remove="Samples\03 - IfCondition\IfCondition.main.dialog" />
-    <None Remove="Samples\05 - WelcomeRule\WelcomeRule.main.dialog" />
-    <None Remove="Samples\06 - DoSteps\DoSteps.main.dialog" />
-    <None Remove="Samples\07 - BeginDialog\BeginDialog.FortuneTellerDialog.dialog" />
-    <None Remove="Samples\07 - BeginDialog\BeginDialog.main.dialog" />
-    <None Remove="Samples\07 - BeginDialog\BeginDialog.TellJokeDialog.dialog" />
-    <None Remove="Samples\08 - ExternalLanguage\ExternalLanguage - Copy.main.lg" />
-    <None Remove="Samples\08 - ExternalLanguage\ExternalLanguage.main.dialog" />
-    <None Remove="Samples\08 - ExternalLanguage\ExternalLanguage.main.lg" />
-    <None Remove="Samples\08 - ExternalLanguage\FortuneTellerDialog.dialog" />
-    <None Remove="Samples\08 - ExternalLanguage\TellJokeDialog.dialog" />
-    <None Remove="Samples\09 - EndDialog\EndDialog.main.dialog" />
-    <None Remove="Samples\CalendarBot\Service\MSGraph\UpdateMeetingService.dialog" />
-    <None Remove="Samples\EmailBot\Service\MSGraph\ForwardEmails.dialog" />
-    <None Remove="Samples\EmailBot\Service\MSGraph\ReplyEmails.dialog" />
-    <None Remove="Samples\RootDialog\RootDialog.lg" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <_ContentIncludedByDefault Remove="Samples\04 - TextInput\TextInput.main.dialog" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Samples\CalendarBot\Service\MSGraph\UpdateMeetingService.dialog" />
-    <Content Include="CustomSteps\Testbot.CalculateDogYears.schema" />
-    <Content Include="CustomSteps\Testbot.CSharpStep.schema" />
-    <Content Include="CustomSteps\Testbot.JavascriptStep.schema" />
-    <Content Include="Samples\RootDialog\RootDialog.lg" />
-    <Content Include="Samples\RootDialog\RootDialog.main.dialog" />
-    <Content Include="Samples\08 - ExternalLanguage\ExternalLanguage.main.lg" />
-    <Content Include="Samples\08 - ExternalLanguage\ExternalLanguage.main.dialog" />
-    <Content Include="Samples\07 - BeginDialog\BeginDialog.FortuneTellerDialog.dialog" />
-    <Content Include="Samples\07 - BeginDialog\BeginDialog.TellJokeDialog.dialog" />
-    <Content Include="Samples\07 - BeginDialog\BeginDialog.main.dialog" />
-    <Content Include="Samples\06 - DoSteps\DoSteps.main.dialog" />
-    <Content Include="Samples\05 - WelcomeRule\WelcomeRule.main.dialog" />
-    <Content Include="Samples\03 - IfCondition\IfCondition.main.dialog" />
-    <Content Include="Samples\02 - EndTurn\EndTurn.main.dialog" />
-    <Content Include="Samples\09 - EndDialog\EndDialog.main.dialog" />
-
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Jurassic" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.1.0-beta1-final" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Startup.cs
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Startup.cs
@@ -2,29 +2,22 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.LanguageGeneration.Renderer;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
-using Microsoft.Bot.Builder.Integration;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Schema;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Debug;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
 
 namespace Microsoft.Bot.Builder.TestBot.Json
 {
@@ -34,17 +27,6 @@ namespace Microsoft.Bot.Builder.TestBot.Json
         {
             this.HostingEnvironment = env;
             this.Configuration = configuration;
-
-            // set the configuration for types
-            TypeFactory.Configuration = this.Configuration;
-
-            // register adaptive library types
-            TypeFactory.RegisterAdaptiveTypes();
-
-            // register custom types
-            TypeFactory.Register("Testbot.CalculateDogYears", typeof(CalculateDogYears));
-            TypeFactory.Register("Testbot.JavascriptStep", typeof(JavascriptStep));
-            TypeFactory.Register("Testbot.CSharpStep", typeof(CSharpStep));
         }
 
         public IHostingEnvironment HostingEnvironment { get; }
@@ -54,58 +36,49 @@ namespace Microsoft.Bot.Builder.TestBot.Json
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                TelemetryConfiguration.Active.DisableTelemetry = true;
-            }
-            
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+
             services.AddSingleton<IConfiguration>(this.Configuration);
 
-            IStorage dataStore = new MemoryStorage();
-            var userState = new UserState(dataStore);
-            var conversationState = new ConversationState(dataStore);
+            // Create the credential provider to be used with the Bot Framework Adapter.
+            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
 
-            // manage all bot resources
+            IStorage storage = new MemoryStorage();
+            var userState = new UserState(storage);
+            var conversationState = new ConversationState(storage);
             var resourceExplorer = ResourceExplorer
-                .LoadProject(HostingEnvironment.ContentRootPath, ignoreFolders: new string[] { "models" });
+                .LoadProject(HostingEnvironment.ContentRootPath);
+            
+            // TODO get rid of this dependency
+            TypeFactory.Configuration = this.Configuration;
 
-            // add LuisRecognizer .dialog files for current environment/authoringRegion
-
-            services.AddBot<IBot>(
-                (IServiceProvider sp) =>
-                {
-                    // declarative Adaptive dialogs bot sample
-                    return new TestBot(userState, conversationState, resourceExplorer, DebugSupport.SourceRegistry);
-
-                    // LG bot sample
-                    // return new TestBotLG(accessors);
-                },
-                (BotFrameworkOptions options) =>
-                {
-                    options.OnTurnError = async (turnContext, exception) =>
+            // set up bot framework runtime environment (Aka the adapter)
+            services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>((s) =>
+            {
+                var adapter = new BotFrameworkHttpAdapter();
+                adapter
+                    .UseStorage(storage)
+                    .UseState()
+                    .UseResourceExplorer(resourceExplorer, () =>
                     {
-                        await conversationState.ClearStateAsync(turnContext);
-                        await conversationState.SaveChangesAsync(turnContext);
-                    };
+                        TypeFactory.Register("Testbot.CalculateDogYears", typeof(CalculateDogYears));
+                        TypeFactory.Register("Testbot.JavascriptStep", typeof(JavascriptStep));
+                        TypeFactory.Register("Testbot.CSharpStep", typeof(CSharpStep));
+                    })
+                    .UseLanguageGenerator(new LGLanguageGenerator(resourceExplorer))
+                    .UseDebugger(Configuration.GetValue<int>("debugport", 4712));
 
-                    options.CredentialProvider = new SimpleCredentialProvider(this.Configuration["AppId"], this.Configuration["AppPassword"]);
-                    options.Middleware.Add(new RegisterClassMiddleware<IStorage>(dataStore));
-                    options.Middleware.Add(new RegisterClassMiddleware<ResourceExplorer>(resourceExplorer));
-                    var lg = new LGLanguageGenerator(resourceExplorer);
-                    options.Middleware.Add(new RegisterClassMiddleware<ILanguageGenerator>(lg));
-                    options.Middleware.Add(new RegisterClassMiddleware<IMessageActivityGenerator>(new TextMessageActivityGenerator(lg)));
-                    options.Middleware.Add(new IgnoreConversationUpdateForBotMiddleware());
-                    options.Middleware.Add(new AutoSaveStateMiddleware(conversationState));
-                    
-                    // hook up debugging support
-                    bool enableDebugger = true;
-                    if (enableDebugger)
-                    {
-                        var sourceMap = new SourceMap();
-                        DebugSupport.SourceRegistry = sourceMap;
-                        options.Middleware.Add(new DebugAdapter(Configuration.GetValue<int>("debugport", 4712), sourceMap, sourceMap, () => Environment.Exit(0), logger: new DebugLogger(nameof(DebugAdapter))));
-                    }
-                });
+                adapter.OnTurnError = async (turnContext, exception) =>
+                {
+                    await turnContext.SendActivityAsync(exception.Message).ConfigureAwait(false);
+
+                    await conversationState.ClearStateAsync(turnContext).ConfigureAwait(false);
+                    await conversationState.SaveChangesAsync(turnContext).ConfigureAwait(false);
+                };
+                return adapter;
+            });
+
+            services.AddSingleton<IBot, TestBot>((sp) => new TestBot(conversationState, resourceExplorer, DebugSupport.SourceRegistry));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -115,28 +88,17 @@ namespace Microsoft.Bot.Builder.TestBot.Json
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            app.UseDefaultFiles()
-                .UseStaticFiles()
-                .UseBotFramework();
-            app.UseExceptionHandler();
-        }
-    }
-}
-
-public class IgnoreConversationUpdateForBotMiddleware : IMiddleware
-{
-    public Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
-    {
-        if (turnContext.Activity.Type == ActivityTypes.ConversationUpdate)
-        {
-            var cu = turnContext.Activity.AsConversationUpdateActivity();
-            if (!cu.MembersAdded.Any(ma => ma.Id != cu.Recipient.Id))
+            else
             {
-                // eat it if it is the bot
-                return Task.CompletedTask;
+                app.UseHsts();
             }
+
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            //app.UseHttpsRedirection();
+            app.UseMvc();
         }
-        return next(cancellationToken);
     }
 }
+

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Startup.cs
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Startup.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.TestBot.Json
                 var adapter = new BotFrameworkHttpAdapter();
                 adapter
                     .UseStorage(storage)
-                    .UseState()
+                    .UseState(userState, conversationState)
                     .UseResourceExplorer(resourceExplorer, () =>
                     {
                         TypeFactory.Register("Testbot.CalculateDogYears", typeof(CalculateDogYears));

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/TestBot.cs
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/TestBot.cs
@@ -17,50 +17,37 @@ using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Expressions.Parser;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Recognizers.Text;
-using Newtonsoft.Json;
-
+using static Microsoft.Bot.Builder.Dialogs.Debugging.Source;
 
 namespace Microsoft.Bot.Builder.TestBot.Json
 {
     public class TestBot : IBot
     {
         private DialogSet _dialogs;
-
         private IDialog rootDialog;
-
         private readonly ResourceExplorer resourceExplorer;
 
-        private UserState userState;
-        private ConversationState conversationState;
-        private IStatePropertyAccessor<DialogState> dialogState;
-
-        private Source.IRegistry registry;
-
-        public TestBot(UserState userState, ConversationState conversationState, ResourceExplorer resourceExplorer, Source.IRegistry registry)
+        public TestBot(ConversationState conversationState, ResourceExplorer resourceExplorer, Source.IRegistry registry = null)
         {
-            dialogState = conversationState.CreateProperty<DialogState>("DialogState");
+            _dialogs = new DialogSet(conversationState.CreateProperty<DialogState>("DialogState"));
 
-            this.registry = registry;
             this.resourceExplorer = resourceExplorer;
-            
+            registry = registry ?? NullRegistry.Instance;
+
             // auto reload dialogs when file changes
-            this.resourceExplorer.Changed += ResourceExplorer_Changed;
-
-            LoadRootDialogAsync();
-        }
-
-        private void ResourceExplorer_Changed(string[] paths)
-        {
-            if (paths.Any(p => Path.GetExtension(p) == ".dialog"))
+            this.resourceExplorer.Changed += (paths) =>
             {
-                Task.Run(() => this.LoadRootDialogAsync());
-            }
+                if (paths.Any(p => Path.GetExtension(p) == ".dialog"))
+                {
+                    Task.Run(() => this.LoadRootDialogAsync(registry));
+                }
+            };
+
+            LoadRootDialogAsync(registry);
         }
 
         
-        private void LoadRootDialogAsync()
+        private void LoadRootDialogAsync(IRegistry registry)
         {
             System.Diagnostics.Trace.TraceInformation("Loading resources...");
             //var rootFile = resourceExplorer.GetResource(@"VARootDialog.main.dialog");
@@ -79,7 +66,6 @@ namespace Microsoft.Bot.Builder.TestBot.Json
             rootDialog = DeclarativeTypeLoader.Load<IDialog>(rootFile, resourceExplorer, registry);
             //rootDialog = LoadCodeDialog();
 
-            _dialogs = new DialogSet(this.dialogState);
             _dialogs.Add(rootDialog);
 
             System.Diagnostics.Trace.TraceInformation("Done loading resources.");


### PR DESCRIPTION
- moved off 4.2 pattern to new MVC controller pattern
- Cleaned up startup.cs 
     - added extensions to BotAdapter so we could reduce the amount of "magic" middleware that need to be added.
    - Removed the amount of dependency injected stuff (people can easily refactor to use more dependency injection if they want)

startup.cs basically looks like this now:
```c#
IStorage storage = new MemoryStorage();
var userState = new UserState(storage);
var conversationState = new ConversationState(storage);
var resourceExplorer = ResourceExplorer
    .LoadProject(HostingEnvironment.ContentRootPath);

// TODO get rid of this dependency
TypeFactory.Configuration = this.Configuration;

// set up bot framework runtime environment (Aka the adapter)
services.AddSingleton<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>((s) =>
{
    var adapter = new BotFrameworkHttpAdapter();
    adapter
        .UseStorage(storage)
        .UseState(userState, conversationState)
        .UseResourceExplorer(resourceExplorer, () =>
        {
            TypeFactory.Register("Testbot.CalculateDogYears", typeof(CalculateDogYears));
            TypeFactory.Register("Testbot.JavascriptStep", typeof(JavascriptStep));
            TypeFactory.Register("Testbot.CSharpStep", typeof(CSharpStep));
        })
        .UseLanguageGenerator(new LGLanguageGenerator(resourceExplorer))
        .UseDebugger(Configuration.GetValue<int>("debugport", 4712));

    adapter.OnTurnError = async (turnContext, exception) =>
    {
        await turnContext.SendActivityAsync(exception.Message).ConfigureAwait(false);

        await conversationState.ClearStateAsync(turnContext).ConfigureAwait(false);
        await conversationState.SaveChangesAsync(turnContext).ConfigureAwait(false);
    };
    return adapter;
});

services.AddSingleton<IBot, TestBot>((sp) => new TestBot(conversationState, resourceExplorer, DebugSupport.SourceRegistry));
```
