### PR TITLE
Move negation into ExpressionEvaluator

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.TriggerTrees/Trigger.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.TriggerTrees/Trigger.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Bot.Builder.AI.TriggerTrees
         /// </summary>
         public Expression OriginalExpression;
 
-        private TriggerTree _tree;
-        private IEnumerable<Quantifier> _quantifiers;
+        private readonly TriggerTree _tree;
+        private readonly IEnumerable<Quantifier> _quantifiers;
         private List<Clause> _clauses;
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.AI.TriggerTrees
             _quantifiers = quantifiers;
             if (expression != null)
             {
-                var normalForm = expression.PushDownNot(new HashSet<string> { "optional", "ignore" });
+                var normalForm = expression.PushDownNot();
                 _clauses = GenerateClauses(normalForm).ToList();
                 RemoveDuplicatedPredicates();
                 OptimizeClauses();

--- a/libraries/Microsoft.Bot.Builder.AI.TriggerTrees/TriggerTree.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.TriggerTrees/TriggerTree.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Bot.Builder.AI.TriggerTrees
             if (type == Optional || type == Ignore)
             {
                 eval = new ExpressionEvaluator(type, null, ReturnType.Boolean, BuiltInFunctions.ValidateUnaryBoolean);
+                eval.Negation = eval;
             }
             else 
             {
@@ -108,7 +109,7 @@ namespace Microsoft.Bot.Builder.AI.TriggerTrees
             return eval;
         }
 
-        private static IExpressionParser _parser = new ExpressionEngine(LookupFunction);
+        private static readonly IExpressionParser _parser = new ExpressionEngine(LookupFunction);
 
         public static Expression Parse(string expr) => _parser.Parse(expr);
 
@@ -230,16 +231,6 @@ namespace Microsoft.Bot.Builder.AI.TriggerTrees
             {
                 GenerateGraph(output, child, indent + 2);
             }
-        }
-
-        private static void IWrite(StreamWriter writer, params string[] strings)
-        {
-            writer.Write("  ");
-            foreach (var str in strings)
-            {
-                writer.Write(str);
-            }
-            writer.WriteLine();
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Bot.Builder.Expressions
         public static ExpressionEvaluator Comparison(string type, Func<IReadOnlyList<dynamic>, bool> function, ValidateExpressionDelegate validator, VerifyExpression verify = null)
             => new ExpressionEvaluator(type, (expression, state) =>
             {
-                bool result = false;
+                var result = false;
                 string error = null;
                 IReadOnlyList<dynamic> args;
                 (args, error) = EvaluateChildren(expression, state, verify);
@@ -1276,7 +1276,7 @@ namespace Microsoft.Bot.Builder.Expressions
                 // Misc
                 new ExpressionEvaluator(ExpressionType.Accessor, Accessor, ReturnType.Object, ValidateAccessor),
                 new ExpressionEvaluator(ExpressionType.Property, Property, ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
-                new ExpressionEvaluator(ExpressionType.If, (expression, state) => If(expression, state), 
+                new ExpressionEvaluator(ExpressionType.If, (expression, state) => If(expression, state),
                     ReturnType.Object, (expression) => ValidateArityAndAnyType(expression, 3, 3)),
                 new ExpressionEvaluator(ExpressionType.Rand, Apply(args => Randomizer.Next(args[0], args[1]), VerifyInteger),
                     ReturnType.Number, ValidateBinaryNumber),
@@ -1311,14 +1311,19 @@ namespace Microsoft.Bot.Builder.Expressions
                 new ExpressionEvaluator(ExpressionType.Foreach, Foreach, ReturnType.Object, ValidateForeach),
             };
 
-        var lookup = new Dictionary<string, ExpressionEvaluator>();
+            var lookup = new Dictionary<string, ExpressionEvaluator>();
             foreach (var function in functions)
             {
                 lookup.Add(function.Type, function);
             }
 
-    // Math aliases
-    lookup.Add("add", lookup[ExpressionType.Add]); // more than 1 params
+            // Attach negations
+            lookup[ExpressionType.LessThan].Negation = lookup[ExpressionType.GreaterThanOrEqual];
+            lookup[ExpressionType.LessThanOrEqual].Negation = lookup[ExpressionType.GreaterThan];
+            lookup[ExpressionType.Equal].Negation = lookup[ExpressionType.NotEqual];
+
+            // Math aliases
+            lookup.Add("add", lookup[ExpressionType.Add]); // more than 1 params
             lookup.Add("div", lookup[ExpressionType.Divide]); // more than 1 params
             lookup.Add("mul", lookup[ExpressionType.Multiply]);// more than 1 params
             lookup.Add("sub", lookup[ExpressionType.Subtract]);// more than 1 params
@@ -1339,9 +1344,9 @@ namespace Microsoft.Bot.Builder.Expressions
             return lookup;
         }
 
-/// <summary>
-/// Dictionary of built-in functions.
-/// </summary>
-public static Dictionary<string, ExpressionEvaluator> _functions = BuildFunctionLookup();
+        /// <summary>
+        /// Dictionary of built-in functions.
+        /// </summary>
+        public static Dictionary<string, ExpressionEvaluator> _functions = BuildFunctionLookup();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Expressions/Constant.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/Constant.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Expressions
             {
                 return "null";
             }
-            else if (Value is string str)
+            else if (Value is string)
             {
                 return $"'{Value}'";
             }

--- a/libraries/Microsoft.Bot.Builder.Expressions/ExpressionEvaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/ExpressionEvaluator.cs
@@ -29,6 +29,10 @@ namespace Microsoft.Bot.Builder.Expressions
     /// </summary>
     public class ExpressionEvaluator
     {
+        private readonly ValidateExpressionDelegate _validator;
+        private readonly EvaluateExpressionDelegate _evaluator;
+        private ExpressionEvaluator _negation;
+
         /// <summary>
         /// Constructor for expression information.
         /// </summary>
@@ -46,8 +50,7 @@ namespace Microsoft.Bot.Builder.Expressions
             _validator = validator ?? new ValidateExpressionDelegate((expr) => { });
         }
 
-        private ValidateExpressionDelegate _validator;
-        private EvaluateExpressionDelegate _evaluator;
+        public override string ToString() => $"{Type} => {ReturnType}";
 
         /// <summary>
         /// Expression type for evaluator.
@@ -74,5 +77,24 @@ namespace Microsoft.Bot.Builder.Expressions
         /// Type expected by evaluating the expression.
         /// </summary>
         public ReturnType ReturnType { get; set; }
+
+        /// <summary>
+        /// Define the evaluator that is a negation of this one.
+        /// </summary>
+        /// <remarks>
+        /// When doing <see cref="Extensions.PushDownNot(Expression)"/> then negations will replace an expression and remove not parent.
+        /// By default no negation is defined and not parent will remain.
+        /// If a negation is defined then this is automatically set as its negation.
+        /// If an evaluator is its own negation, then the negation will be passed through to children.
+        /// </remarks>
+        public ExpressionEvaluator Negation
+        {
+            get => _negation;
+            set
+            {
+                value._negation = this;
+                _negation = value;
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Expressions/ExtensionsRewriters.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/ExtensionsRewriters.cs
@@ -12,13 +12,12 @@ namespace Microsoft.Bot.Builder.Expressions
         /// Rewrite the expression by pushing not down to the leaves.
         /// </summary>
         /// <remarks>
-        /// This uses DeMorgan's law to push not through and/or/not to the leaves.  
-        /// It also rewrites comparisons to invert them.
+        /// Push down not to the leaves if possible.  For and/or/not this uses DeMorgan's law and rewrites comparisons.  
+        /// You can define your own behavior by setting <see cref="ExpressionEvaluator.Negation"/> to the negated evaluator.
         /// </remarks>
         /// <param name="expression">Expression to rewrite.</param>
-        /// <param name="passThrough">Any functions that do not change with not.</param>
         /// <returns>Rewritten expression.</returns>
-        static public Expression PushDownNot(this Expression expression, HashSet<string> passThrough = null) => PushDownNot(expression, passThrough, false);
+        public static Expression PushDownNot(this Expression expression) => PushDownNot(expression, false);
 
         /// <summary>
         /// Rewrite expression into disjunctive normal form.
@@ -28,21 +27,15 @@ namespace Microsoft.Bot.Builder.Expressions
         /// to leaves.
         /// </remarks>
         /// <param name="expression">Expression to rewrite.</param>
-        /// <param name="passThrough">Any functions that not should pass through.</param>
         /// <returns>Normalized expression.</returns>
-        static public Expression DisjunctiveNormalForm(this Expression expression, HashSet<string> passThrough = null)
+        public static Expression DisjunctiveNormalForm(this Expression expression)
         {
             Expression result;
-            if (passThrough == null)
-            {
-                passThrough = new HashSet<string>();
-            }
-            var clauses = Conjunctions(expression.PushDownNot(passThrough));
+            var clauses = Conjunctions(expression.PushDownNot());
             var children = new List<Expression>();
-            foreach(var clause in clauses)
+            foreach (var clause in clauses)
             {
-                if (clause.Type == ExpressionType.And &&
-                    clause.Children.Length == 1)
+                if (clause.Type == ExpressionType.And && clause.Children.Length == 1)
                 {
                     children.Add(clause.Children[0]);
                 }
@@ -66,7 +59,7 @@ namespace Microsoft.Bot.Builder.Expressions
             return result;
         }
 
-        static private IEnumerable<Expression> Conjunctions(Expression expression)
+        private static IEnumerable<Expression> Conjunctions(Expression expression)
         {
             switch (expression.Type)
             {
@@ -150,88 +143,42 @@ namespace Microsoft.Bot.Builder.Expressions
             }
         }
 
-        static private Expression PushDownNot(Expression expression, HashSet<string> passThrough, bool inNot)
+        private static Expression PushDownNot(Expression expression, bool inNot)
         {
             var newExpr = expression;
+            var negation = expression.Evaluator.Negation;
             switch (expression.Type)
             {
                 case ExpressionType.And:
-                    {
-                        if (inNot)
-                        {
-                            newExpr = Expression.MakeExpression(ExpressionType.Or, (from child in expression.Children select PushDownNot(child, passThrough, true)).ToArray());
-                        }
-                        else
-                        {
-                            newExpr = Expression.MakeExpression(ExpressionType.And, (from child in expression.Children select PushDownNot(child, passThrough, false)).ToArray());
-                        }
-                    }
+                    newExpr = Expression.MakeExpression(inNot ? ExpressionType.Or : ExpressionType.And, (from child in expression.Children select PushDownNot(child, inNot)).ToArray());
                     break;
                 case ExpressionType.Or:
+                    newExpr = Expression.MakeExpression(inNot ? ExpressionType.And : ExpressionType.Or, (from child in expression.Children select PushDownNot(child, inNot)).ToArray());
+                    break;
+                case ExpressionType.Not:
+                    newExpr = PushDownNot(expression.Children[0], !inNot);
+                    break;
+                default:
+                    if (inNot)
                     {
-                        if (inNot)
+                        if (negation != null)
                         {
-                            newExpr = Expression.MakeExpression(ExpressionType.And, (from child in expression.Children select PushDownNot(child, passThrough, true)).ToArray());
+                            if (expression.Type == negation.Type)
+                            {
+                                // Pass through like optional/ignore
+                                newExpr = Expression.MakeExpression(negation, (from child in expression.Children select PushDownNot(child, true)).ToArray());
+                            }
+                            else
+                            {
+                                // Replace with negation and stop
+                                newExpr = Expression.MakeExpression(negation, expression.Children);
+                            }
                         }
                         else
                         {
-                            newExpr = Expression.MakeExpression(ExpressionType.Or, (from child in expression.Children select PushDownNot(child, passThrough, false)).ToArray());
+                            // Keep not
+                            newExpr = Expression.MakeExpression(ExpressionType.Not, expression);
                         }
-                    }
-                    break;
-                case ExpressionType.Not:
-                    newExpr = PushDownNot(expression.Children[0], passThrough, !inNot);
-                    break;
-                // Rewrite comparison operators
-                case ExpressionType.LessThan:
-                    if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.GreaterThanOrEqual, expression.Children);
-                    }
-                    break;
-                case ExpressionType.LessThanOrEqual:
-                    if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.GreaterThan, expression.Children);
-                    }
-                    break;
-                case ExpressionType.Equal:
-                    if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.NotEqual, expression.Children);
-                    }
-                    break;
-                case ExpressionType.NotEqual:
-                    if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.Equal, expression.Children);
-                    }
-                    break;
-                case ExpressionType.GreaterThanOrEqual:
-                    if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.LessThan, expression.Children);
-                    }
-                    break;
-                case ExpressionType.GreaterThan:
-                    if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.LessThanOrEqual, expression.Children);
-                    }
-                    break;
-                case ExpressionType.Exists:
-                    // Rewrite exists(x) -> x != null
-                    newExpr = Expression.MakeExpression(inNot ? ExpressionType.Equal : ExpressionType.NotEqual, expression.Children[0], Expression.ConstantExpression(null));
-                    break;
-                default:
-                    if (passThrough.Contains(expression.Type))
-                    {
-                        // Pass through marker functions like optional/ignore to children
-                        newExpr = Expression.MakeExpression(expression.Evaluator, PushDownNot(expression.Children[0], passThrough, inNot));
-                    }
-                    else if (inNot)
-                    {
-                        newExpr = Expression.MakeExpression(ExpressionType.Not, expression);
                     }
                     break;
             }

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
         public static object[] Test(string input, object value, HashSet<string> paths = null) => new object[] { input, value, paths };
 
         public static HashSet<string> one = new HashSet<string> { "one" };
-        public static HashSet<string> oneTwo = new HashSet<string> {"one", "two" };
+        public static HashSet<string> oneTwo = new HashSet<string> { "one", "two" };
 
-        object scope = new
+        private readonly object scope = new
         {
             one = 1.0,
             two = 2.0,
@@ -240,7 +240,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("bool(0)", true),
             Test("bool(null)", false),
             Test("bool(hello * 5)", false),
-            Test("bool('false')", true), 
+            Test("bool('false')", true),
             Test("bool('hi')", true),
             Test("createArray('h', 'e', 'l', 'l', 'o')", new List<object>{"h", "e", "l", "l", "o" }),
             Test("createArray(1, bool(0), string(bool(1)), float('10'))", new List<object>{1, true, "true", 10.0f }),
@@ -258,7 +258,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("min(4, 5) ", 4),
             Test("min(4) ", 4),
             Test("min(1.0, two) + max(one, 2.0)", 3.0, oneTwo),
-           
+
             Test("sub(2, 1)", 1),
             Test("sub(2, 1, 1)", 0),
             Test("sub(2.0, 0.5)", 1.5),
@@ -402,20 +402,18 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             }
         }
 
-        public static bool IsNumber(object value)
-        {
-            return value is sbyte
-                    || value is byte
-                    || value is short
-                    || value is ushort
-                    || value is int
-                    || value is uint
-                    || value is long
-                    || value is ulong
-                    || value is float
-                    || value is double
-                    || value is decimal;
-        }
+        public static bool IsNumber(object value) =>
+            value is sbyte
+            || value is byte
+            || value is short
+            || value is ushort
+            || value is int
+            || value is uint
+            || value is long
+            || value is ulong
+            || value is float
+            || value is double
+            || value is decimal;
 
         private void AssertObjectEquals(object expected, object actual)
         {
@@ -424,7 +422,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
                 Assert.IsTrue(Convert.ToSingle(actual) == Convert.ToSingle(expected));
             }
             // Compare two lists
-            else if(expected is IList expectedList
+            else if (expected is IList expectedList
                 && actual is IList actualList)
             {
                 Assert.AreEqual(expectedList.Count, actualList.Count);


### PR DESCRIPTION
This simplifies the apis by getting through a wonky parameter and maintains that the knowledge about expressions is defined when the expression is created rather than needing to be passed in later.
Also did a little code cleanup.