### PR TITLE
Modifications to number of attempts property behavior

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             state[PersistedOptions] = opt;
             state[PersistedState] = new Dictionary<string, object>
             {
-                { NumberOfAttemptsKey, 1 },
+                { NumberOfAttemptsKey, 0 },
             };
 
             // Send initial prompt
@@ -86,15 +86,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             var options = (PromptOptions)instance.State[PersistedOptions];
             var recognized = await OnRecognizeAsync(dc.Context, state, options, cancellationToken).ConfigureAwait(false);
 
+            // Increment attempt count
+            state[NumberOfAttemptsKey] = (int)state[NumberOfAttemptsKey] + 1;
+
             // Validate the return value
             var isValid = false;
             if (_validator != null)
             {
                 var promptContext = new PromptValidatorContext<T>(dc.Context, recognized, state, options);
                 isValid = await _validator(promptContext, cancellationToken).ConfigureAwait(false);
-
-                // Increment attempt count
-                state[NumberOfAttemptsKey] = (int)state[NumberOfAttemptsKey] + 1;
             }
             else if (recognized.Succeeded)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <typeparam name="T">The type of the <see cref="Prompt{T}"/>.</typeparam>
     public abstract class Prompt<T> : Dialog
     {
-        internal const string NumberOfAttemptsKey = "NumberOfAttempts";
+        internal const string AttemptCountKey = "AttemptCount";
 
         private const string PersistedOptions = "options";
         private const string PersistedState = "state";
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             state[PersistedOptions] = opt;
             state[PersistedState] = new Dictionary<string, object>
             {
-                { NumberOfAttemptsKey, 0 },
+                { AttemptCountKey, 0 },
             };
 
             // Send initial prompt
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             var recognized = await OnRecognizeAsync(dc.Context, state, options, cancellationToken).ConfigureAwait(false);
 
             // Increment attempt count
-            state[NumberOfAttemptsKey] = (int)state[NumberOfAttemptsKey] + 1;
+            state[AttemptCountKey] = (int)state[AttemptCountKey] + 1;
 
             // Validate the return value
             var isValid = false;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             _validator = validator;
         }
 
-        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (dc == null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Bot.Builder.Dialogs
     public abstract class Prompt<T> : Dialog
     {
         internal const string NumberOfAttemptsKey = "NumberOfAttempts";
-        internal const string PersistedState = "state";
 
         private const string PersistedOptions = "options";
+        private const string PersistedState = "state";
         private readonly PromptValidator<T> _validator;
 
         public Prompt(string dialogId, PromptValidator<T> validator = null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             state[PersistedOptions] = opt;
             state[PersistedState] = new Dictionary<string, object>
             {
-                { NumberOfAttemptsKey, 0 },
+                { NumberOfAttemptsKey, 1 },
             };
 
             // Send initial prompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -37,7 +37,5 @@ namespace Microsoft.Bot.Builder.Dialogs
         public ListStyle? Style { get; set; }
 
         public object Validations { get; set; }
-
-        public int NumberOfAttempts { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <summary>
         /// Gets the number of times the prompt has been executed.
         /// </summary>
-        /// <value>A number indicating how many times the prompt was invoked (starting at 1 for the first time it was invoked).</value>
+        /// <value>A number indicating how many times the prompt was invoked (starting at 1 for the first time it was called).</value>
         public int AttemptCount => (int)State[Prompt<T>.AttemptCountKey];
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <summary>
         /// Gets the number of times the prompt has been executed.
         /// </summary>
-        /// <value>A number indicating how many times the prompt was invoked.</value>
+        /// <value>A number indicating how many times the prompt was invoked (starting at 1 for the first time it was invoked).</value>
         public int NumberOfAttempts => (int)State[Prompt<T>.NumberOfAttemptsKey];
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Gets the number of times the prompt has been executed.
         /// </summary>
         /// <value>A number indicating how many times the prompt was invoked (starting at 1 for the first time it was invoked).</value>
-        public int NumberOfAttempts => (int)State[Prompt<T>.NumberOfAttemptsKey];
+        public int AttemptCount => (int)State[Prompt<T>.AttemptCountKey];
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
     public class PromptValidatorContext<T>
     {
-        internal PromptValidatorContext(ITurnContext turnContext, PromptRecognizerResult<T> recognized, IDictionary<string, object> state,  PromptOptions options)
+        internal PromptValidatorContext(ITurnContext turnContext, PromptRecognizerResult<T> recognized, IDictionary<string, object> state, PromptOptions options)
         {
             Context = turnContext;
             Options = options;
@@ -23,5 +22,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         public PromptOptions Options { get; }
 
         public IDictionary<string, object> State { get; }
+
+        /// <summary>
+        /// Gets the number of times the prompt has been executed.
+        /// </summary>
+        /// <value>A number indicating how many times the prompt was invoked.</value>
+        public int NumberOfAttempts => (int)State[Prompt<T>.NumberOfAttemptsKey];
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
@@ -140,6 +140,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var result = promptContext.Recognized.Value;
                 if (result.Length > 3)
                 {
+                    var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.NumberOfAttempts}th try!");
+                    await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
                     return true;
                 }
 
@@ -178,12 +180,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .Send("hello")
                 .AssertReply("Please type your name.")
                 .Send("hi")
-                .AssertReply("Please send a name that is longer than 3 characters. 0")
-                .Send("hi")
                 .AssertReply("Please send a name that is longer than 3 characters. 1")
                 .Send("hi")
                 .AssertReply("Please send a name that is longer than 3 characters. 2")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 3")
                 .Send("John")
+                .AssertReply("You got it at the 4th try!")
                 .AssertReply("John is a great name!")
                 .StartTestAsync();
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
@@ -140,12 +140,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var result = promptContext.Recognized.Value;
                 if (result.Length > 3)
                 {
-                    var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.NumberOfAttempts}th try!");
+                    var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
                     await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
                     return true;
                 }
 
-                var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.NumberOfAttempts}");
+                var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
                 await promptContext.Context.SendActivityAsync(reply, cancellationToken);
 
                 return false;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
@@ -22,46 +22,43 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var dialogs = new DialogSet(dialogState);
 
-            dialogs.Add(new TextPrompt("namePrompt", (promptContext, cancellationToken) =>
-            {
-                return Task.FromResult(true);
-            }));
+            dialogs.Add(new TextPrompt("namePrompt", (promptContext, cancellationToken) => Task.FromResult(true)));
 
             var steps = new WaterfallStep[]
-                    {
-                        async (stepContext, cancellationToken) =>
-                        {
-                            return await stepContext.PromptAsync("namePrompt", new PromptOptions { Prompt = new Activity { Text = "Please type your name.", Type = ActivityTypes.Message } }, cancellationToken);
-                        },
-                        async (stepContext, cancellationToken) =>
-                        {
-                            var name = (string)stepContext.Result;
-                            await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
-                            return await stepContext.EndDialogAsync();
-                        },
-                    };
+            {
+                async (stepContext, cancellationToken) =>
+                {
+                    return await stepContext.PromptAsync("namePrompt", new PromptOptions { Prompt = new Activity { Text = "Please type your name.", Type = ActivityTypes.Message } }, cancellationToken);
+                },
+                async (stepContext, cancellationToken) =>
+                {
+                    var name = (string)stepContext.Result;
+                    await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
+                    return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+                },
+            };
             dialogs.Add(new WaterfallDialog(
                 "nameDialog",
                 steps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext);
-                await dc.ContinueDialogAsync();
-                if (!turnContext.Responded)
                 {
-                    await dc.BeginDialogAsync("nameDialog");
-                }
-            })
-            .Send("hello")
-            .AssertReply("Please type your name.")
-            .Send("John")
-            .AssertReply("John is a great name!")
-            .Send("Hi again")
-            .AssertReply("Please type your name.")
-            .Send("1")
-            .AssertReply("1 is a great name!")
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                    await dc.ContinueDialogAsync(cancellationToken);
+                    if (!turnContext.Responded)
+                    {
+                        await dc.BeginDialogAsync("nameDialog", cancellationToken: cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply("Please type your name.")
+                .Send("John")
+                .AssertReply("John is a great name!")
+                .Send("Hi again")
+                .AssertReply("Please type your name.")
+                .Send("1")
+                .AssertReply("1 is a great name!")
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -70,15 +67,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            TestAdapter adapter = new TestAdapter()
+            var adapter = new TestAdapter()
                 .Use(new AutoSaveStateMiddleware(convoState));
 
-            DialogSet dialogs = new DialogSet(dialogState);
+            var dialogs = new DialogSet(dialogState);
 
             // Create TextPrompt with dialogId "namePrompt" and custom validator
             dialogs.Add(new TextPrompt("namePrompt", async (promptContext, cancellationToken) =>
             {
-                string result = promptContext.Recognized.Value;
+                var result = promptContext.Recognized.Value;
                 if (result.Length > 3)
                 {
                     return true;
@@ -92,38 +89,38 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }));
 
             var steps = new WaterfallStep[]
-                    {
-                        async (stepContext, cancellationToken) =>
-                        {
-                            return await stepContext.PromptAsync("namePrompt", new PromptOptions { Prompt = new Activity { Text = "Please type your name.", Type = ActivityTypes.Message } }, cancellationToken);
-                        },
-                        async (stepContext, cancellationToken) =>
-                        {
-                            var name = (string)stepContext.Result;
-                            await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
-                            return await stepContext.EndDialogAsync();
-                        },
-                    };
+            {
+                async (stepContext, cancellationToken) =>
+                {
+                    return await stepContext.PromptAsync("namePrompt", new PromptOptions { Prompt = new Activity { Text = "Please type your name.", Type = ActivityTypes.Message } }, cancellationToken);
+                },
+                async (stepContext, cancellationToken) =>
+                {
+                    var name = (string)stepContext.Result;
+                    await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
+                    return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+                },
+            };
             dialogs.Add(new WaterfallDialog(
                 "nameDialog",
                 steps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-                await dc.ContinueDialogAsync(cancellationToken);
-                if (!turnContext.Responded)
                 {
-                    await dc.BeginDialogAsync("nameDialog", null, cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("Please type your name.")
-            .Send("hi")
-            .AssertReply("Please send a name that is longer than 3 characters.")
-            .Send("John")
-            .AssertReply("John is a great name!")
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                    await dc.ContinueDialogAsync(cancellationToken);
+                    if (!turnContext.Responded)
+                    {
+                        await dc.BeginDialogAsync("nameDialog", null, cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply("Please type your name.")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters.")
+                .Send("John")
+                .AssertReply("John is a great name!")
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -132,65 +129,63 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            TestAdapter adapter = new TestAdapter()
+            var adapter = new TestAdapter()
                 .Use(new AutoSaveStateMiddleware(convoState));
 
-            DialogSet dialogs = new DialogSet(dialogState);
+            var dialogs = new DialogSet(dialogState);
 
             // Create TextPrompt with dialogId "namePrompt" and custom validator
             dialogs.Add(new TextPrompt("namePrompt", async (promptContext, cancellationToken) =>
             {
-                string result = promptContext.Recognized.Value;
+                var result = promptContext.Recognized.Value;
                 if (result.Length > 3)
                 {
                     return true;
                 }
-                else
-                {
-                    var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.Options.NumberOfAttempts}");
-                    await promptContext.Context.SendActivityAsync(reply, cancellationToken);
-                }
+
+                var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.NumberOfAttempts}");
+                await promptContext.Context.SendActivityAsync(reply, cancellationToken);
 
                 return false;
             }));
 
             var steps = new WaterfallStep[]
-                    {
-                        async (stepContext, cancellationToken) =>
-                        {
-                            return await stepContext.PromptAsync("namePrompt", new PromptOptions { Prompt = new Activity { Text = "Please type your name.", Type = ActivityTypes.Message } }, cancellationToken);
-                        },
-                        async (stepContext, cancellationToken) =>
-                        {
-                            var name = (string)stepContext.Result;
-                            await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
-                            return await stepContext.EndDialogAsync();
-                        },
-                    };
+            {
+                async (stepContext, cancellationToken) =>
+                {
+                    return await stepContext.PromptAsync("namePrompt", new PromptOptions { Prompt = new Activity { Text = "Please type your name.", Type = ActivityTypes.Message } }, cancellationToken);
+                },
+                async (stepContext, cancellationToken) =>
+                {
+                    var name = (string)stepContext.Result;
+                    await stepContext.Context.SendActivityAsync(MessageFactory.Text($"{name} is a great name!"), cancellationToken);
+                    return await stepContext.EndDialogAsync(cancellationToken: cancellationToken);
+                },
+            };
             dialogs.Add(new WaterfallDialog(
                 "nameDialog",
                 steps));
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-            {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
-                await dc.ContinueDialogAsync(cancellationToken);
-                if (!turnContext.Responded)
                 {
-                    await dc.BeginDialogAsync("nameDialog", null, cancellationToken);
-                }
-            })
-            .Send("hello")
-            .AssertReply("Please type your name.")
-            .Send("hi")
-            .AssertReply("Please send a name that is longer than 3 characters. 0")
-            .Send("hi")
-            .AssertReply("Please send a name that is longer than 3 characters. 1")
-            .Send("hi")
-            .AssertReply("Please send a name that is longer than 3 characters. 2")
-            .Send("John")
-            .AssertReply("John is a great name!")
-            .StartTestAsync();
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                    await dc.ContinueDialogAsync(cancellationToken);
+                    if (!turnContext.Responded)
+                    {
+                        await dc.BeginDialogAsync("nameDialog", null, cancellationToken);
+                    }
+                })
+                .Send("hello")
+                .AssertReply("Please type your name.")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 0")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 1")
+                .Send("hi")
+                .AssertReply("Please send a name that is longer than 3 characters. 2")
+                .Send("John")
+                .AssertReply("John is a great name!")
+                .StartTestAsync();
         }
     }
 }


### PR DESCRIPTION
@johnataylor / @cleemullins:  these changes address #1748. Please revuew and let me know what you think..

Changes include:
 - Removed NumberOfAttempts from PromptOptions
 - Added NumberOfAttempts getter to PromptValidatorContext
 - Implemented logic to keep internal count of number of attempts in the prompt state.
 - Updated unit test to compile and pass (this counter is 1 based)
 - Added missing cancellationTokens where needed
