### PR TITLE
misc traceactivity cleanup

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.TraceActivity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.TraceActivity.schema
@@ -15,9 +15,9 @@
             "title": "Value Type",
             "description": "Value type of the trace activity"
         },
-        "valueProperty": {
+        "value": {
             "$role": "memoryPath",
-            "title": "Value Property",
+            "title": "Value",
             "description": "Property path to memory object to send as the value of the trace activity"
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/TraceActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/TraceActivity.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
 {
@@ -29,7 +30,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
         /// <summary>
         /// Property binding to memory to send as the value 
         /// </summary>
-        public string ValueProperty { get; set; }
+        public string Value { get; set; }
 
         [JsonConstructor]
         public TraceActivity([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
@@ -45,12 +46,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
             }
 
             object value = null;
-            if (!string.IsNullOrEmpty(this.ValueProperty))
+            if (!string.IsNullOrEmpty(this.Value))
             {
-                value = dc.State.GetValue<object>(this.ValueProperty);
+                value = JObject.FromObject(dc.State.GetValue<object>(this.Value));
+            }
+            else
+            {
+                value = JObject.FromObject(dc.State);
             }
 
-            var traceActivity = Activity.CreateTraceActivity(this.Name, this.ValueType, value);
+            var traceActivity = Activity.CreateTraceActivity(this.Name, valueType: this.ValueType, value: value);
             await dc.Context.SendActivityAsync(traceActivity, cancellationToken).ConfigureAwait(false);
 
             return await dc.EndDialogAsync(traceActivity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/StepsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/StepsTests.cs
@@ -98,8 +98,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                         new TraceActivity()
                         {
                             Name = "test",
-                            ValueType = "user.name",
-                            ValueProperty = "user.name"
+                            ValueType = "user",
+                            Value = "user"
+                        },
+                        new TraceActivity()
+                        {
+                            Name = "test",
+                            ValueType = "memory"
                         }
                     })});
 
@@ -109,8 +114,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 {
                     var traceActivity = (ITraceActivity)activity;
                     Assert.AreEqual(ActivityTypes.Trace, traceActivity.Type, "type doesn't match");
-                    Assert.AreEqual("user.name", traceActivity.ValueType, "ValueType doesn't match");
-                    Assert.AreEqual("frank", traceActivity.Value, "Value doesn't match");
+                    Assert.AreEqual("user", traceActivity.ValueType, "ValueType doesn't match");
+                    Assert.AreEqual("frank", (string)((dynamic)traceActivity.Value).name, "Value doesn't match");
+                })
+                .AssertReply((activity) =>
+                {
+                    var traceActivity = (ITraceActivity)activity;
+                    Assert.AreEqual(ActivityTypes.Trace, traceActivity.Type, "type doesn't match");
+                    Assert.AreEqual("memory", traceActivity.ValueType, "ValueType doesn't match");
+                    Assert.AreEqual("frank", (string)((dynamic)traceActivity.Value).user.name, "Value doesn't match");
                 })
                 .StartTestAsync();
         }


### PR DESCRIPTION
- if you don't give value, value will be State
- changed property name to value instead of valueProperty
- Jobject convert it so that consumers get dynamic version of object