### PR TITLE
state changes for sidecar

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Inspection/InspectionActivityExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/Inspection/InspectionActivityExtensions.cs
@@ -9,17 +9,14 @@ namespace Microsoft.Bot.Builder
 {
     internal static class InspectionActivityExtensions
     {
-        public static Activity TraceActivity(this BotState state, ITurnContext turnContext)
+        public static Activity MakeCommandActivity(this string command)
         {
-            if (turnContext == null)
-            {
-                throw new ArgumentNullException(nameof(turnContext));
-            }
+            return (Activity)Activity.CreateTraceActivity("Command", "https://www.botframework.com/schemas/command", command, "Command");
+        }
 
-            var name = state.GetType().Name;
-            var cachedState = turnContext.TurnState.Get<object>(name);
-            var obj = JObject.FromObject(cachedState)["State"];
-            return (Activity)Activity.CreateTraceActivity("BotState", "https://www.botframework.com/schemas/botState", obj, "Bot State");
+        public static Activity TraceActivity(this JObject state)
+        {
+            return (Activity)Activity.CreateTraceActivity("BotState", "https://www.botframework.com/schemas/botState", state, "Bot State");
         }
 
         public static Activity TraceActivity(this Activity activity, string name, string label)


### PR DESCRIPTION
Emulator when in sidecar debugging mode would like to see the following:
- a single state object containing properties for each bot state.
- a trace activity as the response to the initial /INSPECT open

(This is the same change as the JavaScript.)

