### PR TITLE
Take magic code detection out of OAuth BeginDialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -186,8 +186,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <param name="turnContext">Context for the current turn of the conversation with the user.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="code">(Optional) login code received from the user.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<TokenResponse> GetUserTokenAsync(ITurnContext turnContext, string code = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<TokenResponse> GetUserTokenAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken), string code = null)
         {
             if (!(turnContext.Adapter is IUserTokenProvider adapter))
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -182,6 +182,22 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
+        /// Get a token for a user signed in.
+        /// </summary>
+        /// <param name="turnContext">Context for the current turn of the conversation with the user.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task<TokenResponse> GetUserTokenAsync(ITurnContext turnContext, string code = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!(turnContext.Adapter is IUserTokenProvider adapter))
+            {
+                throw new InvalidOperationException("OAuthPrompt.GetUserToken(): not supported by the current adapter");
+            }
+
+            return await adapter.GetUserTokenAsync(turnContext, _settings.ConnectionName, code, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Sign Out the User.
         /// </summary>
         /// <param name="turnContext">Context for the current turn of the conversation with the user.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -188,14 +188,14 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <param name="code">(Optional) login code received from the user.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task<TokenResponse> GetUserTokenAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken), string code = null)
+        public async Task<TokenResponse> GetUserTokenAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (!(turnContext.Adapter is IUserTokenProvider adapter))
             {
                 throw new InvalidOperationException("OAuthPrompt.GetUserToken(): not supported by the current adapter");
             }
 
-            return await adapter.GetUserTokenAsync(turnContext, _settings.ConnectionName, code, cancellationToken).ConfigureAwait(false);
+            return await adapter.GetUserTokenAsync(turnContext, _settings.ConnectionName, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var token = "abc123";
             var magicCode = "888999";
 
-            // Create new DialogSet.
+            // Create new DialogSet
             var dialogs = new DialogSet(dialogState);
             dialogs.Add(new OAuthPrompt("OAuthPrompt", new OAuthPromptSettings() { Text = "Please sign in", ConnectionName = connectionName, Title = "Sign in" }));
 


### PR DESCRIPTION
Fixes #1596 

Also related: https://stackoverflow.com/questions/55970661/ms-bot-framework-doesnt-remember-authentication/55975228#55975228 - this seems like a pretty easy issue to run into.

## Issue Summary

`OAuthPrompt` has to be called to for certain messages. If that message contains a string that has a 6-digit number, `OAuthPrompt` used that number as the magic code, which was invalid, so it re-prompted for Login. The JS SDK doesn't have this issue because [it doesn't check for the magic code in `beginDialog()`](https://github.com/Microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts#L198)
.

## Changes

* Removes attempt to detect magic code in `BeginDialogAsync()`
* Removes some other checks in `GetUserTokenAsync()` that are unnecessary because of the above change that are handled elsewhere

## Important Notes

* I couldn't really get the Auth Sample (18) on `master` to work well with or without this change. The `samples-work-in-progress` sample works fine now.
* Neither sample worked in Teams -- I'm not sure if they ever did. the Login button pops up and then nothing happens after clicking it.
* I rarely use Auth, so a review to make sure this wouldn't break something I'm missing would be much appreciated
* As you might gather by looking through my commits, I think some code duplication can be avoided by making more calls to `OAuthPrompt.GetUserTokenAsync()`. @fuselabs was throwing errors when I attempted to do this, however, since it required adding `, string code = null` to the `GetUserTokenAsync()` arguments (which would make it match the Node version). 

## Testing

![image](https://user-images.githubusercontent.com/40401643/57046716-6cb6ff00-6c26-11e9-94cf-900c323d3762.png)

These are using the `samples-work-in-progress` branch:

### Before

![image](https://user-images.githubusercontent.com/40401643/57046731-780a2a80-6c26-11e9-8330-506813ad17ad.png)

### After

![image](https://user-images.githubusercontent.com/40401643/57046740-822c2900-6c26-11e9-9dd1-e449a38e1690.png)
