### PR TITLE
add debug annotations and plumb through AdaptiveEvents

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/PlanningContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/PlanningContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -402,6 +403,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public object Result { get; set; }
     }
 
+    [DebuggerDisplay("{DialogId}")]
     public class PlanStepState : DialogState
     {
         public PlanStepState()
@@ -421,6 +423,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public object Options { get; set; }
     }
 
+    [DebuggerDisplay("{Title}")]
     public class PlanState
     {
         [JsonProperty(PropertyName = "title")]
@@ -440,6 +443,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         ReplacePlan
     }
 
+    [DebuggerDisplay("{ChangeType}:{Desire}")]
     public class PlanChangeList
     {
         [JsonProperty(PropertyName = "changeType")]

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -18,6 +19,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Rules
     /// <summary>
     /// Defines basic Rule contract
     /// </summary>
+    [DebuggerDisplay("{GetIdentity()}")]
     public abstract class Rule : IRule, IItemIdentity
     {
         private Expression constraint;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebugAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebugAdapter.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using static Microsoft.Bot.Builder.Dialogs.DialogContext;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
@@ -109,7 +110,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         public DebugAdapter(int port, Source.IRegistry registry, IBreakpoints breakpoints, Action terminate, IEvents events = null, ICodeModel codeModel = null, IDataModel dataModel = null, ILogger logger = null, ICoercion coercion = null)
             : base(logger)
         {
-            this.events = events ?? new Events();
+            this.events = events ?? new Events<DialogEvents>();
             this.codeModel = codeModel ?? new CodeModel();
             this.dataModel = dataModel ?? new DataModel(coercion ?? new Coercion());
             this.registry = registry ?? throw new ArgumentNullException(nameof(registry));
@@ -173,7 +174,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         {
             try
             {
-                var turnText = context.Context.Activity.Text.Trim();
+                var turnText = context.Context.Activity.Text?.Trim() ?? String.Empty;
                 if (turnText.Length == 0)
                     turnText = context.Context.Activity.Type;
                 var threadText = $"'{Ellipsis(turnText, 18)}'";
@@ -263,7 +264,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
             var phase = run.Phase;
             var suffix = item != null ? $" ==> {codeModel.NameFor(item)}" : string.Empty;
-            var threadText = $"'{Ellipsis(thread?.Name, 18)}'";
+            var threadText = $"{Ellipsis(thread?.Name, 18)}";
             if (threadText.Length <= 2)
                 threadText = thread.TurnContext.Activity.Type;
             var description = $"{threadText} ==> {phase.ToString().PadRight(16)}{suffix}";

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events.cs
@@ -2,7 +2,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using static Microsoft.Bot.Builder.Dialogs.DialogContext;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
@@ -22,7 +24,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         }
     }
 
-    public sealed class Events : IEvents
+    public sealed class Events<DialogEventsT> : IEvents
+        where DialogEventsT : DialogEvents
     {
         private readonly ConcurrentDictionary<string, bool> stateByFilter = new ConcurrentDictionary<string, bool>();
 
@@ -30,7 +33,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         {
             if (filters == null)
             {
-                filters = from field in typeof(DialogContext.DialogEvents).GetFields()
+                filters = from field in typeof(DialogEventsT)
+                          .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
                           where field.FieldType == typeof(string)
                           select (string)field.GetValue(null);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ActivityTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ActivityTemplate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 
@@ -9,6 +10,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <summary>
     /// Defines an activity Template where the template expression is local aka "inline".
     /// </summary>
+    [DebuggerDisplay("{Template}")]
     public class ActivityTemplate : IActivityTemplate
     {
         // Fixed text constructor for inline template

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
@@ -12,6 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <summary>
     /// Base class for all dialogs.
     /// </summary>
+    [DebuggerDisplay("{Id}")]
     public abstract class Dialog : IDialog
     {
         public static readonly DialogTurnResult EndOfTurn = new DialogTurnResult(DialogTurnStatus.Waiting);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
     /// <summary>
     /// Tracking information for a dialog on the stack.
     /// </summary>
+    [DebuggerDisplay("{Id}")]
     public class DialogInstance
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/TextTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/TextTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Dialogs
@@ -7,6 +8,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <summary>
     /// Defines an text Template where the template expression is local aka "inline".
     /// </summary>
+    [DebuggerDisplay("{Template}")]
     public class TextTemplate : ITextTemplate
     {
         // Fixed text constructor for inline template

--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
@@ -17,6 +18,7 @@ namespace Microsoft.Bot.Schema
     /// The Activity class contains all properties that individual, more specific activities
     /// could contain. It is a superset type.
     /// </remarks>
+    [DebuggerDisplay("[{Type}] {Text ?? System.String.Empty}")]
     public partial class Activity :
         IActivity,
         IConversationUpdateActivity,

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/TestBotHttpAdapter.cs
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/TestBotHttpAdapter.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
@@ -34,7 +35,7 @@ namespace Microsoft.Bot.Builder.TestBot.Json
                 TypeFactory.Register("Testbot.JavascriptStep", typeof(JavascriptStep));
             });
             this.UseLanguageGenerator(new LGLanguageGenerator(resourceExplorer));
-            this.UseDebugger(configuration.GetValue<int>("debugport", 4712));
+            this.UseDebugger(configuration.GetValue<int>("debugport", 4712), events: new Events<AdaptiveEvents>());
 
             this.OnTurnError = async (turnContext, exception) =>
             {


### PR DESCRIPTION
- debugger now displays friendly descriptions for
    - dialog
    - activity
    - templates
    - dialoginstance
- Plumb through adaptive events so that we get full events in debugger