### PR TITLE
Made OnTurn method on TelemetryLoggerMiddleware virtual

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(context);
 


### PR DESCRIPTION
As discussed with @daveta - adding virtual to OnTurn method to allow override. This can then be used to enable logging of information from the context, such as TurnState.