### PR TITLE
Add workaround to temporarily use fixed version of Archive module

### DIFF
--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -13,6 +13,10 @@ $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterpr
 dotnet tool install coveralls.net --version 1.0.0 --tool-path tools
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
+# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
+Import-Module .\archive.psm1
+
 Write-Host "Analyze coverage [$coverageAnalyzer] with args:"
 $coverageFiles = Get-ChildItem -Path "$pathToCoverageFiles" -Include "*.coverage" -Recurse | Select -Exp FullName
 $analyzeArgs = @(


### PR DESCRIPTION
The current Archive module that ships with PowerShell has an issue where it uses the backslash for directory path separator which creates archives that don't expand correctly on non-Windows machines as the backslash is a valid path character.

Until the PowerShell images (AzDevOps in this case for this build) gets updated to the (yet to be published) fixed version, this is a temporary workaround to pull down the latest version from master branch of Archive repo which has the fix.

Once the AzDevOps image is updated, this workaround should be removed.