### PR TITLE
Update master with the powershell hack

### DIFF
--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -10,6 +10,10 @@ param
 )
 pushd $path
 
+# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
+Import-Module .\archive.psm1
+
 [int]$itemsProcessed = 0
 if ($extract) {
     # Extract .nupkg packages in the path.


### PR DESCRIPTION
Fixed #1871 

Adds the powershell hack in while we wait for the powershell team to merge/deploy the fix. 