### PR TITLE
Refactoring LG error handler

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
@@ -29,10 +29,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public string Message { get; }
 
-        public override string ToString()
-        {
-            return $"{Severity}: {Message}";
-        }
+        public override string ToString() => $"[{Severity}] {Range}: {Message}";
     }
 
     /// <summary>
@@ -49,6 +46,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public Position Start { get; set; }
 
         public Position End { get; set; }
+
+        public override string ToString()
+        {
+            var result = Start.ToString();
+            if (Start.Line <= End.Line && Start.Character < End.Character)
+            {
+                result += " - ";
+                result += End.ToString();
+            }
+            return result;
+        }
     }
 
     /// <summary>
@@ -66,6 +74,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public int Line { get; set; }
 
         public int Character { get; set; }
+
+        public override string ToString() => $"line {Line}:{Character}";
     }
 
     /// <summary>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
@@ -19,14 +19,45 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             Severity = severity;
         }
 
+        /// <summary>
+        ///  Gets or sets a code or identifier for this diagnostics.
+        /// </summary>
+        /// <value>
+        /// A code or identifier for this diagnostics.
+        /// </value>
         public string Code { get; set; }
 
+        /// <summary>
+        ///  Gets or sets the range to which this diagnostic applies.
+        /// </summary>
+        /// <value>
+        /// The range to which this diagnostic applies.
+        /// </value>
         public Range Range { get; set; }
 
+        /// <summary>
+        /// Gets or sets the severity, default is <see cref="DiagnosticSeverity.Error"/>.
+        /// </summary>
+        /// <value>
+        /// The severity, default is <see cref="DiagnosticSeverity.Error"/>.
+        /// </value>
         public DiagnosticSeverity Severity { get; set; }
 
+        /// <summary>
+        /// Gets or sets a human-readable string describing the source of this
+        /// diagnostic, e.g. 'typescript' or 'super lint'.
+        /// </summary>
+        /// <value>
+        /// A human-readable string describing the source.
+        /// </value>
         public string Source { get; set; }
 
+        /// <summary>
+        /// Gets the human-readable message.
+        /// </summary>
+        /// <value>
+        /// The human-readable message.
+        /// </value>
         public string Message { get; }
 
         public override string ToString() => $"[{Severity}] {Range}: {Message}";
@@ -43,8 +74,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             End = end;
         }
 
+        /// <summary>
+        /// Gets or sets the start position. It is before or equal to <see cref="End"/>.
+        /// </summary>
+        /// <value>
+        /// The start position. It is before or equal to <see cref="End"/>.
+        /// </value>
         public Position Start { get; set; }
 
+        /// <summary>
+        /// Gets or sets the end position. It is after or equal to <see cref="Start"/>.
+        /// </summary>
+        /// <value>
+        /// The end position. It is after or equal to <see cref="Start"/>.
+        /// </value>
         public Position End { get; set; }
 
         public override string ToString()
@@ -71,8 +114,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             Character = character;
         }
 
+        /// <summary>
+        /// Gets or sets the zero-based line value.
+        /// </summary>
+        /// <value>
+        /// The zero-based line value.
+        /// </value>
         public int Line { get; set; }
 
+        /// <summary>
+        /// Gets or sets the zero-based character value.
+        /// </summary>
+        /// <value>
+        /// The zero-based character value.
+        /// </value>
         public int Character { get; set; }
 
         public override string ToString() => $"line {Line}:{Character}";

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Builder.LanguageGeneration
+{
+    /// <summary>
+    /// Error/Warning report when parsing/evaluating template/inlineText.
+    /// </summary>
+    public class Diagnostic
+    {
+        public Diagnostic(
+            Range range,
+            string message,
+            DiagnosticSeverity severity = DiagnosticSeverity.Error)
+        {
+            Message = message;
+            Range = range;
+            Severity = severity;
+        }
+
+        public string Code { get; set; }
+
+        public Range Range { get; set; }
+
+        public DiagnosticSeverity Severity { get; set; }
+
+        public string Source { get; set; }
+
+        public string Message { get; }
+
+        public override string ToString()
+        {
+            return $"{Severity}: {Message}";
+        }
+    }
+
+    /// <summary>
+    /// A range represents an ordered pair of two positions.
+    /// </summary>
+    public class Range
+    {
+        public Range(Position start, Position end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public Position Start { get; set; }
+
+        public Position End { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a line and character position, such as
+    /// the position of the cursor.
+    /// </summary>
+    public class Position
+    {
+        public Position(int line, int character)
+        {
+            Line = line;
+            Character = character;
+        }
+
+        public int Line { get; set; }
+
+        public int Character { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the severity of diagnostics.
+    /// </summary>
+    public enum DiagnosticSeverity
+    {
+        /// <summary>
+        /// Catch Error info.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Catch Warning info.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Something to inform about but not a problem.
+        /// </summary>
+        Information,
+
+        /// <summary>
+        /// Something to hint to a better way of doing it, like proposing
+        /// a refactoring.
+        /// </summary>
+        Hint,
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public override void SyntaxError([NotNull] IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e)
         {
             var start = new Position(line, charPositionInLine);
-            var stop = new Position(line, charPositionInLine + offendingSymbol.StopIndex - offendingSymbol.StartIndex);
+            var stop = new Position(line, charPositionInLine + offendingSymbol.StopIndex - offendingSymbol.StartIndex + 1);
             var range = new Range(start, stop);
             msg = "syntax error at " + msg;
             var diagnostic = new Diagnostic(range, msg, DiagnosticSeverity.Error);

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     {
         public override void SyntaxError([NotNull] IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e)
         {
-            var start = new Position(line, charPositionInLine);
-            var stop = new Position(line, charPositionInLine + offendingSymbol.StopIndex - offendingSymbol.StartIndex + 1);
-            var range = new Range(start, stop);
+            var startPosition = new Position(line, charPositionInLine);
+            var stopPosition = new Position(line, charPositionInLine + offendingSymbol.StopIndex - offendingSymbol.StartIndex + 1);
+            var range = new Range(startPosition, stopPosition);
             msg = "syntax error at " + msg;
             var diagnostic = new Diagnostic(range, msg, DiagnosticSeverity.Error);
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
@@ -1,11 +1,21 @@
 ﻿using System;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
     public class ErrorListener : BaseErrorListener
     {
-        public override void SyntaxError([NotNull] IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e) => throw new Exception($"[ERROR]: syntax error at line {line}:{charPositionInLine} {msg}");
+        public override void SyntaxError([NotNull] IRecognizer recognizer, [Nullable] IToken offendingSymbol, int line, int charPositionInLine, [NotNull] string msg, [Nullable] RecognitionException e)
+        {
+            var start = new Position(line, charPositionInLine);
+            var stop = new Position(line, charPositionInLine + offendingSymbol.StopIndex - offendingSymbol.StartIndex);
+            var range = new Range(start, stop);
+            msg = "syntax error at " + msg;
+            var diagnostic = new Diagnostic(range, msg, DiagnosticSeverity.Error);
+
+            throw new Exception(JsonConvert.SerializeObject(diagnostic));
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGParser.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public static IList<LGTemplate> Parse(string text, string source = "")
         {
             var parseSuccess = TryParse(text, out var templates, out var diagnostic, source);
-            if (parseSuccess)
+            if (!parseSuccess)
             {
-                return templates;
+                throw new Exception(diagnostic.ToString());
             }
 
-            throw new Exception(diagnostic.ToString());
+            return templates;
         }
 
         /// <summary>
@@ -46,11 +46,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             catch (Exception e)
             {
                 diagnostic = JsonConvert.DeserializeObject<Diagnostic>(e.Message);
+                return false;
             }
 
             templates = ToLGTemplates(fileContext, source);
 
-            return diagnostic == null;
+            return true;
         }
 
         private static LGFileParser.FileContext GetFileContentContext(string text)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGParser.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             return true;
         }
 
+        /// <summary>
+        /// Get parsed tree node from text by antlr4 engine.
+        /// </summary>
+        /// <param name="text">Original text which will be parsed.</param>
+        /// <returns>Parsed tree node.</returns>
         private static LGFileParser.FileContext GetFileContentContext(string text)
         {
             if (string.IsNullOrEmpty(text))

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGParser.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <returns>LG template list.</returns>
         public static IList<LGTemplate> Parse(string text, string source = "")
         {
-            var parseSuccess = TryParse(text, out var templates, out var diagnostic, source);
+            var parseSuccess = TryParse(text, out var templates, out var error, source);
             if (!parseSuccess)
             {
-                throw new Exception(diagnostic.ToString());
+                throw new Exception(error.ToString());
             }
 
             return templates;
@@ -30,13 +30,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// </summary>
         /// <param name="text">LG file content or inline text.</param>
         /// <param name="templates">LG template list.</param>
-        /// <param name="diagnostic">error/warning list.</param>
+        /// <param name="error">error/warning list.</param>
         /// <param name="source">text source.</param>
         /// <returns>LG template if parse success.</returns>
-        public static bool TryParse(string text, out IList<LGTemplate> templates, out Diagnostic diagnostic, string source = "")
+        public static bool TryParse(string text, out IList<LGTemplate> templates, out Diagnostic error, string source = "")
         {
             LGFileParser.FileContext fileContext = null;
-            diagnostic = null;
+            error = null;
             templates = new List<LGTemplate>();
 
             try
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
             catch (Exception e)
             {
-                diagnostic = JsonConvert.DeserializeObject<Diagnostic>(e.Message);
+                error = JsonConvert.DeserializeObject<Diagnostic>(e.Message);
                 return false;
             }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGTemplate.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// </value>
         public LGFileParser.TemplateDefinitionContext ParseTree { get; }
 
-        private string ExtractBody(LGFileParser.TemplateDefinitionContext parseTree) => parseTree.templateBody().GetText();
+        private string ExtractBody(LGFileParser.TemplateDefinitionContext parseTree) => parseTree.templateBody()?.GetText();
 
         private string ExtractName(LGFileParser.TemplateDefinitionContext parseTree) => parseTree.templateNameLine().templateName().GetText();
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -320,6 +320,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             return result;
         }
 
+        /// <summary>
+        /// Build LG diagnostic with antlr tree node context.
+        /// </summary>
+        /// <param name="message">error/warning message. <see cref="Diagnostic.Message"/>.</param>
+        /// <param name="severity">diagnostic Severity <see cref="DiagnosticSeverity"/> to get more info.</param>
+        /// <param name="context">the parsed tree node context of the diagnostic.</param>
+        /// <returns>new Diagnostic object.</returns>
         private Diagnostic BuildLGDiagnostic(
             string message,
             DiagnosticSeverity severity = DiagnosticSeverity.Error,

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     var sources = string.Join(":", g.Select(x => x.Source));
 
                     var msg = $"Duplicated definitions found for template: {name} in {sources}";
-                    result.Add(BuildBotDiagnostic(msg));
+                    result.Add(BuildLGDiagnostic(msg));
                 });
 
                 return result;
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (Templates.Count == 0)
             {
-                result.Add(BuildBotDiagnostic(
+                result.Add(BuildLGDiagnostic(
                     "File must have at least one template definition ",
                     DiagnosticSeverity.Warning));
             }
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (context.templateBody() == null)
             {
-                result.Add(BuildBotDiagnostic($"There is no template body in template {templateName}", context: context.templateNameLine()));
+                result.Add(BuildLGDiagnostic($"There is no template body in template {templateName}", context: context.templateNameLine()));
             }
             else
             {
@@ -86,14 +86,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 if (parameters.CLOSE_PARENTHESIS() == null
                        || parameters.OPEN_PARENTHESIS() == null)
                 {
-                    result.Add(BuildBotDiagnostic($"parameters: {parameters.GetText()} format error", context: context.templateNameLine()));
+                    result.Add(BuildLGDiagnostic($"parameters: {parameters.GetText()} format error", context: context.templateNameLine()));
                 }
 
                 var invalidSeperateCharacters = parameters.INVALID_SEPERATE_CHAR();
                 if (invalidSeperateCharacters != null
                     && invalidSeperateCharacters.Length > 0)
                 {
-                    result.Add(BuildBotDiagnostic("Parameters for templates must be separated by comma.", context: context.templateNameLine()));
+                    result.Add(BuildLGDiagnostic("Parameters for templates must be separated by comma.", context: context.templateNameLine()));
                 }
             }
 
@@ -131,27 +131,27 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                 if (node.GetText().Count(u => u == ' ') > 1)
                 {
-                    result.Add(BuildBotDiagnostic($"At most 1 whitespace is allowed between IF/ELSEIF/ELSE and :. expression: '{context.conditionalTemplateBody().GetText()}", context: conditionNode));
+                    result.Add(BuildLGDiagnostic($"At most 1 whitespace is allowed between IF/ELSEIF/ELSE and :. expression: '{context.conditionalTemplateBody().GetText()}", context: conditionNode));
                 }
 
                 if (idx == 0 && !ifExpr)
                 {
-                    result.Add(BuildBotDiagnostic($"condition is not start with if: '{context.conditionalTemplateBody().GetText()}'", DiagnosticSeverity.Warning, conditionNode));
+                    result.Add(BuildLGDiagnostic($"condition is not start with if: '{context.conditionalTemplateBody().GetText()}'", DiagnosticSeverity.Warning, conditionNode));
                 }
 
                 if (idx > 0 && ifExpr)
                 {
-                    result.Add(BuildBotDiagnostic($"condition can't have more than one if: '{context.conditionalTemplateBody().GetText()}'", context: conditionNode));
+                    result.Add(BuildLGDiagnostic($"condition can't have more than one if: '{context.conditionalTemplateBody().GetText()}'", context: conditionNode));
                 }
 
                 if (idx == ifRules.Length - 1 && !elseExpr)
                 {
-                    result.Add(BuildBotDiagnostic($"condition is not end with else: '{context.conditionalTemplateBody().GetText()}'", DiagnosticSeverity.Warning, conditionNode));
+                    result.Add(BuildLGDiagnostic($"condition is not end with else: '{context.conditionalTemplateBody().GetText()}'", DiagnosticSeverity.Warning, conditionNode));
                 }
 
                 if (idx > 0 && idx < ifRules.Length - 1 && !elseIfExpr)
                 {
-                    result.Add(BuildBotDiagnostic($"only elseif is allowed in middle of condition: '{context.conditionalTemplateBody().GetText()}'", context: conditionNode));
+                    result.Add(BuildLGDiagnostic($"only elseif is allowed in middle of condition: '{context.conditionalTemplateBody().GetText()}'", context: conditionNode));
                 }
 
                 // check rule should should with one and only expression
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     if (ifRules[idx].ifCondition().EXPRESSION().Length != 1)
                     {
-                        result.Add(BuildBotDiagnostic($"if and elseif should followed by one valid expression: '{ifRules[idx].GetText()}'", context: conditionNode));
+                        result.Add(BuildLGDiagnostic($"if and elseif should followed by one valid expression: '{ifRules[idx].GetText()}'", context: conditionNode));
                     }
                     else
                     {
@@ -170,7 +170,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     if (ifRules[idx].ifCondition().EXPRESSION().Length != 0)
                     {
-                        result.Add(BuildBotDiagnostic($"else should not followed by any expression: '{ifRules[idx].GetText()}'", context: conditionNode));
+                        result.Add(BuildLGDiagnostic($"else should not followed by any expression: '{ifRules[idx].GetText()}'", context: conditionNode));
                     }
                 }
 
@@ -180,7 +180,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
                 else
                 {
-                    result.Add(BuildBotDiagnostic($"no normal template body in condition block: '{ifRules[idx].GetText()}'", context: conditionNode));
+                    result.Add(BuildLGDiagnostic($"no normal template body in condition block: '{ifRules[idx].GetText()}'", context: conditionNode));
                 }
             }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 switch (node.Symbol.Type)
                 {
                     case LGFileParser.INVALID_ESCAPE:
-                        result.Add(BuildBotDiagnostic($"escape character {node.GetText()} is invalid", context: context));
+                        result.Add(BuildLGDiagnostic($"escape character {node.GetText()} is invalid", context: context));
                         break;
                     case LGFileParser.TEMPLATE_REF:
                         result.AddRange(CheckTemplateRef(node.GetText(), context));
@@ -233,14 +233,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var argsEndPos = exp.LastIndexOf(')');
                 if (argsEndPos < 0 || argsEndPos < argsStartPos + 1)
                 {
-                    result.Add(BuildBotDiagnostic($"Not a valid template ref: {exp}", context: context));
+                    result.Add(BuildLGDiagnostic($"Not a valid template ref: {exp}", context: context));
                 }
                 else
                 {
                     var templateName = exp.Substring(0, argsStartPos);
                     if (!templateMap.ContainsKey(templateName))
                     {
-                        result.Add(BuildBotDiagnostic($"[{templateName}] template not found", context: context));
+                        result.Add(BuildLGDiagnostic($"[{templateName}] template not found", context: context));
                     }
                     else
                     {
@@ -253,7 +253,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 if (!templateMap.ContainsKey(exp))
                 {
-                    result.Add(BuildBotDiagnostic($"[{exp}] template not found", context: context));
+                    result.Add(BuildLGDiagnostic($"[{exp}] template not found", context: context));
                 }
             }
 
@@ -284,7 +284,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (exp.StartsWith("```"))
             {
-                result.Add(BuildBotDiagnostic("Multi line variation must be enclosed in ```", context: context));
+                result.Add(BuildLGDiagnostic("Multi line variation must be enclosed in ```", context: context));
             }
 
             return result;
@@ -297,7 +297,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (argsNumber != parametersNumber)
             {
-                result.Add(BuildBotDiagnostic($"Arguments count mismatch for template ref {templateName}, expected {parametersNumber}, actual {argsNumber}", context: context));
+                result.Add(BuildLGDiagnostic($"Arguments count mismatch for template ref {templateName}, expected {parametersNumber}, actual {argsNumber}", context: context));
             }
 
             return result;
@@ -313,14 +313,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
             catch (Exception e)
             {
-                result.Add(BuildBotDiagnostic(e.Message + $" in expression `{exp}`", context: context));
+                result.Add(BuildLGDiagnostic(e.Message + $" in expression `{exp}`", context: context));
                 return result;
             }
 
             return result;
         }
 
-        private Diagnostic BuildBotDiagnostic(
+        private Diagnostic BuildLGDiagnostic(
             string message,
             DiagnosticSeverity severity = DiagnosticSeverity.Error,
             ParserRuleContext context = null)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -332,9 +332,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             DiagnosticSeverity severity = DiagnosticSeverity.Error,
             ParserRuleContext context = null)
         {
-            var start = context == null ? new Position(0, 0) : new Position(context.Start.Line - 1, context.Start.Column);
-            var stop = context == null ? new Position(0, 0) : new Position(context.Stop.Line - 1, context.Stop.Column);
-            var range = new Range(start, stop);
+            var startPosition = context == null ? new Position(0, 0) : new Position(context.Start.Line - 1, context.Start.Column);
+            var stopPosition = context == null ? new Position(0, 0) : new Position(context.Stop.Line - 1, context.Stop.Column);
+            var range = new Range(startPosition, stopPosition);
             return new Diagnostic(range, message, severity);
         }
     }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public TemplateEngine AddText(string text)
         {
             Templates.AddRange(LGParser.Parse(text, "text"));
-            RunStaticCheck(text: text);
+            RunStaticCheck();
             return this;
         }
 
@@ -85,41 +85,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// Check templates/text to match LG format.
         /// </summary>
         /// <param name="templates">the templates which should be checked.</param>
-        /// <param name="text">the original text which should be checked.</param>
-        public void RunStaticCheck(List<LGTemplate> templates = null, string text = null)
+        public void RunStaticCheck(List<LGTemplate> templates = null)
         {
-            var diagnostics = GetAllDiagnostics(templates, text);
+            var teamplatesToCheck = templates ?? this.Templates;
+            var checker = new StaticChecker(teamplatesToCheck);
+            var diagnostics = checker.Check();
 
             var errors = diagnostics.Where(u => u.Severity == DiagnosticSeverity.Error).ToList();
             if (errors.Count != 0)
             {
                 throw new Exception(string.Join("\n", errors));
             }
-        }
-
-        /// <summary>
-        /// Get all diagnostic including Errors/Warnings from template/texts.
-        /// Everyone should use this function to get all code suggestions.
-        /// </summary>
-        /// <param name="templates">the templates which should be checked.</param>
-        /// <param name="text">the original text which should be checked.</param>
-        /// <returns>Diagnostic list.</returns>
-        public IList<Diagnostic> GetAllDiagnostics(List<LGTemplate> templates = null, string text = null)
-        {
-            var teamplatesToCheck = templates ?? this.Templates;
-            var checker = new StaticChecker(teamplatesToCheck);
-            var diagnostics = checker.Check();
-
-            if (!string.IsNullOrWhiteSpace(text))
-            {
-                var parseSuccess = LGParser.TryParse(text, out var _, out var syntaxError, "text");
-                if (!parseSuccess)
-                {
-                    diagnostics.Add(syntaxError);
-                }
-            }
-
-            return diagnostics;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var checker = new StaticChecker(teamplatesToCheck);
             var report = checker.Check();
 
-            var errors = report.Where(u => u.Type == ReportEntryType.ERROR).ToList();
+            var errors = report.Where(u => u.Severity == DiagnosticSeverity.Error).ToList();
             if (errors.Count != 0)
             {
                 throw new Exception(string.Join("\n", errors));

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
@@ -77,22 +77,49 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public TemplateEngine AddText(string text)
         {
             Templates.AddRange(LGParser.Parse(text, "text"));
-
-            RunStaticCheck();
+            RunStaticCheck(text: text);
             return this;
         }
 
-        public void RunStaticCheck(List<LGTemplate> templates = null)
+        /// <summary>
+        /// Check templates/text to match LG format.
+        /// </summary>
+        /// <param name="templates">the templates which should be checked.</param>
+        /// <param name="text">the original text which should be checked.</param>
+        public void RunStaticCheck(List<LGTemplate> templates = null, string text = null)
         {
-            var teamplatesToCheck = templates ?? this.Templates;
-            var checker = new StaticChecker(teamplatesToCheck);
-            var report = checker.Check();
+            var diagnostics = GetAllDiagnostics(templates, text);
 
-            var errors = report.Where(u => u.Severity == DiagnosticSeverity.Error).ToList();
+            var errors = diagnostics.Where(u => u.Severity == DiagnosticSeverity.Error).ToList();
             if (errors.Count != 0)
             {
                 throw new Exception(string.Join("\n", errors));
             }
+        }
+
+        /// <summary>
+        /// Get all diagnostic including Errors/Warnings from template/texts.
+        /// Everyone should use this function to get all code suggestions.
+        /// </summary>
+        /// <param name="templates">the templates which should be checked.</param>
+        /// <param name="text">the original text which should be checked.</param>
+        /// <returns>Diagnostic list.</returns>
+        public IList<Diagnostic> GetAllDiagnostics(List<LGTemplate> templates = null, string text = null)
+        {
+            var teamplatesToCheck = templates ?? this.Templates;
+            var checker = new StaticChecker(teamplatesToCheck);
+            var diagnostics = checker.Check();
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                var parseSuccess = LGParser.TryParse(text, out var _, out var syntaxError, "text");
+                if (!parseSuccess)
+                {
+                    diagnostics.Add(syntaxError);
+                }
+            }
+
+            return diagnostics;
         }
 
         /// <summary>


### PR DESCRIPTION
Refer to the diagnostics specification of vscode Extension to add more information to the error handling, including starting rows/columns, stopping rows and columns.