### PR TITLE
[TestBot] Configure an endpoint for each bot

### DIFF
--- a/FunctionalTests/ExportedTemplate/template.json
+++ b/FunctionalTests/ExportedTemplate/template.json
@@ -76,7 +76,7 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/mybot')]"
     },
     "resources": [
         {

--- a/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -49,10 +49,28 @@ namespace Microsoft.BotBuilderSamples
             services.AddSingleton<MainDialog>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
+            services.AddScoped<MyBot>();
+            services.AddScoped<DialogBot<MainDialog>>();
+            services.AddScoped<DialogAndWelcomeBot<MainDialog>>();
 
             // We can also run the inspection at a different endpoint. Just uncomment these lines.
             // services.AddSingleton<DebugAdapter>();
             // services.AddTransient<DebugBot>();
+            services.AddTransient<Func<string, IBot>>(serviceProvider => key =>
+            {
+                switch (key)
+                {
+                    case "mybot":
+                        return serviceProvider.GetService<MyBot>();
+                    case "dialogbot":
+                        return serviceProvider.GetService<DialogBot<MainDialog>>();
+                    case "messages":
+                    case "dialogandwelcomebot":
+                        return serviceProvider.GetService<DialogAndWelcomeBot<MainDialog>>();
+                    default:
+                        return null;
+                }
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -71,10 +89,12 @@ namespace Microsoft.BotBuilderSamples
             app.UseStaticFiles();
 
             // app.UseHttpsRedirection();
-            app.UseMvc();
-        }
-
+            app.UseMvc(routes =>
             {
+                routes.MapRoute(
+                    name: "default",
+                    template: "api/{controller}");
+            });
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -22,8 +22,6 @@ namespace Microsoft.BotBuilderSamples
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            GetEnvironmentVariables();
-
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
             // Create the credential provider to be used with the Bot Framework Adapter.
@@ -51,20 +49,6 @@ namespace Microsoft.BotBuilderSamples
             services.AddSingleton<MainDialog>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            switch (chosenBot)
-            {
-                case "EchoBot":
-                    services.AddTransient<IBot, MyBot>();
-                    break;
-
-                case "DialogBot":
-                    services.AddTransient<IBot, DialogBot<MainDialog>>();
-                    break;
-
-                default:
-                    services.AddTransient<IBot, DialogAndWelcomeBot<MainDialog>>();
-                    break;
-            }
 
             // We can also run the inspection at a different endpoint. Just uncomment these lines.
             // services.AddSingleton<DebugAdapter>();
@@ -90,16 +74,7 @@ namespace Microsoft.BotBuilderSamples
             app.UseMvc();
         }
 
-        public void GetEnvironmentVariables()
-        {
-            if (string.IsNullOrWhiteSpace(chosenBot))
             {
-                chosenBot = Environment.GetEnvironmentVariable("CHOSENBOT");
-                if (string.IsNullOrWhiteSpace(chosenBot))
-                {
-                    chosenBot = "DialogAndWelcomeBot";
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Closes #1924 

# Proposed Changes

- Remove the _switch_-based bot assignation and its variable, and replace it with a `Func<string, IBot>` service.
- Add a different endpoint for each bot to the controller.

## Modifications in Pipelines

With these changes we can remove the `CHOSENBOT` variable from the Pipelines build and the line where we set that `CHOSENBOT` into Azure's WebApp.

![image](https://user-images.githubusercontent.com/42191764/58480217-3fc81000-8130-11e9-9c44-0841dbb010ca.png)

![image](https://user-images.githubusercontent.com/42191764/58480222-45255a80-8130-11e9-8a84-655855c57486.png)
