### PR TITLE
Add support in ActivityHandler for Teams signin (invoke) response

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Bot.Builder
             if (turnContext.Activity.Name == "signin/verifyState")
             {
                 turnContext.SendActivityAsync(new Activity(ActivityTypesEx.InvokeResponse, value: null)).Wait(cancellationToken);
-                return OnMsTeamsTokenResponseEventAsync(turnContext, cancellationToken);
+                return OnMsTeamsSigninResponseInvokeAsync(turnContext, cancellationToken);
             }
 
             return OnInvokeActivityAsync(turnContext, cancellationToken);
@@ -225,7 +225,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        protected virtual Task OnMsTeamsTokenResponseEventAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
+        protected virtual Task OnMsTeamsSigninResponseInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        private Task OnInvokeActivityAsync(DelegatingTurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
+        private Task OnInvokeActivityAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
         {
             if (turnContext.Activity.Name == "signin/verifyState")
             {
@@ -212,7 +212,7 @@ namespace Microsoft.Bot.Builder
                 return OnMsTeamsSigninResponseInvokeAsync(turnContext, cancellationToken);
             }
 
-            return OnInvokeActivityAsync(turnContext, cancellationToken);
+            return OnInvokeAsync(turnContext, cancellationToken);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        protected virtual Task OnInvokeActivityAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        protected virtual Task OnInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Added support for Invoke Activities to ActivityHandler, with specific support for enabling forwarding of Teams Sign-in response to current dialog.

Currently ActivityHandler allows a developer to override the OnTokenResponseEventAsync activity to forward incoming token responses to the current dialog.

This change

* Adds Invoke activity support to the ActivityHandler
* Checks for an incoming signin/verifyState invoke activity from teams and sends an appropriate Invoke response back to Teams
* Allows a developer to override new method OnMsTeamsSigninResponseInvokeAsync to forward to the current dialog (the OAuthPrompt already contains a check for an MSTeams Invoke Activity of this type).

e.g.

```cs
protected override async Task OnMsTeamsSigninResponseInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
        {
            Logger.LogInformation("Running dialog with MsTeams Token Response Event Activity.");

            // Run the Dialog with the new MsTeams Token Response Event Activity.
            await Dialog.Run(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
        }
```