### PR TITLE
Updated recognizer project NuGet references to 1.2

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -29,8 +29,8 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-		<PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.1.3" />
-		<PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
+		<PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.2.0" />
+		<PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.0" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
 	</ItemGroup>
 

--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/Microsoft.Bot.Builder.TestBot.WebApi.csproj
@@ -112,7 +112,7 @@
       <Version>2.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression">
-      <Version>1.1.6</Version>
+      <Version>1.2.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.1</Version>

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.1.5" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the following NuGet packages.

* Microsoft.Recognizers.Text.Choice to 1.2
* Microsoft.Recognizers.Text.DataTypes.TimexExpression to 1.2
* Microsoft.Recognizers.Text.DateTime to 1.2

Note: This was previously blocked due to a breaking change causing the **MultipleResolutionsDateTimePrompt** test to fail as tracked in #1622 and some other related issues.  This has been addressed and the unit test is now passing with the latest package.