### PR TITLE
The signin card type for non Teams channel was changed accidentally i…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                                 {
                                     Title = _settings.Title,
                                     Value = link,
-                                    Type = turnContext.Activity.ChannelId == "msteams" ? ActionTypes.Signin : ActionTypes.OpenUrl,
+                                    Type = ActionTypes.Signin,
                                 },
                             },
                         },


### PR DESCRIPTION
…n https://github.com/microsoft/botbuilder-dotnet/pull/1579. Fix it.