### PR TITLE
a manual cherry pick from 4.4

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -7,7 +7,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder.BotFramework;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core
@@ -17,6 +19,19 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// </summary>
     public class BotFrameworkHttpAdapter : BotFrameworkAdapter, IBotFrameworkHttpAdapter
     {
+        public BotFrameworkHttpAdapter(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger = null)
+            : base(new ConfigurationCredentialProvider(configuration), new ConfigurationChannelProvider(configuration), customHttpClient: null, middleware: null, logger: logger)
+        {
+            var openIdEndpoint = configuration.GetSection(AuthenticationConstants.BotOpenIdMetadataKey)?.Value;
+
+            if (!string.IsNullOrEmpty(openIdEndpoint))
+            {
+                // Indicate which Cloud we are using, for example, Public or Sovereign.
+                ChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
+                GovernmentChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
+            }
+        }
+
         public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider = null, IChannelProvider channelProvider = null, ILogger<BotFrameworkHttpAdapter> logger = null)
             : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, null, null, logger)
         {

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpAdapterTests.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Rest.Serialization;
 using Moq;
 using Moq.Protected;
@@ -101,6 +105,41 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
             // Assert
             mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public void ConstructorWithConfiguration()
+        {
+            // Arrange
+            var appSettings = new Dictionary<string, string>
+            {
+                { "MicrosoftAppId", "appId" },
+                { "MicrosoftAppPassword", "appPassword" },
+                { "ChannelService", "channelService" },
+                { "BotOpenIdMetadata", "botOpenIdMetadata" },
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(appSettings)
+                .Build();
+
+            // Act
+            var adapter = new BotFrameworkHttpAdapter(configuration);
+
+            // Assert
+
+            // Note this is a special case testing a little more than just the public interface.
+            var credentialProviderField = typeof(BotFrameworkAdapter).GetField("_credentialProvider", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+            var channelProviderField = typeof(BotFrameworkAdapter).GetField("_channelProvider", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
+
+            var credentialProvider = (SimpleCredentialProvider)credentialProviderField.GetValue(adapter);
+            var channelProvider = (SimpleChannelProvider)channelProviderField.GetValue(adapter);
+
+            Assert.Equal("appId", credentialProvider.AppId);
+            Assert.Equal("appPassword", credentialProvider.Password);
+            Assert.Equal("channelService", channelProvider.ChannelService);
+            Assert.Equal("botOpenIdMetadata", ChannelValidation.OpenIdMetadataUrl);
+            Assert.Equal("botOpenIdMetadata", GovernmentChannelValidation.OpenIdMetadataUrl);
         }
 
         private static Stream CreateMessageActivityStream()


### PR DESCRIPTION
We added an extra constructor for BotFrameworkHttpAdapter in 4.4.

This brings that change into master.
