### PR TITLE
Adds overrides to LuisRecognizer.RecognizeAsync that take luis LuisPredictionOptions

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/ITelemetryRecognizer.cs
@@ -37,6 +37,13 @@ namespace Microsoft.Bot.Builder.AI.Luis
         Task<T> RecognizeAsync<T>(ITurnContext turnContext, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new();
 
+        /// <summary>
+        /// Runs an utterance through a recognizer and returns a strongly-typed recognizer result.
+        /// </summary>
+        /// <typeparam name="T">The recognition result type.</typeparam>
+        /// <param name="turnContext">Turn context.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Analysis of utterance.</returns>
         new Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
             where T : IRecognizerConvert, new();
     }

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisPredictionOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisPredictionOptions.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <value>
         /// The time in milliseconds to wait before the request times out. Default is 100000 milliseconds.
         /// </value>
+        /// <remarks>
+        /// This value can only be set when <see cref="LuisRecognizer"/> is created and can't be changed
+        /// in individual <see cref="IRecognizer.RecognizeAsync"/> calls.
+        /// </remarks>
         public double Timeout { get; set; } = 100000;
 
         /// <summary>
@@ -80,6 +84,10 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <value>
         /// The client used to log telemetry events.
         /// </value>
+        /// <remarks>
+        /// This value can only be set when <see cref="LuisRecognizer"/> is created and can't be changed
+        /// in individual <see cref="IRecognizer.RecognizeAsync"/> calls.
+        /// </remarks>
         [JsonIgnore]
         public IBotTelemetryClient TelemetryClient { get; set; } = new NullBotTelemetryClient();
 
@@ -87,6 +95,10 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
         /// </summary>
         /// <value>If true, personal information is logged to Telemetry; otherwise the properties will be filtered.</value>
+        /// <remarks>
+        /// This value can only be set when <see cref="LuisRecognizer"/> is created and can't be changed
+        /// in individual <see cref="IRecognizer.RecognizeAsync"/> calls.
+        /// </remarks>
         public bool LogPersonalInformation { get; set; } = false;
     }
 }

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/EmptyLuisResponseClientHandler.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/EmptyLuisResponseClientHandler.cs
@@ -8,17 +8,21 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Tests
 {
+    /// <inheritdoc />
     /// <summary>
-    /// This HttpClientHandler returns a hard coded response equivallent to a LUIS no-match-found result.
+    /// An HttpClientHandler that returns a hard coded response equivalent to a LUIS no-match-found result.
     /// </summary>
     public class EmptyLuisResponseClientHandler : HttpClientHandler
     {
         public string UserAgent { get; private set; }
 
+        public HttpRequestMessage RequestMessage { get; private set; }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            // Grab the user-agent so we can examine it after the call completes.
+            // Capture the user-agent and the HttpRequestMessage so we can examine it after the call completes.
             UserAgent = request.Headers.UserAgent.ToString();
+            RequestMessage = request;
 
             return Task.FromResult(new HttpResponseMessage
             {

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.AI.Luis.Tests
+{
+    public class LuisRecognizerTests
+    {
+        private readonly LuisApplication _luisApp;
+        private readonly EmptyLuisResponseClientHandler _mockHttpClientHandler;
+
+        public LuisRecognizerTests()
+        {
+            _luisApp = new LuisApplication(Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), "https://someluisendpoint");
+            _mockHttpClientHandler = new EmptyLuisResponseClientHandler();
+        }
+
+        [Theory]
+        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(true, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42, true, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", true, false)]
+        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, true)]
+        [InlineData(null, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, null, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42, null, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42, false, null, false, false)]
+        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", null, false)]
+        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, null)]
+        [InlineData(null, null, null, null, null, null)]
+        public async Task LuisPredictionOptionsAreUsedInTheRequest(bool? includeAllIntents, double? timezoneOffset, bool? spellCheck, string bingSpellCheckSubscriptionKey, bool? log, bool? staging)
+        {
+            // Arrange
+            var expectedOptions = new LuisPredictionOptions()
+            {
+                IncludeAllIntents = includeAllIntents,
+                TimezoneOffset = timezoneOffset,
+                SpellCheck = spellCheck,
+                BingSpellCheckSubscriptionKey = bingSpellCheckSubscriptionKey,
+                Log = log ?? true,
+                Staging = staging,
+            };
+
+            var sut = new LuisRecognizer(_luisApp, expectedOptions, clientHandler: _mockHttpClientHandler);
+
+            // Act
+            await sut.RecognizeAsync(BuildTurnContextForUtterance("hi"), CancellationToken.None);
+
+            // Assert
+            AssertLuisRequest(_mockHttpClientHandler.RequestMessage, expectedOptions);
+        }
+
+        [Theory]
+        [InlineData(false, null, null, null, null, null)]
+        [InlineData(null, 55, null, null, null, null)]
+        [InlineData(null, null, false, null, null, null)]
+        [InlineData(null, null, null, "Override-EC0A-472D-95B7-A7132D159E03", null, null)]
+        [InlineData(null, null, null, null, true, null)]
+        [InlineData(null, null, null, null, null, false)]
+        [InlineData(null, null, null, null, null, null)]
+        public async Task ShouldOverridePredictionOptionsIfProvided(bool? includeAllIntents, double? timezoneOffset, bool? spellCheck, string bingSpellCheckSubscriptionKey, bool? log, bool? staging)
+        {
+            // Arrange
+            // Initialize options with non default values so we can assert they have been overriden.
+            var constructorOptions = new LuisPredictionOptions()
+            {
+                IncludeAllIntents = true,
+                TimezoneOffset = 42,
+                SpellCheck = true,
+                BingSpellCheckSubscriptionKey = "Fake2806-EC0A-472D-95B7-A7132D159E03",
+                Log = false,
+                Staging = true,
+            };
+
+            // Create overriden options for call
+            var overridenOptions = new LuisPredictionOptions()
+            {
+                IncludeAllIntents = includeAllIntents,
+                TimezoneOffset = timezoneOffset,
+                SpellCheck = spellCheck,
+                BingSpellCheckSubscriptionKey = bingSpellCheckSubscriptionKey,
+                Log = log,
+                Staging = staging,
+            };
+
+            // Create combined options for assertion taking the test case value if not null or the constructor value if not null.
+            var expectedOptions = new LuisPredictionOptions()
+            {
+                IncludeAllIntents = includeAllIntents ?? constructorOptions.IncludeAllIntents,
+                TimezoneOffset = timezoneOffset ?? constructorOptions.TimezoneOffset,
+                SpellCheck = spellCheck ?? constructorOptions.SpellCheck,
+                BingSpellCheckSubscriptionKey = bingSpellCheckSubscriptionKey ?? constructorOptions.BingSpellCheckSubscriptionKey,
+                Log = log ?? constructorOptions.Log,
+                Staging = staging ?? constructorOptions.Staging,
+                LogPersonalInformation = constructorOptions.LogPersonalInformation,
+            };
+
+            var sut = new LuisRecognizer(_luisApp, constructorOptions, clientHandler: _mockHttpClientHandler);
+
+            // Act/Assert RecognizeAsync override
+            await sut.RecognizeAsync(BuildTurnContextForUtterance("hi"), overridenOptions, CancellationToken.None);
+            AssertLuisRequest(_mockHttpClientHandler.RequestMessage, expectedOptions);
+
+            // these values can't be overriden and should stay unchanged.
+            Assert.Equal(constructorOptions.TelemetryClient, sut.TelemetryClient);
+            Assert.Equal(constructorOptions.LogPersonalInformation, sut.LogPersonalInformation);
+
+            // Act/Assert RecognizeAsync<T> override
+            await sut.RecognizeAsync<Contoso_App>(BuildTurnContextForUtterance("hi"), overridenOptions, CancellationToken.None);
+            AssertLuisRequest(_mockHttpClientHandler.RequestMessage, expectedOptions);
+
+            // these values can't be overriden and should stay unchanged.
+            Assert.Equal(constructorOptions.TelemetryClient, sut.TelemetryClient);
+            Assert.Equal(constructorOptions.LogPersonalInformation, sut.LogPersonalInformation);
+        }
+
+        private static void AssertLuisRequest(HttpRequestMessage httpRequestForLuis, LuisPredictionOptions expectedOptions)
+        {
+            var queryStringParameters = HttpUtility.ParseQueryString(httpRequestForLuis.RequestUri.Query);
+            Assert.Equal(expectedOptions.BingSpellCheckSubscriptionKey?.ToString(CultureInfo.InvariantCulture), queryStringParameters["bing-spell-check-subscription-key"]);
+            Assert.Equal(expectedOptions.SpellCheck?.ToString(CultureInfo.InvariantCulture).ToLower(), queryStringParameters["spellCheck"]);
+            Assert.Equal(expectedOptions.IncludeAllIntents?.ToString(CultureInfo.InvariantCulture).ToLower(), queryStringParameters["verbose"]);
+            Assert.Equal(expectedOptions.Staging?.ToString(CultureInfo.InvariantCulture).ToLower(), queryStringParameters["staging"]);
+            Assert.Equal(expectedOptions.Log?.ToString(CultureInfo.InvariantCulture).ToLower(), queryStringParameters["log"]);
+        }
+
+        private static TurnContext BuildTurnContextForUtterance(string utterance)
+        {
+            var testAdapter = new TestAdapter();
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Message,
+                Text = utterance,
+                Conversation = new ConversationAccount(),
+                Recipient = new ChannelAccount(),
+                From = new ChannelAccount(),
+            };
+            return new TurnContext(testAdapter, activity);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -7,10 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added overrides to LuisRecognizer.RecognizeAsync that take LuisPredictionOptions.
Added unit tests for the different use case.
Removed IRecognizer from LuisRecognizer (it is implicit through the implementation of ITelemetryRecognizer)
Updated EmptyLuisResponseClientHandler to be able to use it with the recognizer tests.