### PR TITLE
Updated ComponentDialog so it returns DialogTurnStatus.Cancelled when the dialog is cancelled

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 if (turnResult.Status == DialogTurnStatus.Cancelled)
                 {
+                    await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
                     return new DialogTurnResult(DialogTurnStatus.Cancelled, turnResult.Result);
                 }
 
@@ -92,6 +93,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 if (turnResult.Status == DialogTurnStatus.Cancelled)
                 {
+                    await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
                     return new DialogTurnResult(DialogTurnStatus.Cancelled, turnResult.Result);
                 }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -62,14 +62,17 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Check for end of inner dialog
             if (turnResult.Status != DialogTurnStatus.Waiting)
             {
+                if (turnResult.Status == DialogTurnStatus.Cancelled)
+                {
+                    return new DialogTurnResult(DialogTurnStatus.Cancelled, turnResult.Result);
+                }
+
                 // Return result to calling dialog
                 return await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                // Just signal waiting
-                return Dialog.EndOfTurn;
-            }
+
+            // Just signal waiting
+            return Dialog.EndOfTurn;
         }
 
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext outerDc, CancellationToken cancellationToken = default(CancellationToken))
@@ -87,12 +90,15 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             if (turnResult.Status != DialogTurnStatus.Waiting)
             {
+                if (turnResult.Status == DialogTurnStatus.Cancelled)
+                {
+                    return new DialogTurnResult(DialogTurnStatus.Cancelled, turnResult.Result);
+                }
+
                 return await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                return Dialog.EndOfTurn;
-            }
+
+            return Dialog.EndOfTurn;
         }
 
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext outerDc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -179,7 +185,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
         protected virtual Task<DialogTurnResult> EndComponentAsync(DialogContext outerDc, object result, CancellationToken cancellationToken)
         {
-            return outerDc.EndDialogAsync(result);
+            return outerDc.EndDialogAsync(result, cancellationToken);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 async (step, ct) =>
                 {
-                    await step.Context.SendActivityAsync("Child started.");
+                    await step.Context. SendActivityAsync("Child started.");
                     return await step.BeginDialogAsync("parentDialog", options);
                 },
                 async (step, ct) =>
@@ -288,6 +288,74 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
+        [TestMethod]
+        public async Task CancelDialogOnFirstStepTest()
+        {
+            var steps = new WaterfallStep[]
+            {
+                CancelledWaterfallStep,
+            };
+            var waterfallDialog = new WaterfallDialog("test-waterfall", steps);
+            var testFlow = CreateTestFlow(waterfallDialog);
+            await testFlow
+                .Send("hello")
+                .AssertReply("Component dialog cancelled (result value is 42).")
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task CancelDialogOnSecondStepTest()
+        {
+            var steps = new WaterfallStep[]
+            {
+                WaterfallStep1,
+                CancelledWaterfallStep,
+            };
+            var waterfallDialog = new WaterfallDialog("test-waterfall", steps);
+            var testFlow = CreateTestFlow(waterfallDialog);
+            await testFlow
+                .Send("hello")
+                .AssertReply("Enter a number.")
+                .Send("42")
+                .AssertReply("Component dialog cancelled (result value is 42).")
+                .StartTestAsync();
+        }
+
+        private static TestFlow CreateTestFlow(WaterfallDialog waterfallDialog)
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var testFlow = new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var state = await dialogState.GetAsync(turnContext, () => new DialogState(), cancellationToken);
+                var dialogs = new DialogSet(dialogState);
+
+                dialogs.Add(new CancelledComponentDialog(waterfallDialog));
+
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    results = await dc.BeginDialogAsync("TestComponentDialog", null, cancellationToken);
+                }
+                if (results.Status == DialogTurnStatus.Cancelled)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Component dialog cancelled (result value is {results.Result?.ToString()})."), cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var value = (int)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Bot received the number '{value}'."), cancellationToken);
+                }
+            });
+            return testFlow;
+        }
+
         private static WaterfallDialog CreateWaterfall()
         {
             var steps = new WaterfallStep[]
@@ -327,6 +395,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             return await stepContext.BeginDialogAsync("TestComponentDialog", null, cancellationToken);
         }
 
+        private static Task<DialogTurnResult> CancelledWaterfallStep(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new DialogTurnResult(DialogTurnStatus.Cancelled, 42));
+        }
+
         private class TestComponentDialog : ComponentDialog
         {
             public TestComponentDialog()
@@ -353,6 +426,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     steps));
                 AddDialog(new NumberPrompt<int>("number", defaultLocale: Culture.English));
                 AddDialog(new TestComponentDialog());
+            }
+        }
+
+        private class CancelledComponentDialog : ComponentDialog
+        {
+            public CancelledComponentDialog(Dialog waterfallDialog)
+                : base("TestComponentDialog")
+            {
+                AddDialog(waterfallDialog);
+                AddDialog(new NumberPrompt<int>("number", defaultLocale: Culture.English));
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 async (step, ct) =>
                 {
-                    await step.Context. SendActivityAsync("Child started.");
+                    await step.Context.SendActivityAsync("Child started.");
                     return await step.BeginDialogAsync("parentDialog", options);
                 },
                 async (step, ct) =>


### PR DESCRIPTION
Right now, if a component dialog is cancelled, the status returned is Completed, this is inconsistent with the behavior for Dialogs

This PR updates the ComponentDialog class to return Cancelled if the dialog is cancelled. It will still return the results object in case the dev wants to use this value to return information regarding the cancellation.