### PR TITLE
make new constructor protected to avoid potential ambiguity in DI

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -19,7 +19,17 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// </summary>
     public class BotFrameworkHttpAdapter : BotFrameworkAdapter, IBotFrameworkHttpAdapter
     {
-        public BotFrameworkHttpAdapter(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger = null)
+        public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider = null, IChannelProvider channelProvider = null, ILogger<BotFrameworkHttpAdapter> logger = null)
+            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, null, null, logger)
+        {
+        }
+
+        public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider, IChannelProvider channelProvider, HttpClient httpClient, ILogger<BotFrameworkHttpAdapter> logger)
+            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, httpClient, null, logger)
+        {
+        }
+
+        protected BotFrameworkHttpAdapter(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger = null)
             : base(new ConfigurationCredentialProvider(configuration), new ConfigurationChannelProvider(configuration), customHttpClient: null, middleware: null, logger: logger)
         {
             var openIdEndpoint = configuration.GetSection(AuthenticationConstants.BotOpenIdMetadataKey)?.Value;
@@ -30,16 +40,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 ChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
                 GovernmentChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
             }
-        }
-
-        public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider = null, IChannelProvider channelProvider = null, ILogger<BotFrameworkHttpAdapter> logger = null)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, null, null, logger)
-        {
-        }
-
-        public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider, IChannelProvider channelProvider, HttpClient httpClient, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, httpClient, null, logger)
-        {
         }
 
         public async Task ProcessAsync(HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default(CancellationToken))

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpAdapterTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 .Build();
 
             // Act
-            var adapter = new BotFrameworkHttpAdapter(configuration);
+            var adapter = new MyAdapter(configuration);
 
             // Assert
 
@@ -175,6 +175,14 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             textWriter.Flush();
             stream.Seek(0, SeekOrigin.Begin);
             return stream;
+        }
+
+        private class MyAdapter : BotFrameworkHttpAdapter
+        {
+            public MyAdapter(IConfiguration configuration)
+                : base(configuration)
+            {
+            }
         }
 
         private class InvokeResponseBot : IBot


### PR DESCRIPTION
The constructor we added in 4.4.4 introduced ambiguity in the DI system in some usage patterns.

The implication is any project being updated to 4.4.4 from anything after 4.3.* can hit this ambiguity if they have included the BotFrameworkHttpAdapter directly in the DI setup. The ambiguity is only hit when you attempt to use the constructor directly, the ideal pattern in the application code is to subclass (and we follow this in the majority of the samples.) However we managed to break this code:

    services.AddSingletone<IBotFrameworkHttpAdapter, BotFrameworkHttpAdapter>();

This is not strictly recommended however it is real a shame to have broken this. We like the new constructor (it also abstracted the gov initialization) and we think subclassing is the nicest pattern. A fix that avoids the ambiguity is to make the new constructor protected.

This is technically a breaking change from 4.4.4 although it fixes the range [4.3.2, 4.4.3], the specific code broken by us changing this constructor is someone who has 4.4.4 and used a lambda as follows:

    services.AddSingleton<IBotFrameworkHttpAdapter>(
        (sp) => new BotFrameworkHttpAdapter(sp.GetRequiredService<IConfiguration>()));

This would break with a compile error. The ambiguity is actually only detected at runtime.


 