### PR TITLE
Enable TypeNameHandling.None for storage providers

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Bot.Builder
                     // the item found will be a JObject.
                     turnContext.TurnState[_contextServiceKey] = new CachedBotState(asJobject.ToObject<IDictionary<string, object>>());
                 }
-                else if (val is null)
+                else if (val == null)
                 {
                     // This is the case where the dictionary did not exist in the store.
-                    turnContext.TurnState[_contextServiceKey] = new CachedBotState((IDictionary<string, object>)val);
+                    turnContext.TurnState[_contextServiceKey] = new CachedBotState();
                 }
                 else
                 {

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -67,7 +67,27 @@ namespace Microsoft.Bot.Builder
             {
                 var items = await _storage.ReadAsync(new[] { storageKey }, cancellationToken).ConfigureAwait(false);
                 items.TryGetValue(storageKey, out object val);
-                turnContext.TurnState[_contextServiceKey] = new CachedBotState((IDictionary<string, object>)val);
+
+                if (val is IDictionary<string, object> asDictionary)
+                {
+                    turnContext.TurnState[_contextServiceKey] = new CachedBotState(asDictionary);
+                }
+                else if (val is JObject asJobject)
+                {
+                    // If types are not used by storage serialization, and Newtonsoft is the serializer
+                    // the item found will be a JObject.
+                    turnContext.TurnState[_contextServiceKey] = new CachedBotState(asJobject.ToObject<IDictionary<string, object>>());
+                }
+                else if (val is null)
+                {
+                    // This is the case where the dictionary did not exist in the store.
+                    turnContext.TurnState[_contextServiceKey] = new CachedBotState((IDictionary<string, object>)val);
+                }
+                else
+                {
+                    // This should never happen
+                    throw new InvalidOperationException("Data is not in the correct format for BotState.");
+                }
             }
         }
 
@@ -190,6 +210,13 @@ namespace Microsoft.Bot.Builder
             }
 
             var cachedState = turnContext.TurnState.Get<CachedBotState>(_contextServiceKey);
+
+            // If types are not used by storage serialization, and Newtonsoft is the serializer,
+            // use Newtonsoft to convert the object to the type expected.
+            if (cachedState.State[propertyName] is JObject obj)
+            {
+                return Task.FromResult(obj.ToObject<T>());
+            }
 
             // if there is no value, this will throw, to signal to IPropertyAccesor that a default value should be computed
             // This allows this to work with value types

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 }
             }
         }
-
+        
         [TestMethod]
         public void Sanatize_Key_Should_Work()
         {
@@ -533,6 +533,19 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
                 // Should throw DocumentClientException: Cross partition query is required but disabled
                 await Assert.ThrowsExceptionAsync<DocumentClientException>(async () => await storage.ReadAsync<StoreItem>(new string[] { DocumentId }, CancellationToken.None));
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
+        {
+            if (CheckEmulator())
+            {
+                var storage = new CosmosDbStorage(
+                                   CreateCosmosDbStorageOptions(),
+                                   new JsonSerializer() { TypeNameHandling = TypeNameHandling.None });
+                await StatePersistsThroughMultiTurn(storage);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Tests/MemoryStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MemoryStorageTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Tests
 {
@@ -30,6 +32,13 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
+        public void MemoryParamTest()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                new MemoryStorage((JsonSerializer)null));
+        }
+
+        [TestMethod]
         public async Task MemoryStorage_ReadUnknownTest()
         {
             await ReadUnknownTest(storage);
@@ -51,6 +60,13 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task MemoryStorage_HandleCrazyKeys()
         {
             await HandleCrazyKeys(storage);
+        }
+
+        [TestMethod]
+        public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
+        {
+            storage = new MemoryStorage(new JsonSerializer() { TypeNameHandling = TypeNameHandling.None });
+            await StatePersistsThroughMultiTurn(storage);
         }
     }
 }


### PR DESCRIPTION
This PR simply provides customers with the option to use our storage providers without serializing type information.  The default is still TypeNameHandling.All.  

Allowing the storage providers to serialize/deserialize without types enables a generic UserState migration from Bot Builder V3.

Thank you @carlosscastro for this idea!