### PR TITLE
Auth: Support required endorsements

### DIFF
--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -9,7 +9,7 @@ Param(
 
 Write-Host Install tools
 $basePath = (get-item $pathToCoverageFiles ).parent.FullName
-$coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
+$coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
 dotnet tool install coveralls.net --version 1.0.0 --tool-path tools
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Bot.Builder
         private readonly RetryPolicy _connectorClientRetryPolicy;
         private readonly ILogger _logger;
         private readonly ConcurrentDictionary<string, MicrosoftAppCredentials> _appCredentialMap = new ConcurrentDictionary<string, MicrosoftAppCredentials>();
+        private readonly AuthenticationConfiguration _authConfiguration;
 
         // There is a significant boost in throughput if we reuse a connectorClient
         // _connectorClients is a cache using [serviceUrl + appId].
@@ -69,6 +70,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="customHttpClient">The HTTP client.</param>
         /// <param name="middleware">The middleware to initially add to the adapter.</param>
         /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        /// <param name="authConfig">The optional authentication configuration.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="credentialProvider"/> is <c>null</c>.</exception>
         /// <remarks>Use a <see cref="MiddlewareSet"/> object to add multiple middleware
@@ -81,13 +83,15 @@ namespace Microsoft.Bot.Builder
             RetryPolicy connectorClientRetryPolicy = null,
             HttpClient customHttpClient = null,
             IMiddleware middleware = null,
-            ILogger logger = null)
+            ILogger logger = null,
+            AuthenticationConfiguration authConfig = null)
         {
             _credentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
             _channelProvider = channelProvider;
             _httpClient = customHttpClient ?? _defaultHttpClient;
             _connectorClientRetryPolicy = connectorClientRetryPolicy;
             _logger = logger ?? NullLogger.Instance;
+            _authConfiguration = authConfig;
 
             if (middleware != null)
             {
@@ -211,7 +215,7 @@ namespace Microsoft.Bot.Builder
         {
             BotAssert.ActivityNotNull(activity);
 
-            var claimsIdentity = await JwtTokenValidation.AuthenticateRequest(activity, authHeader, _credentialProvider, _channelProvider, _httpClient).ConfigureAwait(false);
+            var claimsIdentity = await JwtTokenValidation.AuthenticateRequest(activity, authHeader, _credentialProvider, _channelProvider, _httpClient, _authConfiguration).ConfigureAwait(false);
             return await ProcessActivityAsync(claimsIdentity, activity, callback, cancellationToken).ConfigureAwait(false);
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// General configuration settings for authentication.
+    /// </summary>
+    /// <remarks>
+    /// Note that this is explicitly a class and not an interface, 
+    /// since interfaces don't support default values, after the initial release any change would break backwards compatibility.
+    /// </remarks>
+    public class AuthenticationConfiguration
+    {
+        public string[] RequiredEndorsements { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -13,6 +12,6 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </remarks>
     public class AuthenticationConfiguration
     {
-        public string[] RequiredEndorsements { get; set; }
+        public string[] RequiredEndorsements { get; set; } = new string[] { };
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -48,10 +48,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The optional authentication configuration.</param>
         /// <returns>
         /// A valid ClaimsIdentity.
         /// </returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
         {
             var tokenExtractor = new JwtTokenExtractor(
                 httpClient,
@@ -59,7 +60,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 OpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.
@@ -115,10 +116,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The optional authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
         {
-            var identity = await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId);
+            var identity = await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig);
 
             var serviceUrlClaim = identity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.ServiceUrlClaim)?.Value;
             if (string.IsNullOrWhiteSpace(serviceUrlClaim))

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -48,19 +48,44 @@ namespace Microsoft.Bot.Connector.Authentication
         /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
-        /// <param name="authConfig">The optional authentication configuration.</param>
         /// <returns>
         /// A valid ClaimsIdentity.
         /// </returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId)
         {
+            return await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validate the incoming Auth Header as a token sent from the Bot Framework Service.
+        /// </summary>
+        /// <remarks>
+        /// A token issued by the Bot Framework emulator will FAIL this check.
+        /// </remarks>
+        /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]".</param>
+        /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
+        /// setup and teardown, so a shared HttpClient is recommended.</param>
+        /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <returns>
+        /// A valid ClaimsIdentity.
+        /// </returns>
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+        {
+            if (authConfig == null)
+            {
+                throw new ArgumentNullException(nameof(authConfig));
+            }
+
             var tokenExtractor = new JwtTokenExtractor(
                 httpClient,
                 ToBotFromChannelTokenValidationParameters,
                 OpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.
@@ -116,10 +141,31 @@ namespace Microsoft.Bot.Connector.Authentication
         /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
-        /// <param name="authConfig">The optional authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
         {
+            return await AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validate the incoming Auth Header as a token sent from the Bot Framework Service.
+        /// </summary>
+        /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]".</param>
+        /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="serviceUrl">Service url.</param>
+        /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
+        /// setup and teardown, so a shared HttpClient is recommended.</param>
+        /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <returns>ClaimsIdentity.</returns>
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+        {
+            if (authConfig == null)
+            {
+                throw new ArgumentNullException(nameof(authConfig));
+            }
+
             var identity = await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig);
 
             var serviceUrlClaim = identity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.ServiceUrlClaim)?.Value;

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -109,8 +109,35 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
-        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
+        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId)
         {
+            return await AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validate the incoming Auth Header as a token sent from the Bot Framework Emulator.
+        /// </summary>
+        /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]".</param>
+        /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="channelProvider">The channelService value that distinguishes public Azure from US Government Azure.</param>
+        /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
+        /// setup and teardown, so a shared HttpClient is recommended.</param>
+        /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <returns>
+        /// A valid ClaimsIdentity.
+        /// </returns>
+        /// <remarks>
+        /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
+        /// </remarks>
+        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+        {
+            if (authConfig == null)
+            {
+                throw new ArgumentNullException(nameof(authConfig));
+            }
+
             var openIdMetadataUrl = (channelProvider != null && channelProvider.IsGovernment()) ?
                 GovernmentAuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl :
                 AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl;
@@ -121,7 +148,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     openIdMetadataUrl,
                     AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
-        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId)
+        public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
         {
             var openIdMetadataUrl = (channelProvider != null && channelProvider.IsGovernment()) ?
                 GovernmentAuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl :
@@ -121,7 +121,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     openIdMetadataUrl,
                     AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
@@ -12,11 +12,16 @@ namespace Microsoft.Bot.Connector.Authentication
     public static class EndorsementsValidator
     {
         /// <summary>
-        /// Verify that a channel matches the endorsements found on the JWT token.
+        /// Verify that the specified endorsement exists on the JWT token. Call this method multiple times to validate multiple endorsements.
         /// For example, if an <see cref="Schema.Activity"/> comes from WebChat, that activity's
         /// <see cref="Schema.Activity.ChannelId"/> property is set to "webchat" and the signing party
         /// of the JWT token must have a corresponding endorsement of “Webchat”.
         /// </summary>
+        /// <remarks>
+        /// JWT token signing keys contain endorsements matching the IDs of the channels they are approved to sign for.
+        /// They also contain keywords representing compliance certifications. This code ensures that a channel ID or compliance
+        /// certification is present on the signing key used for the request's token.
+        /// </remarks>
         /// <param name="expectedEndorsement">The expected endorsement. Generally the ID of the channel to validate, typically extracted from the activity's
         /// <see cref="Schema.Activity.ChannelId"/> property, that to which the Activity is affinitized.</param>
         /// <param name="endorsements">The JWT token’s signing party is permitted to send activities only for

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// certification is present on the signing key used for the request's token.
         /// </remarks>
         /// <param name="expectedEndorsement">The expected endorsement. Generally the ID of the channel to validate, typically extracted from the activity's
-        /// <see cref="Schema.Activity.ChannelId"/> property, that to which the Activity is affinitized.</param>
+        /// <see cref="Schema.Activity.ChannelId"/> property, that to which the Activity is affinitized. Alternatively, it could represent a compliance certification that is required.</param>
         /// <param name="endorsements">The JWT token’s signing party is permitted to send activities only for
         /// specific channels. That list, the set of channels the service can sign for, is called the the endorsement list.
         /// The activity’s <see cref="Schema.Activity.ChannelId"/> MUST be found in the endorsement list, or the incoming

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsValidator.cs
@@ -17,18 +17,18 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <see cref="Schema.Activity.ChannelId"/> property is set to "webchat" and the signing party
         /// of the JWT token must have a corresponding endorsement of “Webchat”.
         /// </summary>
-        /// <param name="channelId">The ID of the channel to validate, typically extracted from the activity's
+        /// <param name="expectedEndorsement">The expected endorsement. Generally the ID of the channel to validate, typically extracted from the activity's
         /// <see cref="Schema.Activity.ChannelId"/> property, that to which the Activity is affinitized.</param>
         /// <param name="endorsements">The JWT token’s signing party is permitted to send activities only for
         /// specific channels. That list, the set of channels the service can sign for, is called the the endorsement list.
         /// The activity’s <see cref="Schema.Activity.ChannelId"/> MUST be found in the endorsement list, or the incoming
         /// activity is not considered valid.</param>
         /// <returns>True if the channel ID is found in the endorsements list; otherwise, false.</returns>
-        public static bool Validate(string channelId, HashSet<string> endorsements)
+        public static bool Validate(string expectedEndorsement, HashSet<string> endorsements)
         {
             // If the Activity came in and doesn't have a channel ID then it's making no
             // assertions as to who endorses it. This means it should pass.
-            if (string.IsNullOrEmpty(channelId))
+            if (string.IsNullOrEmpty(expectedEndorsement))
             {
                 return true;
             }
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Connector.Authentication
             //          JWTTokenExtractor
 
             // Does the set of endorsements match the channelId that was passed in?
-            var endorsementPresent = endorsements.Contains(channelId);
+            var endorsementPresent = endorsements.Contains(expectedEndorsement);
             return endorsementPresent;
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -40,8 +40,31 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId)
         {
+            return await AuthenticateChannelToken(authHeader, credentials, channelProvider, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validate the incoming Auth Header as a token sent from a Bot Framework Channel Service.
+        /// </summary>
+        /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]".</param>
+        /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="channelProvider">The user defined configuration for the channel.</param>
+        /// <param name="serviceUrl">The service url from the request.</param>
+        /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
+        /// setup and teardown, so a shared HttpClient is recommended.</param>
+        /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <returns>ClaimsIdentity.</returns>
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+        {
+            if (authConfig == null)
+            {
+                throw new ArgumentNullException(nameof(authConfig));
+            }
+
             var channelService = await channelProvider.GetChannelServiceAsync().ConfigureAwait(false);
 
             var tokenExtractor = new JwtTokenExtractor(
@@ -50,7 +73,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 string.Format(AuthenticationConstants.ToBotFromEnterpriseChannelOpenIdMetadataUrlFormat, channelService),
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
 
             await ValidateIdentity(identity, credentials, serviceUrl).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
         {
             var channelService = await channelProvider.GetChannelServiceAsync().ConfigureAwait(false);
 
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 string.Format(AuthenticationConstants.ToBotFromEnterpriseChannelOpenIdMetadataUrlFormat, channelService),
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements).ConfigureAwait(false);
 
             await ValidateIdentity(identity, credentials, serviceUrl).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
         {
             var tokenExtractor = new JwtTokenExtractor(
                 httpClient,
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 OpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements).ConfigureAwait(false);
 
             await ValidateIdentity(identity, credentials, serviceUrl).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -41,15 +41,37 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
-        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig = null)
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
         {
+            return await AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validate the incoming Auth Header as a token sent from a Bot Framework Government Channel Service.
+        /// </summary>
+        /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]".</param>
+        /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="serviceUrl">The service url from the request.</param>
+        /// <param name="httpClient">Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
+        /// setup and teardown, so a shared HttpClient is recommended.</param>
+        /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <returns>ClaimsIdentity.</returns>
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+        {
+            if (authConfig == null)
+            {
+                throw new ArgumentNullException(nameof(authConfig));
+            }
+
             var tokenExtractor = new JwtTokenExtractor(
                 httpClient,
                 ToBotFromGovernmentChannelTokenValidationParameters,
                 OpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig?.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
 
             await ValidateIdentity(identity, credentials, serviceUrl).ConfigureAwait(false);
 

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Xunit;
 
 namespace Microsoft.Bot.Connector.Authentication.Tests
@@ -46,13 +47,12 @@ namespace Microsoft.Bot.Connector.Authentication.Tests
         }
 
         [Fact]
-        public async Task Connector_TokenExtractor_NullRequiredEndorsements_ShouldValidate()
+        public async Task Connector_TokenExtractor_NullRequiredEndorsements_ShouldFail()
         {
             var configRetriever = new TestConfigurationRetriever();
 
             configRetriever.EndorsementTable.Add(keyId, new HashSet<string>() { randomEndorsement, complianceEndorsement, testChannelName});
-            var claimsIdentity = await RunTestCase(configRetriever);
-            Assert.True(claimsIdentity.IsAuthenticated);
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await RunTestCase(configRetriever));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Microsoft.IdentityModel.Protocols;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Authentication.Tests
+{
+    public class TestConfigurationRetriever : IConfigurationRetriever<IDictionary<string, HashSet<string>>>
+    {
+        public readonly Dictionary<string, HashSet<string>> EndorsementTable = new Dictionary<string, HashSet<string>>();
+
+        public async Task<IDictionary<string, HashSet<string>>> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
+        {
+            return EndorsementTable;
+        }
+    }
+
+    public class JwtTokenExtractorTests
+    {
+        private readonly HttpClient client;
+        private readonly HttpClient emptyClient;
+
+        private const string keyId = "CtfQC8Le-8NsC7oC2zQkZpcrfOc";
+        private const string testChannelName = "testChannel";
+        private const string complianceEndorsement = "o365Compliant";
+        private const string randomEndorsement = "2112121212";
+
+        public JwtTokenExtractorTests()
+        {
+            ChannelValidation.ToBotFromChannelTokenValidationParameters.ValidateLifetime = false;
+            ChannelValidation.ToBotFromChannelTokenValidationParameters.ValidateIssuer = false;
+
+            client = new HttpClient
+            {
+                BaseAddress = new Uri("https://webchat.botframework.com/"),
+            };
+            emptyClient = new HttpClient();
+        }
+
+        [Fact]
+        public async Task Connector_TokenExtractor_NullRequiredEndorsements_ShouldValidate()
+        {
+            var configRetriever = new TestConfigurationRetriever();
+
+            configRetriever.EndorsementTable.Add(keyId, new HashSet<string>() { randomEndorsement, complianceEndorsement, testChannelName});
+            var claimsIdentity = await RunTestCase(configRetriever);
+            Assert.True(claimsIdentity.IsAuthenticated);
+        }
+
+        [Fact]
+        public async Task Connector_TokenExtractor_EmptyRequireEndorsements_ShouldValidate()
+        {
+            var configRetriever = new TestConfigurationRetriever();
+
+            configRetriever.EndorsementTable.Add(keyId, new HashSet<string>() { randomEndorsement, complianceEndorsement, testChannelName });
+            var claimsIdentity = await RunTestCase(configRetriever, new string[] { });
+            Assert.True(claimsIdentity.IsAuthenticated);
+        }
+
+        [Fact]
+        public async Task Connector_TokenExtractor_RequiredEndorsementsPresent_ShouldValidate()
+        {
+            var configRetriever = new TestConfigurationRetriever();
+
+            configRetriever.EndorsementTable.Add(keyId, new HashSet<string>() { randomEndorsement, complianceEndorsement, testChannelName });
+            var claimsIdentity = await RunTestCase(configRetriever, new string[] { complianceEndorsement });
+            Assert.True(claimsIdentity.IsAuthenticated);
+        }
+
+        [Fact]
+        public async Task Connector_TokenExtractor_RequiredEndorsementsPartiallyPresent_ShouldNotValidate()
+        {
+            var configRetriever = new TestConfigurationRetriever();
+
+            configRetriever.EndorsementTable.Add(keyId, new HashSet<string>() { randomEndorsement, complianceEndorsement, testChannelName });
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RunTestCase(configRetriever, new string[] { complianceEndorsement, "notSatisfiedEndorsement" }));
+        }
+
+        private async Task<ClaimsIdentity> RunTestCase(IConfigurationRetriever<IDictionary<string, HashSet<string>>> configRetriever, string[] requiredEndorsements = null)
+        {
+            var tokenExtractor = new JwtTokenExtractor(
+                emptyClient,
+                EmulatorValidation.ToBotFromEmulatorTokenValidationParameters,
+                AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl,
+                AuthenticationConstants.AllowedSigningAlgorithms,
+                new ConfigurationManager<IDictionary<string, HashSet<string>>>("http://test", configRetriever));
+
+            string header = $"Bearer {await new MicrosoftAppCredentials("2cd87869-38a0-4182-9251-d056e8f0ac24", "2.30Vs3VQLKt974F").GetTokenAsync()}";
+
+            return await tokenExtractor.GetIdentityAsync(header, "testChannel", requiredEndorsements);
+        }
+    }
+}


### PR DESCRIPTION
- Support for enforcing required endorsements in the auth layer
- Created AuthConfiguration abstraction received by the BotAdapter. It is a class and not an interface since interfaces cannot be added fields to after first release, so it is quite inconvenient.
- Changed JwtTokenValidator and JwtToken extractor to support testing of endorsements, including mocking the endorsement retriever, which can now optionally be received as a constructor parameter.
- Added JwtTokenExtractor tests to verify the change and further allow future coverage increases in this code area