### PR TITLE
Update LuisRecognizer.cs to allow for custom HttpClient

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         {
         }
 
-        public static HttpClient DefaultHttpClient { get; private set; }
+        public static HttpClient DefaultHttpClient { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to log personal information that came from the user to telemetry.


### PR DESCRIPTION
Propose changing public static HttpClient DefaultHttpClient { get; private set; }  to public static HttpClient DefaultHttpClient { get; set; }

A public setter is required in the case that you need to supply a custom HttpClient instance (i.e. accessing Luis from corporate network which requires specifying a proxy).