### PR TITLE
Add a comment telling folks not to fix the typo due to Back Compat

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -377,6 +377,11 @@ namespace Microsoft.Bot.Builder.Azure
             /// <summary>
             /// Gets or sets the un-sanitized Id/Key.
             /// </summary>
+            /// <remarks>
+            /// Note: There is a Typo in the property name ("ReadlId"), that can't be changed due to compatability concerns. The
+            /// Json is correct due to the JsonProperty field, but the Typo needs to stay.
+            /// </remarks>
+            // DO NOT FIX THE TYPO BELOW (See Remarks above).
             [JsonProperty("realId")]
             public string ReadlId { get; internal set; }
 


### PR DESCRIPTION
We have a typo in the [DocumentStoreItem](https://github.com/microsoft/botbuilder-dotnet/blob/091f96915f94ea4d0cb28b2840d9d4ae11ab93f9/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs#L381) Class. The serialized property is correct, so things work. 

This is a private classe used (only) by the CosmosDB class. It could *probably* be changed, but I'm super-paranoid about this as breaking it invalidates stored state for everyone using this provider. We should just continue to live with the typo. 