### PR TITLE
remove random from auto assigned ids

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -259,22 +259,25 @@ namespace Microsoft.Bot.Configuration
                 throw new ArgumentNullException(nameof(newService));
             }
 
-            if (this.Services.Where(s => s.Type == newService.Type && s.Id == newService.Id).Any())
+            if (string.IsNullOrEmpty(newService.Id))
+            {
+                int maxValue = 0;
+                foreach(var service in this.Services)
+                {
+                    if (int.TryParse(service.Id, out int id) && id > maxValue)
+                    {
+                        maxValue = id;
+                    }
+                }
+
+                newService.Id = (++maxValue).ToString();
+            }
+            else if (this.Services.Where(s => s.Type == newService.Type && s.Id == newService.Id).Any())
             {
                 throw new Exception($"service with {newService.Id} is already connected");
             }
-            else
-            {
-                // Assign a unique random id between 0-255 (255 services seems like a LOT of services
-                var rnd = new Random();
-                do
-                {
-                    newService.Id = rnd.Next(byte.MaxValue).ToString();
-                }
-                while (this.Services.Where(s => s.Id == newService.Id).Any());
 
-                this.Services.Add(newService);
-            }
+            this.Services.Add(newService);
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Configuration.Tests/ConnectionTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ConnectionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Configuration.Tests
 {
@@ -18,7 +19,7 @@ namespace Microsoft.Bot.Configuration.Tests
             var config2 = new BotConfiguration();
             foreach (var service in config.Services)
             {
-                service.Id = "1";
+                service.Id = String.Empty;
                 config2.ConnectService(service);
             }
 


### PR DESCRIPTION
Fixes #1910 
* only assign if id is null or empty
* only check for duplicate if user is giving their own unique id
* using random() is inefficient, switch to just identifying the next available slot with single scan.
