### PR TITLE
Modify EvaluateTemplate to use scope nullable

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="scope">The state visible in the evaluation.</param>
         /// <param name="methodBinder">Optional methodBinder to extend or override functions.</param>
         /// <returns>Evaluate result.</returns>
-        public string EvaluateTemplate(string templateName, object scope, IGetMethod methodBinder = null)
+        public string EvaluateTemplate(string templateName, object scope = null, IGetMethod methodBinder = null)
         {
             var evaluator = new Evaluator(Templates, methodBinder);
             return evaluator.EvaluateTemplate(templateName, scope);
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="methodBinder">input method.</param>
         /// <param name="importResolver">resolver to resolve LG import id to template text.</param>
         /// <returns>Evaluate result.</returns>
-        public string Evaluate(string inlineStr, object scope, IGetMethod methodBinder = null, ImportResolverDelegate importResolver = null)
+        public string Evaluate(string inlineStr, object scope = null, IGetMethod methodBinder = null, ImportResolverDelegate importResolver = null)
         {
             // wrap inline string with "# name and -" to align the evaluation process
             var fakeTemplateId = "__temp__";

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var engine = new TemplateEngine().AddFile(GetExampleFilePath("2.lg"));
 
-            var evaled = engine.EvaluateTemplate("wPhrase", null);
+            var evaled = engine.EvaluateTemplate("wPhrase");
             var options = new List<string> { "Hi", "Hello", "Hiya " };
 
             Assert.IsTrue(options.Contains(evaled), $"The result `{evaled}` is not in those options [{string.Join(",", options)}]");
@@ -201,6 +201,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestBasicInlineTemplate()
         {
             var emptyEngine = new TemplateEngine().AddText(content: String.Empty, name: "test", importResolver: null);
+            Assert.AreEqual(emptyEngine.Evaluate("Hi"), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi", null), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name}", new { name = "DL" }), "Hi DL");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name.FirstName}{name.LastName}", new { name = new { FirstName = "D", LastName = "L" } }), "Hi DL");
@@ -214,6 +215,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestInlineTemplateWithTemplateFile()
         {
             var emptyEngine = new TemplateEngine().AddFile(GetExampleFilePath("8.lg"));
+            Assert.AreEqual(emptyEngine.Evaluate("Hi"), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi", null), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name}", new { name = "DL" }), "Hi DL");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name.FirstName}{name.LastName}", new { name = new { FirstName = "D", LastName = "L" } }), "Hi DL");


### PR DESCRIPTION
refer to #1965

Origin PR is raised by @vicentegnz but he does not have permission to merge it. So I recommit his update here.

```
I think it is a good option to put the scope nullable, 
with this we don't force to pass a null by parameter.

I have also added a new test case to verify that everything 
is correct without passing the scope by parameter.

Thanks,
```