### PR TITLE
Add OnPromptAsync overload with isRetry parameter

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             var state = (IDictionary<string, object>)instance.State[PersistedState];
             var options = (PromptOptions)instance.State[PersistedOptions];
-            await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
+            await OnPromptAsync(turnContext, state, options, true, cancellationToken).ConfigureAwait(false);
         }
 
         protected virtual async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
@@ -152,7 +152,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            if (isRetry == true && options.RetryPrompt != null)
+            if (isRetry && options.RetryPrompt != null)
             {
                 await turnContext.SendActivityAsync(options.RetryPrompt, cancellationToken).ConfigureAwait(false);
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -148,6 +148,33 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
+        protected virtual async Task OnPromptAsync(
+            ITurnContext turnContext,
+            IDictionary<string, object> state,
+            PromptOptions options,
+            bool isRetry,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (turnContext == null)
+            {
+                throw new ArgumentNullException(nameof(turnContext));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (isRetry == true && options.RetryPrompt != null)
+            {
+                await turnContext.SendActivityAsync(options.RetryPrompt, cancellationToken).ConfigureAwait(false);
+            }
+            else if (options.Prompt != null)
+            {
+                await turnContext.SendActivityAsync(options.Prompt, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         protected virtual Task<PromptRecognizerResult<Activity>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(new PromptRecognizerResult<Activity>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             };
 
             // Send initial prompt
-            await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], cancellationToken).ConfigureAwait(false);
+            await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], false, cancellationToken).ConfigureAwait(false);
             return Dialog.EndOfTurn;
         }
 
@@ -131,22 +131,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         protected virtual async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (turnContext == null)
-            {
-                throw new ArgumentNullException(nameof(turnContext));
-            }
-
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            if (options.Prompt != null)
-            {
-                await turnContext.SendActivityAsync(options.Prompt, cancellationToken).ConfigureAwait(false);
-            }
-        }
+            => await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
 
         protected virtual async Task OnPromptAsync(
             ITurnContext turnContext,

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -108,8 +108,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
             else
             {
-                return Dialog.EndOfTurn;
+                await OnPromptAsync(dc.Context, state, options, true, cancellationToken).ConfigureAwait(false);
             }
+
+            return EndOfTurn;
         }
 
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -120,14 +122,14 @@ namespace Microsoft.Bot.Builder.Dialogs
             // To avoid the prompt prematurely ending we need to implement this method and
             // simply re-prompt the user.
             await RepromptDialogAsync(dc.Context, dc.ActiveDialog, cancellationToken).ConfigureAwait(false);
-            return Dialog.EndOfTurn;
+            return EndOfTurn;
         }
 
         public override async Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default(CancellationToken))
         {
             var state = (IDictionary<string, object>)instance.State[PersistedState];
             var options = (PromptOptions)instance.State[PersistedOptions];
-            await OnPromptAsync(turnContext, state, options, cancellationToken).ConfigureAwait(false);
+            await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
         }
 
         protected virtual async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // Send initial prompt
             await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], false, cancellationToken).ConfigureAwait(false);
-            return Dialog.EndOfTurn;
+            return EndOfTurn;
         }
 
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public async Task OnPromptErrorsWithNullContext()
         {
-            var eventPrompt = new EventActivityWithoutRetryPrompt("EventActivityWithoutRetryPrompt", Validator);
+            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
 
             var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "please send an event." } };
 
@@ -253,7 +253,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var dialogs = new DialogSet(dialogState);
 
             // Create and add custom activity prompt to DialogSet.
-            var eventPrompt = new EventActivityWithoutRetryPrompt("EventActivityPrompt", Validator);
+            var eventPrompt = new EventActivityPrompt("EventActivityPrompt", Validator);
             dialogs.Add(eventPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ActivityPromptTests.cs
@@ -168,7 +168,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var results = await dc.ContinueDialogAsync(cancellationToken);
                 if (results.Status == DialogTurnStatus.Empty)
                 {
-                    var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "please send an event." } };
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity
+                        {
+                            Type = ActivityTypes.Message,
+                            Text = "please send an event.",
+                        },
+                        RetryPrompt = new Activity
+                        {
+                            Type = ActivityTypes.Message,
+                            Text = "Retrying - please send an event.",
+                        },
+                    };
                     await dc.PromptAsync("EventActivityPrompt", options);
                 }
 
@@ -181,7 +193,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             })
             .Send("hello")
             .AssertReply("please send an event.")
-            .AssertReply("please send an event.")
+            .Send("test")
+            .AssertReply("Retrying - please send an event.")
             .AssertReply("Test complete.")
             .StartTestAsync();
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityPrompt.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityPrompt.cs
@@ -16,5 +16,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             : base(dialogId, validator)
         {
         }
+
+        public async Task OnPromptNullContext(object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var opt = (PromptOptions)options;
+
+            // should throw ArgumentNullException
+            await OnPromptAsync(turnContext: null, state: null, options: opt, isRetry: false);
+        }
+
+        public async Task OnPromptNullOptions(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // should throw ArgumentNullException
+            await OnPromptAsync(dc.Context, state: null, options: null, isRetry: false);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityWithoutRetryPrompt.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityWithoutRetryPrompt.cs
@@ -60,11 +60,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             var opt = (PromptOptions)options;
 
+            // should throw ArgumentNullException
             await OnPromptAsync(turnContext: null, state: null, options: opt, isRetry: false);
         }
 
         public async Task OnPromptNullOptions(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
+            // should throw ArgumentNullException
             await OnPromptAsync(dc.Context, state: null, options: null, isRetry: false);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityWithoutRetryPrompt.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityWithoutRetryPrompt.cs
@@ -55,19 +55,5 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], cancellationToken).ConfigureAwait(false);
             return EndOfTurn;
         }
-
-        public async Task OnPromptNullContext(object options, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var opt = (PromptOptions)options;
-
-            // should throw ArgumentNullException
-            await OnPromptAsync(turnContext: null, state: null, options: opt, isRetry: false);
-        }
-
-        public async Task OnPromptNullOptions(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            // should throw ArgumentNullException
-            await OnPromptAsync(dc.Context, state: null, options: null, isRetry: false);
-        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityWithoutRetryPrompt.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/EventActivityWithoutRetryPrompt.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    public class EventActivityWithoutRetryPrompt : ActivityPrompt
+    {
+        private const string PersistedOptions = "options";
+        private const string PersistedState = "state";
+
+        public EventActivityWithoutRetryPrompt(string dialogId, PromptValidator<Activity> validator)
+            : base(dialogId, validator)
+        {
+        }
+
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (dc == null)
+            {
+                throw new ArgumentNullException(nameof(dc));
+            }
+
+            if (!(options is PromptOptions))
+            {
+                throw new ArgumentOutOfRangeException(nameof(options), "Prompt options are required for Prompt dialogs");
+            }
+
+            // Ensure prompts have input hint set
+            var opt = (PromptOptions)options;
+            if (opt.Prompt != null && string.IsNullOrEmpty(opt.Prompt.InputHint))
+            {
+                opt.Prompt.InputHint = InputHints.ExpectingInput;
+            }
+
+            if (opt.RetryPrompt != null && string.IsNullOrEmpty(opt.RetryPrompt.InputHint))
+            {
+                opt.RetryPrompt.InputHint = InputHints.ExpectingInput;
+            }
+
+            // Initialize prompt state
+            var state = dc.ActiveDialog.State;
+            state[PersistedOptions] = opt;
+            state[PersistedState] = new Dictionary<string, object>
+            {
+                { "AttemptCount", 0 },
+            };
+
+            // Send initial prompt, calling OnPromptAsync() overload that does not have isRetry parameter
+            await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], cancellationToken).ConfigureAwait(false);
+            return EndOfTurn;
+        }
+
+        public async Task OnPromptNullContext(object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var opt = (PromptOptions)options;
+
+            await OnPromptAsync(turnContext: null, state: null, options: opt, isRetry: false);
+        }
+
+        public async Task OnPromptNullOptions(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await OnPromptAsync(dc.Context, state: null, options: null, isRetry: false);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2004 

## Description
* `ActivityPrompt` class [in other repos include the `isRetry` parameter](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts#L101) in the `OnPrompt` method
* Additionally, other prompt classes in the dotnet repo itself also include this parameter ([`AttachmentPrompt`](https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AttachmentPrompt.cs#L19), [`ChoicePrompt`](https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs#L43), [`Prompt.cs`](https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs#L137), etc.)
* To remain consistent across repos and the other prompt classes, **adding an `OnPromptAsync` overload with an `isRetry`  parameter to the `ActivityPrompt` class** that will allow the user to send the `RetryPrompt` off an activity if desired

## Specific Changes
* added `OnPromptAsync()` overload to `ActvityPrompt` class that also accepts boolean `isRetry` parameter
* older `OnPromptAsync()` calls new `OnPromptAsync()` method that has `isRetry` parameter