### PR TITLE
[LG] refactor analyzer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
@@ -11,20 +11,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 {
     public class AnalyzerResult
     {
-        public AnalyzerResult(HashSet<string> variables = null, HashSet<string> templateRefNames = null)
+        public AnalyzerResult(List<string> variables = null, List<string> templateRefNames = null)
         {
-            this.Variables = variables ?? new HashSet<string>();
-            this.TemplateRefNames = templateRefNames ?? new HashSet<string>();
+            this.Variables = (variables ?? new List<string>()).Distinct().ToList();
+            this.TemplateRefNames = (templateRefNames ?? new List<string>()).Distinct().ToList();
         }
 
-        public HashSet<string> Variables { get; set; }
+        public List<string> Variables { get; set; }
 
-        public HashSet<string> TemplateRefNames { get; set; }
+        public List<string> TemplateRefNames { get; set; }
 
         public AnalyzerResult Union(AnalyzerResult outputItem)
         {
-            this.Variables.UnionWith(outputItem.Variables);
-            this.TemplateRefNames.UnionWith(outputItem.TemplateRefNames);
+            this.Variables = this.Variables.Union(outputItem.Variables).ToList();
+            this.TemplateRefNames = this.TemplateRefNames.Union(outputItem.TemplateRefNames).ToList();
             return this;
         }
     }
@@ -185,7 +185,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             if (exp.Type == "lgTemplate")
             {
                 var templateName = (exp.Children[0] as Constant).Value.ToString();
-                result.Union(new AnalyzerResult(templateRefNames: new HashSet<string>() { templateName }));
+                result.Union(new AnalyzerResult(templateRefNames: new List<string>() { templateName }));
 
                 if (exp.Children.Length == 1)
                 {
@@ -217,7 +217,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             var references = parsed.References();
 
-            result.Union(new AnalyzerResult(variables: new HashSet<string>(references)));
+            result.Union(new AnalyzerResult(variables: new List<string>(references)));
             result.Union(this.AnalyzeExpressionDirectly(parsed));
 
             return result;
@@ -246,12 +246,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var templateName = exp.Substring(0, argsStartPos);
 
                 // add this template
-                result.Union(new AnalyzerResult(templateRefNames: new HashSet<string>() { templateName }));
+                result.Union(new AnalyzerResult(templateRefNames: new List<string>() { templateName }));
                 templateAnalyzerResult.ToList().ForEach(t => result.Union(t));
             }
             else
             {
-                result.Union(new AnalyzerResult(templateRefNames: new HashSet<string>() { exp }));
+                result.Union(new AnalyzerResult(templateRefNames: new List<string>() { exp }));
 
                 // We analyze tempalte only if the template has no formal parameters
                 // But we should analyzer template reference names for all situation

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
@@ -11,20 +11,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 {
     public class AnalyzerResult
     {
-        public AnalyzerResult(List<string> variables = null, List<string> templateRefNames = null)
+        public AnalyzerResult(List<string> variables = null, List<string> templateReferences = null)
         {
             this.Variables = (variables ?? new List<string>()).Distinct().ToList();
-            this.TemplateRefNames = (templateRefNames ?? new List<string>()).Distinct().ToList();
+            this.TemplateReferences = (templateReferences ?? new List<string>()).Distinct().ToList();
         }
 
         public List<string> Variables { get; set; }
 
-        public List<string> TemplateRefNames { get; set; }
+        public List<string> TemplateReferences { get; set; }
 
         public AnalyzerResult Union(AnalyzerResult outputItem)
         {
             this.Variables = this.Variables.Union(outputItem.Variables).ToList();
-            this.TemplateRefNames = this.TemplateRefNames.Union(outputItem.TemplateRefNames).ToList();
+            this.TemplateReferences = this.TemplateReferences.Union(outputItem.TemplateReferences).ToList();
             return this;
         }
     }
@@ -185,7 +185,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             if (exp.Type == "lgTemplate")
             {
                 var templateName = (exp.Children[0] as Constant).Value.ToString();
-                result.Union(new AnalyzerResult(templateRefNames: new List<string>() { templateName }));
+                result.Union(new AnalyzerResult(templateReferences: new List<string>() { templateName }));
 
                 if (exp.Children.Length == 1)
                 {
@@ -194,8 +194,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 else
                 {
                     // only get template ref names
-                    var templateRefNames = this.AnalyzeTemplate((exp.Children[0] as Constant).Value.ToString()).TemplateRefNames;
-                    result.Union(new AnalyzerResult(templateRefNames: templateRefNames));
+                    var templateRefNames = this.AnalyzeTemplate((exp.Children[0] as Constant).Value.ToString()).TemplateReferences;
+                    result.Union(new AnalyzerResult(templateReferences: templateRefNames));
 
                     // analyzer other children
                     exp.Children.ToList().ForEach(x => result.Union(this.AnalyzeExpressionDirectly(x)));
@@ -246,12 +246,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var templateName = exp.Substring(0, argsStartPos);
 
                 // add this template
-                result.Union(new AnalyzerResult(templateRefNames: new List<string>() { templateName }));
+                result.Union(new AnalyzerResult(templateReferences: new List<string>() { templateName }));
                 templateAnalyzerResult.ToList().ForEach(t => result.Union(t));
             }
             else
             {
-                result.Union(new AnalyzerResult(templateRefNames: new List<string>() { exp }));
+                result.Union(new AnalyzerResult(templateReferences: new List<string>() { exp }));
 
                 // We analyze tempalte only if the template has no formal parameters
                 // But we should analyzer template reference names for all situation
@@ -261,7 +261,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
                 else
                 {
-                    result.Union(new AnalyzerResult(templateRefNames: this.AnalyzeTemplate(exp).TemplateRefNames));
+                    result.Union(new AnalyzerResult(templateReferences: this.AnalyzeTemplate(exp).TemplateReferences));
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
@@ -9,7 +9,27 @@ using Microsoft.Bot.Builder.Expressions.Parser;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
-    public class Analyzer : LGFileParserBaseVisitor<List<string>>
+    public class AnalyzerResult
+    {
+        public AnalyzerResult(HashSet<string> variables = null, HashSet<string> templateRefNames = null)
+        {
+            this.Variables = variables ?? new HashSet<string>();
+            this.TemplateRefNames = templateRefNames ?? new HashSet<string>();
+        }
+
+        public HashSet<string> Variables { get; set; }
+
+        public HashSet<string> TemplateRefNames { get; set; }
+
+        public AnalyzerResult Append(AnalyzerResult outputItem)
+        {
+            this.Variables.UnionWith(outputItem.Variables);
+            this.TemplateRefNames.UnionWith(outputItem.TemplateRefNames);
+            return this;
+        }
+    }
+
+    public class Analyzer : LGFileParserBaseVisitor<AnalyzerResult>
     {
         private readonly Dictionary<string, LGTemplate> templateMap;
 
@@ -26,7 +46,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public List<LGTemplate> Templates { get; }
 
-        public List<string> AnalyzeTemplate(string templateName)
+        public AnalyzerResult AnalyzeTemplate(string templateName)
         {
             if (!templateMap.ContainsKey(templateName))
             {
@@ -40,20 +60,18 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             // Using a stack to track the evalution trace
             evaluationTargetStack.Push(new EvaluationTarget(templateName, null));
-            var rawDependencies = Visit(templateMap[templateName].ParseTree);
 
             // we don't exclude paratemters any more
             // because given we don't track down for templates have paramters
             // the only scenario that we are still analyzing an paramterized template is
             // this template is root template to anaylze, in this we also don't have exclude paramters
-            var dependencies = rawDependencies.Distinct().ToList();
-
+            var dependencies = Visit(templateMap[templateName].ParseTree);
             evaluationTargetStack.Pop();
 
             return dependencies;
         }
 
-        public override List<string> VisitTemplateDefinition([NotNull] LGFileParser.TemplateDefinitionContext context)
+        public override AnalyzerResult VisitTemplateDefinition([NotNull] LGFileParser.TemplateDefinitionContext context)
         {
             var templateNameContext = context.templateNameLine();
             if (templateNameContext.templateName().GetText().Equals(CurrentTarget().TemplateName))
@@ -67,24 +85,24 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             throw new Exception("template name match failed");
         }
 
-        public override List<string> VisitNormalBody([NotNull] LGFileParser.NormalBodyContext context) => Visit(context.normalTemplateBody());
+        public override AnalyzerResult VisitNormalBody([NotNull] LGFileParser.NormalBodyContext context) => Visit(context.normalTemplateBody());
 
-        public override List<string> VisitNormalTemplateBody([NotNull] LGFileParser.NormalTemplateBodyContext context)
+        public override AnalyzerResult VisitNormalTemplateBody([NotNull] LGFileParser.NormalTemplateBodyContext context)
         {
-            var result = new List<string>();
+            var result = new AnalyzerResult();
 
             foreach (var templateStr in context.normalTemplateString())
             {
                 var item = Visit(templateStr);
-                result.AddRange(item);
+                result.Append(item);
             }
 
             return result;
         }
 
-        public override List<string> VisitIfElseBody([NotNull] LGFileParser.IfElseBodyContext context)
+        public override AnalyzerResult VisitIfElseBody([NotNull] LGFileParser.IfElseBodyContext context)
         {
-            var result = new List<string>();
+            var result = new AnalyzerResult();
 
             var ifRules = context.ifElseTemplateBody().ifConditionRule();
             foreach (var ifRule in ifRules)
@@ -92,41 +110,41 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var expression = ifRule.ifCondition().EXPRESSION(0);
                 if (expression != null)
                 {
-                    result.AddRange(AnalyzeExpression(expression.GetText()));
+                    result.Append(AnalyzeExpression(expression.GetText()));
                 }
 
                 if (ifRule.normalTemplateBody() != null)
                 {
-                    result.AddRange(Visit(ifRule.normalTemplateBody()));
+                    result.Append(Visit(ifRule.normalTemplateBody()));
                 }
             }
 
             return result;
         }
 
-        public override List<string> VisitSwitchCaseBody([NotNull] LGFileParser.SwitchCaseBodyContext context)
+        public override AnalyzerResult VisitSwitchCaseBody([NotNull] LGFileParser.SwitchCaseBodyContext context)
         {
-            var result = new List<string>();
+            var result = new AnalyzerResult();
             var switchCaseNodes = context.switchCaseTemplateBody().switchCaseRule();
             foreach (var iterNode in switchCaseNodes)
             {
                 var expression = iterNode.switchCaseStat().EXPRESSION();
                 if (expression.Length > 0)
                 {
-                    result.AddRange(AnalyzeExpression(expression[0].GetText()));
+                    result.Append(AnalyzeExpression(expression[0].GetText()));
                 }
                 if (iterNode.normalTemplateBody() != null)
                 {
-                    result.AddRange(Visit(iterNode.normalTemplateBody()));
+                    result.Append(Visit(iterNode.normalTemplateBody()));
                 }
             }
 
             return result;
         }
 
-        public override List<string> VisitNormalTemplateString([NotNull] LGFileParser.NormalTemplateStringContext context)
+        public override AnalyzerResult VisitNormalTemplateString([NotNull] LGFileParser.NormalTemplateStringContext context)
         {
-            var result = new List<string>();
+            var result = new AnalyzerResult();
             foreach (ITerminalNode node in context.children)
             {
                 switch (node.Symbol.Type)
@@ -134,13 +152,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     case LGFileParser.DASH:
                         break;
                     case LGFileParser.EXPRESSION:
-                        result.AddRange(AnalyzeExpression(node.GetText()));
+                        result.Append(AnalyzeExpression(node.GetText()));
                         break;
                     case LGFileParser.TEMPLATE_REF:
-                        result.AddRange(AnalyzeTemplateRef(node.GetText()));
+                        result.Append(AnalyzeTemplateRef(node.GetText()));
                         break;
                     case LGFileLexer.MULTI_LINE_TEXT:
-                        result.AddRange(AnalyzeMultiLineText(node.GetText()));
+                        result.Append(AnalyzeMultiLineText(node.GetText()));
                         break;
                     default:
                         break;
@@ -161,35 +179,53 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// </summary>
         /// <param name="exp">Expression.</param>
         /// <returns>template refs.</returns>
-        private List<string> GetDirectTemplateRefs(Expression exp)
+        private AnalyzerResult AnalyzeExpressionDirectly(Expression exp)
         {
-            if (exp.Type == "lgTemplate" && exp.Children.Length == 1)
+            var result = new AnalyzerResult();
+            if (exp.Type == "lgTemplate")
             {
-                return new List<string> { (string)(exp.Children[0] as Constant).Value };
+                var templateName = (exp.Children[0] as Constant).Value.ToString();
+                result.Append(new AnalyzerResult(templateRefNames: new HashSet<string>() { templateName }));
+
+                if (exp.Children.Length == 1)
+                {
+                    result.Append(this.AnalyzeTemplate((exp.Children[0] as Constant).Value.ToString()));
+                }
+                else
+                {
+                    // only get template ref names
+                    var templateRefNames = this.AnalyzeTemplate((exp.Children[0] as Constant).Value.ToString()).TemplateRefNames;
+                    result.Append(new AnalyzerResult(templateRefNames: templateRefNames));
+
+                    // analyzer other children
+                    exp.Children.Select(x => result.Append(this.AnalyzeExpressionDirectly(x)));
+                }
             }
             else
             {
-                return exp.Children.Select(x => GetDirectTemplateRefs(x)).SelectMany(x => x).ToList();
+                exp.Children.Select(x => result.Append(this.AnalyzeExpressionDirectly(x)));
             }
+
+            return result;
         }
 
-        private List<string> AnalyzeExpression(string exp)
+        private AnalyzerResult AnalyzeExpression(string exp)
         {
+            var result = new AnalyzerResult();
             exp = exp.TrimStart('@').TrimStart('{').TrimEnd('}');
             var parsed = _expressionParser.Parse(exp);
 
             var references = parsed.References();
 
-            var referencesInTemplates = GetDirectTemplateRefs(parsed)
-                                            .Select(x => AnalyzeTemplate(x))
-                                            .SelectMany(x => x)
-                                            .ToList();
+            result.Append(new AnalyzerResult(variables: new HashSet<string>(references)));
+            result.Append(this.AnalyzeExpressionDirectly(parsed));
 
-            return references.Concat(referencesInTemplates).ToList();
+            return result;
         }
 
-        private List<string> AnalyzeTemplateRef(string exp)
+        private AnalyzerResult AnalyzeTemplateRef(string exp)
         {
+            var result = new AnalyzerResult();
             exp = exp.TrimStart('[').TrimEnd(']').Trim();
 
             var argsStartPos = exp.IndexOf('(');
@@ -201,23 +237,40 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var argsEndPos = exp.LastIndexOf(')');
 
                 var args = exp.Substring(argsStartPos + 1, argsEndPos - argsStartPos - 1).Split(',');
-                var refs = args.Select(arg => AnalyzeExpression(arg)).SelectMany(x => x).ToList();
 
                 // Before we have a matural solution to analyze paramterized template, we stop digging into
                 // templates with paramters, we just analyze it's args.
                 // With this approach we may not get a very fine-grained result
                 // but the result will still be accurate
-                return refs;
+                var templateAnalyzerResult = args.Select(arg => this.AnalyzeExpression(arg));
+                var templateName = exp.Substring(0, argsStartPos);
+
+                // add this template
+                result.Append(new AnalyzerResult(templateRefNames: new HashSet<string>() { templateName }));
+                templateAnalyzerResult.Select(t => result.Append(t));
             }
             else
             {
-                return AnalyzeTemplate(exp);
+                result.Append(new AnalyzerResult(templateRefNames: new HashSet<string>() { exp }));
+
+                // We analyze tempalte only if the template has no formal parameters
+                // But we should analyzer template reference names for all situation
+                if (this.templateMap[exp].Paramters == null || this.templateMap[exp].Paramters.Count == 0)
+                {
+                    result.Append(this.AnalyzeTemplate(exp));
+                }
+                else
+                {
+                    result.Append(new AnalyzerResult(templateRefNames: this.AnalyzeTemplate(exp).TemplateRefNames));
+                }
             }
+
+            return result;
         }
 
-        private List<string> AnalyzeMultiLineText(string exp)
+        private AnalyzerResult AnalyzeMultiLineText(string exp)
         {
-            var result = new List<string>();
+            var result = new AnalyzerResult();
 
             // remove ``` ```
             exp = exp.Substring(3, exp.Length - 6);
@@ -227,7 +280,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 if (matchItem.Success)
                 {
-                    result.AddRange(AnalyzeExpression(matchItem.Value));
+                    result.Append(AnalyzeExpression(matchItem.Value));
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             return evaluator.EvaluateTemplate(templateName, scope);
         }
 
-        public List<string> AnalyzeTemplate(string templateName)
+        public AnalyzerResult AnalyzeTemplate(string templateName)
         {
             var analyzer = new Analyzer(Templates);
             return analyzer.AnalyzeTemplate(templateName);

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/analyzer.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/analyzer.lg
@@ -1,13 +1,13 @@
-﻿#wPhrase
+﻿# wPhrase
 - Hi {userName}
  
-#pizzaOrderConfirmation
+# pizzaOrderConfirmation
 - Your pizza order of {base} with toppings {join(topping, ',', 'and')} is confirmed.
  
-#sandwichOrderConfirmation
+# sandwichOrderConfirmation
 - Your {bread} sandwich with {meat} is on its way. Thanks.
  
-#orderReadOut
+# orderReadOut
 - IF: {orderType == 'pizza'}
 - [wPhrase] [pizzaOrderConfirmation] 
 - ELSEIF: {orderType == 'sandwich'}
@@ -19,12 +19,12 @@
 # template2
 - {join(foreach(alarms, x, lgTemplate('template3', customer)), ',', 'and')} {tasks[0]}
 
-#template3(input)
-- {input.property} 
+# template3(input)
+- {input.property}
 
 # template4
 - ```
-@{city} @{lgTemplate('template5')} 
+@{city} @{lgTemplate('template5')}
 ```
 
 # template5
@@ -32,4 +32,24 @@
 
 # template6(input)
 - hi
+
+# LatteOrderConfirmation
+-Here is your {size} Latte. You need to pay {price} dollars! Thank you!
+
+# MochaOrderConfirmation
+-Here is your {size} Mocha. You need to pay {price} dollars! Thank you!
+
+# CuppuccinoOrderConfirmation
+-Here is your {size} Cuppuccino. You need to pay {price} dollars! Thank you!
+
+# coffee-to-go-order
+-SWITCH:{coffee}
+- CASE: {'Latte'}
+    - [wPhrase] [LatteOrderConfirmation]
+- CASE: {'Mocha'}
+    - [wPhrase] [MochaOrderConfirmation]
+- CASE: {'CuppuccinoOrderConfirmation'}
+    - [wPhrase] [CuppuccinoOrderConfirmation]
+- DEFAULT:
+   - [wPhrase], welcome next time!
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/lgTemplate.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/lgTemplate.lg
@@ -1,0 +1,14 @@
+# TemplateA
+- Hi
+- Hello
+
+# TemplateB(a)
+- Hi {a}
+- Hello {a}
+
+
+# TemplateC
+- {lgTemplate('TemplateA')}
+
+#TemplateD
+- {lgTemplate('TemplateB', b)}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -208,4 +208,10 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Examples\lgTemplate.lg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -292,18 +292,71 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         [TestMethod]
         public void TestAnalyzer()
         {
-            var engine = new TemplateEngine().AddFile(GetExampleFilePath("analyzer.lg"));
-            var evaled1 = engine.AnalyzeTemplate("orderReadOut");
-            var evaled1Options = new List<string> { "orderType", "userName", "base", "topping", "bread", "meat" };
-            Assert.IsTrue(evaled1.All(evaled1Options.Contains) && evaled1.Count == evaled1Options.Count);
+            var testData = new object[]
+            {   new
+                {
+                    name = "orderReadOut",
+                    variableOptions = new string[] { "orderType", "userName", "base", "topping", "bread", "meat" },
+                    templateRefOptions = new string[] { "wPhrase", "pizzaOrderConfirmation", "sandwichOrderConfirmation" }
+                },
+                new
+                {
+                    name = "sandwichOrderConfirmation",
+                    variableOptions = new string[] { "bread", "meat" },
+                    templateRefOptions = new string[] { }
+                },
+                new
+                {
+                    name = "template1",
+                    // TODO: input.property should really be: customer.property but analyzer needs to be 
+                    variableOptions = new string[] { "alarms", "customer", "tasks[0]", "age", "city" },
+                    templateRefOptions = new string[] { "template2", "template3", "template4", "template5", "template6" }
+                },
+                new
+                {
+                    name = "coffee-to-go-order",
+                    variableOptions = new string[] { "coffee", "userName", "size", "price" },
+                    templateRefOptions = new string[] { "wPhrase", "LatteOrderConfirmation", "MochaOrderConfirmation", "CuppuccinoOrderConfirmation" }
+                }
+            };
 
-            var evaled2 = engine.AnalyzeTemplate("sandwichOrderConfirmation");
-            var evaled2Options = new List<string> { "bread", "meat" };
-            Assert.IsTrue(evaled2.All(evaled2Options.Contains) && evaled2.Count == evaled2Options.Count);
+            foreach (var testItem in testData)
+            {
+                var engine = new TemplateEngine().AddFile(GetExampleFilePath("analyzer.lg"));
+                var evaled1 = engine.AnalyzeTemplate(testItem.GetType().GetProperty("name").GetValue(testItem).ToString());
+                var variableEvaled = evaled1.Variables;
+                var variableEvaledOptions = testItem.GetType().GetProperty("variableOptions").GetValue(testItem) as string[];
+                Assert.AreEqual(variableEvaledOptions.Length, variableEvaled.Count);
+                variableEvaledOptions.ToList().ForEach(element => Assert.AreEqual(variableEvaled.Contains(element), true));
+                //var templateEvaled = evaled1.TemplateRefNames;
+                //var templateEvaledOptions = testItem.GetType().GetProperty("templateRefOptions").GetValue(testItem) as string[];
+                //Assert.AreEqual(templateEvaledOptions.Length, templateEvaled.Count);
+                //templateEvaledOptions.ToList().ForEach(element => Assert.AreEqual(templateEvaled.Contains(element), true));
+            }
+        }
 
-            var evaled3 = engine.AnalyzeTemplate("template1");
-            var evaled3Options = new List<string> { "alarms", "customer", "tasks[0]", "age", "city" };
-            Assert.IsTrue(evaled3.All(evaled3Options.Contains) && evaled3.Count == evaled3Options.Count);
+        [TestMethod]
+        public void TestlgTemplateFunction()
+        {
+            var engine = new TemplateEngine().AddFile(GetExampleFilePath("lgTemplate.lg"));
+            var evaled = engine.EvaluateTemplate("TemplateC", "");
+            var options = new List<string> { "Hi", "Hello" };
+            Assert.AreEqual(options.Contains(evaled), true);
+
+            evaled = engine.EvaluateTemplate("TemplateD", new { b = "morning"});
+            options = new List<string> { "Hi morning", "Hello morning" };
+            Assert.AreEqual(options.Contains(evaled), true);
+        }
+
+        [TestMethod]
+        public void TestAnalyzelgTemplateFunction()
+        {
+            var engine = new TemplateEngine().AddFile(GetExampleFilePath("lgTemplate.lg"));
+            var evaled = engine.AnalyzeTemplate("TemplateD");
+            var variableEvaled = evaled.Variables;
+            var options = new List<string>() { "b" };
+            Assert.AreEqual(variableEvaled.Count, options.Count);
+            options.ForEach(e => Assert.AreEqual(variableEvaled.Contains(e), true));
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 var variableEvaledOptions = testItem.GetType().GetProperty("variableOptions").GetValue(testItem) as string[];
                 Assert.AreEqual(variableEvaledOptions.Length, variableEvaled.Count);
                 variableEvaledOptions.ToList().ForEach(element => Assert.AreEqual(variableEvaled.Contains(element), true));
-                var templateEvaled = evaled1.TemplateRefNames;
+                var templateEvaled = evaled1.TemplateReferences;
                 var templateEvaledOptions = testItem.GetType().GetProperty("templateRefOptions").GetValue(testItem) as string[];
                 Assert.AreEqual(templateEvaledOptions.Length, templateEvaled.Count);
                 templateEvaledOptions.ToList().ForEach(element => Assert.AreEqual(templateEvaled.Contains(element), true));

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -328,10 +328,10 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 var variableEvaledOptions = testItem.GetType().GetProperty("variableOptions").GetValue(testItem) as string[];
                 Assert.AreEqual(variableEvaledOptions.Length, variableEvaled.Count);
                 variableEvaledOptions.ToList().ForEach(element => Assert.AreEqual(variableEvaled.Contains(element), true));
-                //var templateEvaled = evaled1.TemplateRefNames;
-                //var templateEvaledOptions = testItem.GetType().GetProperty("templateRefOptions").GetValue(testItem) as string[];
-                //Assert.AreEqual(templateEvaledOptions.Length, templateEvaled.Count);
-                //templateEvaledOptions.ToList().ForEach(element => Assert.AreEqual(templateEvaled.Contains(element), true));
+                var templateEvaled = evaled1.TemplateRefNames;
+                var templateEvaledOptions = testItem.GetType().GetProperty("templateRefOptions").GetValue(testItem) as string[];
+                Assert.AreEqual(templateEvaledOptions.Length, templateEvaled.Count);
+                templateEvaledOptions.ToList().ForEach(element => Assert.AreEqual(templateEvaled.Contains(element), true));
             }
         }
 


### PR DESCRIPTION
origin issue: #2093 

Originally analyzeTemplate(templateName: string) would return a list of variables.
From now , this function will reture a structure dat, including a list of variables and list of templateref names.