### PR TITLE
The next path separator fix hack for Linux NuGet installs

### DIFF
--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -11,8 +11,17 @@ param
 pushd $path
 
 # Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
-Import-Module .\archive.psm1
+#Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
+#Import-Module .\archive.psm1
+
+# Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
+$ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
+if ($ver -lt '1.2.3.0') { 
+    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0"
+    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
+} else { 
+    Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
+}
 
 [int]$itemsProcessed = 0
 if ($extract) {

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -17,7 +17,7 @@ pushd $path
 # Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
 $ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
 if ($ver -lt '1.2.3.0') { 
-    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0"
+    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"
     Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
 } else { 
     Write-Host "Already installed: Microsoft.Powershell.Archive $ver"


### PR DESCRIPTION
https://github.com/microsoft/botbuilder-dotnet/issues/1872

This is pending someone from support verifying the generated NuGet package installs on a Mac.

Example: Microsoft.Bot.Builder 4.5.0-preview-190620-16