### PR TITLE
issue 1960 private to public

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="dialogs">Parent dialog set.</param>
         /// <param name="turnContext">Context for the current turn of conversation with the user.</param>
         /// <param name="state">Current dialog state.</param>
-        internal DialogContext(DialogSet dialogs, ITurnContext turnContext, DialogState state)
+        public DialogContext(DialogSet dialogs, ITurnContext turnContext, DialogState state)
         {
             Dialogs = dialogs ?? throw new ArgumentNullException(nameof(dialogs));
             Context = turnContext ?? throw new ArgumentNullException(nameof(turnContext));

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Bot.Builder
         /// A TurnContext with a strongly typed Activity property that wraps an untyped inner TurnContext.
         /// </summary>
         /// <typeparam name="T">An IActivity derived type, that is one of IMessageActivity, IConversationUpdateActivity etc.</typeparam>
-        private class DelegatingTurnContext<T> : ITurnContext<T>
+        protected class DelegatingTurnContext<T> : ITurnContext<T>
             where T : IActivity
         {
             private ITurnContext _innerTurnContext;


### PR DESCRIPTION
- make DialogContext constructor public (it was internal) this was a customer ask from two independent sources
- make DelegatingTurnContext protected rather than private in ActivityHandler - this allows derived classes to also get the benefit of slightly stronger typing (this was really a bug as ActivityHandler was intended for extensibility through inheritance)
