### PR TITLE
SwitchCondition: support numeric and boolean types, and do not require quotes for string literals

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/SwitchCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/SwitchCondition.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
         /// assumes that switch case values are compile time constants and not expressions
         /// that can be evaluated against state.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>An expression that reflects the constant case value</returns>
         public Expression CreateValueExpression()
         {
             Expression expression = null;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/SwitchCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/SwitchCondition.cs
@@ -27,11 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
         /// Value expression to be compared against condition.
         /// </summary>
         [JsonProperty("value")]
-        public string Value
-        {
-            get;
-            set;
-        }
+        public string Value { get; set; }
 
         /// <summary>
         /// Set of steps to be executed given that the condition of the switch matches the value of this case.

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/03 - IfCondition/SwitchCondition.main.dialog
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/03 - IfCondition/SwitchCondition.main.dialog
@@ -1,0 +1,35 @@
+{
+    "$schema": "../../app.schema",
+    "$type": "Microsoft.AdaptiveDialog",
+    "steps": [
+        {
+            "$type": "Microsoft.SetProperty",
+            "property": "user.age",
+            "value": "22"
+        },
+        {
+            "$type": "Microsoft.SwitchCondition",
+            "condition": "user.age",
+            "cases": [
+                {
+                    "value": "21",
+                    "steps": [
+                        {
+                            "$type": "Microsoft.SendActivity",
+                            "activity": "Age is 21!"
+                        }
+                    ]
+                },
+                {
+                    "value": "22",
+                    "steps": [
+                        {
+                            "$type": "Microsoft.SendActivity",
+                            "activity": "Age is 22!"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/EmailBot/Dialogs/ShowEmail/DisplayEmailList.dialog
+++ b/samples/Microsoft.Bot.Builder.TestBot.Json/Samples/EmailBot/Dialogs/ShowEmail/DisplayEmailList.dialog
@@ -27,7 +27,7 @@
                     "condition": "dialog.choice",
                     "cases": [
                         {
-                            "case": "'1'",
+                            "case": "1",
                             "steps": [
                                 {
                                     "$type": "Microsoft.SetProperty",
@@ -38,7 +38,7 @@
                         },
                         {
 
-                            "case": "'2'",
+                            "case": "2",
                             "steps": [
                                 {
                                     "$type": "Microsoft.SetProperty",
@@ -49,7 +49,7 @@
                         },
                         {
 
-                            "case": "'3'",
+                            "case": "3",
                             "steps": [
                                 {
                                     "$type": "Microsoft.SetProperty",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/StepsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/StepsTests.cs
@@ -173,9 +173,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                             Condition = "user.name",
                             Cases = new List<Case>()
                             {
-                                new Case("'susan'", new List<IDialog>() { new SendActivity("hi susan") } ),
-                                new Case("'bob'", new List<IDialog>() { new SendActivity("hi bob") } ),
-                                new Case("'frank'", new List<IDialog>() { new SendActivity("hi frank") } )
+                                new Case("susan", new List<IDialog>() { new SendActivity("hi susan") } ),
+                                new Case("bob", new List<IDialog>() { new SendActivity("hi bob") } ),
+                                new Case("frank", new List<IDialog>() { new SendActivity("hi frank") } )
                             },
                             Default = new List<IDialog>() { new SendActivity("Who are you?") }
                         },
@@ -185,6 +185,101 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             await CreateFlow(testDialog)
             .Send("hi")
                 .AssertReply("hi frank")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task Step_Switch_Default()
+        {
+            var testDialog = new AdaptiveDialog("planningTest")
+            {
+                Steps = new List<IDialog>()
+                    {
+                        new SetProperty()
+                        {
+                            Property = "user.name",
+                            Value = new ExpressionEngine().Parse("'Zoidberg'")
+                        },
+                        new SwitchCondition()
+                        {
+                            Condition = "user.name",
+                            Cases = new List<Case>()
+                            {
+                                new Case("susan", new List<IDialog>() { new SendActivity("hi susan") } ),
+                                new Case("bob", new List<IDialog>() { new SendActivity("hi bob") } ),
+                                new Case("frank", new List<IDialog>() { new SendActivity("hi frank") } )
+                            },
+                            Default = new List<IDialog>() { new SendActivity("Who are you?") }
+                        },
+                    }
+            };
+
+            await CreateFlow(testDialog)
+            .Send("hi")
+                .AssertReply("Who are you?")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task Step_Switch_Number()
+        {
+            var testDialog = new AdaptiveDialog("planningTest")
+            {
+                Steps = new List<IDialog>()
+                    {
+                        new SetProperty()
+                        {
+                            Property = "user.age",
+                            Value = new ExpressionEngine().Parse("22")
+                        },
+                        new SwitchCondition()
+                        {
+                            Condition = "user.age",
+                            Cases = new List<Case>()
+                            {
+                                new Case("21", new List<IDialog>() { new SendActivity("Age is 21") } ),
+                                new Case("22", new List<IDialog>() { new SendActivity("Age is 22") } ),
+                                new Case("23", new List<IDialog>() { new SendActivity("Age is 23") } )
+                            },
+                            Default = new List<IDialog>() { new SendActivity("Who are you?") }
+                        },
+                    }
+            };
+
+            await CreateFlow(testDialog)
+            .Send("hi")
+                .AssertReply("Age is 22")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task Step_Switch_Bool()
+        {
+            var testDialog = new AdaptiveDialog("planningTest")
+            {
+                Steps = new List<IDialog>()
+                    {
+                        new SetProperty()
+                        {
+                            Property = "user.isVip",
+                            Value = new ExpressionEngine().Parse("true")
+                        },
+                        new SwitchCondition()
+                        {
+                            Condition = "user.isVip",
+                            Cases = new List<Case>()
+                            {
+                                new Case("True", new List<IDialog>() { new SendActivity("User is VIP") } ),
+                                new Case("False", new List<IDialog>() { new SendActivity("User is NOT VIP") } )
+                            },
+                            Default = new List<IDialog>() { new SendActivity("Who are you?") }
+                        },
+                    }
+            };
+
+            await CreateFlow(testDialog)
+            .Send("hi")
+                .AssertReply("User is VIP")
             .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -80,6 +80,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         }
 
         [TestMethod]
+        public async Task JsonDialogLoad_SwitchCondition_Number()
+        {
+            await BuildTestFlow("SwitchCondition.main.dialog")
+            .Send("Hi")
+            .AssertReply("Age is 22!")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task JsonDialogLoad_TextInputWithoutProperty()
         {
             await BuildTestFlow("TextInput.WithoutProperty.main.dialog")


### PR DESCRIPTION
Fixes #1975