### PR TITLE
Fix publishtocoveralls.ps1

### DIFF
--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -41,7 +41,7 @@ $uploadArgs = @(
     "--jobId ""$env:Build_BuildId""",
     "--commitId ""$env:Build_SourceVersion""",
     "--commitAuthor ""$env:Build_RequestedFor""",
-    "--commitEmail ""$env:Build_RequestedForEmail""",
+    "--commitEmail ""$env:Build_RequestedForEmail """,
     "--commitMessage ""$env:Build_SourceVersionMessage""",
     "--serviceName ""$serviceName"""
 );


### PR DESCRIPTION
Add a space in the --commitEmail argument. That prevents an empty email argument from killing the coveralls upload as happened in BotBuilder-DotNet-master-CI-PR build # 66992.