### PR TITLE
DialogTestClient constructor updates and XUnitOutputMiddleware renames

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Testing/DialogTestClient.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/DialogTestClient.cs
@@ -31,18 +31,18 @@ namespace Microsoft.Bot.Builder.Testing
         /// <param name="targetDialog">The dialog to be tested. This will be the root dialog for the test client.</param>
         /// <param name="initialDialogOptions">(Optional) additional argument(s) to pass to the dialog being started.</param>
         /// <param name="middlewares">(Optional) A list of middlewares to be added to the test adapter.</param>
-        /// <param name="callback">(Optional) The bot turn processing logic for the test. If this value is not provided, the test client will create a default <see cref="BotCallbackHandler"/>.</param>
-        public DialogTestClient(string channelId, Dialog targetDialog, object initialDialogOptions = null, IEnumerable<IMiddleware> middlewares = null, BotCallbackHandler callback = null)
+        /// <param name="conversationState">(Optional) A <see cref="ConversationState"/> to use in the test client.</param>
+        public DialogTestClient(string channelId, Dialog targetDialog, object initialDialogOptions = null, IEnumerable<IMiddleware> middlewares = null, ConversationState conversationState = null)
         {
-            var convoState = new ConversationState(new MemoryStorage());
+            ConversationState = conversationState ?? new ConversationState(new MemoryStorage());
             _testAdapter = new TestAdapter(channelId)
-                .Use(new AutoSaveStateMiddleware(convoState));
+                .Use(new AutoSaveStateMiddleware(ConversationState));
 
             AddUserMiddlewares(middlewares);
 
-            var dialogState = convoState.CreateProperty<DialogState>("DialogState");
+            var dialogState = ConversationState.CreateProperty<DialogState>("DialogState");
 
-            _callback = callback ?? GetDefaultCallback(targetDialog, initialDialogOptions, dialogState);
+            _callback = GetDefaultCallback(targetDialog, initialDialogOptions, dialogState);
         }
 
         /// <summary>
@@ -52,24 +52,30 @@ namespace Microsoft.Bot.Builder.Testing
         /// <param name="targetDialog">The dialog to be tested. This will be the root dialog for the test client.</param>
         /// <param name="initialDialogOptions">(Optional) additional argument(s) to pass to the dialog being started.</param>
         /// <param name="middlewares">(Optional) A list of middlewares to be added to the test adapter.</param>
-        /// <param name="callback">(Optional) The bot turn processing logic for the test. If this value is not provided, the test client will create a default <see cref="BotCallbackHandler"/>.</param>
-        public DialogTestClient(TestAdapter testAdapter, Dialog targetDialog, object initialDialogOptions = null, IEnumerable<IMiddleware> middlewares = null, BotCallbackHandler callback = null)
+        /// <param name="conversationState">(Optional) A <see cref="ConversationState"/> to use in the test client.</param>
+        public DialogTestClient(TestAdapter testAdapter, Dialog targetDialog, object initialDialogOptions = null, IEnumerable<IMiddleware> middlewares = null, ConversationState conversationState = null)
         {
-            var convoState = new ConversationState(new MemoryStorage());
-            _testAdapter = testAdapter.Use(new AutoSaveStateMiddleware(convoState));
+            ConversationState = conversationState ?? new ConversationState(new MemoryStorage());
+            _testAdapter = testAdapter.Use(new AutoSaveStateMiddleware(ConversationState));
 
             AddUserMiddlewares(middlewares);
 
-            var dialogState = convoState.CreateProperty<DialogState>("DialogState");
+            var dialogState = ConversationState.CreateProperty<DialogState>("DialogState");
 
-            _callback = callback ?? GetDefaultCallback(targetDialog, initialDialogOptions, dialogState);
+            _callback = GetDefaultCallback(targetDialog, initialDialogOptions, dialogState);
         }
 
         /// <summary>
         /// Gets the latest <see cref="DialogTurnResult"/> for the dialog being tested.
         /// </summary>
         /// <value>A <see cref="DialogTurnResult"/> instance with the result of the last turn.</value>
-        public virtual DialogTurnResult DialogTurnResult { get; private set; }
+        public DialogTurnResult DialogTurnResult { get; private set; }
+
+        /// <summary>
+        /// Gets the latest <see cref="ConversationState"/> for <see cref="DialogTestClient"/>.
+        /// </summary>
+        /// <value>A <see cref="ConversationState"/> instance for the current test client.</value>
+        public ConversationState ConversationState { get; }
 
         /// <summary>
         /// Sends an <see cref="Activity"/> to the target dialog.

--- a/libraries/Microsoft.Bot.Builder.Testing/XUnit/XUnitDialogTestLogger.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/XUnit/XUnitDialogTestLogger.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
     /// A middleware to output incoming and outgoing activities as json strings to the console during
     /// unit tests.
     /// </summary>
-    public class XUnitOutputMiddleware : IMiddleware
+    public class XUnitDialogTestLogger : IMiddleware
     {
         private readonly string _stopWatchStateKey;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="XUnitOutputMiddleware"/> class.
+        /// Initializes a new instance of the <see cref="XUnitDialogTestLogger"/> class.
         /// </summary>
         /// <remarks>
         /// This middleware outputs the incoming and outgoing activities for the XUnit based test to the console window.
@@ -33,9 +33,9 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
         /// An XUnit <see cref="ITestOutputHelper"/> instance.
         /// See <see href="https://xunit.net/docs/capturing-output.html">Capturing Output</see> in the XUnit documentation for additional details.
         /// </param>
-        public XUnitOutputMiddleware(ITestOutputHelper xunitOutputHelper)
+        public XUnitDialogTestLogger(ITestOutputHelper xunitOutputHelper)
         {
-            _stopWatchStateKey = $"{nameof(XUnitOutputMiddleware)}.Stopwatch.{Guid.NewGuid()}";
+            _stopWatchStateKey = $"{nameof(XUnitDialogTestLogger)}.Stopwatch.{Guid.NewGuid()}";
             Output = xunitOutputHelper;
         }
 
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
             if (activity.Type == ActivityTypes.Message)
             {
                 var messageActivity = activity.AsMessageActivity();
-                Output.WriteLine($"\r\n{actor} Text={messageActivity.Text}\r\n       Speak={messageActivity.Speak}\r\n       InputHint={messageActivity.InputHint}");
+                Output.WriteLine($"\r\n{actor} Text = {messageActivity.Text}\r\n       Speak = {messageActivity.Speak}\r\n       InputHint = {messageActivity.InputHint}");
             }
             else
             {

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/BookingDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/BookingDialogTests.cs
@@ -18,12 +18,12 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
 {
     public class BookingDialogTests : BotTestBase
     {
-        private readonly XUnitOutputMiddleware[] _middlewares;
+        private readonly XUnitDialogTestLogger[] _middlewares;
 
         public BookingDialogTests(ITestOutputHelper output)
             : base(output)
         {
-            _middlewares = new[] { new XUnitOutputMiddleware(output) };
+            _middlewares = new[] { new XUnitDialogTestLogger(output) };
         }
 
         [Theory]

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/CancelAndHelpDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/CancelAndHelpDialogTests.cs
@@ -18,12 +18,12 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
 {
     public class CancelAndHelpDialogTests : BotTestBase
     {
-        private readonly XUnitOutputMiddleware[] _middlewares;
+        private readonly XUnitDialogTestLogger[] _middlewares;
 
         public CancelAndHelpDialogTests(ITestOutputHelper output)
             : base(output)
         {
-            _middlewares = new[] { new XUnitOutputMiddleware(output) };
+            _middlewares = new[] { new XUnitDialogTestLogger(output) };
         }
 
         [Theory]

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/DateResolverDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/DateResolverDialogTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
             // Arrange
             var testCaseData = testData.GetObject<DateResolverDialogTestCase>();
             var sut = new DateResolverDialog();
-            var testClient = new DialogTestClient(Channels.Test, sut, testCaseData.InitialData, new[] { new XUnitOutputMiddleware(Output) });
+            var testClient = new DialogTestClient(Channels.Test, sut, testCaseData.InitialData, new[] { new XUnitDialogTestLogger(Output) });
 
             // Act/Assert
             Output.WriteLine($"Test Case: {testCaseData.Name}");

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/GetBookingDetailsDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/GetBookingDetailsDialogTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
             // Arrange
             var bookingTestData = testData.GetObject<GetBookingDetailsDialogTestCase>();
             var sut = new GetBookingDetailsDialog();
-            var testClient = new DialogTestClient(Channels.Test, sut, bookingTestData.InitialBookingDetails, new[] { new XUnitOutputMiddleware(Output) });
+            var testClient = new DialogTestClient(Channels.Test, sut, bookingTestData.InitialBookingDetails, new[] { new XUnitDialogTestLogger(Output) });
 
             // Act/Assert
             Output.WriteLine($"Test Case: {bookingTestData.Name}");

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/MainDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/MainDialogTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
         {
             // Arrange
             var sut = new MainDialog(_mockLogger.Object, null, _mockBookingDialog);
-            var testClient = new DialogTestClient(Channels.Test, sut, middlewares: new[] { new XUnitOutputMiddleware(Output) });
+            var testClient = new DialogTestClient(Channels.Test, sut, middlewares: new[] { new XUnitDialogTestLogger(Output) });
 
             // Act/Assert
             var reply = await testClient.SendActivityAsync<IMessageActivity>("hi");
@@ -69,7 +69,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
         {
             // Arrange
             var sut = new MainDialog(_mockLogger.Object, SimpleMockFactory.CreateMockLuisRecognizer<IRecognizer>(null).Object, _mockBookingDialog);
-            var testClient = new DialogTestClient(Channels.Test, sut, middlewares: new[] { new XUnitOutputMiddleware(Output) });
+            var testClient = new DialogTestClient(Channels.Test, sut, middlewares: new[] { new XUnitDialogTestLogger(Output) });
 
             // Act/Assert
             var reply = await testClient.SendActivityAsync<IMessageActivity>("hi");
@@ -93,7 +93,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
                 });
 
             var sut = new MainDialog(_mockLogger.Object, mockLuisRecognizer.Object, _mockBookingDialog);
-            var testClient = new DialogTestClient(Channels.Test, sut, middlewares: new[] { new XUnitOutputMiddleware(Output) });
+            var testClient = new DialogTestClient(Channels.Test, sut, middlewares: new[] { new XUnitDialogTestLogger(Output) });
 
             var reply = await testClient.SendActivityAsync<IMessageActivity>("hi");
             Assert.Equal("What can I help you with today?", reply.Text);

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/DialogTestClientTests.cs
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/DialogTestClientTests.cs
@@ -132,23 +132,6 @@ namespace Microsoft.Bot.Builder.Testing.Tests
                     It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        [Fact]
-        public async Task ShouldUseCustomCallback()
-        {
-            var callbackCalled = false;
-
-            async Task TestCallback(ITurnContext context, CancellationToken token)
-            {
-                callbackCalled = true;
-                await context.SendActivityAsync("test reply from the bot", cancellationToken: token);
-            }
-
-            var sut = new DialogTestClient(Channels.Test, _mockDialog.Object, callback: TestCallback);
-
-            await sut.SendActivityAsync<IActivity>("test message");
-            Assert.True(callbackCalled);
-        }
-
         private class TestOptions
         {
             public string SomeText { get; set; }

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/XUnit/XUnitOutputMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/XUnit/XUnitOutputMiddlewareTests.cs
@@ -23,13 +23,13 @@ namespace Microsoft.Bot.Builder.Testing.Tests.XUnit
         public async Task ShouldLogIncomingAndOutgoingMessageActivities(string utterance, string textReply, string speakReply, string inputHint)
         {
             var mockOutput = new MockTestOutputHelper();
-            var sut = new XUnitOutputMiddleware(mockOutput);
+            var sut = new XUnitDialogTestLogger(mockOutput);
             var testClient = new DialogTestClient(Channels.Test, new EchoDialog(textReply, speakReply, inputHint), null, new List<IMiddleware> { sut });
             await testClient.SendActivityAsync<IMessageActivity>(utterance);
 
             Assert.Equal("\r\nUser:  Hi", mockOutput.Output[0]);
             Assert.StartsWith("       -> ts: ", mockOutput.Output[1]);
-            Assert.StartsWith($"\r\nBot:   Text={textReply}\r\n       Speak={speakReply}\r\n       InputHint={inputHint}", mockOutput.Output[2]);
+            Assert.StartsWith($"\r\nBot:   Text = {textReply}\r\n       Speak = {speakReply}\r\n       InputHint = {inputHint}", mockOutput.Output[2]);
             Assert.StartsWith("       -> ts: ", mockOutput.Output[3]);
             Assert.Contains("elapsed", mockOutput.Output[3]);
         }
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Testing.Tests.XUnit
         public async Task ShouldLogOtherIncomingAndOutgoingActivitiesAsRawJson(string activityType)
         {
             var mockOutput = new MockTestOutputHelper();
-            var sut = new XUnitOutputMiddleware(mockOutput);
+            var sut = new XUnitDialogTestLogger(mockOutput);
             var testClient = new DialogTestClient(Channels.Test, new EchoDialog(), null, new List<IMiddleware> { sut });
 
             var activity = new Activity(activityType);


### PR DESCRIPTION
Renamed XUnitOutputMiddleware to XUnitDialogTestLogger (so its name is closer to js).
Added some spaces to the XUnitDialogTestLogger  output so it reads better.
Removed callback constructor parameter from DialogTestClient (it relies on an internal DialogTurnResult and that's fishy, we will need to find a better solution in the future to support this).
Added optional ConversationState parameter to the DialogTestClient constructor and exposed a property to allow people to inspect it or access it.