### PR TITLE
fix bug: Empty or invalid constraint in Rule will break the dialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
@@ -72,9 +72,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Rules
         protected virtual Expression BuildExpression(IExpressionParser factory)
         {
             List<Expression> allExpressions = new List<Expression>();
-            if (this.Constraint != null)
+            if (!string.IsNullOrWhiteSpace(this.Constraint))
             {
-                allExpressions.Add(factory.Parse(this.Constraint));
+                try
+                {
+                    allExpressions.Add(factory.Parse(this.Constraint));
+                }
+                catch
+                {
+                    throw new Exception($"Invalid constraint expression: {this.Constraint}");
+                }
             }
 
             if (this.extraConstraints.Any())
@@ -98,10 +105,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Rules
         /// <param name="constraint"></param>
         public void AddConstraint(string constraint)
         {
-            lock (this.extraConstraints)
+            try
             {
-                this.extraConstraints.Add(new ExpressionEngine().Parse(constraint));
-                this.fullConstraint = null; // reset to force it to be recalcaulated
+                lock (this.extraConstraints)
+                {
+                    this.extraConstraints.Add(new ExpressionEngine().Parse(constraint));
+                    this.fullConstraint = null; // reset to force it to be recalcaulated
+                }
+            }
+            catch
+            {
+                throw new Exception($"Invalid constraint expression: {constraint}");
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
@@ -78,9 +78,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Rules
                 {
                     allExpressions.Add(factory.Parse(this.Constraint));
                 }
-                catch
+                catch(Exception e)
                 {
-                    throw new Exception($"Invalid constraint expression: {this.Constraint}");
+                    throw new Exception($"Invalid constraint expression: {this.Constraint}, {e.Message}");
                 }
             }
 
@@ -113,9 +113,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Rules
                     this.fullConstraint = null; // reset to force it to be recalcaulated
                 }
             }
-            catch
+            catch (Exception e)
             {
-                throw new Exception($"Invalid constraint expression: {constraint}");
+                throw new Exception($"Invalid constraint expression: {this.Constraint}, {e.Message}");
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Rules/Rule.cs
@@ -105,18 +105,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Rules
         /// <param name="constraint"></param>
         public void AddConstraint(string constraint)
         {
-            try
+            if (!string.IsNullOrWhiteSpace(constraint))
             {
-                lock (this.extraConstraints)
+                try
                 {
-                    this.extraConstraints.Add(new ExpressionEngine().Parse(constraint));
-                    this.fullConstraint = null; // reset to force it to be recalcaulated
+                    lock (this.extraConstraints)
+                    {
+                        this.extraConstraints.Add(new ExpressionEngine().Parse(constraint));
+                        this.fullConstraint = null; // reset to force it to be recalcaulated
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new Exception($"Invalid constraint expression: {this.Constraint}, {e.Message}");
                 }
             }
-            catch (Exception e)
-            {
-                throw new Exception($"Invalid constraint expression: {this.Constraint}, {e.Message}");
-            }
+                
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 new IntentRule("trigger", constraint: "user.b == 1 || user.c == 1", steps: new List<IDialog> { new SendActivity("ruleBorC") }),
                 new IntentRule("trigger", constraint: "user.a == 1 && user.b == 1", steps: new List<IDialog> { new SendActivity("ruleAandB") }),
                 new IntentRule("trigger", constraint: "user.a == 1 && user.c == 1", steps: new List<IDialog> { new SendActivity("ruleAandC") }),
-                new IntentRule("trigger", steps: new List<IDialog> { new SendActivity("default")})
+                new IntentRule("trigger", constraint: "", steps: new List<IDialog> { new SendActivity("default")})
             });
             dialog.AutoEndDialog = false;
 


### PR DESCRIPTION
fix #2197 