### PR TITLE
Updating trusted URLs for US Gov

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Bot.Connector.Authentication
             // { "state.botframework.com", DateTime.MaxValue }, // deprecated state api
             { "api.botframework.com", DateTime.MaxValue },       // bot connector API
             { "token.botframework.com", DateTime.MaxValue },    // oauth token endpoint
-            { "api.botframework.us", DateTime.MaxValue },        // bot connector API in US Government DataCenters
-            { "token.botframework.us", DateTime.MaxValue },      // oauth token endpoint in US Government DataCenters
+            { "api.botframework.azure.us", DateTime.MaxValue },        // bot connector API in US Government DataCenters
+            { "token.botframework.azure.us", DateTime.MaxValue },      // oauth token endpoint in US Government DataCenters
         };
 
         /// <summary>


### PR DESCRIPTION
The US Gov endpoint should be .azure.us instead of .us