### PR TITLE
Stylecop fixes

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Rules for StyleCop.Analyzers" Description="Source analysis rules treat as errors for BotBuilder-DotNet solution." ToolsVersion="15.0">
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
-    <Rule Id="AvoidAsyncVoid" Action="Warning" />
-    <Rule Id="UseConfigureAwait" Action="Warning" />
+    <Rule Id="AvoidAsyncVoid" Action="Error" />
+    <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>
 
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -63,14 +63,16 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             Assert.True(claimsIdentity.IsAuthenticated);
         }
 
-        //[Fact]
-        //public async Task Connector_TokenExtractor_RequiredEndorsementsPartiallyPresent_ShouldNotValidate()
-        //{
-        //    var configRetriever = new TestConfigurationRetriever();
+        /*
+        [Fact]
+        public async Task Connector_TokenExtractor_RequiredEndorsementsPartiallyPresent_ShouldNotValidate()
+        {
+            var configRetriever = new TestConfigurationRetriever();
 
-        //    configRetriever.EndorsementTable.Add(KeyId, new HashSet<string>() { RandomEndorsement, ComplianceEndorsement, TestChannelName });
-        //    await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RunTestCase(configRetriever, new string[] { ComplianceEndorsement, "notSatisfiedEndorsement" }));
-        //}
+            configRetriever.EndorsementTable.Add(KeyId, new HashSet<string>() { RandomEndorsement, ComplianceEndorsement, TestChannelName });
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RunTestCase(configRetriever, new string[] { ComplianceEndorsement, "notSatisfiedEndorsement" }));
+        }
+        */
 
         private async Task<ClaimsIdentity> RunTestCase(IConfigurationRetriever<IDictionary<string, HashSet<string>>> configRetriever, string[] requiredEndorsements = null)
         {


### PR DESCRIPTION
Code fixed to eliminate Stylecop warnings. Stylecop warnings set as errors. Ref: https://github.com/microsoft/botbuilder-dotnet/pull/2171