### PR TITLE
Reverts PR 1993

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -62,18 +62,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Check for end of inner dialog
             if (turnResult.Status != DialogTurnStatus.Waiting)
             {
-                if (turnResult.Status == DialogTurnStatus.Cancelled)
-                {
-                    await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
-                    return new DialogTurnResult(DialogTurnStatus.Cancelled, turnResult.Result);
-                }
-
                 // Return result to calling dialog
                 return await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
             }
 
             // Just signal waiting
-            return Dialog.EndOfTurn;
+            return EndOfTurn;
         }
 
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext outerDc, CancellationToken cancellationToken = default(CancellationToken))
@@ -91,16 +85,11 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             if (turnResult.Status != DialogTurnStatus.Waiting)
             {
-                if (turnResult.Status == DialogTurnStatus.Cancelled)
-                {
-                    await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
-                    return new DialogTurnResult(DialogTurnStatus.Cancelled, turnResult.Result);
-                }
-
+                // Return result to calling dialog
                 return await EndComponentAsync(outerDc, turnResult.Result, cancellationToken).ConfigureAwait(false);
             }
 
-            return Dialog.EndOfTurn;
+            return EndOfTurn;
         }
 
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext outerDc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ComponentDialogTests.cs
@@ -288,39 +288,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
-        public async Task CancelDialogOnFirstStepTest()
-        {
-            var steps = new WaterfallStep[]
-            {
-                CancelledWaterfallStep,
-            };
-            var waterfallDialog = new WaterfallDialog("test-waterfall", steps);
-            var testFlow = CreateTestFlow(waterfallDialog);
-            await testFlow
-                .Send("hello")
-                .AssertReply("Component dialog cancelled (result value is 42).")
-                .StartTestAsync();
-        }
-
-        [TestMethod]
-        public async Task CancelDialogOnSecondStepTest()
-        {
-            var steps = new WaterfallStep[]
-            {
-                WaterfallStep1,
-                CancelledWaterfallStep,
-            };
-            var waterfallDialog = new WaterfallDialog("test-waterfall", steps);
-            var testFlow = CreateTestFlow(waterfallDialog);
-            await testFlow
-                .Send("hello")
-                .AssertReply("Enter a number.")
-                .Send("42")
-                .AssertReply("Component dialog cancelled (result value is 42).")
-                .StartTestAsync();
-        }
-
         private static TestFlow CreateTestFlow(WaterfallDialog waterfallDialog)
         {
             var convoState = new ConversationState(new MemoryStorage());

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/CancelAndHelpDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/CancelAndHelpDialogTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
 
             reply = await testClient.SendActivityAsync<IMessageActivity>(cancelUtterance);
             Assert.Equal("Cancelling", reply.Text);
-            Assert.Equal(DialogTurnStatus.Cancelled, testClient.DialogTurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Complete, testClient.DialogTurnResult.Status);
         }
 
         [Theory]

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/GetBookingDetailsDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/GetBookingDetailsDialogTests.cs
@@ -39,11 +39,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs
                 Assert.Equal(bookingTestData.UtterancesAndReplies[i, 1], reply?.Text);
             }
 
-            if (testClient.DialogTurnResult.Status == DialogTurnStatus.Cancelled)
-            {
-                Assert.Null(testClient.DialogTurnResult.Result);
-            }
-            else
+            if (testClient.DialogTurnResult.Result != null)
             {
                 var bookingResults = (BookingDetails)testClient.DialogTurnResult.Result;
                 Assert.Equal(bookingTestData.ExpectedBookingDetails.Origin, bookingResults.Origin);

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/TestData/BookingDialogTestsDataGenerator.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Dialogs/TestData/BookingDialogTestsDataGenerator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Dialogs.TestData
                     { "cancel", "Cancelling" },
                 },
                 true,
-                new DialogTurnResult(DialogTurnStatus.Cancelled));
+                new DialogTurnResult(DialogTurnStatus.Complete));
 
             yield return BuildTestCaseObject(
                 "Full flow with failed call to FlightBookingService",


### PR DESCRIPTION
This PR reverts changed made in https://github.com/microsoft/botbuilder-dotnet/pull/1993.

At this moment, is not possible to return cancelled from a component dialog.