### PR TITLE
Added MentionWorkaroundForSkypeMiddleware, reverted RemoveMentionText

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityExtensions.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityExtensions.cs
@@ -44,10 +44,8 @@ namespace Microsoft.Bot.Schema
         }
 
         /// <summary>
-        /// Replace any mention text for given id from Text property. First checks for and replaces the name of the
-        /// recipient with the matching id and then checks for the leftover <at></at> tags (this is done to handle
-        /// the way Skype sends mention text.
-        /// Use with caution because this function is altering the text on the Activity.
+        /// Remove any mention text for given id from Text property.  For example, given the message
+        /// @echoBot Hi Bot, this will remove "@echoBot", leaving "Hi Bot".
         /// </summary>
         /// <param name="activity">activity.</param>
         /// <param name="id">id to match.</param>
@@ -56,12 +54,7 @@ namespace Microsoft.Bot.Schema
         {
             foreach (var mention in activity.GetMentions().Where(mention => mention.Mentioned.Id == id))
             {
-                var mentionNameMatch = Regex.Match(mention.Text, @"(?<=<at.*>)(.*?)(?=<\/at>)", RegexOptions.IgnoreCase);
-                if (mentionNameMatch.Success)
-                {
-                    activity.Text = activity.Text.Replace(mentionNameMatch.Value, string.Empty);
-                    activity.Text = Regex.Replace(activity.Text, "<at></at>", string.Empty, RegexOptions.IgnoreCase);
-                }
+                activity.Text = Regex.Replace(activity.Text, mention.Text, string.Empty, RegexOptions.IgnoreCase).Trim();
             }
 
             return activity.Text;


### PR DESCRIPTION
Fixes #2181 Added MentionWorkaroundForSkypeMiddleware to patch Skype mentions so that RemoveMentionText can properly removed mention text.

ActivityExtensions.cs
Reverts commit 4daa9b97, with the addition of a Trim() added.  That commit did not work for other channel mention types.

BotFrameworkAdapter
Added internal middleware class MentionWorkaroundForSkypeMiddleware to remove the <at> tags from Mention.Text for Skype mentions.  This allows RemoveMentionText to properly remove user names from Activity.Text