### PR TITLE
Add support for transient services depending on scoped services.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/BotFrameworkApplicationBuilderExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/BotFrameworkApplicationBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,8 +20,9 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
         /// </summary>
         /// <param name="applicationBuilder">The application builder that defines the bot's pipeline.<see cref="IApplicationBuilder"/>.</param>
         /// <param name="middlewareSet">The set of middleware the bot executes on each turn. <see cref="MiddlewareSet"/>.</param>
+        /// <param name="onTurnError">Callback to execute when an error occurs while executing the pipeline.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
-        public static IApplicationBuilder UseBotFrameworkNamedPipe(this IApplicationBuilder applicationBuilder, IList<IMiddleware> middlewareSet = null)
+        public static IApplicationBuilder UseBotFrameworkNamedPipe(this IApplicationBuilder applicationBuilder, IList<IMiddleware> middlewareSet = null, Func<ITurnContext, Exception, Task> onTurnError = null)
         {
             if (applicationBuilder == null)
             {
@@ -28,7 +30,7 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
             }
 
             var connector = new NamedPipeConnector();
-            connector.InitializeNamedPipeServer(applicationBuilder.ApplicationServices, middlewareSet);
+            connector.InitializeNamedPipeServer(applicationBuilder.ApplicationServices, middlewareSet, onTurnError);
 
             return applicationBuilder;
         }

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
@@ -248,5 +248,5 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
 
             return response;
         }
-        }
-   }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
@@ -199,9 +199,16 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
             try
             {
                 var adapter = new BotFrameworkStreamingExtensionsAdapter(_transportServer, _middlewareSet, logger);
+                IBot bot = null;
 
                 // First check if an IBot type definition is available from the service provider.
-                var bot = _services?.GetService<IBot>();
+                if (_services?.GetService<IBot>() != null)
+                {
+                    /* Creating a new scope for each request allows us to support
+                     * bots that inject scoped services as dependencies.
+                     */
+                    bot = _services.CreateScope().ServiceProvider.GetService<IBot>();
+                }
 
                 // If no bot has been set, check if a singleton bot is associated with this request handler.
                 if (bot == null)
@@ -241,5 +248,5 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
 
             return response;
         }
-    }
-}
+        }
+   }

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
                 IBot bot = null;
 
                 // First check if an IBot type definition is available from the service provider.
-                if (_services?.GetService<IBot>() != null)
+                if (_services != null)
                 {
                     /* Creating a new scope for each request allows us to support
                      * bots that inject scoped services as dependencies.


### PR DESCRIPTION
Two fixes:

1) Unblocks users designing transient bots with scoped dependencies, by creating a new scope for each request in the same manner an MVC controller would.

2) Allows for passing in of OnTurnError logic via the application extension for bots using named pipes.