### PR TITLE
NumberPrompt considers culture when parsing

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -108,7 +109,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     var text = results[0].Resolution["value"].ToString();
                     if (typeof(T) == typeof(float))
                     {
-                        if (float.TryParse(text, out var value))
+                        if (float.TryParse(text, NumberStyles.Any, new CultureInfo(culture), out var value))
                         {
                             result.Succeeded = true;
                             result.Value = (T)(object)value;
@@ -116,7 +117,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else if (typeof(T) == typeof(int))
                     {
-                        if (int.TryParse(text, out var value))
+                        if (int.TryParse(text, NumberStyles.Any, new CultureInfo(culture), out var value))
                         {
                             result.Succeeded = true;
                             result.Value = (T)(object)value;
@@ -124,7 +125,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else if (typeof(T) == typeof(long))
                     {
-                        if (long.TryParse(text, out var value))
+                        if (long.TryParse(text, NumberStyles.Any, new CultureInfo(culture), out var value))
                         {
                             result.Succeeded = true;
                             result.Value = (T)(object)value;
@@ -132,7 +133,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else if (typeof(T) == typeof(double))
                     {
-                        if (double.TryParse(text, out var value))
+                        if (double.TryParse(text, NumberStyles.Any, new CultureInfo(culture), out var value))
                         {
                             result.Succeeded = true;
                             result.Value = (T)(object)value;
@@ -140,15 +141,11 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else if (typeof(T) == typeof(decimal))
                     {
-                        if (decimal.TryParse(text, out var value))
+                        if (decimal.TryParse(text, NumberStyles.Any, new CultureInfo(culture), out var value))
                         {
                             result.Succeeded = true;
                             result.Value = (T)(object)value;
                         }
-                    }
-                    else
-                    {
-                        throw new NotSupportedException($"NumberPrompt: type argument T of type 'typeof(T)' is not supported");
                     }
                 }
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptMock.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptMock.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    public class NumberPromptMock: NumberPrompt<int>
+    {
+        public NumberPromptMock(string dialogId, PromptValidator<int> validator = null, string defaultLocale = null)
+            : base(dialogId, validator, defaultLocale)
+        {
+        }
+
+        public async Task OnPromptNullContext(object options, CancellationToken cancellationToken = default)
+        {
+            var opt = (PromptOptions)options;
+
+            // should throw ArgumentNullException
+            await OnPromptAsync(turnContext: null, state: null, options: opt, isRetry: false);
+        }
+
+        public async Task OnPromptNullOptions(DialogContext dc, CancellationToken cancellationToken = default)
+        {
+            // should throw ArgumentNullException
+            await OnPromptAsync(dc.Context, state: null, options: null, isRetry: false);
+        }
+
+        public async Task OnRecognizeNullContext(CancellationToken cancellationToken = default)
+        {
+            // should throw ArgumentNullException
+            await OnRecognizeAsync(turnContext: null, state: null, options: null);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
@@ -40,6 +40,53 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task NumberPromptWithNullTurnContextShouldFail()
+        {
+            var numberPromptMock = new NumberPromptMock("NumberPromptMock");
+
+            var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "Please send a number." } };
+
+            await numberPromptMock.OnPromptNullContext(options);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task OnPromptErrorsWithNullOptions()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            var numberPromptMock = new NumberPromptMock("NumberPromptMock");
+            dialogs.Add(numberPromptMock);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                await numberPromptMock.OnPromptNullOptions(dc);
+            })
+            .Send("hello")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task OnRecognizeWithNullTurnContextShouldFail()
+        {
+            var numberPromptMock = new NumberPromptMock("NumberPromptMock");
+
+            await numberPromptMock.OnRecognizeNullContext();
+        }
+
+        [TestMethod]
         public async Task NumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -267,6 +314,124 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var dialogs = new DialogSet(dialogState);
 
             var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.English);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Bot received the number '{numberResult}'."), cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send("3.14")
+            .AssertReply("Bot received the number '3.14'.")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task CultureThruNumberPromptCtor()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.Dutch);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    Assert.AreEqual(3.14, numberResult);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send("3,14")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task CultureThruActivityNumberPrompt()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.Dutch);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    Assert.AreEqual(3.14, numberResult);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send(new Activity { Type = ActivityTypes.Message, Text = "3,14", Locale = Culture.Dutch })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task NumberPromptDefaultsToEnUsLocale()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt");
             dialogs.Add(numberPrompt);
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>


### PR DESCRIPTION
Fixes #2288 

## Changes
* `NumberPrompt` now takes into account culture while parsing value from `Recognizers.Text.ModelResult`
* Wrote more tests for NumberPrompt to reach 100% code coverage for `NumberPrompt.cs` file

## Specific Changes
* Uses C#'s `TryParse()` overload that accepts culture
* Added tests that test culture different from default (`en-us`)
* Added tests that checked that expected errors were thrown when expected params were missing
* Removed redundant type check from `NumberPrompt.OnPromptAsync()`, which was already covered in ctor's logic