### PR TITLE
Dialog and Sequence Context: make decisions about inherited state more flexible

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/SequenceContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/SequenceContext.cs
@@ -252,6 +252,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return false;
         }
 
+        /// <summary>
+        /// Specifies whether a given dialog should inherit dialog-level state. For adaptive dialogs, 
+        /// we take our base class cases plus we explicitly ask that InputDialogs inherit state as well.
+        /// InputDialogs don't inherit state out of the box because they inherit directly from Dialog and 
+        /// are declared in the Adaptive assembly, so the base class, DialogContext does not explicitly
+        /// request that they inherit state. Thus, we add it here. This enables seamless usage of
+        /// dialog level properties such as $name across Input dialogs and / or steps within an adaptive dialog.
+        /// </summary>
+        /// <param name="dialog">The dialog to be tested.</param>
+        /// <returns>Whether the passed dialog should inherit dialog-level state.</returns>
         protected override bool ShouldInheritState(IDialog dialog)
         {
             return base.ShouldInheritState(dialog) || dialog is InputDialog;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/SequenceContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/SequenceContext.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
@@ -20,12 +21,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public AdaptiveDialogState Plans { get; private set; }
 
         /// <summary>
-        /// List of steps being executed
+        /// List of steps being executed.
         /// </summary>
         public List<StepState> Steps { get; set; }
         
         /// <summary>
-        /// List of changes that are queued to be applied
+        /// List of changes that are queued to be applied.
         /// </summary>
         public List<StepChangeList> Changes
         {
@@ -249,6 +250,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             }
 
             return false;
+        }
+
+        protected override bool ShouldInheritState(IDialog dialog)
+        {
+            return base.ShouldInheritState(dialog) || dialog is InputDialog;
         }
     }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             Dictionary<string, object> state = null;
             int? stateIndex = null;
 
-            if (dialog is DialogCommand)
+            if (ShouldInheritState(dialog))
             {
                 if (Stack.Count > 0)
                 {
@@ -298,7 +298,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             // set dialog result
-            if (dialog is DialogCommand)
+            if (ShouldInheritState(dialog))
             {
                 State.SetValue(DialogContextState.STEP_OPTIONS_PROPERTY, options);
             }
@@ -540,16 +540,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             return null;
         }
 
-        public class DialogEvents
-        {
-            public const string BeginDialog = "beginDialog";
-            public const string ResumeDialog = "resumeDialog";
-            public const string RepromptDialog = "repromptDialog";
-            public const string CancelDialog = "cancelDialog";
-            public const string EndDialog = "endDialog";
-            public const string ActivityReceived = "activityReceived";
-        }
-
         /// <summary>
         /// Searches for a dialog with a given ID.
         /// Emits a named event for the current dialog, or someone who started it, to handle.
@@ -557,7 +547,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="name">Name of the event to raise.</param>
         /// <param name="value">Value to send along with the event.</param>
         /// <param name="bubble">Flag to control whether the event should be bubbled to its parent if not handled locally. Defaults to a value of `true`.</param>
-        /// <param name="fromLeaf"></param>
+        /// <param name="fromLeaf">Whether the event is emitted from a leaf node.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>True if the event was handled.</returns>
         public async Task<bool> EmitEventAsync(string name, object value = null, bool bubble = true, bool fromLeaf = false, CancellationToken cancellationToken = default(CancellationToken))
@@ -605,6 +595,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             return false;
+        }
+
+        protected virtual bool ShouldInheritState(IDialog dialog)
+        {
+            return dialog is DialogCommand;
         }
 
         private async Task EndActiveDialogAsync(DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
@@ -671,5 +666,14 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
+        public class DialogEvents
+        {
+            public const string BeginDialog = "beginDialog";
+            public const string ResumeDialog = "resumeDialog";
+            public const string RepromptDialog = "repromptDialog";
+            public const string CancelDialog = "cancelDialog";
+            public const string EndDialog = "endDialog";
+            public const string ActivityReceived = "activityReceived";
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -597,6 +597,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             return false;
         }
 
+        /// <summary>
+        /// Specifies whether a given dialog should inherit dialog-level state. 
+        /// </summary>
+        /// <param name="dialog">The dialog to be tested.</param>
+        /// <returns>Whether the passed dialog should inherit dialog-level state.</returns>
         protected virtual bool ShouldInheritState(IDialog dialog)
         {
             return dialog is DialogCommand;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -875,5 +875,45 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             .StartTestAsync();
         }
 
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingReferValueInLaterStep()
+        {
+            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
+            {
+                Generator = new TemplateEngineLanguageGenerator(),
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new TextInput()
+                            {
+                                Property = "$name",
+                                Prompt = new ActivityTemplate("What is your name?")
+                            },
+                            new NumberInput()
+                            {
+                                Property = "$age",
+                                Prompt = new ActivityTemplate("Hello {$name}, how old are you?")
+                            },
+                            new SendActivity()
+                            {
+                                Activity = new ActivityTemplate("Hello {$name}, I have your age as {$age}")
+                            }
+                        }
+                    }
+                }
+            };
+
+            await CreateFlow(rootDialog)
+            .Send("Hi")
+                .AssertReply("What is your name?")
+            .Send("zoidberg")
+                .AssertReply("Hello zoidberg, how old are you?")
+            .Send("22")
+                .AssertReply("Hello zoidberg, I have your age as 22")
+            .StartTestAsync();
+        }
     }
 }


### PR DESCRIPTION
This allows us to explicitly ask that inputs inherit state as well. 

The scenario that this enables is the following:

```
            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
            {
                Generator = new TemplateEngineLanguageGenerator(),
                Rules = new List<IRule>()
                {
                    new UnknownIntentRule()
                    {
                        Steps = new List<IDialog>()
                        {
                            new TextInput()
                            {
                                Property = "$name",
                                Prompt = new ActivityTemplate("What is your name?")
                            },
                            new NumberInput()
                            {
                                Property = "$age",
                                Prompt = new ActivityTemplate("Hello {$name}, how old are you?")
                            },
                            new SendActivity()
                            {
                                Activity = new ActivityTemplate("Hello {$name}, I have your age as {$age}")
                            }
                        }
                    }
                }
            };

            await CreateFlow(rootDialog)
            .Send("Hi")
                .AssertReply("What is your name?")
            .Send("zoidberg")
                .AssertReply("Hello zoidberg, how old are you?")
            .Send("22")
                .AssertReply("Hello zoidberg, I have your age as 22")
```

Without this change, $name would not exist in the second dialog and would be evaluated to null. However, to achieve our goal of simple things should be simple, we want users to refer to these dialog-level properties simply using $prop.