### PR TITLE
Adaptive: Options are passed to child steps + BeginDialog databinds options

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -12,6 +12,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Rules;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Expressions;
+using Microsoft.Bot.Builder.Expressions.Parser;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json.Linq;
 using static Microsoft.Bot.Builder.Dialogs.Debugging.DebugSupport;
@@ -126,7 +127,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             await this.OnDialogEventAsync(dc, dialogEvent, cancellationToken).ConfigureAwait(false);
 
             // Continue step execution
-            return await this.ContinueStepsAsync(dc, cancellationToken).ConfigureAwait(false);
+            return await this.ContinueStepsAsync(dc, options, cancellationToken).ConfigureAwait(false);
         }
 
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
@@ -134,7 +135,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             EnsureDependenciesInstalled();
 
             // Continue step execution
-            return await ContinueStepsAsync(dc, cancellationToken).ConfigureAwait(false);
+            return await ContinueStepsAsync(dc, null, cancellationToken).ConfigureAwait(false);
         }
 
         protected override async Task<bool> OnPreBubbleEvent(DialogContext dc, DialogEvent dialogEvent, CancellationToken cancellationToken = default(CancellationToken))
@@ -322,9 +323,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 return $"AdaptiveDialog({Path.GetFileName(range.Path)}:{range.Start.LineIndex})";
             }
+
             return $"AdaptiveDialog[{this.BindingPath()}]";
         }
-
+        
         public override DialogContext CreateChildContext(DialogContext dc)
         {
             var activeDialogState = dc.ActiveDialog.State as Dictionary<string, object>;
@@ -351,7 +353,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return dc.Stack.Count > 0 ? $"{dc.Stack.Count}:{dc.ActiveDialog.Id}" : string.Empty;
         }
 
-        protected async Task<DialogTurnResult> ContinueStepsAsync(DialogContext dc, CancellationToken cancellationToken)
+        protected async Task<DialogTurnResult> ContinueStepsAsync(DialogContext dc, object options, CancellationToken cancellationToken)
         {
             // Apply any queued up changes
             var sequenceContext = this.ToSequenceContext(dc);
@@ -378,7 +380,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 if (result.Status == DialogTurnStatus.Empty && GetUniqueInstanceId(sequenceContext) == instanceId)
                 {
                     var nextStep = step.Steps.First();
-                    result = await step.BeginDialogAsync(nextStep.DialogId, nextStep.Options, cancellationToken).ConfigureAwait(false);
+
+                    // Compute options object for the step
+                    object effectiveOptions = ComputeEffectiveOptions(options, nextStep.Options);
+
+                    // Call begin dialog on our next step, passing the effective options we computed
+                    result = await step.BeginDialogAsync(nextStep.DialogId, effectiveOptions, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Increment turns step count
@@ -493,6 +500,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 }
             }
             return false;
+        }
+
+        private object ComputeEffectiveOptions(object adaptiveOptions, object stepOptions)
+        {
+            var effectiveOptions = adaptiveOptions;
+
+            if (effectiveOptions == null)
+            {
+                // If no options were passed in from the adaptive dialog, just use the step's option
+                effectiveOptions = stepOptions;
+            }
+            else if (stepOptions != null)
+            {
+                // If we were passed in options and also have non-null options for the next step,
+                // overlay the step options on top of the adaptive options 
+                ObjectPath.Assign<object>(effectiveOptions, stepOptions);
+            }
+
+            return effectiveOptions;
         }
 
         private void EnsureDependenciesInstalled()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/BeginDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/BeginDialog.cs
@@ -7,8 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
@@ -32,8 +30,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
                 throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
             }
 
+            var dialog = this.ResolveDialog(dc);
+
             Options = ObjectPath.Merge(Options, options ?? new object());
-            var dialog = this.resolveDialog(dc);
+            BindOptions(dc);
+
             return await dc.BeginDialogAsync(dialog.Id, Options, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/ReplaceDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/ReplaceDialog.cs
@@ -31,9 +31,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
             {
                 throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
             }
+            
+            var dialog = this.ResolveDialog(dc);
 
             Options = ObjectPath.Merge(Options, options ?? new object());
-            var dialog = this.resolveDialog(dc);
+            BindOptions(dc);
+
             return await dc.ReplaceDialogAsync(dialog.Id, Options, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -125,7 +125,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 },
                 new InitProperty() { Property = "user.todos", Type = "array" },
                 new EditArray(EditArray.ArrayChangeType.Push, "user.todos", "dialog.todo"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
                 new TextInput()
                 {
                     AlwaysPrompt = true,
@@ -133,7 +133,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     Property = "dialog.todo"
                 },
                 new EditArray(EditArray.ArrayChangeType.Push, "user.todos", "dialog.todo"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
 
                 // Remove item
                 new TextInput()
@@ -143,7 +143,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     Property = "dialog.todo"
                 },
                 new EditArray(EditArray.ArrayChangeType.Remove, "user.todos", "dialog.todo"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
 
                 // Add item and pop item
                 new TextInput()
@@ -160,18 +160,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     Property = "dialog.todo"
                 },
                 new EditArray(EditArray.ArrayChangeType.Push, "user.todos", "dialog.todo"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
 
                 new EditArray(EditArray.ArrayChangeType.Pop, "user.todos"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
 
                 // Take item
                 new EditArray(EditArray.ArrayChangeType.Take, "user.todos"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
 
                 // Clear list
                 new EditArray(EditArray.ArrayChangeType.Clear, "user.todos"),
-                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ',')}") },
+                new SendActivity() { Activity = new ActivityTemplate("Your todos: {join(user.todos, ', ')}") },
             };
 
             await CreateFlow(dialog)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -875,5 +875,223 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             .StartTestAsync();
         }
 
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingCaptureValueWithinSameAdaptive()
+        {
+            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
+            {
+                Generator = new TemplateEngineLanguageGenerator(),
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new NumberInput()
+                            {
+                                Property = "$number",
+                                Prompt = new ActivityTemplate("Give me a number")
+                            },
+                            new SendActivity()
+                            {
+                                Activity = new ActivityTemplate("You said {$number}")
+                            }
+                        }
+                    }
+                }
+            };
+
+            await CreateFlow(rootDialog)
+            .Send("hi")
+                .AssertReply("Give me a number")
+            .Send("32")
+                .AssertReply("You said 32")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingReferValueInNestedStep()
+        {
+            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
+            {
+                Generator = new TemplateEngineLanguageGenerator(),
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new NumberInput()
+                            {
+                                Property = "$age",
+                                Prompt = new ActivityTemplate("Hello, how old are you?")
+                            },
+                            new IfCondition()
+                            {
+                                Condition = "$age > 80",
+                                Steps = new List<IDialog>()
+                                {
+                                    new SendActivity("Thanks, you are quite young!")
+                                },
+                                ElseSteps = new List<IDialog>()
+                                {
+                                    new SendActivity("Thanks, you are awesome!")
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            await CreateFlow(rootDialog)
+            .Send("Hi")
+                .AssertReply("Hello, how old are you?")
+            .Send("94")
+                .AssertReply("Thanks, you are quite young!")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingOptionsAcrossAdaptiveDialogs()
+        {
+            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
+            {
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new NumberInput()
+                            {
+                                Property = "$age",
+                                Prompt = new ActivityTemplate("Hello, how old are you?")
+                            },
+                            new BeginDialog("ageDialog")
+                            {
+                                Options = new
+                                {
+                                    userAge = "$age"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var ageDialog = new AdaptiveDialog("ageDialog")
+            {
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new SendActivity("Hello, you are {dialog.options.userAge} years old!"),
+                            new SendActivity("And your actual age is {$options.userAge}")
+                        }
+                    }
+                }
+            };
+
+            rootDialog.AddDialog(ageDialog);
+
+            await CreateFlow(rootDialog)
+            .Send("Hi")
+                .AssertReply("Hello, how old are you?")
+            .Send("44")
+                .AssertReply("Hello, you are 44 years old!")
+                .AssertReply("And your actual age is 44")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingTwoWayAcrossAdaptiveDialogs_AnonymousOptions()
+        {
+            await TestBindingTwoWayAcrossAdaptiveDialogs(new { userName = "$name" });
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingTwoWayAcrossAdaptiveDialogs_ObjectDictionaryOptions()
+        {
+            await TestBindingTwoWayAcrossAdaptiveDialogs(new Dictionary<string, object>() { { "userName", "$name" } });
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingTwoWayAcrossAdaptiveDialogs_StringDictionaryOptions()
+        {
+            await TestBindingTwoWayAcrossAdaptiveDialogs(new Dictionary<string, string>() { { "userName", "$name" } });
+        }
+
+        class Person
+        {
+            public string userName { get; set; }
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_BindingTwoWayAcrossAdaptiveDialogs_StronglyTypedOptions()
+        {
+            await TestBindingTwoWayAcrossAdaptiveDialogs(new Person() { userName = "$name" });
+        }
+
+        public async Task TestBindingTwoWayAcrossAdaptiveDialogs(object options)
+        {
+            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
+            {
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new TextInput()
+                            {
+                                Property = "$name",
+                                Prompt = new ActivityTemplate("Hello, what is your name?")
+                            },
+                            new BeginDialog("ageDialog")
+                            {
+                                Options = options,
+                                Property = "$age"
+                            },
+                            new SendActivity("Hello {$name}, you are {$age} years old!")
+                        }
+                    }
+                }
+            };
+
+            var ageDialog = new AdaptiveDialog("ageDialog")
+            {
+                Rules = new List<IRule>()
+                {
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new NumberInput()
+                            {
+                                Prompt = new ActivityTemplate("Hello {$options.userName}, how old are you?"),
+                                Property = "$age"
+                            },
+                            new EndDialog()
+                            {
+                                ResultProperty = "$age"
+                            }
+                        }
+                    }
+                }
+            };
+
+            rootDialog.AddDialog(ageDialog);
+
+            await CreateFlow(rootDialog)
+            .Send("Hi")
+                .AssertReply("Hello, what is your name?")
+            .Send("zoidberg")
+                .AssertReply("Hello zoidberg, how old are you?")
+            .Send("I'm 77")
+                .AssertReply("Hello zoidberg, you are 77 years old!")
+            .StartTestAsync();
+        }
     }
 }


### PR DESCRIPTION
Fix a bug where options are not passed from adaptive dialog to steps, plus enable basic option databinding to enable calls such as the following:

```csharp
new BeginDialog("ageDialog")
{
    Options = new
    {
        userAge = "$age"
    }
}
```

See the tests for more variations on enabled scenarios by this PR. 

TBD whether we want to do recursive databinding of multilevel properties in options but wanted to get this piece out for designer.