### PR TITLE
Make allowInterruptions realy allow interruptions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return $"AttachmentInput[{BindingPath()}]";
         }
 
-        protected override Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation)
+        protected override Task<InputState> OnRecognizeInput(DialogContext dc)
         {
             var input = dc.State.GetValue<List<Attachment>>(INPUT_PROPERTY);
             var first = input.Count > 0 ? input[0] : null;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return $"ChoiceInput[{BindingPath()}]";
         }
 
-        protected override Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation)
+        protected override Task<InputState> OnRecognizeInput(DialogContext dc)
         {
             var input = dc.State.GetValue<object>(INPUT_PROPERTY);
             var options = dc.State.GetValue<ChoiceInputOptions>(DialogContextState.DIALOG_OPTIONS);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return $"ConfirmInput[{BindingPath()}]";
         }
 
-        protected override Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation)
+        protected override Task<InputState> OnRecognizeInput(DialogContext dc)
         {
             var input = dc.State.GetValue<object>(INPUT_PROPERTY);
             if (dc.Context.Activity.Type == ActivityTypes.Message)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/DateTimeInput.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return $"DateTimeInput[{BindingPath()}]";
         }
 
-        protected override Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation)
+        protected override Task<InputState> OnRecognizeInput(DialogContext dc)
         {
             var input = dc.State.GetValue<object>(INPUT_PROPERTY);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             dc.State.SetValue(TURN_COUNT_PROPERTY, turnCount);
 
             // Perform base recognition
-            var state = await this.RecognizeInput(dc,);
+            var state = await this.RecognizeInput(dc);
 
             if (state == InputState.Valid)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             dc.State.SetValue(TURN_COUNT_PROPERTY, 0);
             dc.State.SetValue(INPUT_PROPERTY, null);
 
-            var state = this.AlwaysPrompt ? InputState.Missing : await this.RecognizeInput(dc, false);
+            var state = this.AlwaysPrompt ? InputState.Missing : await this.RecognizeInput(dc);
             if (state == InputState.Valid)
             {
                 var input = dc.State.GetValue<object>(INPUT_PROPERTY);
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             dc.State.SetValue(TURN_COUNT_PROPERTY, turnCount);
 
             // Perform base recognition
-            var state = await this.RecognizeInput(dc, false);
+            var state = await this.RecognizeInput(dc,);
 
             if (state == InputState.Valid)
             {
@@ -170,7 +170,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return await this.PromptUser(dc, InputState.Missing);
         }
 
-        protected abstract Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation);
+        protected abstract Task<InputState> OnRecognizeInput(DialogContext dc);
 
         protected override async Task<bool> OnPreBubbleEvent(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {
@@ -178,8 +178,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             {
                 if (this.AllowInterruptions)
                 {
-                    var state = await this.RecognizeInput(dc, true).ConfigureAwait(false);
-                    return state == InputState.Valid;
+                    // once we allow interruptions, we don't handle in Input first
+                    return await Task.FromResult(false);
                 }
                 else
                 {
@@ -288,7 +288,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return await this.Prompt.BindToData(dc.Context, dc.State);
         }
 
-        private async Task<InputState> RecognizeInput(DialogContext dc, bool consultation)
+        private async Task<InputState> RecognizeInput(DialogContext dc)
         {
             dynamic input = null;
 
@@ -332,7 +332,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             dc.State.SetValue(INPUT_PROPERTY, input);
             if (input != null)
             {
-                var state = await this.OnRecognizeInput(dc, consultation).ConfigureAwait(false);
+                var state = await this.OnRecognizeInput(dc).ConfigureAwait(false);
                 if (state == InputState.Valid)
                 {
                     foreach (var validation in this.Validations)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return $"NumberInput[{BindingPath()}]";
         }
 
-        protected override Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation)
+        protected override Task<InputState> OnRecognizeInput(DialogContext dc)
         {
             var input = dc.State.GetValue<object>(INPUT_PROPERTY);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -32,13 +32,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return $"TextInput[{BindingPath()}]";
         }
 
-        protected override Task<InputState> OnRecognizeInput(DialogContext dc, bool consultation)
+        protected override Task<InputState> OnRecognizeInput(DialogContext dc)
         {
-            if (consultation)
-            {
-                return Task.FromResult(InputState.Unrecognized);
-            }
-
             var input = dc.State.GetValue<string>(INPUT_PROPERTY);
 
             switch (this.OutputFormat)


### PR DESCRIPTION
Fix #2314 

When i looked at code, i thought by design we want when allowInterruption=true, the active InputDialog still recongize first, so I opened the previous issue, then i confirm with @vishwacsena , we don't want InputDialog to recognize before bubble up.

So it would not necessary to call in prebubble and have an parameter called consultation at all