### PR TITLE
Added turn.processInput as a way for input step to re-process user utterance

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -214,7 +214,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     case AllowInterruptions.NotRecognized:
                         var state = await this.RecognizeInput(dc).ConfigureAwait(false);
 
-                        // We only bubble up when recognizeInput comes back with 
+                        // RecognizedInput can come back with different InputState enum values. 
+                        // We need to have predictible behavior for users here so when NotRecognized is set
+                        //    we do not bubble up when InputState is either Valid or Invalid. 
+                        //    not consulting on Invalid is critical so the bot can continue to re-prompt the user 
+                        //    or in the ideal case, render 'InvalidPrompt' if user has specified one. 
                         // RecognizeInput => 
                         //      InputState.Invalid      -> Do not bubble up -> return true
                         //      InputState.Valid        -> Do not bubble up -> return true


### PR DESCRIPTION
- Fixes #2258 
- Fixes an issue introduced by #2334 where `allowInterruption = NotRecognized` was incorrectly bubbling up when the input step recognized an invalid input. 
- Added 10+ new tests to cover both 'turn.processInput' addition as well as test the `allowInterruption` enum across possible conditions. 