### PR TITLE
Add InternalsVisibleTo to fix CS0122

### DIFF
--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/Microsoft.Bot.Builder.StreamingExtensions.csproj
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/Microsoft.Bot.Builder.StreamingExtensions.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DefineConstants>SIGNASSEMBLY</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
@@ -36,20 +36,10 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
 
         private readonly IServiceProvider _services;
 
-#if DEBUG
-        public
-#else
-        private
-#endif
-        IStreamingTransportServer _transportServer;
+        private IStreamingTransportServer _transportServer;
 
 #pragma warning disable IDE0044
-#if DEBUG
-        public
-#else
-        private
-#endif
-        string _userAgent;
+        private string _userAgent;
 #pragma warning restore IDE0044
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
@@ -16,10 +16,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+#if SIGNASSEMBLY
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif
 
 namespace Microsoft.Bot.Builder.StreamingExtensions
 {

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/StreamingRequestHandler.cs
@@ -16,6 +16,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
+
 namespace Microsoft.Bot.Builder.StreamingExtensions
 {
 #pragma warning disable SA1202
@@ -36,10 +41,10 @@ namespace Microsoft.Bot.Builder.StreamingExtensions
 
         private readonly IServiceProvider _services;
 
-        private IStreamingTransportServer _transportServer;
+        internal IStreamingTransportServer _transportServer;
 
 #pragma warning disable IDE0044
-        private string _userAgent;
+        internal string _userAgent;
 #pragma warning restore IDE0044
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/VersionInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/VersionInfo.cs
@@ -3,12 +3,7 @@
 
 namespace Microsoft.Bot.Builder.StreamingExtensions
 {
-#if DEBUG
-    public
-#else
-    internal
-#endif
-    class VersionInfo
+    internal class VersionInfo
     {
         public string UserAgent { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/VersionInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/VersionInfo.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
 
 namespace Microsoft.Bot.Builder.StreamingExtensions
 {

--- a/libraries/Microsoft.Bot.Builder.StreamingExtensions/VersionInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.StreamingExtensions/VersionInfo.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#if SIGNASSEMBLY
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif
 
 namespace Microsoft.Bot.Builder.StreamingExtensions
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 
-#if DEBUG
-[assembly: InternalsVisibleTo("Microsoft.Bot.StreamingExtensions.Tests")]
-#endif
+[assembly: InternalsVisibleTo("Microsoft.Bot.StreamingExtensions.Tests PublicKey=00240000048" +
+    "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
+    "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
+    "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
@@ -4,10 +4,8 @@
 using System.Runtime.CompilerServices;
 
 #if SIGNASSEMBLY
-[assembly: InternalsVisibleTo("Microsoft.Bot.StreamingExtensions.Tests PublicKey=00240000048" +
-    "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
-    "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
-    "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 #else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]

--- a/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
@@ -3,12 +3,12 @@
 
 using System.Runtime.CompilerServices;
 
-#if DEBUG
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
-    "Microsoft.Bot.StreamingExtensions.Tests")]
-#else
+#if SIGNASSEMBLY
 [assembly: InternalsVisibleTo("Microsoft.Bot.StreamingExtensions.Tests PublicKey=00240000048" +
     "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
     "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
     "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
 #endif

--- a/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
@@ -3,9 +3,12 @@
 
 using System.Runtime.CompilerServices;
 
+#if DEBUG
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
+#else
 [assembly: InternalsVisibleTo("Microsoft.Bot.StreamingExtensions.Tests PublicKey=00240000048" +
     "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
     "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
     "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
-    "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/AssemblyInfo.cs
@@ -7,3 +7,5 @@ using System.Runtime.CompilerServices;
     "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
     "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
     "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]

--- a/libraries/Microsoft.Bot.StreamingExtensions/Microsoft.Bot.StreamingExtensions.csproj
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Microsoft.Bot.StreamingExtensions.csproj
@@ -5,9 +5,11 @@
     <Version Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</Version>
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">1.0.0</PackageVersion>
     <PackageVersion Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</PackageVersion>
+    <DefineConstants></DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DefineConstants>SIGNASSEMBLY</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>

--- a/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Assemblers/IAssembler.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Assemblers/IAssembler.cs
@@ -1,6 +1,14 @@
 ﻿using System;
 using System.IO;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests.Microsoft.Bot.StreamingExtensions.UnitTests.Mocks, PublicKey=00240000048" +
+    "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
+    "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
+    "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+
 namespace Microsoft.Bot.StreamingExtensions.Payloads
 {
     internal interface IAssembler

--- a/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Assemblers/IAssembler.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Assemblers/IAssembler.cs
@@ -6,10 +6,13 @@ using System.IO;
 //    "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
 //    "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
 //    "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#if SIGNASSEMBLY
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif
 
 namespace Microsoft.Bot.StreamingExtensions.Payloads
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Assemblers/IAssembler.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Assemblers/IAssembler.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.IO;
 
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
-    "Microsoft.Bot.StreamingExtensions.Tests.Microsoft.Bot.StreamingExtensions.UnitTests.Mocks, PublicKey=00240000048" +
-    "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
-    "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
-    "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+//[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+//    "Microsoft.Bot.StreamingExtensions.Tests.Microsoft.Bot.StreamingExtensions.UnitTests.Mocks, PublicKey=00240000048" +
+//    "00000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c49" +
+//    "2651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e" +
+//    "8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
 
 namespace Microsoft.Bot.StreamingExtensions.Payloads
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Models/Header.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Models/Header.cs
@@ -5,10 +5,13 @@ using System;
 using System.IO;
 using Microsoft.Bot.StreamingExtensions.Transport;
 
+#if SIGNASSEMBLY
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif
 
 namespace Microsoft.Bot.StreamingExtensions.Payloads
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Models/Header.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Models/Header.cs
@@ -7,6 +7,8 @@ using Microsoft.Bot.StreamingExtensions.Transport;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
 
 namespace Microsoft.Bot.StreamingExtensions.Payloads
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Models/Header.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Payloads/Models/Header.cs
@@ -5,6 +5,9 @@ using System;
 using System.IO;
 using Microsoft.Bot.StreamingExtensions.Transport;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+
 namespace Microsoft.Bot.StreamingExtensions.Payloads
 {
      /*

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransport.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransport.cs
@@ -5,12 +5,7 @@ using System;
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 {
-#if DEBUG
-    public
-#else
-    internal
-#endif
-    interface ITransport : IDisposable
+    internal interface ITransport : IDisposable
     {
         bool IsConnected { get; }
 

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransport.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransport.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 {
-    internal interface ITransport : IDisposable
+    public interface ITransport : IDisposable
     {
         bool IsConnected { get; }
 

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportReceiver.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportReceiver.cs
@@ -3,6 +3,9 @@
 
 using System.Threading.Tasks;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+
 namespace Microsoft.Bot.StreamingExtensions.Transport
 {
     internal interface ITransportReceiver : ITransport

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportReceiver.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportReceiver.cs
@@ -3,10 +3,13 @@
 
 using System.Threading.Tasks;
 
+#if SIGNASSEMBLY
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportReceiver.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportReceiver.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 {

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 { 
-    internal interface ITransportSender : ITransport
+    public interface ITransportSender : ITransport
     {
         Task<int> SendAsync(byte[] buffer, int offset, int count);
     }

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
@@ -3,10 +3,13 @@
 
 using System.Threading.Tasks;
 
+#if SIGNASSEMBLY
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests")]
+#endif
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 { 

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
@@ -3,14 +3,12 @@
 
 using System.Threading.Tasks;
 
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+
 namespace Microsoft.Bot.StreamingExtensions.Transport
-{
-#if DEBUG
-    public
-#else
-    internal
-#endif
-    interface ITransportSender : ITransport
+{ 
+    internal interface ITransportSender : ITransport
     {
         Task<int> SendAsync(byte[] buffer, int offset, int count);
     }

--- a/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
+++ b/libraries/Microsoft.Bot.StreamingExtensions/Transport/ITransportSender.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
     "Microsoft.Bot.StreamingExtensions.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(
+    "Microsoft.Bot.StreamingExtensions.Tests")]
 
 namespace Microsoft.Bot.StreamingExtensions.Transport
 { 

--- a/tests/Microsoft.Bot.StreamingExtensions.Test/Microsoft.Bot.StreamingExtensions.Tests.csproj
+++ b/tests/Microsoft.Bot.StreamingExtensions.Test/Microsoft.Bot.StreamingExtensions.Tests.csproj
@@ -5,6 +5,12 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="ReceiveBaseTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes "inaccessible due to its protection level" errors. Also supports the (new) multi-configuration CI builds. Passed in this build: https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=73079&view=results

ITransportSender was made public to be visible to the proxy generator used by Moq. It probably doesn't need the #if SIGNASSEMBLY directive any longer.