### PR TITLE
[LG] Fix lg reference parameter issue

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -241,7 +241,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         private string EvalTemplateRef(string exp)
         {
             exp = exp.TrimStart('[').TrimEnd(']').Trim();
-            exp = exp.IndexOf('(') < 0 ? exp + "()" : exp;
+            if (exp.IndexOf('(') < 0)
+            {
+                if (TemplateMap.ContainsKey(exp))
+                {
+                    exp = exp + "(" + string.Join(",", TemplateMap[exp].Parameters) + ")";
+                }
+                else
+                {
+                    exp = exp + "()";
+                }
+            }
 
             return EvalExpression(exp);
         }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -256,7 +256,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         private List<string> EvalTemplateRef(string exp)
         {
             exp = exp.TrimStart('[').TrimEnd(']').Trim();
-            exp = exp.IndexOf('(') < 0 ? exp + "()" : exp;
+            if (exp.IndexOf('(') < 0)
+            {
+                if (TemplateMap.ContainsKey(exp))
+                {
+                    exp = exp + "(" + string.Join(",", TemplateMap[exp].Parameters) + ")";
+                }
+                else
+                {
+                    exp = exp + "()";
+                }
+            }
 
             return EvalExpression(exp);
         }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/GetMethodExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/GetMethodExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var expectedArgsCount = _evaluator.TemplateMap[templateName].Parameters.Count();
             var actualArgsCount = expression.Children.Length;
 
-            if (actualArgsCount > 0 && actualArgsCount != expectedArgsCount)
+            if (expectedArgsCount != actualArgsCount)
             {
                 throw new Exception($"arguments mismatch for template {templateName}, expect {expectedArgsCount} actual {actualArgsCount}");
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/GetMethodExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/GetMethodExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var expectedArgsCount = _evaluator.TemplateMap[templateName].Parameters.Count();
             var actualArgsCount = expression.Children.Length;
 
-            if (expectedArgsCount != actualArgsCount)
+            if (actualArgsCount > 0 && actualArgsCount != expectedArgsCount)
             {
                 throw new Exception($"arguments mismatch for template {templateName}, expect {expectedArgsCount} actual {actualArgsCount}");
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -396,7 +396,18 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var result = new List<Diagnostic>();
 
                 exp = exp.TrimStart('[').TrimEnd(']').Trim();
-                var expression = exp.IndexOf('(') < 0 ? exp + "()" : exp;
+                var expression = exp;
+                if (exp.IndexOf('(') < 0)
+                {
+                    if (this.templateMap.ContainsKey(exp))
+                    {
+                        expression = exp + "(" + string.Join(",", this.templateMap[exp].Parameters) + ")";
+                    }
+                    else
+                    {
+                        expression = exp + "()";
+                    }
+                }
 
                 try
                 {
@@ -443,6 +454,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 var result = new List<Diagnostic>();
                 exp = exp.TrimStart('@').TrimStart('{').TrimEnd('}');
+
                 try
                 {
                     new ExpressionEngine(new GetMethodExtensions(new Evaluator(this.Templates, null)).GetMethodX).Parse(exp);

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Renderer.Tests/Fallback/test.en-US.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Renderer.Tests/Fallback/test.en-US.lg
@@ -1,3 +1,5 @@
 # test
 - english-us
 
+# test2(country)
+- english-{country}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Renderer.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Renderer.Tests/LGGeneratorTests.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             // test targeted in each language
             Assert.AreEqual("english-us", await lg.Generate(GetTurnContext("en-us", lg), "[test]", null));
+            Assert.AreEqual("english-us", await lg.Generate(GetTurnContext("en-us", lg), "[test2]", new { country = "us" }));
             Assert.AreEqual("english-gb", await lg.Generate(GetTurnContext("en-gb", lg), "[test]", null));
             Assert.AreEqual("english", await lg.Generate(GetTurnContext("en", lg), "[test]", null));
             Assert.AreEqual("default", await lg.Generate(GetTurnContext("", lg), "[test]", null));

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/TemplateRef.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/TemplateRef.lg
@@ -1,6 +1,15 @@
 ﻿# Hello
 - [Welcome(time)] {name}
 
+# Hello2
+- [Welcome] {name}
+
+# Hello3
+- [Welcome()] {name}
+
+# Hello4
+- {Welcome()} {name}
+
 # Welcome(time)
 - IF: {time == 'morning'}
  - Good morning

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/TemplateRef.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/TemplateRef.lg
@@ -5,10 +5,7 @@
 - [Welcome] {name}
 
 # Hello3
-- [Welcome()] {name}
-
-# Hello4
-- {Welcome()} {name}
+- {Welcome(time)} {name}
 
 # Welcome(time)
 - IF: {time == 'morning'}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/ExceptionExamples/TemplateParamsNotMatchArgsNum.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/ExceptionExamples/TemplateParamsNotMatchArgsNum.lg
@@ -1,10 +1,16 @@
-﻿# template
-- [templateRef('p1','p2','p3')]
-
-# templateRef(arg1, arg2)
+﻿# templateRef(arg1, arg2)
 - hi 
+
+# template
+- [templateRef('p1','p2','p3')]
 
 # template2
 - ```
    @{templateRef('p1')}
  ```
+
+# template3
+- {templateRef()}
+
+# template4
+- [templateRef()]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/ExceptionExamples/TemplateParamsNotMatchArgsNum.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/ExceptionExamples/TemplateParamsNotMatchArgsNum.lg
@@ -1,11 +1,10 @@
 ﻿# template
-- [templateRef('p1','p2')]
+- [templateRef('p1','p2','p3')]
 
-# templateRef(arg)
+# templateRef(arg1, arg2)
 - hi 
-
 
 # template2
 - ```
-   @{templateRef()}
+   @{templateRef('p1')}
  ```

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -273,7 +273,9 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 name = "Dong Lei"
             };
             Assert.AreEqual(engine.EvaluateTemplate("Hello", scope), "Good morning Dong Lei");
-
+            Assert.AreEqual(engine.EvaluateTemplate("Hello2", scope), "Good morning Dong Lei");
+            Assert.AreEqual(engine.EvaluateTemplate("Hello3", scope), "Good morning Dong Lei");
+            Assert.AreEqual(engine.EvaluateTemplate("Hello4", scope), "Good morning Dong Lei");
         }
 
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -275,11 +275,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(engine.EvaluateTemplate("Hello", scope), "Good morning Dong Lei");
             Assert.AreEqual(engine.EvaluateTemplate("Hello2", scope), "Good morning Dong Lei");
             Assert.AreEqual(engine.EvaluateTemplate("Hello3", scope), "Good morning Dong Lei");
-            Assert.AreEqual(engine.EvaluateTemplate("Hello4", scope), "Good morning Dong Lei");
         }
-
-
-
 
         [TestMethod]
         public void TestEscapeCharacter()
@@ -288,7 +284,6 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var evaled1 = engine.EvaluateTemplate("wPhrase", null);
             Assert.AreEqual(evaled1, "Hi \r\n\t[]{}\\");
         }
-
 
         [TestMethod]
         public void TestAnalyzer()
@@ -348,7 +343,6 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             options = new List<string> { "Hi morning", "Hello morning" };
             Assert.AreEqual(options.Contains(evaled), true);
         }
-
 
         [TestMethod]
         public void TestTemplateAsFunction()


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/2344

We have a validation function in static checker period which is validating whether the parameters number from template definition is same with the number from the actual template call function. This PR is to make the validation always pass if the actual parameter number is zero. This is by design that no parameters mean parameters are inherited from caller's the scope.