### PR TITLE
Fixed CreateConversation tenantId getter

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -828,13 +828,13 @@ namespace Microsoft.Bot.Builder
             if (reference.Conversation != null)
             {
                 var typeOfDynamic = reference.Conversation.GetType();
-                var tenantProperty = typeOfDynamic.GetProperty("tenantId");
+                var tenantProperty = typeOfDynamic.GetProperty("TenantId");
                 var tenantId = tenantProperty?.GetValue(reference.Conversation, null);
 
                 if (tenantId != null)
                 {
                     // Putting tenantId in channelData is a temporary solution while we wait for the Teams API to be updated
-                    conversationParameters.ChannelData = new { tenant = new { tenantId= tenantId.ToString() } };
+                    conversationParameters.ChannelData = new { tenant = new { tenantId = tenantId.ToString() } };
 
                     // Permanent solution is to put tenantId in parameters.tenantId
                     conversationParameters.TenantId = tenantId.ToString();

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.using System.Security.Claims;
 
+using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Microsoft.Rest.TransientFaultHandling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -37,6 +40,46 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.IsNull(activity.Conversation.TenantId);
         }
 
+        [TestMethod]
+        public async Task CreateConversastionOverloadProperlySetsTenantId()
+        {
+            var mockClaims = new Mock<ClaimsIdentity>();
+            var mockCredentialProvider = new Mock<ICredentialProvider>();
+
+            var sut = new MockAdapter(mockCredentialProvider.Object);
+
+            var activity = await ProcessActivity(Channels.Msteams, "theTenantId", null);
+            var parameters = new ConversationParameters()
+            {
+                Activity = new Activity()
+                {
+                    ChannelData = activity.ChannelData,
+                },
+            };
+            var reference = new ConversationReference()
+            {
+                ActivityId = activity.Id,
+                Bot = activity.Recipient,
+                ChannelId = activity.ChannelId,
+                Conversation = activity.Conversation,
+                ServiceUrl = activity.ServiceUrl,
+                User = activity.From,
+            };
+
+            var credentials = new MicrosoftAppCredentials(string.Empty, string.Empty);
+
+            Activity newActivity = null;
+
+            Task UpdateParameters(ITurnContext turnContext, CancellationToken cancellationToken)
+            {
+                newActivity = turnContext.Activity;
+                return Task.CompletedTask;
+            }
+
+            await sut.CreateConversationAsync(activity.ChannelId, activity.ServiceUrl, credentials, parameters, UpdateParameters, reference, new CancellationToken());
+            Assert.AreEqual("theTenantId", newActivity.ChannelData.GetType().GetProperty("TenantId").GetValue(newActivity.ChannelData, null));
+        }
+
         private static async Task<IActivity> ProcessActivity(string channelId, string channelDataTenantId, string conversationTenantId)
         {
             IActivity activity = null;
@@ -65,6 +108,34 @@ namespace Microsoft.Bot.Builder.Tests
                 },
                 CancellationToken.None);
             return activity;
+        }
+
+        private class MockAdapter : BotFrameworkAdapter
+        {
+            private const string BotIdentityKey = "BotIdentity";
+
+            public MockAdapter(
+                ICredentialProvider credentialProvider,
+                IChannelProvider channelProvider = null,
+                RetryPolicy connectorClientRetryPolicy = null,
+                HttpClient customHttpClient = null,
+                IMiddleware middleware = null,
+                ILogger logger = null)
+                : base(credentialProvider, channelProvider, connectorClientRetryPolicy, customHttpClient, middleware, logger)
+            {
+            }
+
+            public async override Task CreateConversationAsync(string channelId, string serviceUrl, MicrosoftAppCredentials credentials, ConversationParameters conversationParameters, BotCallbackHandler callback, CancellationToken cancellationToken)
+            {
+                var activity = conversationParameters.Activity;
+                activity.ChannelData = new
+                {
+                    conversationParameters.TenantId,
+                };
+                await RunPipelineAsync(new TurnContext(this, conversationParameters.Activity), callback, cancellationToken).ConfigureAwait(false);
+
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botbuilder-dotnet/issues/2199

### Issue

One of the overloads for [`BotframeworkAdapter.CreateConversationAsync`](https://github.com/microsoft/botbuilder-dotnet/blob/14dc8aba63f3bb5a2783ce53772ac1802dee4cbb/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L825) attempts to get `TenantId` with "**t**enantId" instead of "**T**enantId", resulting in it being set to `null`. This can cause `TenantIdWorkaroundForTeamsMiddleware` to throw.

### Testing

**Without PR**

![image](https://user-images.githubusercontent.com/40401643/62399692-8a4f7980-b531-11e9-9c3c-604739855255.png)

**With PR**

![image](https://user-images.githubusercontent.com/40401643/62399711-95a2a500-b531-11e9-9673-7eb7b730f9a7.png)

