### PR TITLE
 Changes to BeginDialog, ReplaceDialog, and RepeatDialog steps

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.BeginDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.BeginDialog.schema
@@ -10,10 +10,10 @@
         },
         {
             "properties": {
-                "dialog": {
-                    "$type": "Microsoft.IDialog",
-                    "title": "Dialog",
-                    "description": "This is the dialog to call."
+                "dialogId": {
+                    "$role": "expression",
+                    "title": "Dialog Id",
+                    "description": "The Id the dialog to call."
                 },
                 "options": {
                     "type": "object",
@@ -25,7 +25,7 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to bind to the dialog and store the result in",
                     "examples": [

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.BeginDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.BeginDialog.schema
@@ -17,9 +17,12 @@
                 },
                 "options": {
                     "type": "object",
-                    "additionalProperties": true,
-                    "title": "Options",
-                    "description": "Options to pass to the dialog."
+                    "title": "Options binding",
+                    "description": "Bindings to configure the options object to pass to the dialog.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Options"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.DeleteProperty.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.DeleteProperty.schema
@@ -14,7 +14,7 @@
         {
             "properties": {
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The Memory property path to delete"
                 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.EditArray.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.EditArray.schema
@@ -27,12 +27,12 @@
                     ]
                 },
                 "arrayProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Array Property",
                     "description": "Memory expression of the array to manipulate."
                 },
                 "resultProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Result Property",
                     "description": "Memory expression of the result of this action."
                 },

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.EndDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.EndDialog.schema
@@ -11,7 +11,7 @@
         {
             "properties": {
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "description": "Specifies a path to memory should be returned as the result to the calling dialog.",
                     "examples": [
                         "dialog.name"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.Foreach.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.Foreach.schema
@@ -27,13 +27,13 @@
                     "description": "Steps to execute"
                 },
                 "indexProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Index Property",
                     "description": "The memory path which refers to the index of the item",
                     "default": "dialog.index"
                 },
                 "valueProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value Property",
                     "description": "The memory path which refers to the value of the item",
                     "default": "dialog.value"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.ForeachPage.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.ForeachPage.schema
@@ -33,7 +33,7 @@
                     "default": 10
                 },
                 "valueProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value Property",
                     "description": "The memory path which refers to the value of the item",
                     "default": "dialog.value"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.HttpRequest.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.HttpRequest.schema
@@ -42,7 +42,7 @@
                     "additionalProperties": true
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to store the result of the HTTP call in (as object or string)",
                     "examples": [

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.InitProperty.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.InitProperty.schema
@@ -15,7 +15,7 @@
         {
             "properties": {
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to set the value of",
                     "examples": [

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.ReplaceDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.ReplaceDialog.schema
@@ -10,10 +10,10 @@
         },
         {
             "properties": {
-                "dialog": {
-                    "$type": "Microsoft.IDialog",
-                    "title": "Dialog",
-                    "description": "This is the dialog to switch to."
+                "dialogId": {
+                    "$role": "expression",
+                    "title": "Dialog Id",
+                    "description": "The Id the dialog to call."
                 },
                 "options": {
                     "type": "object",
@@ -25,7 +25,7 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "description": "The property to bind to the dialog and store the result in",
                     "examples": [
                         "user.name"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.ReplaceDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.ReplaceDialog.schema
@@ -17,9 +17,12 @@
                 },
                 "options": {
                     "type": "object",
-                    "additionalProperties": true,
-                    "title": "Options",
-                    "description": "Options to pass to the dialog."
+                    "title": "Options binding",
+                    "description": "Bindings to configure the options object to pass to the dialog.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Options"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.SetProperty.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.SetProperty.schema
@@ -16,7 +16,7 @@
 
             "properties": {
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to set the value of",
                     "examples": [

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.TraceActivity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Steps/Microsoft.TraceActivity.schema
@@ -22,7 +22,7 @@
                     "description": "Value type of the trace activity"
                 },
                 "value": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value",
                     "description": "Property path to memory object to send as the value of the trace activity"
                 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/BeginDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/BeginDialog.cs
@@ -2,12 +2,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
 {
@@ -17,7 +19,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
     public class BeginDialog : BaseInvokeDialog
     {
         [JsonConstructor]
-        public BeginDialog(string dialogIdToCall = null, string property = null, object options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public BeginDialog(string dialogIdToCall = null, string property = null, IDictionary<string, string> options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(dialogIdToCall, property, options)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -32,10 +34,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
 
             var dialog = this.ResolveDialog(dc);
 
-            Options = ObjectPath.Merge(Options, options ?? new object());
-            BindOptions(dc);
+            // use bindingOptions to bind to the bound options
+            var boundOptions = BindOptions(dc, options);
 
-            return await dc.BeginDialogAsync(dialog.Id, Options, cancellationToken).ConfigureAwait(false);
+            // start dialog with bound options passed in as the options
+            return await dc.BeginDialogAsync(dialog.Id, options: boundOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/ReplaceDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Steps/ReplaceDialog.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
     public class ReplaceDialog : BaseInvokeDialog
     {
         [JsonConstructor]
-        public ReplaceDialog(string dialogIdToCall = null, string property = null, object options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public ReplaceDialog(string dialogIdToCall = null, string property = null, IDictionary<string,string> options = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(dialogIdToCall, property, options)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
@@ -31,13 +31,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Steps
             {
                 throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
             }
-            
+
             var dialog = this.ResolveDialog(dc);
 
-            Options = ObjectPath.Merge(Options, options ?? new object());
-            BindOptions(dc);
+            // use bindingOptions to bind to the bound options
+            var boundOptions = BindOptions(dc, options);
 
-            return await dc.ReplaceDialogAsync(dialog.Id, Options, cancellationToken).ConfigureAwait(false);
+            // replace dialog with bound options passed in as the options
+            return await dc.ReplaceDialogAsync(dialog.Id, options: boundOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         public List<string> Tags { get; private set; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets jSONPath expression for the memory slots to bind the dialogs options to on a call to `beginDialog()`.
+        /// Gets or sets expression for the memory slots to bind the dialogs options to on a call to `beginDialog()`.
         /// </summary>
         public Dictionary<string, string> InputBindings { get; set; } = new Dictionary<string, string>();
 

--- a/schemas/baseComponent.schema
+++ b/schemas/baseComponent.schema
@@ -6,9 +6,9 @@
     "definitions": {
         "role": {
             "title": "$role",
-            "description": "Defines the role played in the dialog schema [lg|expression|memoryPath|uniontype()].",
+            "description": "Defines the role played in the dialog schema [lg|expression|expression|uniontype()].",
             "type": "string",
-            "pattern": "^((lg)|(expression)|(memoryPath)|(unionType)|(unionType\\([a-zA-Z][a-zA-Z0-9.]*\\)))$"
+            "pattern": "^((lg)|(expression)|(expression)|(unionType)|(unionType\\([a-zA-Z][a-zA-Z0-9.]*\\)))$"
         },
         "id": {
             "title": "$id",
@@ -40,11 +40,6 @@
         "lg": {
             "type": "string",
             "description": "String is used for language generation."
-        },
-        "memoryPath": {
-            "type": "string",
-            "description": "String must contain a memory path.",
-            "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
         }
     },
     "properties": {

--- a/schemas/component.schema
+++ b/schemas/component.schema
@@ -45,9 +45,9 @@
         },
         "role": {
             "title": "$role",
-            "description": "Defines the role played in the dialog schema [lg|expression|memoryPath|uniontype()].",
+            "description": "Defines the role played in the dialog schema [lg|expression|expression|uniontype()].",
             "type": "string",
-            "pattern": "^((lg)|(expression)|(memoryPath)|(unionType)|(unionType\\([a-zA-Z][a-zA-Z0-9.]*\\)))$"
+            "pattern": "^((lg)|(expression)|(expression)|(unionType)|(unionType\\([a-zA-Z][a-zA-Z0-9.]*\\)))$"
         },
         "id": {
             "title": "$id",
@@ -80,7 +80,7 @@
             "type": "string",
             "description": "String is used for language generation."
         },
-        "memoryPath": {
+        "expression": {
             "type": "string",
             "description": "String must contain a memory path.",
             "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"

--- a/schemas/sdk.schema
+++ b/schemas/sdk.schema
@@ -715,11 +715,11 @@
                         "type": "string"
                     }
                 },
-                "dialog": {
-                    "$type": "Microsoft.IDialog",
-                    "title": "Dialog",
-                    "description": "This is the dialog to call.",
-                    "$ref": "#/definitions/Microsoft.IDialog"
+                "dialogId": {
+                    "$role": "expression",
+                    "title": "Dialog Id",
+                    "description": "The Id the dialog to call.",
+                    "type": "string"
                 },
                 "options": {
                     "type": "object",
@@ -731,14 +731,13 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to bind to the dialog and store the result in",
                     "examples": [
                         "user.name"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -1844,11 +1843,10 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The Memory property path to delete",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -1936,18 +1934,16 @@
                     ]
                 },
                 "arrayProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Array Property",
                     "description": "Memory expression of the array to manipulate.",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "resultProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Result Property",
                     "description": "Memory expression of the result of this action.",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "value": {
                     "$role": "expression",
@@ -2237,13 +2233,12 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "description": "Specifies a path to memory should be returned as the result to the calling dialog.",
                     "examples": [
                         "dialog.name"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -2690,20 +2685,18 @@
                     }
                 },
                 "indexProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Index Property",
                     "description": "The memory path which refers to the index of the item",
                     "default": "dialog.index",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "valueProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value Property",
                     "description": "The memory path which refers to the value of the item",
                     "default": "dialog.value",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -2804,12 +2797,11 @@
                     "default": 10
                 },
                 "valueProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value Property",
                     "description": "The memory path which refers to the value of the item",
                     "default": "dialog.value",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -2983,14 +2975,13 @@
                     "additionalProperties": true
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to store the result of the HTTP call in (as object or string)",
                     "examples": [
                         "dialog.contosodata"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "headers": {
                     "type": "object",
@@ -3538,14 +3529,13 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to set the value of",
                     "examples": [
                         "user.age"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "type": {
                     "type": "string",
@@ -5034,11 +5024,11 @@
                         "type": "string"
                     }
                 },
-                "dialog": {
-                    "$type": "Microsoft.IDialog",
-                    "title": "Dialog",
-                    "description": "This is the dialog to switch to.",
-                    "$ref": "#/definitions/Microsoft.IDialog"
+                "dialogId": {
+                    "$role": "expression",
+                    "title": "Dialog Id",
+                    "description": "The Id the dialog to call.",
+                    "type": "string"
                 },
                 "options": {
                     "type": "object",
@@ -5050,13 +5040,12 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "description": "The property to bind to the dialog and store the result in",
                     "examples": [
                         "user.name"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -5279,14 +5268,13 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to set the value of",
                     "examples": [
                         "user.age"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "value": {
                     "$role": "expression",
@@ -5677,11 +5665,10 @@
                     "description": "Value type of the trace activity"
                 },
                 "value": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value",
                     "description": "Property path to memory object to send as the value of the trace activity",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,

--- a/schemas/sdk.schema
+++ b/schemas/sdk.schema
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/botbuilder-dotnet/4.Future/schemas/component.schema",
+    "$schema": "https://raw.githubusercontent.com/Microsoft/botbuilder-tools/master/packages/DialogSchema/src/dialogSchema.schema",
     "$id": "sdk.schema",
     "type": "object",
     "title": "Component types",
@@ -383,15 +383,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "inputBindings": {
                     "type": "object",
@@ -512,37 +522,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday",
-                        "user.name"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "value.birthday"
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
                     ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
-                },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "prompt": {
                     "$type": "Microsoft.IActivityTemplate",
@@ -595,6 +593,16 @@
                     "title": "Value",
                     "description": "The expression that you evaluated for input.",
                     "type": "string"
+                },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
+                    ],
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "defaultValue": {
                     "$role": "expression",
@@ -687,6 +695,26 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "dialog": {
                     "$type": "Microsoft.IDialog",
                     "title": "Dialog",
@@ -695,9 +723,12 @@
                 },
                 "options": {
                     "type": "object",
-                    "title": "Options",
-                    "description": "Options to pass to the dialog.",
-                    "additionalProperties": true
+                    "title": "Options binding",
+                    "description": "Bindings to configure the options object to pass to the dialog.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Options"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -760,6 +791,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "eventName": {
                     "title": "Event Name",
@@ -852,37 +903,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday",
-                        "user.name"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "value.birthday"
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
                     ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
-                },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "prompt": {
                     "$type": "Microsoft.IActivityTemplate",
@@ -935,6 +974,16 @@
                     "title": "Value",
                     "description": "The expression that you evaluated for input.",
                     "type": "string"
+                },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
+                    ],
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "defaultValue": {
                     "$role": "expression",
@@ -1223,37 +1272,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday",
-                        "user.name"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "value.birthday"
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
                     ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
-                },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "prompt": {
                     "$type": "Microsoft.IActivityTemplate",
@@ -1306,6 +1343,16 @@
                     "title": "Value",
                     "description": "The expression that you evaluated for input.",
                     "type": "string"
+                },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
+                    ],
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "defaultValue": {
                     "$role": "expression",
@@ -1535,37 +1582,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday",
-                        "user.name"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "value.birthday"
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
                     ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
-                },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "prompt": {
                     "$type": "Microsoft.IActivityTemplate",
@@ -1618,6 +1653,16 @@
                     "title": "Value",
                     "description": "The expression that you evaluated for input.",
                     "type": "string"
+                },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
+                    ],
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "defaultValue": {
                     "$role": "expression",
@@ -1705,6 +1750,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "additionalProperties": false,
@@ -1757,6 +1822,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -1817,6 +1902,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "changeType": {
                     "type": "string",
@@ -1907,6 +2012,26 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "changeType": {
                     "type": "string",
                     "title": "Change Type",
@@ -1981,6 +2106,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "eventName": {
                     "title": "Event Name",
@@ -2070,6 +2215,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -2201,6 +2366,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "additionalProperties": false,
@@ -2466,6 +2651,26 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "listProperty": {
                     "$role": "expression",
                     "title": "ListProperty",
@@ -2553,6 +2758,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "listProperty": {
                     "$role": "expression",
@@ -2709,6 +2934,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "method": {
                     "type": "string",
@@ -3171,6 +3416,26 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "condition": {
                     "$role": "expression",
                     "title": "Condition",
@@ -3251,6 +3516,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -3530,6 +3815,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "text": {
                     "type": "string",
@@ -4064,37 +4369,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday",
-                        "user.name"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "value.birthday"
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
                     ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
-                },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "prompt": {
                     "$type": "Microsoft.IActivityTemplate",
@@ -4147,6 +4440,16 @@
                     "title": "Value",
                     "description": "The expression that you evaluated for input.",
                     "type": "string"
+                },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
+                    ],
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "defaultValue": {
                     "$role": "expression",
@@ -4245,36 +4548,116 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
-                    "examples": [
-                        "value.birthday"
-                    ],
+                "id": {
                     "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "value.birthday"
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
                     ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
                 },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
+                "prompt": {
+                    "$type": "Microsoft.IActivityTemplate",
+                    "title": "Initial Prompt",
+                    "description": "The message to send to as prompt for this input.",
                     "examples": [
-                        "value.birthday"
+                        "What is your birth date?"
+                    ],
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "unrecognizedPrompt": {
+                    "$type": "Microsoft.IActivityTemplate",
+                    "title": "Unrecognized Prompt",
+                    "description": "The message to send if the last input is not recognized.",
+                    "examples": [
+                        "Let's try again. What is your birth date?"
+                    ],
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "invalidPrompt": {
+                    "$type": "Microsoft.IActivityTemplate",
+                    "title": "Invalid Prompt",
+                    "description": "The message to send to when then input was not valid for the input type.",
+                    "examples": [
+                        "No date was recognized"
+                    ],
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "maxTurnCount": {
+                    "type": "integer",
+                    "title": "Max Turn Count",
+                    "description": "The max retry count for this prompt.",
+                    "default": 2147483647,
+                    "examples": [
+                        3
+                    ]
+                },
+                "validations": {
+                    "type": "array",
+                    "title": "Validation Expressions",
+                    "description": "Expressions to validate an input.",
+                    "items": {
+                        "$role": "expression",
+                        "type": "string",
+                        "description": "String must contain an expression."
+                    }
+                },
+                "value": {
+                    "$role": "expression",
+                    "title": "Value",
+                    "description": "The expression that you evaluated for input.",
+                    "type": "string"
+                },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
                     ],
                     "type": "string",
                     "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                },
+                "defaultValue": {
+                    "$role": "expression",
+                    "title": "Default Value",
+                    "description": "Value to return if the value expression can't be evaluated.",
+                    "type": "string"
+                },
+                "alwaysPrompt": {
+                    "type": "boolean",
+                    "title": "Always Prompt",
+                    "description": "If set to true this will always prompt the user regardless if you already have the value or not.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "allowInterruptions": {
+                    "type": "string",
+                    "enum": [
+                        "always",
+                        "never",
+                        "notRecognized"
+                    ],
+                    "title": "Allow Interruptions",
+                    "description": "Always will always consult parent dialogs first, never will not consult parent dialogs, notRecognized will consult parent only when it's not recognized",
+                    "default": "notRecognized",
+                    "examples": [
+                        "notRecognized"
+                    ]
                 },
                 "connectionName": {
                     "type": "string",
@@ -4558,6 +4941,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "additionalProperties": false,
@@ -4611,6 +5014,26 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "dialog": {
                     "$type": "Microsoft.IDialog",
                     "title": "Dialog",
@@ -4619,9 +5042,12 @@
                 },
                 "options": {
                     "type": "object",
-                    "title": "Options",
-                    "description": "Options to pass to the dialog.",
-                    "additionalProperties": true
+                    "title": "Options binding",
+                    "description": "Bindings to configure the options object to pass to the dialog.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Options"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -4754,6 +5180,26 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "activity": {
                     "$type": "Microsoft.IActivityTemplate",
                     "title": "Activity",
@@ -4811,6 +5257,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -4884,6 +5350,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "condition": {
                     "$role": "expression",
@@ -4985,63 +5471,25 @@
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
                 },
-                "outputFormat": {
+                "id": {
                     "type": "string",
-                    "enum": [
-                        "none",
-                        "trim",
-                        "lowercase",
-                        "uppercase"
-                    ],
-                    "title": "Output Format",
-                    "description": "The TextInput output format.",
-                    "default": "none"
-                },
-                "allowInterruptions": {
-                    "default": "always",
-                    "type": "string",
-                    "enum": [
-                        "always",
-                        "never",
-                        "notRecognized"
-                    ],
-                    "title": "Allow Interruptions",
-                    "description": "Always will always consult parent dialogs first, never will not consult parent dialogs, notRecognized will consult parent only when it's not recognized",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
                     "examples": [
-                        "notRecognized"
+                        "Dialog2"
                     ]
                 },
-                "property": {
-                    "$role": "memoryPath",
-                    "title": "Property",
-                    "description": "This is that will be passed in as InputProperty and also set as the OutputProperty",
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
                     "examples": [
-                        "value.birthday",
-                        "user.name"
+                        "input",
+                        "confirmation"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
-                },
-                "inputBindings": {
-                    "type": "object",
-                    "title": "Input Bindings",
-                    "description": "This defines properties which be passed as arguments to this dialog",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "additionalProperties": {
+                    "items": {
                         "type": "string"
                     }
-                },
-                "outputBinding": {
-                    "$role": "memoryPath",
-                    "title": "Output Property binding",
-                    "description": "This is the property which the EndDialog(result) will be set to when EndDialog() is called",
-                    "examples": [
-                        "value.birthday"
-                    ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
                 },
                 "prompt": {
                     "$type": "Microsoft.IActivityTemplate",
@@ -5095,6 +5543,16 @@
                     "description": "The expression that you evaluated for input.",
                     "type": "string"
                 },
+                "property": {
+                    "$role": "memoryPath",
+                    "title": "Property",
+                    "description": "Property that this input dialog is bound to",
+                    "examples": [
+                        "$birthday"
+                    ],
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                },
                 "defaultValue": {
                     "$role": "expression",
                     "title": "Default Value",
@@ -5109,6 +5567,32 @@
                     "examples": [
                         false
                     ]
+                },
+                "allowInterruptions": {
+                    "type": "string",
+                    "enum": [
+                        "always",
+                        "never",
+                        "notRecognized"
+                    ],
+                    "title": "Allow Interruptions",
+                    "description": "Always will always consult parent dialogs first, never will not consult parent dialogs, notRecognized will consult parent only when it's not recognized",
+                    "default": "notRecognized",
+                    "examples": [
+                        "notRecognized"
+                    ]
+                },
+                "outputFormat": {
+                    "type": "string",
+                    "enum": [
+                        "none",
+                        "trim",
+                        "lowercase",
+                        "uppercase"
+                    ],
+                    "title": "Output Format",
+                    "description": "The TextInput output format.",
+                    "default": "none"
                 }
             },
             "additionalProperties": false,
@@ -5161,6 +5645,26 @@
                     "title": "$designer",
                     "type": "object",
                     "description": "Extra information for the Bot Framework Designer."
+                },
+                "id": {
+                    "type": "string",
+                    "title": "Id",
+                    "description": "(Optional) id for the dialog",
+                    "examples": [
+                        "Dialog2"
+                    ]
+                },
+                "tags": {
+                    "type": "array",
+                    "title": "Tags",
+                    "description": "Tags are optional strings that you can use to organize components",
+                    "examples": [
+                        "input",
+                        "confirmation"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -116,52 +116,51 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
                     Top = 1
                 });
 
+            var outer = new AdaptiveDialog("outer")
+            {
+                AutoEndDialog = false,
+                Recognizer = new RegexRecognizer()
+                {
+                    Intents = new Dictionary<string, string>()
+                                {
+                                    { "CowboyIntent" , "moo" }
+                                }
+                },
+                Rules = new List<IRule>()
+                {
+                    new IntentRule(intent: "CowboyIntent")
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new SendActivity("Yippee ki-yay!")
+                        }
+                    },
+                    new UnknownIntentRule()
+                    {
+                        Steps = new List<IDialog>()
+                        {
+                            new QnAMakerDialog(qnamaker:qna )
+                            {
+                                OutputBinding = "turn.LastResult"
+                            },
+                            new IfCondition()
+                            {
+                                    Condition = "turn.LastResult == false",
+                                    Steps =   new List<IDialog>()
+                                    {
+                                        new SendActivity("I didn't understand that.")
+                                    }
+                            }
+                        }
+                    }
+                }
+            };
+
             var rootDialog = new AdaptiveDialog("root")
             {
                 Steps = new List<IDialog>()
                 {
-                    new BeginDialog()
-                    {
-                        Dialog = new AdaptiveDialog("outer")
-                        {
-                            AutoEndDialog = false,
-                            Recognizer = new RegexRecognizer()
-                            {
-                                Intents = new Dictionary<string, string>()
-                                {
-                                    { "CowboyIntent" , "moo" }
-                                }
-                            },
-                            Rules = new List<IRule>()
-                            {
-                                new IntentRule(intent: "CowboyIntent")
-                                {
-                                    Steps = new List<IDialog>()
-                                    {
-                                        new SendActivity("Yippee ki-yay!")
-                                    }
-                                },
-                                new UnknownIntentRule()
-                                {
-                                    Steps = new List<IDialog>()
-                                    {
-                                        new QnAMakerDialog(qnamaker:qna )
-                                        {
-                                            OutputBinding = "turn.LastResult"
-                                        },
-                                        new IfCondition()
-                                        {
-                                             Condition = "turn.LastResult == false",
-                                             Steps =   new List<IDialog>()
-                                             {
-                                                 new SendActivity("I didn't understand that.")
-                                             }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    new BeginDialog(outer.Id)
                 },
                 Rules = new List<IRule>()
                 {
@@ -176,6 +175,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
                     }
                 }
             };
+            rootDialog.AddDialog(outer);
+
             return rootDialog;
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -983,7 +983,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                             },
                             new BeginDialog("ageDialog")
                             {
-                                Options = new
+                                Options = new 
                                 {
                                     userAge = "$age"
                                 }

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/BugRepo/BugRepo.main.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/BugRepo/BugRepo.main.dialog
@@ -28,7 +28,7 @@
                 {
                     "$type": "Microsoft.BeginDialog",
                     "property": "dialog.name",
-                    "dialog": "AskForName"
+                    "dialogId": "AskForName"
                 },
                 {
                     "$type": "Microsoft.SendActivity",
@@ -37,7 +37,7 @@
                 {
                     "$type": "Microsoft.BeginDialog",
                     "property": "dialog.name",
-                    "dialog": "AskForName"
+                    "dialogId": "AskForName"
                 },
                 {
                     "$type": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/app.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/app.schema
@@ -726,10 +726,10 @@
                     }
                 },
                 "dialog": {
-                    "$type": "Microsoft.IDialog",
+                    "$role": "expression",
                     "title": "Dialog",
                     "description": "This is the dialog to call.",
-                    "$ref": "#/definitions/Microsoft.IDialog"
+                    "type": "string"
                 },
                 "options": {
                     "type": "object",
@@ -741,14 +741,13 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to bind to the dialog and store the result in",
                     "examples": [
                         "user.name"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -1854,11 +1853,10 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The Memory property path to delete",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -1946,18 +1944,16 @@
                     ]
                 },
                 "arrayProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Array Property",
                     "description": "Memory expression of the array to manipulate.",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "resultProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Result Property",
                     "description": "Memory expression of the result of this action.",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "value": {
                     "$role": "expression",
@@ -2247,13 +2243,12 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "description": "Specifies a path to memory should be returned as the result to the calling dialog.",
                     "examples": [
                         "dialog.name"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -2700,20 +2695,18 @@
                     }
                 },
                 "indexProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Index Property",
                     "description": "The memory path which refers to the index of the item",
                     "default": "dialog.index",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "valueProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value Property",
                     "description": "The memory path which refers to the value of the item",
                     "default": "dialog.value",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -2814,12 +2807,11 @@
                     "default": 10
                 },
                 "valueProperty": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value Property",
                     "description": "The memory path which refers to the value of the item",
                     "default": "dialog.value",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -2993,14 +2985,13 @@
                     "additionalProperties": true
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to store the result of the HTTP call in (as object or string)",
                     "examples": [
                         "dialog.contosodata"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "headers": {
                     "type": "object",
@@ -3558,14 +3549,13 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to set the value of",
                     "examples": [
                         "user.age"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "type": {
                     "type": "string",
@@ -5055,10 +5045,10 @@
                     }
                 },
                 "dialog": {
-                    "$type": "Microsoft.IDialog",
+                    "$role": "expression",
                     "title": "Dialog",
                     "description": "This is the dialog to switch to.",
-                    "$ref": "#/definitions/Microsoft.IDialog"
+                    "type": "string"
                 },
                 "options": {
                     "type": "object",
@@ -5070,13 +5060,12 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "description": "The property to bind to the dialog and store the result in",
                     "examples": [
                         "user.name"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,
@@ -5299,14 +5288,13 @@
                     }
                 },
                 "property": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Property",
                     "description": "The property to set the value of",
                     "examples": [
                         "user.age"
                     ],
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 },
                 "value": {
                     "$role": "expression",
@@ -5697,11 +5685,10 @@
                     "description": "Value type of the trace activity"
                 },
                 "value": {
-                    "$role": "memoryPath",
+                    "$role": "expression",
                     "title": "Value",
                     "description": "Property path to memory object to send as the value of the trace activity",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+                    "type": "string"
                 }
             },
             "additionalProperties": false,

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/app.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/app.schema
@@ -733,9 +733,12 @@
                 },
                 "options": {
                     "type": "object",
-                    "title": "Options",
-                    "description": "Options to pass to the dialog.",
-                    "additionalProperties": true
+                    "title": "Options binding",
+                    "description": "Bindings to configure the options object to pass to the dialog.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Options"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",
@@ -5059,9 +5062,12 @@
                 },
                 "options": {
                     "type": "object",
-                    "title": "Options",
-                    "description": "Options to pass to the dialog.",
-                    "additionalProperties": true
+                    "title": "Options binding",
+                    "description": "Bindings to configure the options object to pass to the dialog.",
+                    "additionalProperties": {
+                        "type": "string",
+                        "title": "Options"
+                    }
                 },
                 "property": {
                     "$role": "memoryPath",


### PR DESCRIPTION
#2012 
* Add Databinding Options for BeginDialog and ReplaceDialog
* Removed memoryPath $role (everything is an expression now)
* changed BeingDialog/ReplaceDialog to use DialogId instead of Dialog so that we can treat it as an expression.