### PR TITLE
change regexrecognizer to return multiple entities 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
@@ -61,23 +61,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                     }
                 }
 
-                var match = regex.Match(utterance);
+                var matches = regex.Matches(utterance);
 
-                if (match.Success)
+                if (matches.Count > 0)
                 {
                     // TODO length weighted match and multiple intents
                     result.Intents.Add(intent.Replace(" ", "_"), new IntentScore() { Score = 1.0 });
 
                     // Check for named capture groups
-                    var entities = new Dictionary<string, string>();
-                    foreach (var name in regex.GetGroupNames().Where(name => name.Length > 1))
+                    var entities = new Dictionary<string, List<string>>();
+
+                    // only if we have a value and the name is not a number "0"
+                    foreach (var groupName in regex.GetGroupNames().Where(name => name.Length > 1))
                     {
-                        // only if we have a value and the name is not a number "0"
-                        if (!string.IsNullOrEmpty(match.Groups[name].Value))
+                        foreach (var match in matches.Cast<Match>())
                         {
-                            entities.Add(name, match.Groups[name].Value);
+                            var group = (Group)match.Groups[groupName];
+                            List<string> values;
+                            if (!entities.TryGetValue(groupName, out values))
+                            {
+                                values = new List<string>();
+                                entities.Add(groupName, values);
+                            }
+                            values.Add(group.Value);
                         }
                     }
+
                     result.Entities = JObject.FromObject(entities);
                 }
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DialogContextStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DialogContextStateTests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     new OnIntent(intent: "NameIntent",
                         actions:new List<IDialog>()
                         {
-                            new SendActivity("{turn.recognized.entities.name}"),
+                            new SendActivity("{turn.recognized.entities.name[0]}"),
                         }),
                 }
             };

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Events;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    [TestClass]
+    public class RegexRecognizerTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public async Task RegexRecognizer_Intent()
+        {
+            var recognizer = new RegexRecognizer()
+            {
+                Intents = new Dictionary<string, string>()
+                 {
+                     { "codeIntent", "(?<code>[a-z][0-9])" },
+                     { "colorIntent", "(?<color>(red|orange|yellow|green|blue|indigo|violet))" }
+                 }
+            };
+            var tc = CreateContext("intent a1 b2");
+
+            var result = await recognizer.RecognizeAsync(tc, CancellationToken.None);
+
+            // intent assertions
+            Assert.AreEqual(1, result.Intents.Count, "Should recognize one intent");
+            Assert.AreEqual("codeIntent", result.Intents.Select(i => i.Key).First(), "Should recognize codeIntent");
+
+            // entity assertions from capture group
+            dynamic entities = result.Entities;
+            Assert.IsNotNull(entities.code, "should find code");
+            Assert.IsNull(entities.color, "should not find color");
+            Assert.AreEqual(2, entities.code.Count, "should find 2 codes");
+            Assert.AreEqual("a1", (string)entities.code[0], "should find a1");
+            Assert.AreEqual("b2", (string)entities.code[1], "should find b2");
+
+            tc = CreateContext("red and orange");
+            // intent assertions
+            result = await recognizer.RecognizeAsync(tc, CancellationToken.None);
+            Assert.AreEqual(1, result.Intents.Count, "Should recognize one intent");
+            Assert.AreEqual("colorIntent", result.Intents.Select(i => i.Key).First(), "Should recognize colorIntent");
+
+            // entity assertions from capture group
+            entities = result.Entities;
+            Assert.IsNotNull(entities.color, "should find color");
+            Assert.IsNull(entities.code, "should not find code");
+            Assert.AreEqual(2, entities.color.Count, "should find 2 colors");
+            Assert.AreEqual("red", (string)entities.color[0], "should find red");
+            Assert.AreEqual("orange", (string)entities.color[1], "should find orange");
+        }
+
+        private static TurnContext CreateContext(string text)
+        {
+            var activity = Activity.CreateMessageActivity();
+            activity.Text = text;
+            return new TurnContext(new TestAdapter(), (Activity)activity);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2330 

to support @ and @@ via capture groups
This makes regexrecognizer align with luisrecognizer to be able to recognizer named entities via multiple capture groups