### PR TITLE
Fix bug in ifCondition 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             if (dc is SequenceContext planning)
             {
                 var (value, error) = condition.TryEvaluate(dc.State);
-                var conditionResult = error == null && (bool)value;
+                var conditionResult = error == null && value != null && (bool)value;
 
                 var actions = new List<IDialog>();
                 if (conditionResult == true)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -161,11 +161,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     {
                         new IfCondition()
                         {
-                            Condition = "user.name == null",
+                            Condition = "!dialog.foo && user.name == null",
                             Actions = new List<IDialog>()
                             {
                                 new TextInput() {
-                                    Prompt  = new ActivityTemplate("Hello, what is your name?"),
+                                    Prompt = new ActivityTemplate("Hello, what is your name?"),
                                     OutputBinding = "user.name"
                                 },
                                 new SendActivity("Hello {user.name}, nice to meet you!")


### PR DESCRIPTION
ifCondition does not handle missing memory references which return null which should be treated as false. 