### PR TITLE
Parse true/false independent of case

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions.Parser/ExpressionEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions.Parser/ExpressionEngine.cs
@@ -133,15 +133,16 @@ namespace Microsoft.Bot.Builder.Expressions.Parser
             {
                 Expression result;
                 var symbol = context.GetText();
-                if (symbol == "false")
+                var normalized = symbol.ToLower();
+                if (normalized == "false")
                 {
                     result = Expression.ConstantExpression(false);
                 }
-                else if (symbol == "true")
+                else if (normalized == "true")
                 {
                     result = Expression.ConstantExpression(true);
                 }
-                else if (symbol == "null")
+                else if (normalized == "null")
                 {
                     result = Expression.ConstantExpression(null);
                 }

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -288,9 +288,10 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("one > 0.5 || two < 1.5", true, oneTwo),
             Test("one / 0 || two", true),
             Test("0/3", 0),
-            # endregion
+            Test("True == true", true),
+            #endregion
 
-            # region  String functions test
+            #region  String functions test
             Test("concat(hello,world)","helloworld"),
             Test("concat('hello','world')","helloworld"),
             Test("concat(\"hello\",\"world\")","helloworld"),


### PR DESCRIPTION
C# ToString on true produces "True" which parses as a memory path.  This normalizes true/false/null to ignore case.