### PR TITLE
[Expression&LG] fix error listener bug in expression and line number issue in LG

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions.Parser/Expression.g4
+++ b/libraries/Microsoft.Bot.Builder.Expressions.Parser/Expression.g4
@@ -41,3 +41,5 @@ IDENTIFIER : (LETTER | '_') (LETTER | DIGIT | '-' | '_')*;
 NEWLINE : '\r'? '\n' -> skip;
 
 STRING : ('\'' (~'\'')* '\'') | ('"' (~'"')* '"');
+
+INVALID_TOKEN_DEFAULT_MODE : . ;

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -477,8 +477,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 DiagnosticSeverity severity = DiagnosticSeverity.Error,
                 ParserRuleContext context = null)
             {
-                var startPosition = context == null ? new Position(0, 0) : new Position(context.Start.Line - 1, context.Start.Column);
-                var stopPosition = context == null ? new Position(0, 0) : new Position(context.Stop.Line - 1, context.Stop.Column + context.Stop.Text.Length);
+                var startPosition = context == null ? new Position(0, 0) : new Position(context.Start.Line, context.Start.Column);
+                var stopPosition = context == null ? new Position(0, 0) : new Position(context.Stop.Line, context.Stop.Column + context.Stop.Text.Length);
                 var range = new Range(startPosition, stopPosition);
                 message = $"source: {currentSource}. error message: {message}";
                 return new Diagnostic(range, message, severity);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DialogContextStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DialogContextStateTests.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                             new SendActivity("{dialog.name}"),
                             new IfCondition()
                             {
-                                Condition= "{dialog.name} == 'testDialog'",
+                                Condition= "dialog.name == 'testDialog'",
                                 Actions = new List<IDialog>()
                                 {
                                     new SendActivity("nested dialogCommand {dialog.name}")

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/BadExpressionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/BadExpressionTests.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("a.#title"),
             Test("\"hello'"),
             Test("'hello'.length()"), // not supported currently
+            Test("user.lists.{dialog.listName}")
         };
 
 

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/12 - GithubIssueBot/show.lg
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/12 - GithubIssueBot/show.lg
@@ -14,7 +14,7 @@
                     "type": "TextBlock",
                     "size": "Medium",
                     "weight": "Bolder",
-                    "text": "@{replace(replace(x.title, '\"', \"'\"), '\\', '\\\\')}"
+                    "text": "@{x.title}"
                 },
                 {
                     "type": "ColumnSet",


### PR DESCRIPTION
1. Expression such as 'user.lists.{dialog.listName}' didn't throw exceptions from errorListener. 
2. Line number in error message should start from one instead of zero as line number of most editors starts from one