### PR TITLE
Expose evaluator lookup

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions.Parser/ExpressionEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions.Parser/ExpressionEngine.cs
@@ -30,8 +30,6 @@ namespace Microsoft.Bot.Builder.Expressions.Parser
             { "~", $"dialog.instance" },
         };
 
-        private readonly EvaluatorLookup _lookup;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ExpressionEngine"/> class.
         /// Constructor.
@@ -39,15 +37,17 @@ namespace Microsoft.Bot.Builder.Expressions.Parser
         /// <param name="lookup">If present delegate to lookup evaluation information from type string.</param>
         public ExpressionEngine(EvaluatorLookup lookup = null)
         {
-            _lookup = lookup ?? BuiltInFunctions.Lookup;
+            EvaluatorLookup = lookup ?? BuiltInFunctions.Lookup;
         }
+
+        public EvaluatorLookup EvaluatorLookup { get; }
 
         /// <summary>
         /// Parse the input into an expression.
         /// </summary>
         /// <param name="expression">Expression to parse.</param>
         /// <returns>Expresion tree.</returns>
-        public Expression Parse(string expression) => new ExpressionTransformer(_lookup).Transform(AntlrParse(expression));
+        public Expression Parse(string expression) => new ExpressionTransformer(EvaluatorLookup).Transform(AntlrParse(expression));
 
         protected static IParseTree AntlrParse(string expression)
         {


### PR DESCRIPTION
Expose the lookup function in ExpressionEngine, so that the upper layer can further customized based on it.

The direction, is ExpressionEngine is the single extension point for functions. Next step would be let LG accept a customized ExpressionEngine.