### PR TITLE
Upgrade Recognizers-Text version from v1.1.3 to v1.2.6 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
         private static List<ModelResult<FoundChoice>> RecognizeOrdinal(string utterance, string culture)
         {
-            var model = new NumberRecognizer(culture).GetOrdinalModel(culture);
+            var model = new NumberRecognizer(culture, NumberOptions.SuppressExtendedTypes).GetOrdinalModel(culture);
             var result = model.Parse(utterance);
             return result.Select(r =>
                 new ModelResult<FoundChoice>
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
         private static List<ModelResult<FoundChoice>> RecognizeNumber(string utterance, string culture)
         {
-            var model = new NumberRecognizer(culture).GetNumberModel(culture);
+            var model = new NumberRecognizer(culture, NumberOptions.SuppressExtendedTypes).GetNumberModel(culture);
             var result = model.Parse(utterance);
             return result.Select(r =>
                 new ModelResult<FoundChoice>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.1.3" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.2.6" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.6" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description
This PR upgrades the version of Recognizers-Text from [v1.1.3](https://github.com/microsoft/Recognizers-Text/releases/tag/dotnet-v1.1.3) to [v1.2.6](https://github.com/microsoft/Recognizers-Text/releases/tag/dotnet-v1.2.6) (latest stable version).
### Changes made
- Change versions of  `Microsoft.Recognizers.Text.Choice` and `Microsoft.Recognizers.Text.DateTime` on `Microsoft.Bot.Builder.Dialogs` to `v.1.2.6`
- Add `NumberOptions.SuppressExtendedTypes` to the NumberRecognizer in `ChoiceRecognizers`
### Testing
![imagen](https://user-images.githubusercontent.com/22912283/63612420-99679b80-c5b4-11e9-87a5-79ce56151bab.png)
