### PR TITLE
Revert dialog id as expression

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -21,7 +21,6 @@
     <Rule Id="SA1412" Action="Warning" />
     <Rule Id="SA1413" Action="None" />
     <Rule Id="SA1600" Action="None" />
-    <Rule Id="SA1609" Action="Warning" />
     <Rule Id="SA1633" Action="None" />
   </Rules>
 </RuleSet>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -13,10 +13,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// </summary>
     public abstract class BaseInvokeDialog : DialogAction
     {
+        // Expression for dialogId to call (allowing dynamic expression)
+        private string dialogIdToCall;
+
         public BaseInvokeDialog(string dialogIdToCall = null, string property = null, IDictionary<string, string> bindingOptions = null)
             : base()
         {
-            this.DialogId = dialogIdToCall;
+            this.dialogIdToCall = dialogIdToCall;
 
             if (bindingOptions != null)
             {
@@ -38,12 +41,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public object Options { get; set; } = new JObject();
 
         /// <summary>
-        /// Gets or sets the dialog ID to call.
+        /// Gets or sets the dialog to call.
         /// </summary>
-        /// <value>
-        /// The dialog ID to call.
-        /// </value>
-        public string DialogId { get; set; }
+        public IDialog Dialog { get; set; }
 
         /// <summary>
         /// Gets or sets the property from memory to pass to the calling dialog and to set the return value to.
@@ -67,24 +67,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
         public override List<IDialog> ListDependencies()
         {
+            if (Dialog != null)
+            {
+                return new List<IDialog>() { Dialog };
+            }
+
             return new List<IDialog>();
         }
 
         protected override string OnComputeId()
         {
-            return $"{this.GetType().Name}[{DialogId}:{this.BindingPath()}]";
+            return $"{this.GetType().Name}[{Dialog?.Id ?? this.dialogIdToCall}:{this.BindingPath()}]";
         }
 
         protected IDialog ResolveDialog(DialogContext dc)
         {
-            var (result, error) = new ExpressionEngine().Parse(this.DialogId).TryEvaluate(dc.State);
-            if (error != null)
+            if (this.Dialog != null)
             {
-                throw new Exception(error);
+                return this.Dialog;
             }
 
-            var dialogId = (string)result ?? this.DialogId ?? throw new Exception($"{this.GetType().Name} requires a dialog to be called.");
-            return dc.FindDialog(dialogId);
+            var dialogId = this.dialogIdToCall ?? throw new Exception($"{this.GetType().Name} requires a dialog to be called.");
+            return dc.FindDialog(dialogId) ?? throw new Exception($"{dialogId} not found.");
         }
 
         protected object BindOptions(DialogContext dc, object options)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.schema
@@ -10,10 +10,10 @@
         },
         {
             "properties": {
-                "dialogId": {
-                    "$role": "expression",
-                    "title": "Dialog Id",
-                    "description": "The Id the dialog to call."
+                "dialog": {
+                    "$type": "Microsoft.IDialog",
+                    "title": "Dialog",
+                    "description": "This is the dialog to call."
                 },
                 "options": {
                     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.schema
@@ -10,10 +10,10 @@
         },
         {
             "properties": {
-                "dialogId": {
-                    "$role": "expression",
-                    "title": "Dialog Id",
-                    "description": "The Id the dialog to call."
+                "dialog": {
+                    "$type": "Microsoft.IDialog",
+                    "title": "Dialog",
+                    "description": "This is the dialog to switch to."
                 },
                 "options": {
                     "type": "object",

--- a/schemas/sdk.schema
+++ b/schemas/sdk.schema
@@ -644,11 +644,11 @@
                         "type": "string"
                     }
                 },
-                "dialogId": {
-                    "$role": "expression",
-                    "title": "Dialog Id",
-                    "description": "The Id the dialog to call.",
-                    "type": "string"
+                "dialog": {
+                    "$type": "Microsoft.IDialog",
+                    "title": "Dialog",
+                    "description": "This is the dialog to call.",
+                    "$ref": "#/definitions/Microsoft.IDialog"
                 },
                 "options": {
                     "type": "object",
@@ -5355,11 +5355,11 @@
                         "type": "string"
                     }
                 },
-                "dialogId": {
-                    "$role": "expression",
-                    "title": "Dialog Id",
-                    "description": "The Id the dialog to call.",
-                    "type": "string"
+                "dialog": {
+                    "$type": "Microsoft.IDialog",
+                    "title": "Dialog",
+                    "description": "This is the dialog to switch to.",
+                    "$ref": "#/definitions/Microsoft.IDialog"
                 },
                 "options": {
                     "type": "object",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -972,17 +972,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         [TestMethod]
         public async Task Action_BeginDialog()
         {
-            var tellJokeDialog = new AdaptiveDialog("TellJokeDialog");
-            tellJokeDialog.AddEvents(new List<IOnEvent>()
+            var tellJokeDialog = new AdaptiveDialog("TellJokeDialog")
             {
-                new OnUnknownIntent(
-                    new List<IDialog>()
+                Events = new List<IOnEvent>()
+                {
+                    new OnUnknownIntent()
                     {
-                        new SendActivity("Why did the chicken cross the road?"),
-                        new EndTurn(),
-                        new SendActivity("To get to the other side")
-                    })
-            });
+                        Actions = new List<IDialog>()
+                        {
+                            new SendActivity("Why did the chicken cross the road?"),
+                            new EndTurn(),
+                            new SendActivity("To get to the other side")
+                        },
+                    }
+                }
+            };
 
             var askNameDialog = new AdaptiveDialog("AskNameDialog")
             {
@@ -1025,21 +1029,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                         new BeginDialog(askNameDialog.Id)
                     }
                 },
-
                 new OnIntent(
                     "JokeIntent",
                     actions: new List<IDialog>()
                     {
-                        new BeginDialog(tellJokeDialog.Id)
+                        new BeginDialog() { Dialog = tellJokeDialog }
                     }),
                 new OnUnknownIntent(
                     actions: new List<IDialog>()
                     {
                         new SendActivity("I'm a joke bot. To get started say 'tell me a joke'")
                     }),
-            });
+            }); 
             testDialog.AddDialog(askNameDialog);
-            testDialog.AddDialog(tellJokeDialog);
 
             await CreateFlow(testDialog)
             .SendConversationUpdate()

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/app.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/app.schema
@@ -654,11 +654,11 @@
                         "type": "string"
                     }
                 },
-                "dialogId": {
-                    "$role": "expression",
-                    "title": "Dialog Id",
-                    "description": "The Id the dialog to call.",
-                    "type": "string"
+                "dialog": {
+                    "$type": "Microsoft.IDialog",
+                    "title": "Dialog",
+                    "description": "This is the dialog to call.",
+                    "$ref": "#/definitions/Microsoft.IDialog"
                 },
                 "options": {
                     "type": "object",
@@ -5375,11 +5375,11 @@
                         "type": "string"
                     }
                 },
-                "dialogId": {
-                    "$role": "expression",
-                    "title": "Dialog Id",
-                    "description": "The Id the dialog to call.",
-                    "type": "string"
+                "dialog": {
+                    "$type": "Microsoft.IDialog",
+                    "title": "Dialog",
+                    "description": "This is the dialog to switch to.",
+                    "$ref": "#/definitions/Microsoft.IDialog"
                 },
                 "options": {
                     "type": "object",


### PR DESCRIPTION
From bug report:


I am trying to bring the latest 4.Future to Composer, but I found a bug about BeginDialog.

 

In this commit, https://github.com/microsoft/botbuilder-dotnet/commit/c2e078f25cf6a793320df4c4bbd2934bd0ad11b7

 

You have disabled Begin a dialog by dialog: “dialogname”, it works well for code but not in declarative format.

 

In declarative, first we did not assign a id (“d2”, “d3”) to the constructor. Second, we did not call d2.AddDialog(d3) in the loader.

 



 

So in declarative, when Begin a dialog, it can’t find the dialog and throw a null reference exception.

What would you suggest on this? fix from the Adaptive side or Declarative side?

 

Thanks,

Lu