### PR TITLE
Fixed Teams TenantId/ChannelData issue

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -784,7 +784,8 @@ namespace Microsoft.Bot.Builder
             eventActivity.ChannelId = channelId;
             eventActivity.ServiceUrl = serviceUrl;
             eventActivity.Id = result.ActivityId ?? Guid.NewGuid().ToString("n");
-            eventActivity.Conversation = new ConversationAccount(id: result.Id);
+            eventActivity.Conversation = new ConversationAccount(id: result.Id, tenantId: conversationParameters.TenantId);
+            eventActivity.ChannelData = conversationParameters.ChannelData;
             eventActivity.Recipient = conversationParameters.Bot;
 
             using (TurnContext context = new TurnContext(this, (Activity)eventActivity))

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -141,38 +141,5 @@ namespace Microsoft.Bot.Builder.Tests
                 CancellationToken.None);
             return activity;
         }
-
-        private class MockAdapter : BotFrameworkAdapter
-        {
-            private const string BotIdentityKey = "BotIdentity";
-
-            public MockAdapter(
-                ICredentialProvider credentialProvider,
-                IChannelProvider channelProvider = null,
-                RetryPolicy connectorClientRetryPolicy = null,
-                HttpClient customHttpClient = null,
-                IMiddleware middleware = null,
-                ILogger logger = null)
-                : base(credentialProvider, channelProvider, connectorClientRetryPolicy, customHttpClient, middleware, logger)
-            {
-            }
-
-            public async override Task CreateConversationAsync(string channelId, string serviceUrl, MicrosoftAppCredentials credentials, ConversationParameters conversationParameters, BotCallbackHandler callback, CancellationToken cancellationToken)
-            {
-                // Create a conversation update activity to represent the result.
-                var eventActivity = Activity.CreateEventActivity();
-                eventActivity.Name = "CreateConversation";
-                eventActivity.ChannelId = channelId;
-                eventActivity.ServiceUrl = serviceUrl;
-                eventActivity.Id = conversationParameters.Activity.Id ?? Guid.NewGuid().ToString("n");
-                eventActivity.Conversation = new ConversationAccount(id: Guid.NewGuid().ToString(), tenantId: conversationParameters.TenantId);
-                eventActivity.ChannelData = conversationParameters.ChannelData;
-                eventActivity.Recipient = conversationParameters.Bot;
-
-                await RunPipelineAsync(new TurnContext(this, conversationParameters.Activity), callback, cancellationToken).ConfigureAwait(false);
-
-                return;
-            }
-        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Logging;
-using Microsoft.Rest.TransientFaultHandling;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;


### PR DESCRIPTION
Fixes: #2480

## Issue

`BotframeworkAdapter.CreateConversation` [strips out the ChannelData of the message here](https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L782). As you can see per linked issue, this can cause problems when using `CreateConversation` with Teams since Teams requires `TenantId` on the `ChannelData`.

I also fixed up an issue where `MockAdapter.CreateConversation` wasn't mimicking our actual code, which would have caught this issue earlier.

## Changes

**BotFrameworkAdapter.cs**

```diff
- eventActivity.Conversation = new ConversationAccount(id: result.Id);
+ eventActivity.Conversation = new ConversationAccount(id: result.Id, tenantId: conversationParameters.TenantId);
+ eventActivity.ChannelData = conversationParameters.ChannelData;
```

**MockAdapter**

```diff
- var activity = conversationParameters.Activity;
- activity.ChannelData = new
- {
- 	conversationParameters.TenantId,
- };
+ // Create a conversation update activity to represent the result.
+ var eventActivity = Activity.CreateEventActivity();
+ eventActivity.Name = "CreateConversation";
+ eventActivity.ChannelId = channelId;
+ eventActivity.ServiceUrl = serviceUrl;
+ eventActivity.Id = conversationParameters.Activity.Id ?? Guid.NewGuid().ToString("n");
+ eventActivity.Conversation = new ConversationAccount(id: Guid.NewGuid().ToString(), tenantId: conversationParameters.TenantId);
+ eventActivity.ChannelData = conversationParameters.ChannelData;
+ eventActivity.Recipient = conversationParameters.Bot;
```

## Testing

No new tests needed. Previous test erroneously covered this and that test has been fixed in the PR via the above change. Only 175 because a few live ones were skipped and a couple Azure ones don't seem to want to pass for me unless I run them separately (I think it has to do with Storage Emulator)

![image](https://user-images.githubusercontent.com/40401643/64461997-d1da9f80-d0b3-11e9-81da-a28ab9acdc34.png)

I also tested this in a few simple bots, including one that creates a Teams conversation using this change and it worked fine.

## Help

**Due to adding additional `ChannelData` to `CreateConversation`, I'm not comfortable saying this PR isn't a breaking change**. I'd be a little surprised if this were a breaking change, but it just seems like an odd thing to have not been included prior.

- [ ] Somebody who knows better, PLEASE PLEASE PLEASE makes sure adding `ChannelData` isn't some weird breaking change