### PR TITLE
Forcing BotState.SaveChangesAsync should not Throw NullReferenceException without CachedBotState

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Bot.Builder
             }
 
             var cachedState = turnContext.TurnState.Get<CachedBotState>(_contextServiceKey);
-            if (force || (cachedState != null && cachedState.IsChanged()))
+            if (cachedState != null && (force || cachedState.IsChanged()))
             {
                 var key = GetStorageKey(turnContext);
                 var changes = new Dictionary<string, object>

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
@@ -756,6 +756,20 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.AreEqual("test-value", json["test-name"]["Value"].ToString());
         }
 
+        [TestMethod]
+        [Description("Should not throw when forcing without cached state")]
+        public async Task State_ForceIsNoOpWithoutCachedBotState()
+        {
+            // Arrange
+            var dictionary = new Dictionary<string, JObject>();
+
+            var userState = new UserState(new MemoryStorage(dictionary));
+            var context = TestUtilities.CreateEmptyContext();
+
+            // Act
+            await userState.SaveChangesAsync(context, true);
+        }
+
         public class TypedObject
         {
             public string Name { get; set; }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botbuilder-dotnet/issues/2457

If there is no CachedBotState, there is nothing to force.