### PR TITLE
[Dialogs] Add numberWithUnit recognizer to NumberPrompt

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.NumberWithUnit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Choices
 {
@@ -137,5 +138,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                     },
                 }).ToList();
         }
+
+        private static List<ModelResult<FoundChoice>> RecognizeNumberWithUnit(string utterance, string culture)
+        {
+            var model = new NumberWithUnitRecognizer(culture).GetCurrencyModel(culture);
+            var result = model.Parse(utterance);
+            return result.Select(r =>
+                new ModelResult<FoundChoice>
+                {
+                    Start = r.Start,
+                    End = r.End,
+                    Text = r.Text,
+                    Resolution = new FoundChoice
+                    {
+                        Value = r.Resolution["value"].ToString(),
+                    },
+                }).ToList();
+        }
+
+        private static AbstractNumberWithUnitModel GetNumberWithUnitModel
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 
@@ -49,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             if (matched.Count == 0)
             {
                 // Next try finding by ordinal
-                var matches = RecognizeOrdinal(utterance, locale);
+                var matches = RecognizeNumbers(utterance, locale, new NumberRecognizer(locale, NumberOptions.SuppressExtendedTypes).GetOrdinalModel(locale));
                 if (matches.Any())
                 {
                     foreach (var match in matches)
@@ -59,8 +60,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 }
                 else
                 {
-                    // Finally try by numerical index
-                    matches = RecognizeNumber(utterance, locale);
+                    // Then try by numerical index
+                    matches = RecognizeNumbers(utterance, locale, new NumberRecognizer(locale, NumberOptions.SuppressExtendedTypes).GetNumberModel(locale));
 
                     foreach (var match in matches)
                     {
@@ -105,9 +106,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             }
         }
 
-        private static List<ModelResult<FoundChoice>> RecognizeOrdinal(string utterance, string culture)
+        private static List<ModelResult<FoundChoice>> RecognizeNumbers(string utterance, string culture, IModel model)
         {
-            var model = new NumberRecognizer(culture, NumberOptions.SuppressExtendedTypes).GetOrdinalModel(culture);
             var result = model.Parse(utterance);
             return result.Select(r =>
                 new ModelResult<FoundChoice>
@@ -121,41 +121,5 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                     },
                 }).ToList();
         }
-
-        private static List<ModelResult<FoundChoice>> RecognizeNumber(string utterance, string culture)
-        {
-            var model = new NumberRecognizer(culture, NumberOptions.SuppressExtendedTypes).GetNumberModel(culture);
-            var result = model.Parse(utterance);
-            return result.Select(r =>
-                new ModelResult<FoundChoice>
-                {
-                    Start = r.Start,
-                    End = r.End,
-                    Text = r.Text,
-                    Resolution = new FoundChoice
-                    {
-                        Value = r.Resolution["value"].ToString(),
-                    },
-                }).ToList();
-        }
-
-        private static List<ModelResult<FoundChoice>> RecognizeNumberWithUnit(string utterance, string culture)
-        {
-            var model = new NumberWithUnitRecognizer(culture).GetCurrencyModel(culture);
-            var result = model.Parse(utterance);
-            return result.Select(r =>
-                new ModelResult<FoundChoice>
-                {
-                    Start = r.Start,
-                    End = r.End,
-                    Text = r.Text,
-                    Resolution = new FoundChoice
-                    {
-                        Value = r.Resolution["value"].ToString(),
-                    },
-                }).ToList();
-        }
-
-        private static AbstractNumberWithUnitModel GetNumberWithUnitModel
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -62,7 +62,6 @@
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
-    <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
     <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.2.6" />
     <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.6" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -4,10 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;
+using Microsoft.Recognizers.Text.NumberWithUnit;
 using static Microsoft.Recognizers.Text.Culture;
 
 namespace Microsoft.Bot.Builder.Dialogs
@@ -102,7 +105,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 var message = turnContext.Activity.AsMessageActivity();
                 var culture = turnContext.Activity.Locale ?? DefaultLocale ?? English;
-                var results = NumberRecognizer.RecognizeNumber(message.Text, culture, NumberOptions.SuppressExtendedTypes);
+                var results = RecognizeNumberWithUnit(message.Text, culture);
                 if (results.Count > 0)
                 {
                     // Try to parse value based on type
@@ -151,6 +154,17 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             return Task.FromResult(result);
+        }
+
+        private static List<ModelResult> RecognizeNumberWithUnit(string utterance, string culture)
+        {
+            var number = NumberRecognizer.RecognizeNumber(utterance, culture, NumberOptions.SuppressExtendedTypes);
+            var currency = NumberWithUnitRecognizer.RecognizeCurrency(utterance, culture);
+            var age = NumberWithUnitRecognizer.RecognizeAge(utterance, culture);
+            var temperature = NumberWithUnitRecognizer.RecognizeTemperature(utterance, culture);
+            var dimension = NumberWithUnitRecognizer.RecognizeDimension(utterance, culture);
+
+            return number.Any() ? number : currency.Any() ? currency : age.Any() ? age : temperature.Any() ? temperature : dimension;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -159,12 +159,24 @@ namespace Microsoft.Bot.Builder.Dialogs
         private static List<ModelResult> RecognizeNumberWithUnit(string utterance, string culture)
         {
             var number = NumberRecognizer.RecognizeNumber(utterance, culture, NumberOptions.SuppressExtendedTypes);
-            var currency = NumberWithUnitRecognizer.RecognizeCurrency(utterance, culture);
-            var age = NumberWithUnitRecognizer.RecognizeAge(utterance, culture);
-            var temperature = NumberWithUnitRecognizer.RecognizeTemperature(utterance, culture);
-            var dimension = NumberWithUnitRecognizer.RecognizeDimension(utterance, culture);
 
-            return number.Any() ? number : currency.Any() ? currency : age.Any() ? age : temperature.Any() ? temperature : dimension;
+            if (number.Any())
+            {
+                // Result when it matches with a number recognizer
+                return number;
+            }
+            else
+            {
+                // Analyze every option for numberWithUnit
+                var results = new List<List<ModelResult>>();
+                results.Add(NumberWithUnitRecognizer.RecognizeCurrency(utterance, culture));
+                results.Add(NumberWithUnitRecognizer.RecognizeAge(utterance, culture));
+                results.Add(NumberWithUnitRecognizer.RecognizeTemperature(utterance, culture));
+                results.Add(NumberWithUnitRecognizer.RecognizeDimension(utterance, culture));
+
+                // Filter the options that returned nothing and return the one that matched
+                return results.FirstOrDefault(r => r.Any()) ?? new List<ModelResult>();
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
@@ -343,6 +343,166 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        public async Task CurrencyNumberPrompt()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.English);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Bot received the number '{numberResult}'."), cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send("$500")
+            .AssertReply("Bot received the number '500'.")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task AgeNumberPrompt()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.English);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Bot received the number '{numberResult}'."), cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send("i am 18 years old")
+            .AssertReply("Bot received the number '18'.")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task DimensionNumberPrompt()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.English);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Bot received the number '{numberResult}'."), cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send("I've run 5km")
+            .AssertReply("Bot received the number '5'.")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TemperatureNumberPrompt()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var dialogs = new DialogSet(dialogState);
+
+            var numberPrompt = new NumberPrompt<double>("NumberPrompt", defaultLocale: Culture.English);
+            dialogs.Add(numberPrompt);
+
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Type = ActivityTypes.Message, Text = "Enter a number." },
+                    };
+                    await dc.PromptAsync("NumberPrompt", options);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var numberResult = (double)results.Result;
+                    await turnContext.SendActivityAsync(MessageFactory.Text($"Bot received the number '{numberResult}'."), cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply("Enter a number.")
+            .Send("The temperature is 32C")
+            .AssertReply("Bot received the number '32'.")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task CultureThruNumberPromptCtor()
         {
             var convoState = new ConversationState(new MemoryStorage());


### PR DESCRIPTION
### Description
This PR adds the `NumberWithUnit` recognizer to catch cases where `Number` fails to recognize.

### Changes made
- Refactor of the `RecognizeNumber` and `RecognizeOrdinal` to avoid repeted logic.
- Add the method `RecognizeNumberWithUnit` to `NumberPrompt`
- Modify the `OnRecognizeAsync` method to call `RecognizeNumberWithUnit`
- Add the recognition of _age_, _currency_, _temperature_ and _dimension_

### Testing
![imagen](https://user-images.githubusercontent.com/22912283/64886469-a2d8a680-d63c-11e9-88cb-f6de5784ee72.png)

