### PR TITLE
Correcting Confirm Prompt and language

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
         private string DetermineCulture(Activity activity)
         {
+            activity.Locale = activity.Locale.ToLower();
             var culture = activity.Locale ?? DefaultLocale;
             if (string.IsNullOrEmpty(culture) || !ChoiceDefaults.ContainsKey(culture))
             {


### PR DESCRIPTION
ConfirmPrompt has a problem with Language and doesn't recognize the standard for the code of the language. So I put to lower the standard to work with the data from the activity. Like that, the activity send us 'fr-FR' and ConfirmPrompt need to recognize 'fr-fr'. So, I take the 'fr-FR' from the activity and put it to lower to be recognize by the ConfirmPrompt
My contact information:
Nathan Pire
nathan@mic-belgique.be