### PR TITLE
Dropped turn.stepCount in favor of turn.interrupted

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DebugBreak.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DebugBreak.cs
@@ -32,9 +32,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             // Best effort
             try
             {
-                // Get stepCount from memory
-                var stepCount = dc.State.GetValue<int>(TurnPath.STEPCOUNT, () => 0);
-
                 // Compute path
                 var path = string.Empty;
                 var connector = string.Empty;
@@ -51,7 +48,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var stepState = dc is SequenceContext sc ? sc.Actions : new List<ActionState>();
                 var actionsIds = stepState.Select(s => s.DialogId);
 
-                Debug.WriteLine($"{path}: {stepCount} actions executed and {actionsIds.Count()} remaining.");
+                Debug.WriteLine($"{path}: {actionsIds.Count()} actions remaining.");
             }
             catch (Exception ex)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -26,12 +26,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 #pragma warning restore SA1310 // Field should not contain underscore.
 
         /// <summary>
-        /// gets or sets If set to true this will always prompt the user regardless if you already have the value or not.
+        /// Gets or sets a value indicating whether the input should always prompt the user regardless of there being a value or not.
         /// </summary>
         public bool AlwaysPrompt { get; set; } = false;
 
         /// <summary>
-        /// gets or sets intteruption policy.
+        /// Gets or sets intteruption policy.
         /// </summary>
         public AllowInterruptions AllowInterruptions { get; set; } = AllowInterruptions.NotRecognized;
 
@@ -116,9 +116,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 return Dialog.EndOfTurn;
             }
 
-            var stepCount = dc.State.GetValue<int>(TurnPath.STEPCOUNT, () => 0);
+            var interrupted = dc.State.GetValue<bool>(TurnPath.INTERRUPTED, () => false);
 
-            if (stepCount > 0)
+            if (interrupted)
             {
                 return await this.PromptUser(dc, InputState.Missing).ConfigureAwait(false);
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Constants/TurnPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Constants/TurnPath.cs
@@ -23,14 +23,14 @@
         public const string TOPINTENT = "turn.recognized.intent";
 
         /// <summary>
-        /// Path to the top scoe
+        /// Path to the top score
         /// </summary>
         public const string TOPSCORE = "turn.recognized.score";
 
         /// <summary>
-        /// Current step count
+        /// If true an interruption has occured
         /// </summary>
-        public const string STEPCOUNT = "turn.stepCount";
+        public const string INTERRUPTED = "turn.interrupted";
 
         /// <summary>
         /// The current dialog event (set during event processings)


### PR DESCRIPTION
Fix for #2425 

Added a new `turn.interrupted` flag that set anytime an "ActivityReceived" event is handled within an `AdaptiveDialog`.  The `InputDialog` now checks for this flag instead of using `turn.stepCount`.

Removed `turn.stepCount` all together.