### PR TITLE
Fix LanguageGeneration initialization with no resourceExplorer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FolderResourceProvider.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FolderResourceProvider.cs
@@ -85,17 +85,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// GetResource by id.
         /// </summary>
         /// <param name="id">Resource ID.</param>
-        /// <returns>Resource.</returns>
-        public IResource GetResource(string id)
+        /// <param name="resource">the found resource </param>
+        /// <returns>true if resource was found.</returns>
+        public bool TryGetResource(string id, out IResource resource)
         {
             lock (this.resources)
             {
                 if (this.resources.TryGetValue(id, out FileResource fileResource))
                 {
-                    return fileResource;
+                    resource = fileResource;
+                    return true;
                 }
 
-                throw new ArgumentException($"Could not find resource '{id}'", paramName: id);
+                resource = null;
+                return false;
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/IResourceProvider.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/IResourceProvider.cs
@@ -18,8 +18,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// Get resource by id.
         /// </summary>
         /// <param name="id">Resource id.</param>
-        /// <returns>The resource.</returns>
-        IResource GetResource(string id);
+        /// <param name="resource">resource</param>
+        /// <returns>true if resource is found</returns>
+        bool TryGetResource(string id, out IResource resource);
 
         /// <summary>
         /// enumerate resources.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -157,22 +157,38 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         }
 
         /// <summary>
-        /// Get resource by filename.
+        /// Get resource by id
         /// </summary>
-        /// <param name="id">The file name.</param>
-        /// <returns>The resource.</returns>
+        /// <param name="id">The resource id .</param>
+        /// <returns>The resource, or throws if not found.</returns>
         public IResource GetResource(string id)
+        {
+            if (TryGetResource(id, out var resource))
+            {
+                return resource;
+            }
+
+            throw new ArgumentException($"Could not find resource '{id}'", paramName: id);
+        }
+
+        /// <summary>
+        /// Try to get the resource by id
+        /// </summary>
+        /// <param name="id">id</param>
+        /// <param name="resource">resource that was found or null</param>
+        /// <returns>true if found</returns>
+        public bool TryGetResource(string id, out IResource resource)
         {
             foreach (var resourceProvider in this.resourceProviders)
             {
-                var resource = resourceProvider.GetResource(id);
-                if (resource != null)
+                if (resourceProvider.TryGetResource(id, out resource))
                 {
-                    return resource;
+                    return true;
                 }
             }
 
-            return null;
+            resource = null;
+            return false;
         }
 
         public void Dispose()

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration.Templates/LGAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration.Templates/LGAdapterExtensions.cs
@@ -18,31 +18,31 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// Register default LG file as language generation.
         /// </summary>
         /// <param name="botAdapter">The <see cref="BotAdapter"/> to add services to.</param>
-        /// <param name="resourceExplorer">resource explorer.</param>
+        /// <param name="resourceExplorer">resource explorer to use for .lg based resources.</param>
         /// <param name="defaultLg">Default LG Resource Id (default: main.lg).</param>
-        /// <param name="messageGenerator">Optional message generator.</param>
         /// <returns>The BotAdapter.</returns>
         public static BotAdapter UseLanguageGeneration(
             this BotAdapter botAdapter,
-            ResourceExplorer resourceExplorer,
-            string defaultLg = null,
-            IActivityGenerator messageGenerator = null)
+            ResourceExplorer resourceExplorer = null,
+            string defaultLg = null)
         {
             if (defaultLg == null)
             {
                 defaultLg = "main.lg";
             }
 
-            DeclarativeTypeLoader.AddComponent(new LanguageGenerationComponentRegistration());
-
-            // if there is no main.lg, then provide default engine (for inline expression evaluation only)
-            if (resourceExplorer.GetResource(defaultLg) == null)
+            if (resourceExplorer == null)
             {
-                botAdapter.UseLanguageGeneration(resourceExplorer, new TemplateEngineLanguageGenerator(string.Empty, defaultLg, LanguageGeneratorManager.ResourceResolver(resourceExplorer)));
+                resourceExplorer = new ResourceExplorer();
+            }
+
+            if (resourceExplorer.TryGetResource(defaultLg, out var resource))
+            {
+                botAdapter.UseLanguageGeneration(resourceExplorer, new ResourceMultiLanguageGenerator(defaultLg));
             }
             else
             {
-                botAdapter.UseLanguageGeneration(resourceExplorer, new ResourceMultiLanguageGenerator(defaultLg));
+                botAdapter.UseLanguageGeneration(resourceExplorer, new TemplateEngineLanguageGenerator(string.Empty, defaultLg, LanguageGeneratorManager.ResourceResolver(resourceExplorer)));
             }
 
             return botAdapter;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -315,11 +315,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                 .Use(new TranscriptLoggerMiddleware(new FileTranscriptLogger()));
 
             var resource = resourceExplorer.GetResource(resourceName);
-            if (resource == null)
-            {
-                throw new Exception($"Resource[{resourceName}] not found");
-            }
-
             var dialog = DeclarativeTypeLoader.Load<Dialog>(resource, resourceExplorer, DebugSupport.SourceRegistry);
             DialogManager dm = new DialogManager(dialog);
 


### PR DESCRIPTION
Fix for #2525  
- Create empty ResourceExplorer
- Change to TryGetResource() semantics for IResourceProvider (we actually don't want a provider to throw)
- Create unit test around no ResourceExplorer