### PR TITLE
Move the SIGNASSEMBLY precompiler directive so the setting can be tak…

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/Microsoft.Bot.Builder.Adapters.Twilio.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/Microsoft.Bot.Builder.Adapters.Twilio.csproj
@@ -20,6 +20,9 @@
     <AssemblyOriginatorKeyFile>..\..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\Microsoft.Bot.Builder.Adapters.Twilio.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SignAssembly)'=='true' ">
     <DefineConstants>SIGNASSEMBLY</DefineConstants>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
@@ -10,6 +10,9 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SignAssembly)'=='true' ">
     <DefineConstants>SIGNASSEMBLY</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
…en off the command line, thus avoiding warning MSB3052.