### PR TITLE
Remove Expressions library dependency from .dialogs assembly 

### DIFF
--- a/Microsoft.Bot.Builder(Preview).sln
+++ b/Microsoft.Bot.Builder(Preview).sln
@@ -1,0 +1,493 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29001.49
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{4269F3C3-6B42-419B-B64A-3E6DC0F1574A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{AD743B78-D61F-4FBF-B620-FA83CE599A50}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Azure", "libraries\Microsoft.Bot.Builder.Azure\Microsoft.Bot.Builder.Azure.csproj", "{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.QnA.Tests", "tests\Microsoft.Bot.Builder.AI.QnA.Tests\Microsoft.Bot.Builder.AI.QnA.Tests.csproj", "{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Azure.Tests", "tests\Microsoft.Bot.Builder.Azure.Tests\Microsoft.Bot.Builder.Azure.Tests.csproj", "{E325A0E2-716A-49E0-9767-5087CF05727C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Connector", "libraries\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj", "{6462DA5D-27DC-4CD5-9467-5EFB998FD838}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Schema", "libraries\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj", "{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder", "libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj", "{ADA8AB8B-2066-4193-B8F7-985669B23E00}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Connector.Tests", "tests\Microsoft.Bot.Connector.Tests\Microsoft.Bot.Connector.Tests.csproj", "{BF414C86-DB3B-4022-9B29-DCE8AA954C12}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{276EBE79-A13A-46BD-A566-B01DC0477A9B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.Luis", "libraries\Microsoft.Bot.Builder.AI.LUIS\Microsoft.Bot.Builder.AI.Luis.csproj", "{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.Luis.Tests", "tests\Microsoft.Bot.Builder.AI.LUIS.Tests\Microsoft.Bot.Builder.AI.Luis.Tests.csproj", "{7BCEBDC1-D57F-4717-9B15-4FACD5473489}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.AspNet.Core", "libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj", "{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TemplateManager", "libraries\Microsoft.Bot.Builder.TemplateManager\Microsoft.Bot.Builder.TemplateManager.csproj", "{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TemplateManager.Tests", "tests\Microsoft.Bot.Builder.TemplateManager\Microsoft.Bot.Builder.TemplateManager.Tests.csproj", "{C93F6192-0123-4121-AD92-374A71E4B0F3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Schema.Tests", "tests\Microsoft.Bot.Schema.Tests\Microsoft.Bot.Schema.Tests.csproj", "{A4184239-F13F-4A09-B2D3-0B9532609248}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.QnA", "libraries\Microsoft.Bot.Builder.AI.QnA\Microsoft.Bot.Builder.AI.QnA.csproj", "{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AI", "AI", "{763168FA-A590-482C-84D8-2922F7ADB1A2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs", "libraries\Microsoft.Bot.Builder.Dialogs\Microsoft.Bot.Builder.Dialogs.csproj", "{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Tests\Microsoft.Bot.Builder.Dialogs.Tests.csproj", "{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.AspNet.Core.Tests", "tests\integration\Microsoft.Bot.Builder.Integration.AspNet.Core.Tests\Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj", "{62C4DC83-3B07-45D7-856E-224FFB368E5F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Tests", "tests\Microsoft.Bot.Builder.Tests\Microsoft.Bot.Builder.Tests.csproj", "{35F9B8A8-1974-4795-930B-5E4980EE85E5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Transcripts.Tests", "tests\Microsoft.Bot.Builder.Transcripts.Tests\Microsoft.Bot.Builder.Transcripts.Tests.csproj", "{71698D71-4C6F-40D5-8BDE-2587514CA21C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Configuration", "libraries\Microsoft.Bot.Configuration\Microsoft.Bot.Configuration.csproj", "{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Configuration.Tests", "tests\Microsoft.Bot.Configuration.Tests\Microsoft.Bot.Configuration.Tests.csproj", "{1B7920E6-5262-4054-B72D-3A8DBBA057D2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.ApplicationInsights.Core", "libraries\integration\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj", "{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.ApplicationInsights", "libraries\Microsoft.Bot.Builder.ApplicationInsights\Microsoft.Bot.Builder.ApplicationInsights.csproj", "{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.ApplicationInsights.Core.Tests", "tests\integration\Microsoft.Bot.ApplicationInsights.Core.Tests\Microsoft.Bot.ApplicationInsights.Core.Tests.csproj", "{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.ApplicationInsights.Tests", "tests\Microsoft.Bot.Builder.ApplicationInsights.Tests\Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj", "{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot", "tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj", "{C113E0AE-5564-4389-BA39-183A8D574210}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.FunctionalTests", "FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj", "{B9DDC8CB-8EDF-4D98-913A-22F19E642223}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FunctionalTests", "FunctionalTests", "{8667F820-8ADA-4498-91AE-AE95DEE5227E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing", "libraries\Microsoft.Bot.Builder.Testing\Microsoft.Bot.Builder.Testing.csproj", "{060F070A-BBFA-490E-BE89-3844C857B771}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing.Tests", "tests\Microsoft.Bot.Builder.Testing.Tests\Microsoft.Bot.Builder.Testing.Tests.csproj", "{E4E13301-9193-4106-B0E3-41276B478E7C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot.Tests", "tests\Microsoft.Bot.Builder.TestBot.Tests\Microsoft.Bot.Builder.TestBot.Tests.csproj", "{76391566-9F22-4994-8B0F-02EFC0E9E228}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Declarative", "libraries\Microsoft.Bot.Builder.Dialogs.Declarative\Microsoft.Bot.Builder.Dialogs.Declarative.csproj", "{1BC05915-044E-4776-8956-B44BBEFF2F84}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Adaptive", "libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\Microsoft.Bot.Builder.Dialogs.Adaptive.csproj", "{3CF175CF-1AF4-4109-96CB-221684DCED7D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Adaptive.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj", "{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.TriggerTrees", "libraries\Microsoft.Bot.Builder.AI.TriggerTrees\Microsoft.Bot.Builder.AI.TriggerTrees.csproj", "{A8BC2784-763B-4256-89ED-24DE029F9B38}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Expressions.Tests", "tests\Microsoft.Bot.Builder.Expressions.Tests\Microsoft.Bot.Builder.Expressions.Tests.csproj", "{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Expressions", "libraries\Microsoft.Bot.Builder.Expressions\Microsoft.Bot.Builder.Expressions.csproj", "{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Expressions.Parser", "libraries\Microsoft.Bot.Builder.Expressions.Parser\Microsoft.Bot.Builder.Expressions.Parser.csproj", "{FB2EA804-158C-4654-AD60-A2105AC366FF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Declarative.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Declarative.Tests\Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj", "{D5E70443-4BA2-42ED-992A-010268440B08}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.TriggerTrees.Tests", "tests\Microsoft.Bot.Builder.AI.TriggerTrees.Tests\Microsoft.Bot.Builder.AI.TriggerTrees.Tests.csproj", "{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Debugging", "libraries\Microsoft.Bot.Builder.Dialogs.Debugging\Microsoft.Bot.Builder.Dialogs.Debugging.csproj", "{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.LanguageGeneration", "libraries\Microsoft.Bot.Builder.LanguageGeneration\Microsoft.Bot.Builder.LanguageGeneration.csproj", "{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.LanguageGeneration.Templates", "libraries\Microsoft.Bot.Builder.LanguageGeneration.Templates\Microsoft.Bot.Builder.LanguageGeneration.Templates.csproj", "{97347C9A-A33B-453D-B176-0C3E13DC8D4F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Debugging.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Debugging.Tests\Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj", "{F59673EA-2D0D-441A-BB85-CD343DE6BE45}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.LanguageGeneration.Tests", "tests\Microsoft.Bot.Builder.LanguageGeneration.Tests\Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj", "{72EE26E2-E8BE-4169-82AD-93E021539C34}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.LanguageGeneration.Templates.Tests", "tests\Microsoft.Bot.Builder.LanguageGeneration.Templates.Tests\Microsoft.Bot.Builder.LanguageGeneration.Templates.Tests.csproj", "{240646C5-EFCB-4CF1-AF8E-7036558CD78C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.StreamingExtensions", "libraries\Microsoft.Bot.StreamingExtensions\Microsoft.Bot.StreamingExtensions.csproj", "{038E1C00-13D6-4923-870E-CD5A97ED97B3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.StreamingExtensions.Tests", "tests\Microsoft.Bot.StreamingExtensions.Test\Microsoft.Bot.StreamingExtensions.Tests.csproj", "{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.StreamingExtensions", "libraries\Microsoft.Bot.Builder.StreamingExtensions\Microsoft.Bot.Builder.StreamingExtensions.csproj", "{BDCAC491-8518-4CE6-B56A-9E36936C7E70}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B6AFE9D-6FA5-4699-B0EB-62335FD431C8}"
+	ProjectSection(SolutionItems) = preProject
+		BotBuilder-DotNet.ruleset = BotBuilder-DotNet.ruleset
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Schemas", "Schemas", "{EE56F2B6-4995-4E8F-ACFF-310AF0A4DA0F}"
+	ProjectSection(SolutionItems) = preProject
+		schemas\baseComponent.schema = schemas\baseComponent.schema
+		schemas\component.schema = schemas\component.schema
+		schemas\readme.md = schemas\readme.md
+		schemas\sdk.schema = schemas\sdk.schema
+		schemas\update.cmd = schemas\update.cmd
+		schemas\updateBranch.cmd = schemas\updateBranch.cmd
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot.Json", "tests\Microsoft.Bot.Builder.TestBot.Json\Microsoft.Bot.Builder.TestBot.Json.csproj", "{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug - NuGet Packages|Any CPU = Debug - NuGet Packages|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Release|Any CPU.Build.0 = Release|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Release|Any CPU.Build.0 = Release|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug - NuGet Packages|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug - NuGet Packages|Any CPU.Build.0 = Debug - NuGet Packages|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8BC2784-763B-4256-89ED-24DE029F9B38}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8BC2784-763B-4256-89ED-24DE029F9B38}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{A8BC2784-763B-4256-89ED-24DE029F9B38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8BC2784-763B-4256-89ED-24DE029F9B38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8BC2784-763B-4256-89ED-24DE029F9B38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8BC2784-763B-4256-89ED-24DE029F9B38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB2EA804-158C-4654-AD60-A2105AC366FF}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB2EA804-158C-4654-AD60-A2105AC366FF}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{FB2EA804-158C-4654-AD60-A2105AC366FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB2EA804-158C-4654-AD60-A2105AC366FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB2EA804-158C-4654-AD60-A2105AC366FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB2EA804-158C-4654-AD60-A2105AC366FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug - NuGet Packages|Any CPU.ActiveCfg = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug - NuGet Packages|Any CPU.Build.0 = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{E325A0E2-716A-49E0-9767-5087CF05727C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{276EBE79-A13A-46BD-A566-B01DC0477A9B} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA} = {763168FA-A590-482C-84D8-2922F7ADB1A2}
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2} = {276EBE79-A13A-46BD-A566-B01DC0477A9B}
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{C93F6192-0123-4121-AD92-374A71E4B0F3} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{A4184239-F13F-4A09-B2D3-0B9532609248} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62} = {763168FA-A590-482C-84D8-2922F7ADB1A2}
+		{763168FA-A590-482C-84D8-2922F7ADB1A2} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F} = {0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8} = {276EBE79-A13A-46BD-A566-B01DC0477A9B}
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7} = {0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{C113E0AE-5564-4389-BA39-183A8D574210} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223} = {8667F820-8ADA-4498-91AE-AE95DEE5227E}
+		{060F070A-BBFA-490E-BE89-3844C857B771} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{E4E13301-9193-4106-B0E3-41276B478E7C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{76391566-9F22-4994-8B0F-02EFC0E9E228} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{1BC05915-044E-4776-8956-B44BBEFF2F84} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{A8BC2784-763B-4256-89ED-24DE029F9B38} = {763168FA-A590-482C-84D8-2922F7ADB1A2}
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{FB2EA804-158C-4654-AD60-A2105AC366FF} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{D5E70443-4BA2-42ED-992A-010268440B08} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{A9E5DD02-E633-46DC-B702-2ABA1AAC2851} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{97347C9A-A33B-453D-B176-0C3E13DC8D4F} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{72EE26E2-E8BE-4169-82AD-93E021539C34} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{240646C5-EFCB-4CF1-AF8E-7036558CD78C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{038E1C00-13D6-4923-870E-CD5A97ED97B3} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{B7DB6561-7D83-4706-9DE0-02C5520DE2B7} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{BDCAC491-8518-4CE6-B56A-9E36936C7E70} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7173C9F3-A7F9-496E-9078-9156E35D6E16}
+	EndGlobalSection
+EndGlobal

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/ExpressionPropertyConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/ExpressionPropertyConverter.cs
@@ -44,5 +44,4 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
             serializer.Serialize(writer, value);
         }
     }
-
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/ExpressionProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/ExpressionProperty.cs
@@ -12,7 +12,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative
     /// <typeparam name="T">type of object the expression should evaluate to</typeparam>
     public class ExpressionProperty<T> : IExpressionProperty
     {
+#pragma warning disable SA1401 // Fields should be private
         protected Expression expression;
+#pragma warning restore SA1401 // Fields should be private
 
         public ExpressionProperty()
         {
@@ -33,18 +35,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative
             this.Value = value;
         }
 
-        public void SetValue(object value)
-        {
-            if (value is string expression)
-            {
-                this.Expression = expression;
-            }
-            else
-            {
-                this.Value = ConvertObject(value);
-            }
-        }
-
         /// <summary>
         /// Gets or sets expression to use to get the value from data
         /// </summary>
@@ -59,6 +49,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative
         /// </summary>
         public T Value { get; set; }
 
+        /// <summary>
+        /// Set the value
+        /// </summary>
+        /// <param name="value">vfalue to set</param>
+        public virtual void SetValue(object value)
+        {
+            if (value is string expression)
+            {
+                this.Expression = expression;
+            }
+            else
+            {
+                this.Value = ConvertObject(value);
+            }
+        }
+
+        /// <summary>
+        /// Get the value 
+        /// </summary>
+        /// <param name="data">data to use for expression binding</param>
+        /// <returns>value</returns>
         public virtual T GetValue(object data)
         {
             if (Value != null)
@@ -81,8 +92,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative
         /// <remarks>
         /// This method is called whenever an object is fected via expression or is deserialized from raw text.
         /// </remarks>
-        /// <param name="result"></param>
-        /// <returns></returns>
+        /// <param name="result">result to convert to object of type T</param>
+        /// <returns>object of type T</returns>
         protected virtual T ConvertObject(object result)
         {
             if (result is T)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             path = this.TransformPath(path ?? throw new ArgumentNullException(nameof(path)));
             var memoryScope = this.ResolveMemoryScope(ref path);
             var memory = memoryScope.GetMemory(this.dialogContext);
-            return ObjectPath.TryGetValue<T>(memory, path, out value);
+            return ObjectPath.TryGetPathValue<T>(memory, path, out value);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             else
             {
                 var memory = memoryScope.GetMemory(this.dialogContext);
-                ObjectPath.SetValue(memory, path, value);
+                ObjectPath.SetPathValue(memory, path, value);
             }
         }
 
@@ -231,7 +231,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             path = this.TransformPath(path ?? throw new ArgumentNullException(nameof(path)));
             var memoryScope = this.ResolveMemoryScope(ref path);
             var memory = memoryScope.GetMemory(this.dialogContext);
-            ObjectPath.RemoveProperty(memory, path);
+            ObjectPath.RemovePathValue(memory, path);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -83,7 +83,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Bot.Builder.Expressions.Parser\Microsoft.Bot.Builder.Expressions.Parser.csproj" />
     <ProjectReference Include="..\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
   </ItemGroup>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -608,7 +608,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                                 Property = "user.color",
                                 Prompt = new ActivityTemplate("Please select a color:"),
                                 UnrecognizedPrompt = new ActivityTemplate("Please select a color:"),
-                                Choices= new ChoiceSet("user.choices"),
+                                Choices = new ChoiceSet("user.choices"),
                                 AlwaysPrompt = true,
                                 Style = ListStyle.Inline
                             },

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ExpressionPropertyTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ExpressionPropertyTests.cs
@@ -145,6 +145,5 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             Assert.AreEqual("Test", foo.Name);
             Assert.AreEqual(22, foo.Age);
         }
-
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs.Memory;
 using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
@@ -27,12 +28,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 var memory = memoryScope.GetMemory(dc);
                 Assert.IsNotNull(memory, "should get memory without any set");
-                ObjectPath.SetValue(memory, "test", 15);
+                ObjectPath.SetPathValue(memory, "test", 15);
                 memory = memoryScope.GetMemory(dc);
-                Assert.AreEqual(15, ObjectPath.GetValue<int>(memory, "test"), "Should roundtrip memory");
-                ObjectPath.SetValue(memory, "test", 25);
+                Assert.AreEqual(15, ObjectPath.GetPathValue<int>(memory, "test"), "Should roundtrip memory");
+                ObjectPath.SetPathValue(memory, "test", 25);
                 memory = memoryScope.GetMemory(dc);
-                Assert.AreEqual(25, ObjectPath.GetValue<int>(memory, "test"), "Should roundtrip memory2");
+                Assert.AreEqual(25, ObjectPath.GetPathValue<int>(memory, "test"), "Should roundtrip memory2");
             }
         }
 
@@ -127,9 +128,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         private void ValidateValue(DialogContext dc, string alias, string path)
         {
-            Assert.IsNotNull(dc.State.GetValue<object>(path));
-            Assert.IsNotNull(dc.State.GetValue<object>(alias));
-            Assert.AreEqual(dc.State.GetValue<object>(alias), dc.State.GetValue<object>(path), $"{alias} should be same as {path}");
+            var p = dc.State.GetValue<object>(path);
+            Assert.IsNotNull(p);
+            var a = dc.State.GetValue<object>(alias);
+            Assert.IsNotNull(a);
+
+            Assert.AreEqual(JsonConvert.SerializeObject(p), JsonConvert.SerializeObject(a), $"{alias} should be same as {path}");
         }
 
         private void ValidateRemoveValue(DialogContext dc, string alias, string path)

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Templates.Tests/LGGeneratorTests.cs
@@ -246,7 +246,6 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             return new TestFlow(adapter, handler);
         }
-
     }
 
     public class MockLanguageGenerator : ILanguageGenerator


### PR DESCRIPTION
Rewrote ObjectPath to not rely on expression library.
Add unit tests to verify all functionality