### PR TITLE
Fix telemetry for custom adapters

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ApplicationBuilderExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ApplicationBuilderExtensions.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
         /// </summary>
         /// <param name="applicationBuilder">The <see cref="IApplicationBuilder"/>.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
+        // This class has been deprecated in favor of using TelemetryInitializerMiddleware in
+        // Microsoft.Bot.Integration.ApplicationInsights.Core and Microsoft.Bot.Integration.ApplicationInsights.WebApi
+        [Obsolete("This class is deprecated. Please add TelemetryInitializerMiddleware to your adapter's middleware pipeline instead.")]
         public static IApplicationBuilder UseBotApplicationInsights(this IApplicationBuilder applicationBuilder)
         {
             if (applicationBuilder == null)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
 
             if (items != null)
             {
-                if ((telemetry is RequestTelemetry || telemetry is EventTelemetry || telemetry is TraceTelemetry)
+                if ((telemetry is RequestTelemetry || telemetry is EventTelemetry
+                    || telemetry is TraceTelemetry || telemetry is DependencyTelemetry)
                     && items.ContainsKey(BotActivityKey))
                 {
                     if (items[BotActivityKey] is JObject body)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
 
                         var conversationId = string.Empty;
                         var conversation = body["conversation"];
-                        if (!string.IsNullOrWhiteSpace(conversation.ToString()))
+                        if (!string.IsNullOrWhiteSpace(conversation?.ToString()))
                         {
                             conversationId = (string)conversation["id"];
                         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(context);
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(context);
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
+{
+    /// <summary>
+    /// Middleware for storing incoming activity on the HttpContext to make it available to the <see cref="TelemetryBotIdInitializer"/>.
+    /// </summary>
+    public class TelemetryInitializerMiddleware : IMiddleware
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryInitializerMiddleware"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The IHttpContextAccessor to allow access to the HttpContext.</param>
+        public TelemetryInitializerMiddleware(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        }
+
+        /// <summary>
+        /// Stores the incoming activity as JSON in the items collection on the HttpContext.
+        /// </summary>
+        /// <param name="context">The context object for this turn.</param>
+        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <seealso cref="ITurnContext"/>
+        /// <seealso cref="Bot.Schema.IActivity"/>
+        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        {
+            BotAssert.ContextNotNull(context);
+
+            if (context.Activity != null)
+            {
+                var activity = context.Activity;
+
+                var httpContext = _httpContextAccessor.HttpContext;
+                var items = httpContext?.Items;
+
+                var activityJson = JObject.FromObject(activity);
+
+                if (items.ContainsKey(TelemetryBotIdInitializer.BotActivityKey))
+                {
+                    items.Remove(TelemetryBotIdInitializer.BotActivityKey);
+                }
+
+                items.Add(TelemetryBotIdInitializer.BotActivityKey, activityJson);
+            }
+
+            await nextTurn(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
@@ -11,6 +11,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
 {
+    // This class has been deprecated in favor of using TelemetryInitializerMiddleware in
+    // Microsoft.Bot.Integration.ApplicationInsights.Core and Microsoft.Bot.Integration.ApplicationInsights.WebApi
+    [Obsolete("This class is deprecated. Please add TelemetryInitializerMiddleware to your adapter's middleware pipeline instead.")]
     public class TelemetrySaveBodyASPMiddleware
     {
         private readonly RequestDelegate _next;

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
             {
                 CacheBody();
 
-                if (telemetry is RequestTelemetry || telemetry is EventTelemetry || telemetry is TraceTelemetry)
+                if (telemetry is RequestTelemetry || telemetry is EventTelemetry
+                    || telemetry is TraceTelemetry || telemetry is DependencyTelemetry)
                 {
                     if (items[BotActivityKey] is JObject body)
                     {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
                     {
                         var userId = string.Empty;
                         var from = body["from"];
-                        if (!string.IsNullOrWhiteSpace(from.ToString()))
+                        if (!string.IsNullOrWhiteSpace(from?.ToString()))
                         {
                             userId = (string)from["id"];
                         }
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
 
                         var conversationId = string.Empty;
                         var conversation = body["conversation"];
-                        if (!string.IsNullOrWhiteSpace(conversation.ToString()))
+                        if (!string.IsNullOrWhiteSpace(conversation?.ToString()))
                         {
                             conversationId = (string)conversation["id"];
                         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryInitializerMiddleware.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(context);
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryInitializerMiddleware.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
+{
+    /// <summary>
+    /// Middleware for storing incoming activity on the HttpContext to make it available to the <see cref="TelemetryBotIdInitializer"/>.
+    /// </summary>
+    public class TelemetryInitializerMiddleware : IMiddleware
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TelemetryInitializerMiddleware"/> class.
+        /// </summary>
+        public TelemetryInitializerMiddleware()
+        {
+        }
+
+        /// <summary>
+        /// Stores the incoming activity as JSON in the items collection on the HttpContext.
+        /// </summary>
+        /// <param name="context">The context object for this turn.</param>
+        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <seealso cref="ITurnContext"/>
+        /// <seealso cref="Bot.Schema.IActivity"/>
+        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        {
+            BotAssert.ContextNotNull(context);
+
+            if (context.Activity != null)
+            {
+                var activity = context.Activity;
+
+                var httpContext = HttpContext.Current;
+                var items = httpContext?.Items;
+
+                var activityJson = JObject.FromObject(activity);
+
+                items.Add(TelemetryBotIdInitializer.BotActivityKey, activityJson);
+            }
+
+            await nextTurn(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryInitializerMiddleware.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             BotAssert.ContextNotNull(context);
 

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -236,6 +238,52 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         }
 
         [TestMethod]
+        public void VerifyDependencyProperties()
+        {
+            var configuration = new TelemetryConfiguration();
+            var sentItems = new List<ITelemetry>();
+            var mockTelemetryChannel = new Mock<ITelemetryChannel>();
+            mockTelemetryChannel.Setup(c => c.Send(It.IsAny<ITelemetry>()))
+                            .Callback<ITelemetry>((telemetry) => sentItems.Add(telemetry))
+                            .Verifiable();
+            configuration.TelemetryChannel = mockTelemetryChannel.Object;
+            configuration.InstrumentationKey = Guid.NewGuid().ToString();
+
+            // Mock http context
+            var httpContext = new Mock<HttpContext>();
+            IDictionary<object, object> items = new Dictionary<object, object>();
+            httpContext.SetupProperty(c => c.Items, items);
+            var httpContextAccessor = new Mock<IHttpContextAccessor>();
+            httpContextAccessor.SetupProperty(c => c.HttpContext, httpContext.Object);
+
+            // Simulate what Middleware does to read body
+            var fromID = "FROMID";
+            var channelID = "CHANNELID";
+            var conversationID = "CONVERSATIONID";
+            var activityID = "ACTIVITYID";
+            var activity = Activity.CreateMessageActivity();
+            activity.From = new ChannelAccount(fromID);
+            activity.ChannelId = channelID;
+            activity.Conversation = new ConversationAccount(false, "CONVOTYPE", conversationID);
+            activity.Id = activityID;
+            var activityBody = JObject.FromObject(activity);
+            items.Add(TelemetryBotIdInitializer.BotActivityKey, activityBody);
+            configuration.TelemetryInitializers.Add(new TelemetryBotIdInitializer(httpContextAccessor.Object));
+            var telemetryClient = new TelemetryClient(configuration);
+
+            telemetryClient.TrackDependency("Foo", "Bar", "Data", DateTimeOffset.Now, TimeSpan.FromSeconds(1.0), true);
+
+            Assert.IsTrue(sentItems.Count == 1);
+            var telem = sentItems[0] as DependencyTelemetry;
+            Assert.IsTrue(telem != null);
+            Assert.IsTrue(telem.Properties["activityId"] == activityID);
+            Assert.IsTrue(telem.Properties["activityType"] == "message");
+            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
+            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+        }
+
+        [TestMethod]
         public void InvalidMessage_NoConversation()
         {
             var configuration = new TelemetryConfiguration();
@@ -279,6 +327,94 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
             Assert.IsTrue(telem.Properties["hello"] == "value");
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+        }
+
+        [TestMethod]
+        [TestCategory("Telemetry")]
+        public async Task Telemetry_InitializerMiddleware_LogActivities_Enabled()
+        {
+            // Arrange
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
+            var mockHttpContextAccessor = new Mock<HttpContextAccessor>();
+            mockHttpContextAccessor.Object.HttpContext = new DefaultHttpContext();
+
+            var adapter = new TestAdapter()
+                .Use(new TelemetryInitializerMiddleware(
+                    mockHttpContextAccessor.Object,
+                    new TelemetryLoggerMiddleware(mockTelemetryClient.Object, false),
+                    logActivityTelemetry: true));
+            string conversationId = null;
+
+            // Act
+            // Default case logging Send/Receive Activities
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                conversationId = context.Activity.Conversation.Id;
+                var typingActivity = new Activity
+                {
+                    Type = ActivityTypes.Typing,
+                    RelatesTo = context.Activity.RelatesTo,
+                };
+                await context.SendActivityAsync(typingActivity);
+                await Task.Delay(500);
+                await context.SendActivityAsync("echo:" + context.Activity.Text);
+            })
+                .Send("foo")
+                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:foo")
+                .Send("bar")
+                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:bar")
+                .StartTestAsync();
+
+            // Assert
+            Assert.IsNotNull(mockHttpContextAccessor.Object.HttpContext.Items);
+            Assert.IsTrue(mockHttpContextAccessor.Object.HttpContext.Items.Count == 1);
+            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 6);
+        }
+
+        [TestMethod]
+        [TestCategory("Telemetry")]
+        public async Task Telemetry_InitializerMiddleware_LogActivities_Disabled()
+        {
+            // Arrange
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
+            var mockHttpContextAccessor = new Mock<HttpContextAccessor>();
+            mockHttpContextAccessor.Object.HttpContext = new DefaultHttpContext();
+
+            var adapter = new TestAdapter()
+                .Use(new TelemetryInitializerMiddleware(
+                    mockHttpContextAccessor.Object,
+                    new TelemetryLoggerMiddleware(mockTelemetryClient.Object, false),
+                    logActivityTelemetry: false));
+            string conversationId = null;
+
+            // Act
+            // Default case logging Send/Receive Activities
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                conversationId = context.Activity.Conversation.Id;
+                var typingActivity = new Activity
+                {
+                    Type = ActivityTypes.Typing,
+                    RelatesTo = context.Activity.RelatesTo,
+                };
+                await context.SendActivityAsync(typingActivity);
+                await Task.Delay(500);
+                await context.SendActivityAsync("echo:" + context.Activity.Text);
+            })
+                .Send("foo")
+                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:foo")
+                .Send("bar")
+                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:bar")
+                .StartTestAsync();
+
+            // Assert
+            Assert.IsNotNull(mockHttpContextAccessor.Object.HttpContext.Items);
+            Assert.IsTrue(mockHttpContextAccessor.Object.HttpContext.Items.Count == 1);
+            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 0);
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/TelemetryInitializerTests.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
+namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
 {
     [TestClass]
     [TestCategory("ApplicationInsights")]
@@ -150,6 +150,51 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             Assert.IsTrue(sentItems.Count == 1);
             var telem = sentItems[0] as RequestTelemetry;
+            Assert.IsTrue(telem != null);
+            Assert.IsTrue(telem.Properties["activityId"] == activityID);
+            Assert.IsTrue(telem.Properties["activityType"] == "message");
+            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
+            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+        }
+
+        [TestMethod]
+        public void VerifyDependencyProperties()
+        {
+            var configuration = new TelemetryConfiguration();
+            var sentItems = new List<ITelemetry>();
+            var mockTelemetryChannel = new Mock<ITelemetryChannel>();
+            mockTelemetryChannel.Setup(c => c.Send(It.IsAny<ITelemetry>()))
+                            .Callback<ITelemetry>((telemetry) => sentItems.Add(telemetry))
+                            .Verifiable();
+            configuration.TelemetryChannel = mockTelemetryChannel.Object;
+            configuration.InstrumentationKey = Guid.NewGuid().ToString();
+
+            // Mock http context
+            var httpContext = new HttpContext(
+                    new HttpRequest(string.Empty, "http://google.com", string.Empty),
+                    new HttpResponse(new StringWriter()));
+            HttpContext.Current = httpContext;
+
+            // Simulate what Middleware does to read body
+            var fromID = "FROMID";
+            var channelID = "CHANNELID";
+            var conversationID = "CONVERSATIONID";
+            var activityID = "ACTIVITYID";
+            var activity = Activity.CreateMessageActivity();
+            activity.From = new ChannelAccount(fromID);
+            activity.ChannelId = channelID;
+            activity.Conversation = new ConversationAccount(false, "CONVOTYPE", conversationID);
+            activity.Id = activityID;
+            var activityBody = JObject.FromObject(activity);
+            HttpContext.Current.Items.Add(TelemetryBotIdInitializer.BotActivityKey, activityBody);
+            configuration.TelemetryInitializers.Add(new TelemetryBotIdInitializer());
+            var telemetryClient = new TelemetryClient(configuration);
+
+            telemetryClient.TrackDependency("Foo", "Bar", "Data", DateTimeOffset.Now, TimeSpan.FromSeconds(1.0), true);
+
+            Assert.IsTrue(sentItems.Count == 1);
+            var telem = sentItems[0] as DependencyTelemetry;
             Assert.IsTrue(telem != null);
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");


### PR DESCRIPTION
Fixes: #2477 
Fixes: #2474 

This change introduces TelemetryInitializerMiddleware, as a replacement for the current TelemetrySaveBodyASPMiddleware.  Marking this PR as review for now until a few people have their chance to review, given a few conversations last week with @munozemilio @daveta among others. 

This existing method stores the incoming http request body in the HttpContext.Items collection.  This is later used by the TelemetryBotIdInitializer classes within the integration libraries to parse the request and set conversation / user / activity channel IDs on outgoing Application Insights requests. The current problem is that the current method assumes an incoming request is a Bot Framework Activity, but if a custom adapter is used, the incoming http request may be something different. This change moves the responsibility for storing the activity in HttpContext.Items into the new middleware class.  This ensures that it can be used by custom adapters and will store an activity once it has been transformed by the adapter.

This is a non-breaking change, given that the existing method using the TelemetrySaveBodyASPMiddleware can be used alongside the new middleware.  However, I have marked the existing methods as obselete as a prompt to users to start to use the new TelemetryInitialzerMiddleware.

I have tested the following scenarios, where all existing telemetry (including RequestTelemetry and EventTelemetry) is captured correctly.

- Bot Framework adapter using the new middleware
- Bot Framework adapter using the new middleware & old method along side
- Custom adapter (Alexa community adapter) using the new middleware
- Custom adapter (Alexa community adapter) using the new middleware & old method along side

TODO:

- Update the Core Bot App Insights sample
- Update the telemetry docs if required
- Identify if this custom adapter issue exists within the other languages and raise parity issues if required
