### PR TITLE
fix http adapter errors

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -62,6 +62,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             // deserialize the incoming Activity
             var activity = HttpHelper.ReadRequest(httpRequest);
 
+            if (string.IsNullOrEmpty(activity?.Type))
+            {
+                httpResponse.StatusCode = (int)HttpStatusCode.BadRequest;
+                return;
+            }
+
             // grab the auth header from the inbound http request
             var authHeader = httpRequest.Headers["Authorization"];
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/HttpHelper.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/HttpHelper.cs
@@ -28,19 +28,26 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
         public static Activity ReadRequest(HttpRequest request)
         {
-            if (request == null)
+            try
             {
-                throw new ArgumentNullException(nameof(request));
+                if (request == null)
+                {
+                    throw new ArgumentNullException(nameof(request));
+                }
+
+                var activity = default(Activity);
+
+                using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)))
+                {
+                    activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                }
+
+                return activity;
             }
-
-            var activity = default(Activity);
-
-            using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)))
+            catch (JsonException)
             {
-                activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                return null;
             }
-
-            return activity;
         }
 
         public static void WriteResponse(HttpResponse response, InvokeResponse invokeResponse)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
@@ -46,6 +46,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
             // deserialize the incoming Activity
             var activity = await HttpHelper.ReadRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 
+            if (string.IsNullOrEmpty(activity?.Type))
+            {
+                httpResponse.StatusCode = HttpStatusCode.BadRequest;
+                return;
+            }
+
             // grab the auth header from the inbound http request
             var authHeader = httpRequest.Headers.Authorization?.ToString();
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpHelper.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpHelper.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Formatting;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
 {
@@ -33,8 +34,19 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
                 throw new ArgumentNullException(nameof(request));
             }
 
-            var activity = await request.Content.ReadAsAsync<Activity>(BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
-            return activity;
+            try
+            {
+                var activity = await request.Content.ReadAsAsync<Activity>(BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
+                return activity;
+            }
+            catch (UnsupportedMediaTypeException)
+            {
+                return null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
         }
 
         public static void WriteResponse(HttpRequestMessage request, HttpResponseMessage response, InvokeResponse invokeResponse)

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests/BotFrameworkHttpAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests/BotFrameworkHttpAdapterTests.cs
@@ -86,6 +86,27 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests
             mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
+        [Fact]
+        public async Task BadRequest()
+        {
+            // Arrange
+            var httpRequest = new HttpRequestMessage();
+            httpRequest.Content = new StringContent("this.is.not.json", Encoding.UTF8, "application/json");
+
+            var httpResponse = new HttpResponseMessage();
+
+            var botMock = new Mock<IBot>();
+            botMock.Setup(b => b.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            // Act
+            var adapter = new BotFrameworkHttpAdapter();
+            await adapter.ProcessAsync(httpRequest, httpResponse, botMock.Object);
+
+            // Assert
+            botMock.Verify(m => m.OnTurnAsync(It.Is<TurnContext>(tc => true), It.Is<CancellationToken>(ct => true)), Times.Never());
+            Assert.Equal(HttpStatusCode.BadRequest, httpResponse.StatusCode);
+        }
+
         private static HttpContent CreateMessageActivityContent()
         {
             return CreateContent(new Activity


### PR DESCRIPTION
Both integration implementations return BadRequest when called with something other than an Activity.

An Activity being something that can be serialized into an Activity with a Type. All fields other than Type are optional. Technically at any one release, Type is restricted in what values it can take, however, this is not practical to constrain at this level (it is handled in the ActivityHandler layer.)

