### PR TITLE
[Teams] Allow null response from OnTeamsTaskModuleSubmitAsync

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.Teams/TeamsActivityHandler.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Bot.Builder.Teams
                         {
                             return CreateInvokeResponse(new TaskModuleResponse { Task = submitResponse });
                         }
+
                     default:
                         return null;
                 }

--- a/libraries/Microsoft.Bot.Builder.Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.Teams/TeamsActivityHandler.cs
@@ -153,8 +153,14 @@ namespace Microsoft.Bot.Builder.Teams
 
                     case "task/submit":
                         var submitResponse = await OnTeamsTaskModuleSubmitAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false);
-                        return CreateInvokeResponse(new TaskModuleResponse { Task = submitResponse });
-
+                        if (submitResponse == null)
+                        {
+                            return CreateInvokeResponse();
+                        }
+                        else
+                        {
+                            return CreateInvokeResponse(new TaskModuleResponse { Task = submitResponse });
+                        }
                     default:
                         return null;
                 }


### PR DESCRIPTION
(testing infrastructure needs updating to more easily test varied responses to event handlers ... no additional unit tests for this right now)