### PR TITLE
Fix DialogStateManager to property return the object in the debugger

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
 
         public ICollection<string> Keys => MemoryScopes.Select(ms => ms.Name).ToList();
 
-        public ICollection<object> Values => MemoryScopes.Cast<object>().ToList();
+        public ICollection<object> Values => MemoryScopes.Select(ms => ms.GetMemory(this.dialogContext)).ToList();
 
         public int Count => MemoryScopes.Count;
 
@@ -290,7 +290,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             foreach (var ms in MemoryScopes)
             {
-                array[arrayIndex++] = new KeyValuePair<string, object>(ms.Name, ms);
+                array[arrayIndex++] = new KeyValuePair<string, object>(ms.Name, ms.GetMemory(this.dialogContext));
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             foreach (var ms in MemoryScopes)
             {
-                yield return new KeyValuePair<string, object>(ms.Name, ms);
+                yield return new KeyValuePair<string, object>(ms.Name, ms.GetMemory(this.dialogContext));
             }
         }
 
@@ -311,7 +311,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             foreach (var ms in MemoryScopes)
             {
-                yield return new KeyValuePair<string, object>(ms.Name, ms);
+                yield return new KeyValuePair<string, object>(ms.Name, ms.GetMemory(this.dialogContext));
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            return dc.Parent?.ActiveDialog?.State ?? dc.ActiveDialog.State;
+            return dc.Parent?.ActiveDialog?.State ?? dc.ActiveDialog?.State;
         }
 
         public override void SetMemory(DialogContext dc, object memory)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Bot.Builder.Expressions.Parser;
 using Microsoft.Bot.Builder.LanguageGeneration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
@@ -200,6 +201,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             Assert.AreEqual(null, state.GetValue<string>("user.xxx"));
             Assert.AreEqual("default", state.GetValue<string>("user.xxx", () => "default"));
+
+            foreach (var key in state.Keys)
+            {
+                Assert.AreEqual(state.GetValue<object>(key), state[key]);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
DialogStateManager implements IDictionary<string, object> but the implementation of the methods were sometimes returning the MemoryScope object instead of the object behind the MemoryScope, preventing the debugger inspector from looking at the value of the memory scope.

This fixes that.