### PR TITLE
CosmosDbPartitionedStorage using v3 SDK.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -106,10 +106,11 @@ namespace Microsoft.Bot.Builder.Azure
 
             foreach (var documentStoreItem in documentStoreItems)
             {
+                var item = documentStoreItem.Document.ToObject(typeof(object), _jsonSerializer);
                 if (documentStoreItem is IStoreItem storeItem)
                 {
                     storeItem.ETag = documentStoreItem.ETag;
-                    storeItems.Add(documentStoreItem.RealId, storeItem);
+                    storeItems.Add(documentStoreItem.RealId, item);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Azure
+{
+    /// <summary>
+    /// Implements an CosmosDB based storage provider using partitioning for a bot.
+    /// </summary>
+    public class CosmosDbPartitionedStorage : IStorage
+    {
+        private readonly JsonSerializer _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+
+        private Container _container;
+        private readonly CosmosDbPartitionedStorageOptions _cosmosDbStorageOptions;
+        private CosmosClient _client;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosDbPartitionedStorage"/> class.
+        /// using the provided CosmosDB credentials, database ID, and container ID.
+        /// </summary>
+        /// <param name="cosmosDbStorageOptions">Cosmos DB partitioned storage configuration options.</param>
+        public CosmosDbPartitionedStorage(CosmosDbPartitionedStorageOptions cosmosDbStorageOptions)
+        {
+            if (cosmosDbStorageOptions == null)
+            {
+                throw new ArgumentNullException(nameof(cosmosDbStorageOptions));
+            }
+
+            if (cosmosDbStorageOptions.CosmosDbEndpoint == null)
+            {
+                throw new ArgumentNullException(nameof(cosmosDbStorageOptions.CosmosDbEndpoint), "Service EndPoint for CosmosDB is required.");
+            }
+
+            if (string.IsNullOrEmpty(cosmosDbStorageOptions.AuthKey))
+            {
+                throw new ArgumentException("AuthKey for CosmosDB is required.", nameof(cosmosDbStorageOptions.AuthKey));
+            }
+
+            if (string.IsNullOrEmpty(cosmosDbStorageOptions.DatabaseId))
+            {
+                throw new ArgumentException("DatabaseId is required.", nameof(cosmosDbStorageOptions.DatabaseId));
+            }
+
+            if (string.IsNullOrEmpty(cosmosDbStorageOptions.ContainerId))
+            {
+                throw new ArgumentException("ContainerId is required.", nameof(cosmosDbStorageOptions.ContainerId));
+            }
+
+            _cosmosDbStorageOptions = cosmosDbStorageOptions;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosDbPartitionedStorage"/> class.
+        /// using the provided CosmosDB credentials, database ID, and collection ID.
+        /// </summary>
+        /// <param name="cosmosDbStorageOptions">Cosmos DB partitioned storage configuration options.</param>
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.All.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
+        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// </param>
+        public CosmosDbPartitionedStorage(CosmosDbPartitionedStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer)
+            : this(cosmosDbStorageOptions)
+        {
+            _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
+        }
+
+        public async Task<IDictionary<string, object>> ReadAsync(string[] keys, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (keys == null)
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
+            if (keys.Length == 0)
+            {
+                // No keys passed in, no result to return.
+                return new Dictionary<string, object>();
+            }
+
+            // Ensure Initialization has been run
+            await InitializeAsync().ConfigureAwait(false);
+
+            var resultSetIterator = _container.GetItemQueryIterator<DocumentStoreItem>(
+                requestOptions: new QueryRequestOptions()
+                {
+                    PartitionKey = new PartitionKey(keys[0]),
+                });
+
+            var documentStoreItems = new List<DocumentStoreItem>(keys.Length);
+            while (resultSetIterator.HasMoreResults)
+            {
+                documentStoreItems.AddRange(await resultSetIterator.ReadNextAsync(cancellationToken).ConfigureAwait(false));
+            }
+
+            var storeItems = new Dictionary<string, object>(keys.Length);
+
+            foreach (var documentStoreItem in documentStoreItems)
+            {
+                if (documentStoreItem is IStoreItem storeItem)
+                {
+                    storeItem.ETag = documentStoreItem.ETag;
+                    storeItems.Add(documentStoreItem.RealId, storeItem);
+                }
+            }
+
+            return storeItems;
+        }
+
+        public async Task WriteAsync(IDictionary<string, object> changes, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (changes == null)
+            {
+                throw new ArgumentNullException(nameof(changes));
+            }
+
+            if (changes.Count == 0)
+            {
+                return;
+            }
+
+            // Ensure Initialization has been run
+            await InitializeAsync().ConfigureAwait(false);
+
+            foreach (var change in changes)
+            {
+                var json = JObject.FromObject(change.Value, _jsonSerializer);
+
+                // Remove etag from JSON object that was copied from IStoreItem.
+                // The ETag information is updated as an _etag attribute in the document metadata.
+                json.Remove("eTag");
+
+                var documentChange = new DocumentStoreItem
+                {
+                    Id = CosmosDbKeyEscape.EscapeKey(change.Key),
+                    RealId = change.Key,
+                    Document = json,
+                };
+
+                var etag = (change.Value as IStoreItem)?.ETag;
+                if (etag == null || etag == "*")
+                {
+                    // if new item or * then insert or replace unconditionally
+                    await _container.UpsertItemAsync(
+                            documentChange,
+                            new PartitionKey(documentChange.PartitionKey),
+                            cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else if (etag.Length > 0)
+                {
+                    // if we have an etag, do opt. concurrency replace
+                    await _container.UpsertItemAsync(
+                            documentChange,
+                            new PartitionKey(documentChange.PartitionKey),
+                            new ItemRequestOptions() { IfMatchEtag = etag, },
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    throw new Exception("etag empty");
+                }
+            }
+        }
+
+        public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            foreach (var key in keys)
+            {
+                await _container.DeleteItemAsync<DocumentStoreItem>(
+                    partitionKey: new PartitionKey(key),
+                    id: CosmosDbKeyEscape.EscapeKey(key),
+                    cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Connects to the CosmosDB database and creates / gets the container.
+        /// </summary>
+        private async Task InitializeAsync()
+        {
+            if (_container == null)
+            {
+                var cosmosClientOptions = _cosmosDbStorageOptions.CosmosClientOptions ?? new CosmosClientOptions();
+
+                _client = new CosmosClient(
+                    _cosmosDbStorageOptions.CosmosDbEndpoint,
+                    _cosmosDbStorageOptions.AuthKey,
+                    cosmosClientOptions);
+
+                _container = await _client
+                        .GetDatabase(_cosmosDbStorageOptions.DatabaseId)
+                        .CreateContainerIfNotExistsAsync(
+                            _cosmosDbStorageOptions.ContainerId,
+                            DocumentStoreItem.PartitionKeyPath,
+                            _cosmosDbStorageOptions.ContainerThroughput)
+                        .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Internal data structure for storing items in a CosmosDB Collection.
+        /// </summary>
+        private class DocumentStoreItem
+        {
+            /// <summary>
+            /// Gets the PartitionKey path to be used for this document type.
+            /// </summary>
+            public static string PartitionKeyPath => "/realId";
+
+            /// <summary>
+            /// Gets or sets the sanitized Id/Key used as PrimaryKey.
+            /// </summary>
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            /// <summary>
+            /// Gets or sets the un-sanitized Id/Key.
+            /// </summary>
+            /// <remarks>
+            /// Note: There is a Typo in the property name ("RealId"), that can't be changed due to compatability concerns. The
+            /// Json is correct due to the JsonProperty field, but the Typo needs to stay.
+            /// </remarks>
+            [JsonProperty("realId")]
+            public string RealId { get; internal set; }
+
+            /// <summary>
+            /// Gets or sets the persisted object.
+            /// </summary>
+            [JsonProperty("document")]
+            public JObject Document { get; set; }
+
+            /// <summary>
+            /// Gets or sets the ETag information for handling optimistic concurrency updates.
+            /// </summary>
+            [JsonProperty("_etag")]
+            public string ETag { get; set; }
+
+            /// <summary>
+            /// Gets the PartitionKey value for the document.
+            /// </summary>
+            public string PartitionKey => this.RealId;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Internal data structure for storing items in a CosmosDB Collection.
         /// </summary>
-        private class DocumentStoreItem
+        private class DocumentStoreItem : IStoreItem
         {
             /// <summary>
             /// Gets the PartitionKey path to be used for this document type.

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+
+namespace Microsoft.Bot.Builder.Azure
+{
+    /// <summary>
+    /// Cosmos DB Partitioned Storage Options.
+    /// </summary>
+    public class CosmosDbPartitionedStorageOptions
+    {
+        /// <summary>
+        /// Gets or sets the CosmosDB endpoint.
+        /// </summary>
+        /// <value>
+        /// The CosmosDB endpoint.
+        /// </value>
+        public string CosmosDbEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the authentication key for Cosmos DB.
+        /// </summary>
+        /// <value>
+        /// The authentication key for Cosmos DB.
+        /// </value>
+        public string AuthKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the database identifier for Cosmos DB instance.
+        /// </summary>
+        /// <value>
+        /// The database identifier for Cosmos DB instance.
+        /// </value>
+        public string DatabaseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the container identifier.
+        /// </summary>
+        /// <value>
+        /// The container identifier.
+        /// </value>
+        public string ContainerId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the options for the CosmosClient.
+        /// </summary>
+        /// <value>
+        /// The options for use with the CosmosClient.
+        /// </value>
+        public CosmosClientOptions CosmosClientOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the throughput set when creating the Container. Defaults to 400.
+        /// </summary>
+        /// <value>
+        /// Container throughput. Defaults to 400.
+        /// </value>
+        public int ContainerThroughput { get; set; } = 400;
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -37,11 +37,12 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' == '' " Version="4.0.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(PackageVersion)' != '' " Version="$(PackageVersion)" />
   </ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -1,0 +1,348 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    [TestClass]
+    [TestCategory("Storage")]
+    [TestCategory("Storage - CosmosDB Partitioned")]
+    public class CosmosDbPartitionStorageTests : StorageBaseTests
+    {
+        // Endpoint and Authkey for the CosmosDB Emulator running locally
+        private const string CosmosServiceEndpoint = "https://localhost:8081";
+        private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string CosmosDatabaseName = "test-db";
+        private const string CosmosCollectionName = "bot-storage";
+
+        private const string _noEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
+        private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
+        private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
+        {
+            if (File.Exists(_emulatorPath))
+            {
+                var p = new Process
+                {
+                    StartInfo =
+                    {
+                        UseShellExecute = true,
+                        FileName = _emulatorPath,
+                        Arguments = "/GetStatus",
+                    },
+                };
+                p.Start();
+                p.WaitForExit();
+
+                return p.ExitCode == 2;
+            }
+
+            return false;
+        });
+
+        private IStorage _storage;
+
+        [ClassInitialize]
+        public static async Task AllTestsInitialize(TestContext testContext)
+        {
+            if (_hasEmulator.Value)
+            {
+                var client = new CosmosClient(
+                    CosmosServiceEndpoint,
+                    CosmosAuthKey,
+                    new CosmosClientOptions());
+
+                await client.CreateDatabaseIfNotExistsAsync(CosmosDatabaseName);
+            }
+        }
+
+        // Use ClassCleanup to run code after all tests in a class have run
+        [ClassCleanup]
+        public static async Task AllTestsCleanup()
+        {
+            var client = new CosmosClient(
+                CosmosServiceEndpoint,
+                CosmosAuthKey,
+                new CosmosClientOptions());
+            try
+            {
+                await client.GetDatabase(CosmosDatabaseName).DeleteAsync();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Error cleaning up resources: {0}", ex.ToString());
+            }
+        }
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            if (_hasEmulator.Value)
+            {
+                _storage = new CosmosDbPartitionedStorage(
+                    new CosmosDbPartitionedStorageOptions
+                    {
+                        AuthKey = CosmosAuthKey,
+                        ContainerId = CosmosCollectionName,
+                        CosmosDbEndpoint = CosmosServiceEndpoint,
+                        DatabaseId = CosmosDatabaseName,
+                    });
+            }
+        }
+
+        [TestCleanup]
+        public async Task TestCleanUp()
+        {
+            _storage = null;
+        }
+
+        [TestMethod]
+        public void Constructor_Should_Throw_On_InvalidOptions()
+        {
+            // No Options. Should throw.
+            Assert.ThrowsException<ArgumentNullException>(() => new CosmosDbPartitionedStorage(null));
+
+            // No Endpoint. Should throw.
+            Assert.ThrowsException<ArgumentNullException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                AuthKey = "test",
+                ContainerId = "testId",
+                DatabaseId = "testDb",
+                CosmosDbEndpoint = null,
+            }));
+
+            // No Auth Key. Should throw.
+            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                AuthKey = null,
+                ContainerId = "testId",
+                DatabaseId = "testDb",
+                CosmosDbEndpoint = "testEndpoint",
+            }));
+
+            // No Database Id. Should throw.
+            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                AuthKey = "testAuthKey",
+                ContainerId = "testId",
+                DatabaseId = null,
+                CosmosDbEndpoint = "testEndpoint",
+            }));
+
+            // No Container Id. Should throw.
+            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                AuthKey = "testAuthKey",
+                ContainerId = null,
+                DatabaseId = "testDb",
+                CosmosDbEndpoint = "testEndpoint",
+            }));
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task CreateObjectTest()
+        {
+            if (CheckEmulator())
+            {
+                await CreateObjectTest(_storage);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task ReadUnknownTest()
+        {
+            if (CheckEmulator())
+            {
+                await ReadUnknownTest(_storage);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task UpdateObjectTest()
+        {
+            if (CheckEmulator())
+            {
+                await UpdateObjectTest(_storage);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task DeleteObjectTest()
+        {
+            if (CheckEmulator())
+            {
+                await DeleteObjectTest(_storage);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task HandleCrazyKeys()
+        {
+            if (CheckEmulator())
+            {
+                await HandleCrazyKeys(_storage);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task ReadingEmptyKeysReturnsEmptyDictionary()
+        {
+            if (CheckEmulator())
+            {
+                var state = await _storage.ReadAsync(new string[] { });
+                Assert.IsInstanceOfType(state, typeof(Dictionary<string, object>));
+                Assert.AreEqual(state.Count, 0);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task ReadingNullKeysThrowException()
+        {
+            if (CheckEmulator())
+            {
+                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.ReadAsync(null));
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task WritingNullStoreItemsThrowException()
+        {
+            if (CheckEmulator())
+            {
+                await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await _storage.WriteAsync(null));
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        [TestMethod]
+        public async Task WritingNoStoreItemsDoesntThrow()
+        {
+            if (CheckEmulator())
+            {
+                var changes = new Dictionary<string, object>();
+                await _storage.WriteAsync(changes);
+            }
+        }
+
+        // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        // For issue https://github.com/Microsoft/botbuilder-dotnet/issues/871
+        // See the linked issue for details. This issue was happening when using the CosmosDB
+        // data store for state. The stepIndex, which was an object being cast to an Int64
+        // after deserialization, was throwing an exception for not being Int32 datatype.
+        // This test checks to make sure that this error is no longer thrown.
+        //
+        // The problem was reintroduced when the prompt retry count feature was implemented:
+        // https://github.com/microsoft/botbuilder-dotnet/issues/1859
+        // The waterfall in this test has been modified to include a prompt.
+        [TestMethod]
+        public async Task WaterfallCosmos()
+        {
+            if (CheckEmulator())
+            {
+                var convoState = new ConversationState(_storage);
+
+                var adapter = new TestAdapter()
+                    .Use(new AutoSaveStateMiddleware(convoState));
+
+                var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+                var dialogs = new DialogSet(dialogState);
+
+                dialogs.Add(new TextPrompt(nameof(TextPrompt), async (promptContext, cancellationToken) =>
+                {
+                    var result = promptContext.Recognized.Value;
+                    if (result.Length > 3)
+                    {
+                        var succeededMessage = MessageFactory.Text($"You got it at the {promptContext.AttemptCount}th try!");
+                        await promptContext.Context.SendActivityAsync(succeededMessage, cancellationToken);
+                        return true;
+                    }
+
+                    var reply = MessageFactory.Text($"Please send a name that is longer than 3 characters. {promptContext.AttemptCount}");
+                    await promptContext.Context.SendActivityAsync(reply, cancellationToken);
+
+                    return false;
+                }));
+
+                var steps = new WaterfallStep[]
+                    {
+                        async (stepContext, ct) =>
+                        {
+                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
+                            await stepContext.Context.SendActivityAsync("step1");
+                            return Dialog.EndOfTurn;
+                        },
+                        async (stepContext, ct) =>
+                        {
+                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
+                            return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please type your name.") }, ct);
+                        },
+                        async (stepContext, ct) =>
+                        {
+                            Assert.AreEqual(stepContext.ActiveDialog.State["stepIndex"].GetType(), typeof(int));
+                            await stepContext.Context.SendActivityAsync("step3");
+                            return Dialog.EndOfTurn;
+                        },
+                    };
+
+                dialogs.Add(new WaterfallDialog(nameof(WaterfallDialog), steps));
+
+                await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext);
+
+                    await dc.ContinueDialogAsync();
+                    if (!turnContext.Responded)
+                    {
+                        await dc.BeginDialogAsync(nameof(WaterfallDialog));
+                    }
+                })
+                    .Send("hello")
+                    .AssertReply("step1")
+                    .Send("hello")
+                    .AssertReply("Please type your name.")
+                    .Send("hi")
+                    .AssertReply("Please send a name that is longer than 3 characters. 1")
+                    .Send("hi")
+                    .AssertReply("Please send a name that is longer than 3 characters. 2")
+                    .Send("hi")
+                    .AssertReply("Please send a name that is longer than 3 characters. 3")
+                    .Send("Kyle")
+                    .AssertReply("You got it at the 4th try!")
+                    .AssertReply("step3")
+                    .StartTestAsync();
+            }
+        }
+
+        public bool CheckEmulator()
+        {
+            if (!_hasEmulator.Value)
+            {
+                Assert.Inconclusive(_noEmulatorMessage);
+            }
+
+            if (Debugger.IsAttached)
+            {
+                Assert.IsTrue(_hasEmulator.Value, _noEmulatorMessage);
+            }
+
+            return _hasEmulator.Value;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/StorageBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/StorageBaseTests.cs
@@ -154,7 +154,10 @@ namespace Microsoft.Bot.Builder.Tests
             // write with empty etag should not work
             try
             {
-                var reloadedStoreItem4 = (await storage.ReadAsync(new[] { "pocoStoreItem" })).OfType<PocoStoreItem>().First();
+                var reloadedStoreItems4 = await storage.ReadAsync(new[] { "pocoStoreItem" });
+                var reloadedStoreItem4 = reloadedStoreItems4["pocoStoreItem"] as PocoStoreItem;
+
+                Assert.IsNotNull(reloadedStoreItem4);
 
                 reloadedStoreItem4.ETag = string.Empty;
                 var dict2 = new Dictionary<string, object>()


### PR DESCRIPTION
Addresses DCR #5467 https://github.com/microsoft/botframework-sdk/issues/5467 

@cleemullins @mdrichardson This is the initial version of the new CosmosDbPartitionedStorage class - I would appreciate your review before I move any further forward.

- The new implementation no longer handles database creation.  We only handle container creation.
- Uses the new v3 SDK
- Implements partitioning for the user, with the option to pass in a key now gone.  We utilize the ID of the item as the partition key.

Tests still need adding following initial review.

