### PR TITLE
Sync read of request body throws on .netcore 3.0

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             }
 
             // deserialize the incoming Activity
-            var activity = HttpHelper.ReadRequest(httpRequest);
+            var activity = await HttpHelper.ReadRequestAsync(httpRequest).ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(activity?.Type))
             {
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 var invokeResponse = await ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
                 // write the response, potentially serializing the InvokeResponse
-                HttpHelper.WriteResponse(httpResponse, invokeResponse);
+                await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
             }
             catch (UnauthorizedAccessException)
             {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/HttpHelper.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/HttpHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest.Serialization;
@@ -26,7 +27,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             Converters = new List<JsonConverter> { new Iso8601TimeSpanConverter() },
         });
 
-        public static Activity ReadRequest(HttpRequest request)
+        public static async Task<Activity> ReadRequestAsync(HttpRequest request)
         {
             try
             {
@@ -37,9 +38,14 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
                 var activity = default(Activity);
 
-                using (var bodyReader = new JsonTextReader(new StreamReader(request.Body, Encoding.UTF8)))
+                using (var memoryStream = new MemoryStream())
                 {
-                    activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                    await request.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8)))
+                    {
+                        activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                    }
                 }
 
                 return activity;
@@ -50,7 +56,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             }
         }
 
-        public static void WriteResponse(HttpResponse response, InvokeResponse invokeResponse)
+        public static async Task WriteResponseAsync(HttpResponse response, InvokeResponse invokeResponse)
         {
             if (response == null)
             {
@@ -69,12 +75,18 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 {
                     response.ContentType = "application/json";
 
-                    using (var writer = new StreamWriter(response.Body))
+                    using (var memoryStream = new MemoryStream())
                     {
-                        using (var jsonWriter = new JsonTextWriter(writer))
+                        using (var writer = new StreamWriter(memoryStream, Encoding.UTF8, 1024, true))
                         {
-                            BotMessageSerializer.Serialize(jsonWriter, invokeResponse.Body);
+                            using (var jsonWriter = new JsonTextWriter(writer))
+                            {
+                                BotMessageSerializer.Serialize(jsonWriter, invokeResponse.Body);
+                            }
                         }
+
+                        memoryStream.Seek(0, SeekOrigin.Begin);
+                        await memoryStream.CopyToAsync(response.Body).ConfigureAwait(false);
                     }
                 }
             }


### PR DESCRIPTION
Serializing http request and response bodies async from memorystream, to avoid .netcore3 sync IO restrictions.
This PR does not address similar issues in Twilio, WebEx and ApplicationInsights projects.

An alternative option would be to use System.Text.Json with superior performance (memory and CPU), but serialization settings would need to be regression tested + it would introduce a new dependency to this package.