### PR TITLE
Allow sub-template access to global memory scope

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -738,7 +738,7 @@ namespace Microsoft.Bot.Builder.Expressions
         /// <param name="instance">Instance with property.</param>
         /// <param name="property">Property to lookup.</param>
         /// <returns>Value and error information if any.</returns>
-        private static (object value, string error) AccessProperty(object instance, string property)
+        public static (object value, string error) AccessProperty(object instance, string property)
         {
             // NOTE: This returns null rather than an error if property is not present
             if (instance == null)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemoryScope.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Bot.Builder.Expressions;
+
+namespace Microsoft.Bot.Builder.LanguageGeneration
+{
+    internal class CustomizedMemoryScope : IDictionary<string, object>
+    {
+        public CustomizedMemoryScope(object localScope, object globalScope)
+        {
+            this.LocalScope = localScope;
+            this.GlobalScope = globalScope;
+        }
+
+        public object LocalScope { get; set; }
+
+        public object GlobalScope { get; set; }
+
+        public ICollection<string> Keys => throw new NotImplementedException();
+
+        public ICollection<object> Values => throw new NotImplementedException();
+
+        public int Count => throw new NotImplementedException();
+
+        public bool IsReadOnly => throw new NotImplementedException();
+
+        public object this[string key] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public void Add(string key, object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Add(KeyValuePair<string, object> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(KeyValuePair<string, object> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ContainsKey(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(KeyValuePair<string, object> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            var (result, error) = BuiltInFunctions.AccessProperty(this.LocalScope, key);
+            if (result != null && error == null)
+            {
+                value = result;
+                return true;
+            }
+
+            (result, error) = BuiltInFunctions.AccessProperty(this.GlobalScope, key);
+            if (result != null && error == null)
+            {
+                value = result;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemoryScope.cs
@@ -6,6 +6,11 @@ using Microsoft.Bot.Builder.Expressions;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
+    /// <summary>
+    /// This customzied memory scope is designed for allow sub template evaluation can refer
+    /// to the orignial evaluation scope passed in by wrap the orignal one in globalScope field
+    /// and inherit that for each sub evaluation 
+    /// </summary>
     internal class CustomizedMemoryScope : IDictionary<string, object>
     {
         public CustomizedMemoryScope(object localScope, object globalScope)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -158,16 +158,27 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public object ConstructScope(string templateName, List<object> args)
         {
             var parameters = TemplateMap[templateName].Parameters;
+            var currentScope = CurrentTarget().Scope;
 
             if (args.Count == 0)
             {
                 // no args to construct, inherit from current scope
-                return CurrentTarget().Scope;
+                return currentScope;
             }
 
             var newScope = parameters.Zip(args, (k, v) => new { k, v })
                                     .ToDictionary(x => x.k, x => x.v);
-            return newScope;
+
+            if (currentScope is CustomizedMemoryScope cms)
+            {
+                // if current scope is already customized, inherit it's global scope
+                return new CustomizedMemoryScope(newScope, cms.GlobalScope);
+
+            } else
+            {
+                return new CustomizedMemoryScope(newScope, currentScope);
+            }
+            
         }
 
         private bool EvalCondition(LGFileParser.IfConditionContext condition)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -173,8 +173,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 // if current scope is already customized, inherit it's global scope
                 return new CustomizedMemoryScope(newScope, cms.GlobalScope);
-
-            } else
+            }
+            else
             {
                 return new CustomizedMemoryScope(newScope, currentScope);
             }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/MemoryScope.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/MemoryScope.lg
@@ -6,3 +6,9 @@
 
 # T3(location)
 - {location} is a beautiful place, how many burgers do you want, {turn.count}?
+
+# AskBread
+- [AskEnum("Bread")]
+
+# AskEnum(prop)
+- Which {prop}, {join(schema[prop].enum, ' or ')} do you want?

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/MemoryScope.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/MemoryScope.lg
@@ -1,0 +1,8 @@
+﻿# T1
+- {T2("Seattle")}
+
+# T2(city)
+- Hi {turn.name}, welcome to {city}, {T3(city)}
+
+# T3(location)
+- {location} is a beautiful place, how many burgers do you want, {turn.count}?

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -238,6 +238,9 @@
     <None Update="Examples\lgTemplate.lg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Examples\MemoryScope.lg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\TemplateAsFunction.lg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -734,7 +734,6 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             });
 
             Assert.AreEqual(evaled, "Which Bread, A or B do you want?");
-
         }
 
         private string GetExampleFilePath(string fileName)

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var todos = new[] { "A", "B", "C" };
             evaled = engine.EvaluateTemplate("showTodo", new { todos });
             Assert.AreEqual(evaled.Replace("\r\n", "\n"), "\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    ");
-            
+
             evaled = engine.EvaluateTemplate("showTodo", null);
             Assert.AreEqual(evaled.Replace("\r\n", "\n"), "\n    You don't have any \"t\\\\odo'\".\n    ");
         }
@@ -715,8 +715,26 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestMemoryScope()
         {
             var engine = new TemplateEngine().AddFile(GetExampleFilePath("MemoryScope.lg"));
-            var evaled = engine.EvaluateTemplate("T1", new { turn = new { name = "Dong", count = 3} });
+            var evaled = engine.EvaluateTemplate("T1", new { turn = new { name = "Dong", count = 3 } });
             Assert.AreEqual(evaled, "Hi Dong, welcome to Seattle, Seattle is a beautiful place, how many burgers do you want, 3?");
+
+            evaled = engine.EvaluateTemplate("AskBread", new
+            {
+                schema = new Dictionary<string, object>()
+                {
+                    {
+                        "Bread", new Dictionary<string, object>()
+                        {
+                            {
+                                "enum", new List<string>() { "A", "B" }
+                            }
+                        }
+                    }
+                }
+            });
+
+            Assert.AreEqual(evaled, "Which Bread, A or B do you want?");
+
         }
 
         private string GetExampleFilePath(string fileName)

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -710,6 +710,15 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(lgResource.Templates[0].Body.Replace("\r\n", "\n"), "- Hi\n- Hello\n- Hiya\n- Hi");
         }
 
+
+        [TestMethod]
+        public void TestMemoryScope()
+        {
+            var engine = new TemplateEngine().AddFile(GetExampleFilePath("MemoryScope.lg"));
+            var evaled = engine.EvaluateTemplate("T1", new { turn = new { name = "Dong", count = 3} });
+            Assert.AreEqual(evaled, "Hi Dong, welcome to Seattle, Seattle is a beautiful place, how many burgers do you want, 3?");
+        }
+
         private string GetExampleFilePath(string fileName)
         {
             return Path.Combine(AppContext.BaseDirectory, "Examples", fileName);


### PR DESCRIPTION
Fix https://github.com/microsoft/botbuilder-dotnet/issues/2612

A few notes:

1. It's implemented in similar approach like how DialogStateManager today injecting shortcuts into expression, by creating a "customized IDictionary<string, object>". 
    
    Those two cases are actually assuming the interface for a customized memory access pattern is IDictionary<string, object>. Which is too implicit, and maybe be true in the future because 

    a. we actually don't need a full IDictionary interface for a memory scope interface. you can see most interface methods are not implemented
    b. a IDictionary don't allow us to include the abstraction of memory stack which might be useful, it we really want a "cacading" memory expose. 

    we might want to reconsider to take https://github.com/microsoft/botbuilder-dotnet/pull/2468/files for an interface solely designed for memory access of expression. 

2.  because the IDictionary are evaluated key by key, which means our local\global search is also step by step (which could be not true if we accumulated the path), so, if local scope has "turn.a", but global have "turn.b",  then "turn.b" can't be accessed, because in first round, evaluating "turn", local scope is already been choosen. 