### PR TITLE
Allow simple computed paths

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     {
         private const string MEMORYSCOPESKEY = "MemoryScopes";
 
-        public MemoryScope(string name, bool isReadOnly=false)
+        public MemoryScope(string name, bool isReadOnly = false)
         {
             this.IsReadOnly = isReadOnly;
             this.Name = name;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
@@ -34,6 +34,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 ObjectPath.SetPathValue(memory, "test", 25);
                 memory = memoryScope.GetMemory(dc);
                 Assert.AreEqual(25, ObjectPath.GetPathValue<int>(memory, "test"), "Should roundtrip memory2");
+                memory = memoryScope.GetMemory(dc);
+                ObjectPath.SetPathValue(memory, "source", "destination");
+                ObjectPath.SetPathValue(memory, "{source}", 24);
+                Assert.AreEqual(24, ObjectPath.GetPathValue<int>(memory, "{source}"), "Roundtrip computed path");
+                ObjectPath.RemovePathValue(memory, "{source}");
+                Assert.AreEqual(false, ObjectPath.TryGetPathValue<int>(memory, "{source}", out var _), "Removed computed path");
+                ObjectPath.RemovePathValue(memory, "source");
+                Assert.AreEqual(false, ObjectPath.TryGetPathValue<int>(memory, "{source}", out var _), "No computed path");
             }
         }
 


### PR DESCRIPTION
Update state manager to allow simple computed paths via using curly braces.  Eventually this can be connected to the expression engine.