### PR TITLE
Fix OnTeamsMessagingExtensionBotMessagePreviewSendAsync to match js

### DIFF
--- a/tests/Teams/ActionBasedMessagingExtension-FetchTask/Bots/ActionBasedMessagingExtensionFetchTaskBot.cs
+++ b/tests/Teams/ActionBasedMessagingExtension-FetchTask/Bots/ActionBasedMessagingExtensionFetchTaskBot.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using AdaptiveCards;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Teams;
 using Microsoft.Bot.Schema;
@@ -26,17 +28,11 @@ namespace Microsoft.BotBuilderSamples.Bots
 
         protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
         {
-            var reply = MessageFactory.Text("OnTeamsMessagingExtensionFetchTaskAsync MessagingExtensionQuery: " + JsonConvert.SerializeObject(query));
-            await turnContext.SendActivityAsync(reply, cancellationToken);
-
             return AdaptiveCardHelper.CreateTaskModuleAdaptiveCardResponse();
         }
 
         protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionSubmitActionAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            var reply = MessageFactory.Text("OnTeamsMessagingExtensionSubmitActionAsync MessagingExtensionAction: " + JsonConvert.SerializeObject(action));
-            await turnContext.SendActivityAsync(reply, cancellationToken);
-
             var submittedData = JsonConvert.DeserializeObject<SubmitExampleData>(action.Data.ToString());
             var adaptiveCard = submittedData.ToAdaptiveCard();
             return adaptiveCard.ToMessagingExtensionBotMessagePreviewResponse();
@@ -44,9 +40,6 @@ namespace Microsoft.BotBuilderSamples.Bots
 
         protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            var reply = MessageFactory.Text("OnTeamsMessagingExtensionBotMessagePreviewEditAsync MessagingExtensionAction: " + JsonConvert.SerializeObject(action));
-            await turnContext.SendActivityAsync(reply, cancellationToken);
-
             var submitData = action.ToSubmitExampleData();
             return AdaptiveCardHelper.CreateTaskModuleAdaptiveCardResponse(
                                                         submitData.Question,
@@ -58,11 +51,31 @@ namespace Microsoft.BotBuilderSamples.Bots
 
         protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            var reply = MessageFactory.Text("OnTeamsMessagingExtensionBotMessagePreviewSendAsync MessagingExtensionAction: " + JsonConvert.SerializeObject(action));
-            await turnContext.SendActivityAsync(reply, cancellationToken);
-
             var submitData = action.ToSubmitExampleData();
             var adaptiveCard = submitData.ToAdaptiveCard();
+            var responseActivity = Activity.CreateMessageActivity();
+            Attachment attachment = new Attachment()
+            {
+                ContentType = AdaptiveCard.ContentType,
+                Content = adaptiveCard,
+            };
+            responseActivity.Attachments.Add(attachment);
+            try
+            {
+                // Send to channel where messaging extension invoked.
+                var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
+                await turnContext.TeamsCreateConversationAsync(channelData.Channel.Id, responseActivity);
+
+                // Send card to "General" channel.
+                var teamDetails = await TeamsInfo.GetTeamDetailsAsync(turnContext);
+                await turnContext.TeamsCreateConversationAsync(teamDetails.Id, responseActivity);
+            }
+            catch (Exception ex)
+            {
+                // In group chat or personal scope..
+                await turnContext.SendActivityAsync($"In Group Chat or Personal Teams scope. Sending card to compose-only.");
+            }
+
             return adaptiveCard.ToComposeExtensionResultResponse();
         }
 

--- a/tests/Teams/ActionBasedMessagingExtension-FetchTask/Bots/ActionBasedMessagingExtensionFetchTaskBot.cs
+++ b/tests/Teams/ActionBasedMessagingExtension-FetchTask/Bots/ActionBasedMessagingExtensionFetchTaskBot.cs
@@ -63,8 +63,8 @@ namespace Microsoft.BotBuilderSamples.Bots
             try
             {
                 // Send to channel where messaging extension invoked.
-                var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
-                await turnContext.TeamsCreateConversationAsync(channelData.Channel.Id, responseActivity);
+                var channelId = turnContext.Activity.TeamsGetChannelId();
+                await turnContext.TeamsCreateConversationAsync(channelId, responseActivity);
 
                 // Send card to "General" channel.
                 var teamDetails = await TeamsInfo.GetTeamDetailsAsync(turnContext);


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/2666
Fix `OnTeamsMessagingExtensionBotMessagePreviewSendAsync` to send the card to:
-  Teams "General" channel (Roster call to retrieve team).
-  Channel the messaging extension was started on.
-  Compose box for the user.
-  Cleanup send activities for other handlers.

Handles if user is in a group chat or personal scope..