### PR TITLE
Twilio / Webex / Invoke use Async for .NET Core 3 compat

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 throw new ArgumentNullException(nameof(bot));
             }
 
-            var activity = TwilioHelper.RequestToActivity(httpRequest, _options.ValidationUrl, _options.AuthToken);
+            var activity = await TwilioHelper.RequestToActivity(httpRequest, _options.ValidationUrl, _options.AuthToken).ConfigureAwait(false);
 
             // create a conversation reference
             using (var context = new TurnContext(this, activity))

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
@@ -69,7 +70,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// <returns>The activity object.</returns>
         /// <seealso cref="TwilioAdapter.ProcessAsync(HttpRequest, HttpResponse, IBot, System.Threading.CancellationToken)"/>
         /// <seealso cref="TwilioAdapterOptions.ValidationUrl"/>
-        public static Activity RequestToActivity(HttpRequest httpRequest, Uri validationUrl, string authToken)
+        public static async Task<Activity> RequestToActivity(HttpRequest httpRequest, Uri validationUrl, string authToken)
         {
             if (httpRequest == null)
             {
@@ -79,7 +80,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
             Dictionary<string, string> body;
             using (var bodyStream = new StreamReader(httpRequest.Body))
             {
-                body = QueryStringToDictionary(bodyStream.ReadToEnd());
+                body = QueryStringToDictionary(await bodyStream.ReadToEndAsync().ConfigureAwait(false));
             }
 
             ValidateRequest(httpRequest, body, validationUrl, authToken);

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             string json;
             using (var bodyStream = new StreamReader(request.Body))
             {
-                json = bodyStream.ReadToEnd();
+                json = await bodyStream.ReadToEndAsync().ConfigureAwait(false);
                 payload = JsonConvert.DeserializeObject<WebhookEventData>(json);
             }
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -16,23 +16,26 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     {
         protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, IAdapterIntegration adapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
-            var requestBody = request.Body;
-
-            // In the case of request buffering being enabled, we could possibly receive a Stream that needs its position reset,
-            // but we can't _blindly_ reset in case buffering hasn't been enabled since we'll be working with a non-seekable Stream
-            // in that case which will throw a NotSupportedException
-            if (requestBody.CanSeek)
-            {
-                requestBody.Position = 0;
-            }
-
             var activity = default(Activity);
 
-            // Get the request body and deserialize to the Activity object.
-            // NOTE: We explicitly leave the stream open here so others can still access it (in case buffering was enabled); ASP.NET runtime will always dispose of it anyway
-            using (var bodyReader = new JsonTextReader(new StreamReader(requestBody, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)))
+            using (var memoryStream = new MemoryStream())
             {
-                activity = BotMessageHandlerBase.BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                await request.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
+
+                // In the case of request buffering being enabled, we could possibly receive a Stream that needs its position reset,
+                // but we can't _blindly_ reset in case buffering hasn't been enabled since we'll be working with a non-seekable Stream
+                // in that case which will throw a NotSupportedException
+                if (request.Body.CanSeek)
+                {
+                    request.Body.Position = 0;
+                }
+
+                // Get the request body and deserialize to the Activity object.
+                // NOTE: We explicitly leave the stream open here so others can still access it (in case buffering was enabled); ASP.NET runtime will always dispose of it anyway
+                using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)))
+                {
+                    activity = BotMessageHandlerBase.BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                }
             }
 
 #pragma warning disable UseConfigureAwait // Use ConfigureAwait

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
@@ -289,22 +289,22 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public void RequestToActivity_Should_Return_Null_With_Null_HttpRequest()
+        public async void RequestToActivity_Should_Return_Null_With_Null_HttpRequest()
         {
-            Assert.Null(TwilioHelper.RequestToActivity(null, _validationUrlString, AuthTokenString));
+            Assert.Null(await TwilioHelper.RequestToActivity(null, _validationUrlString, AuthTokenString));
         }
 
         [Fact]
-        public void ValidateRequest_Should_Fail_With_NonMatching_Signature()
+        public async void ValidateRequest_Should_Fail_With_NonMatching_Signature()
         {
             var httpRequest = new Mock<HttpRequest>();
             httpRequest.SetupAllProperties();
             httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns("wrong_signature");
             httpRequest.Object.Body = Stream.Null;
 
-            Assert.Throws<AuthenticationException>(() =>
+            await Assert.ThrowsAsync<AuthenticationException>(async () =>
             {
-                TwilioHelper.RequestToActivity(httpRequest.Object, null, string.Empty);
+                await TwilioHelper.RequestToActivity(httpRequest.Object, null, string.Empty);
             });
         }
     }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Schema;
 using Moq;
@@ -78,7 +79,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public void QueryStringToDictionary_Should_Return_Empty_Dictionary_With_Empty_Query()
+        public async Task QueryStringToDictionary_Should_Return_Empty_Dictionary_With_Empty_Query()
         {
             var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AuthTokenString));
             var builder = new StringBuilder(_validationUrlString.ToString());
@@ -90,7 +91,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             httpRequest.SetupGet(req => req.Headers[It.IsAny<string>()]).Returns(hash);
             httpRequest.Object.Body = Stream.Null;
 
-            var activity = TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
+            var activity = await TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
 
             Assert.Null(activity.Id);
             Assert.Null(activity.Conversation.Id);
@@ -100,7 +101,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public void QueryStringToDictionary_Should_Return_Dictionary_With_Valid_Query()
+        public async Task QueryStringToDictionary_Should_Return_Dictionary_With_Valid_Query()
         {
             var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AuthTokenString));
             var builder = new StringBuilder(_validationUrlString.ToString());
@@ -139,7 +140,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             httpRequest.Object.Body = stream;
 
-            var activity = TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
+            var activity = await TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
 
             Assert.NotNull(activity.Id);
             Assert.NotNull(activity.Conversation.Id);
@@ -149,7 +150,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public void RequestToActivity_Should_Return_Null_Activity_Attachments_With_NumMedia_EqualToZero()
+        public async Task RequestToActivity_Should_Return_Null_Activity_Attachments_With_NumMedia_EqualToZero()
         {
             var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AuthTokenString));
             var builder = new StringBuilder(_validationUrlString.ToString());
@@ -188,13 +189,13 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             httpRequest.Object.Body = stream;
 
-            var activity = TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
+            var activity = await TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
 
             Assert.Null(activity.Attachments);
         }
 
         [Fact]
-        public void RequestToActivity_Should_Return_Activity_Attachments_With_NumMedia_GreaterThanZero()
+        public async Task RequestToActivity_Should_Return_Activity_Attachments_With_NumMedia_GreaterThanZero()
         {
             var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AuthTokenString));
             var builder = new StringBuilder(_validationUrlString.ToString());
@@ -233,13 +234,13 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             httpRequest.Object.Body = stream;
 
-            var activity = TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
+            var activity = await TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
 
             Assert.NotNull(activity.Attachments);
         }
 
         [Fact]
-        public void RequestToActivity_Should_NotThrow_KeyNotFoundException_With_NumMedia_GreaterThan_Attachments()
+        public async Task RequestToActivity_Should_NotThrow_KeyNotFoundException_With_NumMedia_GreaterThan_Attachments()
         {
             var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(AuthTokenString));
             var builder = new StringBuilder(_validationUrlString.ToString());
@@ -282,7 +283,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             httpRequest.Object.Body = stream;
 
-            var activity = TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
+            var activity = await TwilioHelper.RequestToActivity(httpRequest.Object, _validationUrlString, AuthTokenString);
 
             Assert.NotNull(activity.Attachments);
         }


### PR DESCRIPTION
Update Twilio / Webex and Invoke handlers to use async when reading request / writing to response for compatibility with .NET Core 3 in line with #2614 