### PR TITLE
Bring back lgTemplate function

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -226,6 +226,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public object ConstructScope(string templateName, List<object> args)
         {
+            if (!TemplateMap.ContainsKey(templateName))
+            {
+                throw new Exception($"No such template {templateName}");
+            }
+
             var parameters = TemplateMap[templateName].Parameters;
             var currentScope = CurrentTarget().Scope;
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -396,11 +396,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 return new ExpressionEvaluator(name, BuiltInFunctions.Apply(this.TemplateEvaluator(name)), ReturnType.Object, this.ValidTemplateReference);
             }
 
-            const string lgTempalte = "lgTemplate";
+            const string lgTemplate = "lgTemplate";
 
-            if (name.Equals(lgTempalte))
+            if (name.Equals(lgTemplate))
             {
-                return new ExpressionEvaluator(lgTempalte, BuiltInFunctions.Apply(this.LgTemplate()), ReturnType.Object, this.ValidateLgTemplate);
+                return new ExpressionEvaluator(lgTemplate, BuiltInFunctions.Apply(this.LgTemplate()), ReturnType.Object, this.ValidateLgTemplate);
             }
 
             return baseLookup(name);
@@ -437,7 +437,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var templateName = (children0 as Constant).Value.ToString();
                 if (!this.TemplateMap.ContainsKey(templateName))
                 {
-                    throw new Exception($"no such template '{templateName}' to call in {expression}");
+                    throw new Exception($"No such template '{templateName}' to call in {expression}");
                 }
 
                 var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count();
@@ -445,7 +445,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                 if (expectedArgsCount != actualArgsCount)
                 {
-                    throw new Exception($"arguments mismatch for template {templateName}, expect {expectedArgsCount} actual {actualArgsCount}");
+                    throw new Exception($"Arguments mismatch for template {templateName}, expect {expectedArgsCount} actual {actualArgsCount}");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 return new CustomizedMemoryScope(newScope, currentScope);
             }
-            
+
         }
 
         private bool EvalCondition(LGFileParser.IfConditionContext condition)
@@ -392,8 +392,60 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 return new ExpressionEvaluator(name, BuiltInFunctions.Apply(this.TemplateEvaluator(name)), ReturnType.Object, this.ValidTemplateReference);
             }
 
+            const string lgTempalte = "lgTemplate";
+
+            if (name.Equals(lgTempalte))
+            {
+                return new ExpressionEvaluator(lgTempalte, BuiltInFunctions.Apply(this.LgTemplate()), ReturnType.Object, this.ValidateLgTemplate);
+            }
+
             return baseLookup(name);
         };
+
+        // Evaluator for lgTemplate(templateName, ...args) 
+        // normal case we can just use templateName(...args), but lgTemplate is particularly useful when the template name is not pre-known
+        private Func<IReadOnlyList<object>, object> LgTemplate()
+        => (IReadOnlyList<object> args) =>
+        {
+            var templateName = args[0].ToString();
+            var newScope = this.ConstructScope(templateName, args.Skip(1).ToList());
+            return this.EvaluateTemplate(templateName, newScope);
+        };
+
+        private void ValidateLgTemplate(Expression expression)
+        {
+            if (expression.Children.Length == 0)
+            {
+                throw new Exception("No template name is provided when calling lgTemplate, expected: lgTemplate(templateName, ...args) ");
+            }
+
+            var children0 = expression.Children[0];
+
+            // Validate return type
+            if (children0.ReturnType != ReturnType.Object && children0.ReturnType != ReturnType.String)
+            {
+                throw new Exception($"{children0} can't be used as a template name, must be a string value");
+            }
+
+            // Validate more if the name is string constant
+            if (children0.Type == ExpressionType.Constant)
+            {
+                var templateName = (children0 as Constant).Value.ToString();
+                if (!this.TemplateMap.ContainsKey(templateName))
+                {
+                    throw new Exception($"no such template '{templateName}' to call in {expression}");
+                }
+
+                var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count();
+                var actualArgsCount = expression.Children.Length - 1;
+
+                if (expectedArgsCount != actualArgsCount)
+                {
+                    throw new Exception($"arguments mismatch for template {templateName}, expect {expectedArgsCount} actual {actualArgsCount}");
+                }
+            }
+        }
+
 
         private Func<IReadOnlyList<object>, object> TemplateEvaluator(string templateName)
         => (IReadOnlyList<object> args) =>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -247,7 +247,6 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 return new CustomizedMemoryScope(newScope, currentScope);
             }
-
         }
 
         private bool EvalCondition(LGFileParser.IfConditionContext condition)

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/6.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/6.lg
@@ -22,14 +22,6 @@
 # ShowAlarm(alarm)
 - {alarm.time} at {alarm.date}
 
-# ShowAlarms
-- IF: {count(alarms) == 1}
-   - You have one alarm [ShowAlarm(alarms[0])]
-- ELSEIF: {count(alarms) == 2}
-  - You have {count(alarms)} alarms, {join(alarms, ', ', ' and ')}
-- ELSE:
-  - You don't have any alarms
-
 # ShowAlarmsWithForeach
 - IF: {count(alarms) == 1}
    - You have one alarm [ShowAlarm(alarms[0])]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/6.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/6.lg
@@ -38,10 +38,18 @@
 - ELSE:
   - You don't have any alarms
 
-# ShowAlarmsWithMemberForeach
+# ShowAlarmsWithLgTemplate
 - IF: {count(alarms) == 1}
    - You have one alarm [ShowAlarm(alarms[0])]
 - ELSEIF: {count(alarms) == 2}
-  - You have {count(alarms)} alarms, {join(foreach(alarms, x, ShowAlarm(x)), ', ', ' and ')}
+  - You have {count(alarms)} alarms, {join(foreach(alarms, x, lgTemplate('ShowAlarm', x)), ', ', ' and ')}
+- ELSE:
+  - You don't have any alarms
+
+# ShowAlarmsWithDynamicLgTemplate(templateName)
+- IF: {count(alarms) == 1}
+   - You have one alarm [ShowAlarm(alarms[0])]
+- ELSEIF: {count(alarms) == 2}
+  - You have {count(alarms)} alarms, {join(foreach(alarms, x, lgTemplate(templateName, x)), ', ', ' and ')}
 - ELSE:
   - You don't have any alarms

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -136,6 +136,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var evaled = engine.EvaluateTemplate("ShowAlarmsWithForeach", new { alarms = alarms });
             Assert.AreEqual("You have 2 alarms, 7 am at tomorrow and 8 pm at tomorrow", evaled);
 
+            evaled = engine.EvaluateTemplate("ShowAlarmsWithLgTemplate", new { alarms = alarms });
+            Assert.AreEqual("You have 2 alarms, 7 am at tomorrow and 8 pm at tomorrow", evaled);
+
+            evaled = engine.EvaluateTemplate("ShowAlarmsWithDynamicLgTemplate", new { alarms = alarms, templateName = "ShowAlarm" });
+            Assert.AreEqual("You have 2 alarms, 7 am at tomorrow and 8 pm at tomorrow", evaled);
+
             //var evaled = engine.EvaluateTemplate("ShowAlarmsWithMemberForeach", new { alarms = alarms });
             //Assert.AreEqual("You have 2 alarms, 7 am at tomorrow and 8 pm at tomorrow", evaled);
 


### PR DESCRIPTION
In normal case, use templateName(args) is more straightforward, but when you want to call a template without hard-coding the name, lgTemplate function comes in handy.  It works like reflection. 

So bring it back.