### PR TITLE
Add orderBy/orderByDescending builtin function

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -2239,6 +2239,82 @@ namespace Microsoft.Bot.Builder.Expressions
             return (result, error);
         }
 
+        private static (object, string) OrderBy(Expression expression, object state)
+        {
+            object result = null;
+            string error;
+            object arr;
+            (arr, error) = expression.Children[0].TryEvaluate(state);
+
+            if (error == null)
+            {
+                if (TryParseList(arr, out var list))
+                {
+                    if (expression.Children.Length == 1)
+                    {
+                        result = list.OfType<object>().OrderBy(item => item).ToList();
+                    }
+                    else
+                    {
+                        var jarray = JArray.FromObject(list.OfType<object>().ToList());
+                        var propertyNameExpression = expression.Children[1];
+                        object propertyName;
+                        (propertyName, error) = propertyNameExpression.TryEvaluate(state);
+                        var propertyNameString = string.Empty;
+                        if (error == null)
+                        {
+                            propertyNameString = propertyName == null ? string.Empty : propertyName.ToString();
+                            result = jarray.OrderBy(obj => obj[propertyNameString]).ToList();
+                        }
+                    }
+                }
+                else
+                {
+                    error = $"{expression.Children[0]} is not array";
+                }
+            }
+
+            return (result, error);
+        }
+
+        private static (object, string) OrderByDescending(Expression expression, object state)
+        {
+            object result = null;
+            string error;
+            object arr;
+            (arr, error) = expression.Children[0].TryEvaluate(state);
+
+            if (error == null)
+            {
+                if (TryParseList(arr, out var list))
+                {
+                    if (expression.Children.Length == 1)
+                    {
+                        result = list.OfType<object>().OrderByDescending(item => item).ToList();
+                    }
+                    else
+                    {
+                        var jarray = JArray.FromObject(list.OfType<object>().ToList());
+                        var propertyNameExpression = expression.Children[1];
+                        object propertyName;
+                        (propertyName, error) = propertyNameExpression.TryEvaluate(state);
+                        var propertyNameString = string.Empty;
+                        if (error == null)
+                        {
+                            propertyNameString = propertyName == null ? string.Empty : propertyName.ToString();
+                            result = jarray.OrderByDescending(obj => obj[propertyNameString]).ToList();
+                        }
+                    }
+                }
+                else
+                {
+                    error = $"{expression.Children[0]} is not array";
+                }
+            }
+
+            return (result, error);
+        }
+
         private static bool IsSameDay(DateTime date1, DateTime date2) => date1.Year == date2.Year && date1.Month == date2.Month && date1.Day == date2.Day;
 
         private static Dictionary<string, ExpressionEvaluator> BuildFunctionLookup()
@@ -2395,6 +2471,16 @@ namespace Microsoft.Bot.Builder.Expressions
                     BuiltInFunctions.SubArray,
                     ReturnType.Object,
                     (expression) => BuiltInFunctions.ValidateOrder(expression, new[] { ReturnType.Number }, ReturnType.Object, ReturnType.Number)),
+                new ExpressionEvaluator(
+                    ExpressionType.OrderBy,
+                    BuiltInFunctions.OrderBy,
+                    ReturnType.Object,
+                    (expression) => BuiltInFunctions.ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Object)),
+                new ExpressionEvaluator(
+                    ExpressionType.OrderByDescending,
+                    BuiltInFunctions.OrderByDescending,
+                    ReturnType.Object,
+                    (expression) => BuiltInFunctions.ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Object)),
 
                 // Booleans
                 Comparison(ExpressionType.LessThan, args => args[0] < args[1], ValidateBinaryNumberOrString, VerifyNumberOrString),

--- a/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/BuiltInFunctions.cs
@@ -2239,81 +2239,58 @@ namespace Microsoft.Bot.Builder.Expressions
             return (result, error);
         }
 
-        private static (object, string) OrderBy(Expression expression, object state)
-        {
-            object result = null;
-            string error;
-            object arr;
-            (arr, error) = expression.Children[0].TryEvaluate(state);
-
-            if (error == null)
+        private static EvaluateExpressionDelegate OrderBy(bool isDescending)
+            => (expression, state) =>
             {
-                if (TryParseList(arr, out var list))
+                object result = null;
+                string error;
+                object arr;
+                (arr, error) = expression.Children[0].TryEvaluate(state);
+
+                if (error == null)
                 {
-                    if (expression.Children.Length == 1)
+                    if (TryParseList(arr, out var list))
                     {
-                        result = list.OfType<object>().OrderBy(item => item).ToList();
+                        if (expression.Children.Length == 1)
+                        {
+                            if (isDescending)
+                            {
+                                result = list.OfType<object>().OrderByDescending(item => item).ToList();
+                            }
+                            else
+                            {
+                                result = list.OfType<object>().OrderBy(item => item).ToList();
+                            }
+                        }
+                        else
+                        {
+                            var jarray = JArray.FromObject(list.OfType<object>().ToList());
+                            var propertyNameExpression = expression.Children[1];
+                            object propertyName;
+                            (propertyName, error) = propertyNameExpression.TryEvaluate(state);
+                            var propertyNameString = string.Empty;
+                            if (error == null)
+                            {
+                                propertyNameString = propertyName == null ? string.Empty : propertyName.ToString();
+                                if (isDescending)
+                                {
+                                    result = jarray.OrderByDescending(obj => obj[propertyNameString]).ToList();
+                                }
+                                else
+                                {
+                                    result = jarray.OrderBy(obj => obj[propertyNameString]).ToList();
+                                }
+                            }
+                        }
                     }
                     else
                     {
-                        var jarray = JArray.FromObject(list.OfType<object>().ToList());
-                        var propertyNameExpression = expression.Children[1];
-                        object propertyName;
-                        (propertyName, error) = propertyNameExpression.TryEvaluate(state);
-                        var propertyNameString = string.Empty;
-                        if (error == null)
-                        {
-                            propertyNameString = propertyName == null ? string.Empty : propertyName.ToString();
-                            result = jarray.OrderBy(obj => obj[propertyNameString]).ToList();
-                        }
+                        error = $"{expression.Children[0]} is not array";
                     }
                 }
-                else
-                {
-                    error = $"{expression.Children[0]} is not array";
-                }
-            }
 
-            return (result, error);
-        }
-
-        private static (object, string) OrderByDescending(Expression expression, object state)
-        {
-            object result = null;
-            string error;
-            object arr;
-            (arr, error) = expression.Children[0].TryEvaluate(state);
-
-            if (error == null)
-            {
-                if (TryParseList(arr, out var list))
-                {
-                    if (expression.Children.Length == 1)
-                    {
-                        result = list.OfType<object>().OrderByDescending(item => item).ToList();
-                    }
-                    else
-                    {
-                        var jarray = JArray.FromObject(list.OfType<object>().ToList());
-                        var propertyNameExpression = expression.Children[1];
-                        object propertyName;
-                        (propertyName, error) = propertyNameExpression.TryEvaluate(state);
-                        var propertyNameString = string.Empty;
-                        if (error == null)
-                        {
-                            propertyNameString = propertyName == null ? string.Empty : propertyName.ToString();
-                            result = jarray.OrderByDescending(obj => obj[propertyNameString]).ToList();
-                        }
-                    }
-                }
-                else
-                {
-                    error = $"{expression.Children[0]} is not array";
-                }
-            }
-
-            return (result, error);
-        }
+                return (result, error);
+            };
 
         private static bool IsSameDay(DateTime date1, DateTime date2) => date1.Year == date2.Year && date1.Month == date2.Month && date1.Day == date2.Day;
 
@@ -2473,12 +2450,12 @@ namespace Microsoft.Bot.Builder.Expressions
                     (expression) => BuiltInFunctions.ValidateOrder(expression, new[] { ReturnType.Number }, ReturnType.Object, ReturnType.Number)),
                 new ExpressionEvaluator(
                     ExpressionType.OrderBy,
-                    BuiltInFunctions.OrderBy,
+                    OrderBy(false),
                     ReturnType.Object,
                     (expression) => BuiltInFunctions.ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Object)),
                 new ExpressionEvaluator(
                     ExpressionType.OrderByDescending,
-                    BuiltInFunctions.OrderByDescending,
+                    OrderBy(true),
                     ReturnType.Object,
                     (expression) => BuiltInFunctions.ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Object)),
 

--- a/libraries/Microsoft.Bot.Builder.Expressions/ExpressionType.cs
+++ b/libraries/Microsoft.Bot.Builder.Expressions/ExpressionType.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Bot.Builder.Expressions
         public const string Skip = "skip";
         public const string Take = "take";
         public const string SubArray = "subArray";
+        public const string OrderBy = "orderBy";
+        public const string OrderByDescending = "orderByDescending";
 
         // DateTime
         public const string AddDays = "addDays";

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/BadExpressionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/BadExpressionTests.cs
@@ -319,6 +319,9 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("subArray(items,1,4)"), // the second parameter shoule  less than the length of the collection
             Test("subArray(createArray('H','e','l','l','o'),items[5],5)"), // the second parameter expression is invalid
             Test("subArray(createArray('H','e','l','l','o'),2,items[5])"), // the second parameter expression is invalid
+            Test("orderBy(hello, 'x')"), // first param should be list
+            Test("orderBy(createArray('H','e','l','l','o'), 1)"), // second param should be string
+            Test("orderBy(createArray('H','e','l','l','o'), 'x', hi)"), // second param should be string
             #endregion
 
             #region Object manipulation and construction functions test

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
         };
 
         public static IEnumerable<object[]> Data => new[]
-        {Test("orderBy(items)", new List<object> { "one", "two", "zero" }),
+        {
             #region SetPathToProperty test
             Test("setPathToValue(path.simple, 3) + path.simple", 6),
             Test("setPathToValue(path.simple, 5) + path.simple", 10),

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
         };
 
         public static IEnumerable<object[]> Data => new[]
-        {
+        {Test("orderBy(items)", new List<object> { "one", "two", "zero" }),
             #region SetPathToProperty test
             Test("setPathToValue(path.simple, 3) + path.simple", 6),
             Test("setPathToValue(path.simple, 5) + path.simple", 10),
@@ -723,13 +723,44 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
                 Assert.AreEqual(expectedList.Count, actualList.Count);
                 for (var i = 0; i < expectedList.Count; i++)
                 {
-                    Assert.AreEqual(expectedList[i], actualList[i]);
+                    Assert.AreEqual(ResolveValue(expectedList[i]), ResolveValue(actualList[i]));
                 }
             }
             else
             {
                 Assert.AreEqual(expected, actual);
             }
+        }
+
+        private object ResolveValue(object obj)
+        {
+            object value;
+            if (!(obj is JValue jval))
+            {
+                value = obj;
+            }
+            else
+            {
+                value = jval.Value;
+                if (jval.Type == JTokenType.Integer)
+                {
+                    value = jval.ToObject<int>();
+                }
+                else if (jval.Type == JTokenType.String)
+                {
+                    value = jval.ToObject<string>();
+                }
+                else if (jval.Type == JTokenType.Boolean)
+                {
+                    value = jval.ToObject<bool>();
+                }
+                else if (jval.Type == JTokenType.Float)
+                {
+                    value = jval.ToObject<float>();
+                }
+            }
+
+            return value;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Builder.Expressions.Tests/ExpressionEngineTests.cs
@@ -595,6 +595,10 @@ namespace Microsoft.Bot.Builder.Expressions.Tests
             Test("lastIndexOf(newGuid(), '-')", 23),
             Test("lastIndexOf(hello, '-')", -1),
             Test("length(newGuid())", 36),
+            Test("orderBy(items)", new List<object> { "one", "two", "zero" }),
+            Test("orderBy(nestedItems, 'x')[0].x", 1),
+            Test("orderByDescending(items)", new List<object> { "zero", "two", "one" }),
+            Test("orderByDescending(nestedItems, 'x')[0].x", 3),
 
             #endregion
 


### PR DESCRIPTION
ref: #2380 

`orderBy(items)`, order a simple list, like string list, or use each item as the whole property
`orderBy(nestedItems, 'name')`, order by name property
`orderByDescending (items)`, order a simple list with reverse order, like string list
`orderByDescending (nestedItems, 'name')`, order by name property with reverse order
