### PR TITLE
Class Scope was being returned in Memory Snapshot

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -266,7 +266,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             namedScopes[ScopePath.USER] = newState.UserState;
             namedScopes[ScopePath.CONVERSATION] = newState.ConversationState;
             namedScopes[ScopePath.TURN] = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-            namedScopes[ScopePath.SETTINGS] = Configuration.LoadSettings(context.TurnState.Get<IConfiguration>()) ?? new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
 
             // Create DialogContext
             var dc = new DialogContext(

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
              new MemoryScope(ScopePath.USER),
              new MemoryScope(ScopePath.CONVERSATION),
              new MemoryScope(ScopePath.TURN),
-             new MemoryScope(ScopePath.SETTINGS, isReadOnly: true),
+             new SettingsMemoryScope(),
              new DialogMemoryScope(),
              new ClassMemoryScope(),
              new ThisMemoryScope()

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             var result = new JObject();
 
-            foreach (var scope in DialogStateManager.MemoryScopes)
+            foreach (var scope in DialogStateManager.MemoryScopes.Where(ms => ms.IsReadOnly == false))
             {
                 var memory = scope.GetMemory(this.dialogContext);
                 if (memory != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
 {
@@ -61,6 +62,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// <param name="memory">memory</param>
         public virtual void SetMemory(DialogContext dc, object memory)
         {
+            if (this.IsReadOnly)
+            {
+                throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
+            }
+
             if (dc == null)
             {
                 throw new ArgumentNullException(nameof(dc));

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public class SettingsMemoryScope : MemoryScope
     {
-        private Dictionary<string, object> settings = null;
         private Dictionary<string, object> emptySettings = new Dictionary<string, object>();
 
         public SettingsMemoryScope()
@@ -27,19 +26,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            lock (this.emptySettings)
+            var namedScopes = GetScopesMemory(dc.Context);
+            if (!namedScopes.TryGetValue(ScopePath.SETTINGS, out object settings))
             {
-                if (this.settings == null)
+                var configuration = dc.Context.TurnState.Get<IConfiguration>();
+                if (configuration != null)
                 {
-                    var configuration = dc.Context.TurnState.Get<IConfiguration>();
-                    if (configuration != null)
-                    {
-                        this.settings = Configuration.LoadSettings(configuration);
-                    }
+                    settings = Configuration.LoadSettings(configuration);
+                    namedScopes[ScopePath.SETTINGS] = settings;
                 }
             }
 
-            return this.settings ?? this.emptySettings;
+            return settings ?? emptySettings;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
+{
+    /// <summary>
+    /// SettingsMemoryscope maps "settings" -> IConfiguration
+    /// </summary>
+    public class SettingsMemoryScope : MemoryScope
+    {
+        private Dictionary<string, object> settings = null;
+        private Dictionary<string, object> emptySettings = new Dictionary<string, object>();
+
+        public SettingsMemoryScope()
+            : base(ScopePath.SETTINGS, isReadOnly: true)
+        {
+        }
+
+        public override object GetMemory(DialogContext dc)
+        {
+            if (dc == null)
+            {
+                throw new ArgumentNullException(nameof(dc));
+            }
+
+            lock (this.emptySettings)
+            {
+                if (this.settings == null)
+                {
+                    var configuration = dc.Context.TurnState.Get<IConfiguration>();
+                    if (configuration != null)
+                    {
+                        this.settings = Configuration.LoadSettings(configuration);
+                    }
+                }
+            }
+
+            return this.settings ?? this.emptySettings;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -93,6 +93,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        public void TestMemorySnapshot()
+        {
+            var dialogs = new DialogSet();
+            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
+            DialogStateManager state = new DialogStateManager(dc);
+
+            JObject snapshot = state.GetMemorySnapshot();
+            foreach (var memoryScope in DialogStateManager.MemoryScopes.Where(ms => ms.Name != "dialog" && ms.Name != "this"))
+            {
+                if (memoryScope.IsReadOnly)
+                {
+                    Assert.IsNull(snapshot.Property(memoryScope.Name));
+                }
+                else
+                {
+                    Assert.IsNotNull(snapshot.Property(memoryScope.Name));
+                }
+            }
+        }
+
+        [TestMethod]
         public void TestPathResolverTransform()
         {
             // dollar tests


### PR DESCRIPTION
As was Settings scope.

Since these are immutable values I don't think it makes sense for them to be sent as part of the memory snapshot, as that would push settings secrets into transcript logs as well as attempt to serialize objects that aren't designed to be serialized. 

* changed GetSnapshotMemory() to not take snapshot of readonly memory
* Made settings an explicit implemented memoryscope.  Old code was "filling" the settings in external location, now it's internal to SettingsMemoryScope