### PR TITLE
Change empty template body from error severity to warning severity

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                     if (context.templateBody() == null)
                     {
-                        result.Add(BuildLGDiagnostic($"There is no template body in template {templateName}", context: context.templateNameLine()));
+                        result.Add(BuildLGDiagnostic($"There is no template body in template {templateName}", DiagnosticSeverity.Warning, context.templateNameLine()));
                     }
                     else
                     {

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineThrowExceptionTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineThrowExceptionTest.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
     {
         public static IEnumerable<object[]> StaticCheckExceptionData => new[]
         {
-            Test("EmptyTemplate.lg"),
             Test("ErrorTemplateParameters.lg"),
             Test("NoNormalTemplateBody.lg"),
             Test("ConditionFormatError.lg"),
@@ -35,7 +34,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Test("EmptyLGFile.lg"),
             Test("OnlyNoMatchRule.lg"),
             Test("NoMatchRule.lg"),
-            Test("SwitchCaseWarning.lg")
+            Test("SwitchCaseWarning.lg"),
+            Test("EmptyTemplate.lg"),
         };
 
         public static IEnumerable<object[]> AnalyzerExceptionData => new[]


### PR DESCRIPTION
Change empty template body from error severity to warning severity.
Original:
```
# templateName // error
```

Currently:
```
# templateName // warning
```

