### PR TITLE
Removed step to set ID on sent activities

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -271,8 +271,6 @@ namespace Microsoft.Bot.Builder
                 {
                     var activity = bufferedActivities[index];
 
-                    activity.Id = responses[index].Id;
-
                     sentNonTraceActivity |= activity.Type != ActivityTypes.Trace;
                 }
 


### PR DESCRIPTION
**Background**

At present in C# we set an ID on outgoing activities in the SendActivitiesThroughAdapter method on the TurnContext.  

https://github.com/microsoft/botbuilder-dotnet/blob/d085ac8220bbd990565db75639fa53d9816bf6bf/libraries/Microsoft.Bot.Builder/TurnContext.cs#L270-L285

This is not something that is done in the corresponding JS method.

https://github.com/microsoft/botbuilder-js/blob/7d861550bd1548b230a073275356c510a9da3b28/libraries/botbuilder-core/src/turnContext.ts#L297-L306

This step of setting the ID causes issues, such as RetryPrompt activities being sent with the same ID multiple times, which causes side effects such as subsequent activities not being shown in the emulator.  Multiple issues concerning this have been reported.

https://github.com/microsoft/BotFramework-Emulator/issues/1888
https://github.com/microsoft/botbuilder-dotnet/issues/2689
https://github.com/microsoft/botbuilder-dotnet/issues/2690

This change removed the step of setting the activity ID from C#.

I do not see any side effects of removing this, especially given that parity between the two languages should have been maintained elsewhere.  @cleemullins / @tomlm please chime in if you know of a reason we should leave this in.

**Also considered**

I also considered leaving the ID setting in, but altering the prompts to send a copy of the retry activity, as opposed to changing the TurnContext.  This would have the effect of fixing the reported bugs, but would leave the C# and JS repos out of sync and would also leave the underlying issue in place, which could show up again. As @mdrichardson pointed out in one of the issue threads, there is a ***possibility*** that a developer may have written code expecting that some activities may have a duplicate ID, but I don't believe we have any concrete examples of this.  Therefore, I think it is a better approach for us to bring the two languages in line.