### PR TITLE
[Teams] Hackathon feedback

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder
     public class BotFrameworkAdapter : BotAdapter, IAdapterIntegration, IUserTokenProvider
     {
         internal const string BotIdentityKey = "BotIdentity";
-        private const string InvokeResponseKey = "BotFrameworkAdapter.InvokeResponse";
+        internal const string InvokeResponseKey = "BotFrameworkAdapter.InvokeResponse";
 
         private static readonly HttpClient _defaultHttpClient = new HttpClient();
         private readonly ICredentialProvider _credentialProvider;

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -115,9 +115,16 @@ namespace Microsoft.Bot.Builder.Teams
             {
                 return new InvokeResponse { Status = (int)HttpStatusCode.NotImplemented };
             }
-            catch (BadRequestArgumentException)
+            catch (InvalidOperationException ex)
             {
-                return new InvokeResponse { Status = (int)HttpStatusCode.BadRequest };
+                if (ex.Source == nameof(TeamsActivityHandler))
+                {
+                    return new InvokeResponse { Status = (int)HttpStatusCode.BadRequest };
+                }
+                else
+                {
+                    throw;
+                }
             }
         }
 
@@ -144,7 +151,10 @@ namespace Microsoft.Bot.Builder.Teams
                     return CreateInvokeResponse();
 
                 default:
-                    throw new BadRequestArgumentException($"Allowed values are 'accept' and 'decline'. Received {fileConsentCardResponse.Action}", "Action");
+                    throw new InvalidOperationException($"Allowed values are 'accept' and 'decline'. Received {fileConsentCardResponse.Action}")
+                    {
+                        Source = nameof(TeamsActivityHandler),  
+                    };
             }
         }
 
@@ -196,7 +206,10 @@ namespace Microsoft.Bot.Builder.Teams
                         return await OnTeamsMessagingExtensionBotMessagePreviewSendAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
 
                     default:
-                        throw new BadRequestArgumentException($"Allowed values are 'edit' and 'send'. Received {action.BotMessagePreviewAction}", "BotMessagePreviewAction");
+                        throw new InvalidOperationException($"Allowed values are 'edit' and 'send'. Received {action.BotMessagePreviewAction}")
+                        {
+                            Source = nameof(TeamsActivityHandler),
+                        };
                 }
             }
             else
@@ -323,14 +336,6 @@ namespace Microsoft.Bot.Builder.Teams
             }
 
             return obj.ToObject<T>();
-        }
-
-        private class BadRequestArgumentException : ArgumentException
-        {
-            public BadRequestArgumentException(string message, string paramName)
-                :base(message, paramName)
-            {
-            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -107,35 +107,24 @@ namespace Microsoft.Bot.Builder.Teams
                             return CreateInvokeResponse(await OnTeamsTaskModuleSubmitAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
 
                         default:
-                            throw new NotImplementedException();
+                            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
                     }
                 }
             }
-            catch (NotImplementedException)
+            catch (InvokeResponseException e)
             {
-                return new InvokeResponse { Status = (int)HttpStatusCode.NotImplemented };
-            }
-            catch (InvalidOperationException ex)
-            {
-                if (ex.Source == nameof(TeamsActivityHandler))
-                {
-                    return new InvokeResponse { Status = (int)HttpStatusCode.BadRequest };
-                }
-                else
-                {
-                    throw;
-                }
+                return e.CreateInvokeResponse();
             }
         }
 
         protected virtual Task<InvokeResponse> OnTeamsCardActionInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task OnTeamsSigninVerifyStateAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual async Task<InvokeResponse> OnTeamsFileConsentAsync(ITurnContext<IInvokeActivity> turnContext, FileConsentCardResponse fileConsentCardResponse, CancellationToken cancellationToken)
@@ -151,46 +140,43 @@ namespace Microsoft.Bot.Builder.Teams
                     return CreateInvokeResponse();
 
                 default:
-                    throw new InvalidOperationException($"Allowed values are 'accept' and 'decline'. Received {fileConsentCardResponse.Action}")
-                    {
-                        Source = nameof(TeamsActivityHandler),  
-                    };
+                    throw new InvokeResponseException(HttpStatusCode.BadRequest);
             }
         }
 
         protected virtual Task OnTeamsFileConsentAcceptAsync(ITurnContext<IInvokeActivity> turnContext, FileConsentCardResponse fileConsentCardResponse, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task OnTeamsFileConsentDeclineAsync(ITurnContext<IInvokeActivity> turnContext, FileConsentCardResponse fileConsentCardResponse, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionResponse> OnTeamsMessagingExtensionQueryAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task OnTeamsO365ConnectorCardActionAsync(ITurnContext<IInvokeActivity> turnContext, O365ConnectorCardActionQuery query, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionResponse> OnTeamsAppBasedLinkQueryAsync(ITurnContext<IInvokeActivity> turnContext, AppBasedLinkQuery query, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionResponse> OnTeamsMessagingExtensionSelectItemAsync(ITurnContext<IInvokeActivity> turnContext, JObject query, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionSubmitActionDispatchAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
@@ -206,10 +192,7 @@ namespace Microsoft.Bot.Builder.Teams
                         return await OnTeamsMessagingExtensionBotMessagePreviewSendAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
 
                     default:
-                        throw new InvalidOperationException($"Allowed values are 'edit' and 'send'. Received {action.BotMessagePreviewAction}")
-                        {
-                            Source = nameof(TeamsActivityHandler),
-                        };
+                        throw new InvokeResponseException(HttpStatusCode.BadRequest);
                 }
             }
             else
@@ -220,42 +203,42 @@ namespace Microsoft.Bot.Builder.Teams
 
         protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionSubmitActionAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<MessagingExtensionResponse> OnTeamsMessagingExtensionConfigurationQuerySettingUrlAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task OnTeamsMessagingExtensionConfigurationSettingAsync(ITurnContext<IInvokeActivity> turnContext, JObject settings, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task OnTeamsMessagingExtensionCardButtonClickedAsync(ITurnContext<IInvokeActivity> turnContext, JObject cardData, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<TaskModuleResponse> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected virtual Task<TaskModuleResponse> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
 
         protected override Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
@@ -336,6 +319,21 @@ namespace Microsoft.Bot.Builder.Teams
             }
 
             return obj.ToObject<T>();
+        }
+
+        private class InvokeResponseException : Exception
+        {
+            HttpStatusCode StatusCode { get; set; }
+
+            public InvokeResponseException(HttpStatusCode statusCode)
+            {
+                StatusCode = statusCode;
+            }
+            
+            public InvokeResponse CreateInvokeResponse()
+            {
+                return new InvokeResponse { Status = (int)StatusCode };
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Bot.Builder.Teams
             {
                 case ActivityTypes.Invoke:
                     var invokeResponse = await OnInvokeActivityAsync(new DelegatingTurnContext<IInvokeActivity>(turnContext), cancellationToken).ConfigureAwait(false);
-                    if (invokeResponse != null)
+                    
+                    // If OnInvokeActivityAsync has already sent an InvokeResponse, do not send another one.
+                    if (invokeResponse != null && null == turnContext.TurnState.Get<Activity>(BotFrameworkAdapter.InvokeResponseKey))
                     {
                         await turnContext.SendActivityAsync(new Activity { Value = invokeResponse, Type = ActivityTypesEx.InvokeResponse }).ConfigureAwait(false);
                     }
@@ -62,7 +64,8 @@ namespace Microsoft.Bot.Builder.Teams
                     switch (turnContext.Activity.Name)
                     {
                         case "signin/verifyState":
-                            return await OnTeamsSigninVerifyStateAsync(turnContext, cancellationToken).ConfigureAwait(false);
+                            await OnTeamsSigninVerifyStateAsync(turnContext, cancellationToken).ConfigureAwait(false);
+                            return CreateInvokeResponse();
 
                         case "fileConsent/invoke":
                             return await OnTeamsFileConsentAsync(turnContext, SafeCast<FileConsentCardResponse>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false);
@@ -125,7 +128,7 @@ namespace Microsoft.Bot.Builder.Teams
             throw new NotImplementedException();
         }
 
-        protected virtual Task<InvokeResponse> OnTeamsSigninVerifyStateAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
+        protected virtual Task OnTeamsSigninVerifyStateAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -101,12 +101,10 @@ namespace Microsoft.Bot.Builder.Teams
                             return CreateInvokeResponse();
 
                         case "task/fetch":
-                            var fetchResponse = await OnTeamsTaskModuleFetchAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false);
-                            return CreateInvokeResponse(new TaskModuleResponse { Task = new TaskModuleContinueResponse(fetchResponse) });
+                            return CreateInvokeResponse(await OnTeamsTaskModuleFetchAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
 
                         case "task/submit":
-                            var submitResponse = await OnTeamsTaskModuleSubmitAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false);
-                            return CreateInvokeResponse(submitResponse != null ? new TaskModuleResponse(submitResponse) : null);
+                            return CreateInvokeResponse(await OnTeamsTaskModuleSubmitAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
 
                         default:
                             throw new NotImplementedException();
@@ -237,12 +235,12 @@ namespace Microsoft.Bot.Builder.Teams
             throw new NotImplementedException();
         }
 
-        protected virtual Task<TaskModuleTaskInfo> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected virtual Task<TaskModuleResponse> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        protected virtual Task<TaskModuleResponseBase> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected virtual Task<TaskModuleResponse> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerBadRequestTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerBadRequestTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Tests;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Schema.Teams;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Teams.Tests
+{
+    [TestClass]
+    public class TeamsActivityHandlerBadRequestTests
+    {
+        [TestMethod]
+        public async Task TestFileConsentBadAction()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "fileConsent/invoke",
+                Value = JObject.FromObject(new FileConsentCardResponse
+                {
+                    Action = "this.is.a.bad.action",
+                    UploadInfo = new FileUploadInfo
+                    {
+                        UniqueId = "uniqueId",
+                        FileType = "fileType",
+                        UploadUrl = "uploadUrl",
+                    },
+                }),
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TeamsActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.IsNotNull(activitiesToSend);
+            Assert.AreEqual(1, activitiesToSend.Length);
+            Assert.IsInstanceOfType(activitiesToSend[0].Value, typeof(InvokeResponse));
+            Assert.AreEqual(400, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [TestMethod]
+        public async Task TestMessagingExtensionSubmitActionPreviewBadAction()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/submitAction",
+                Value = JObject.FromObject(new MessagingExtensionAction
+                {
+                    BotMessagePreviewAction = "this.is.a.bad.action",
+                }),
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TeamsActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.IsNotNull(activitiesToSend);
+            Assert.AreEqual(1, activitiesToSend.Length);
+            Assert.IsInstanceOfType(activitiesToSend[0].Value, typeof(InvokeResponse));
+            Assert.AreEqual(400, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
@@ -563,45 +563,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         }
 
         [TestMethod]
-        public async Task TestFileConsentBadAction()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "fileConsent/invoke",
-                Value = JObject.FromObject(new FileConsentCardResponse
-                {
-                    Action = "this.is.a.bad.action",
-                    UploadInfo = new FileUploadInfo
-                    {
-                        UniqueId = "uniqueId",
-                        FileType = "fileType",
-                        UploadUrl = "uploadUrl",
-                    },
-                }),
-            };
-
-            Activity[] activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
-            {
-                activitiesToSend = arg;
-            }
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandlerFileConsent();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.IsNotNull(activitiesToSend);
-            Assert.AreEqual(1, activitiesToSend.Length);
-            Assert.IsInstanceOfType(activitiesToSend[0].Value, typeof(InvokeResponse));
-            Assert.AreEqual(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
-        }
-
-        [TestMethod]
         public async Task TestMessagingExtensionSubmitActionPreviewActionEditImplemented()
         {
             // Arrange
@@ -665,39 +626,6 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             Assert.AreEqual(1, activitiesToSend.Length);
             Assert.IsInstanceOfType(activitiesToSend[0].Value, typeof(InvokeResponse));
             Assert.AreEqual(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
-        }
-
-        [TestMethod]
-        public async Task TestMessagingExtensionSubmitActionPreviewBadAction()
-        {
-            // Arrange
-            var activity = new Activity
-            {
-                Type = ActivityTypes.Invoke,
-                Name = "composeExtension/submitAction",
-                Value = JObject.FromObject(new MessagingExtensionAction
-                {
-                    BotMessagePreviewAction = "this.is.a.bad.action",
-                }),
-            };
-
-            Activity[] activitiesToSend = null;
-            void CaptureSend(Activity[] arg)
-            {
-                activitiesToSend = arg;
-            }
-
-            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
-
-            // Act
-            var bot = new TestActivityHandlerPrevieAction();
-            await ((IBot)bot).OnTurnAsync(turnContext);
-
-            // Assert
-            Assert.IsNotNull(activitiesToSend);
-            Assert.AreEqual(1, activitiesToSend.Length);
-            Assert.IsInstanceOfType(activitiesToSend[0].Value, typeof(InvokeResponse));
-            Assert.AreEqual(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
         }
 
         private class TestActivityHandler : TeamsActivityHandler

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -644,6 +644,38 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             Assert.AreEqual(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
         }
 
+        [TestMethod]
+        public async Task TestSigninVerifyState()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "signin/verifyState",
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+           
+            // Assert
+            Assert.AreEqual(2, bot.Record.Count);
+            Assert.AreEqual("OnInvokeActivityAsync", bot.Record[0]);
+            Assert.AreEqual("OnTeamsSigninVerifyStateAsync", bot.Record[1]);
+            Assert.IsNotNull(activitiesToSend);
+            Assert.AreEqual(1, activitiesToSend.Length);
+            Assert.IsInstanceOfType(activitiesToSend[0].Value, typeof(InvokeResponse));
+            Assert.AreEqual(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
         private class NotImplementedAdapter : BotAdapter
         {
             public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
@@ -834,6 +866,12 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(new TaskModuleResponseBase());
+            }
+
+            protected override Task OnTeamsSigninVerifyStateAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return Task.CompletedTask;
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -770,7 +770,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 return base.OnTeamsMessagingExtensionCardButtonClickedAsync(turnContext, obj, cancellationToken);
             }
 
-            protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
+            protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(new MessagingExtensionActionResponse());

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -856,16 +856,16 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 return base.OnTeamsCardActionInvokeAsync(turnContext, cancellationToken);
             }
 
-            protected override Task<TaskModuleTaskInfo> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+            protected override Task<TaskModuleResponse> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
-                return Task.FromResult(new TaskModuleTaskInfo());
+                return Task.FromResult(new TaskModuleResponse());
             }
 
-            protected override Task<TaskModuleResponseBase> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+            protected override Task<TaskModuleResponse> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
-                return Task.FromResult(new TaskModuleResponseBase());
+                return Task.FromResult(new TaskModuleResponse());
             }
 
             protected override Task OnTeamsSigninVerifyStateAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)

--- a/tests/Teams/ActionBasedMessagingExtensionFetchTask/Bots/ActionBasedMessagingExtensionFetchTaskBot.cs
+++ b/tests/Teams/ActionBasedMessagingExtensionFetchTask/Bots/ActionBasedMessagingExtensionFetchTaskBot.cs
@@ -37,7 +37,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             }
         }
 
-        protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
+        protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             var adaptiveCardEditor = AdaptiveCardHelper.CreateAdaptiveCardEditor();
 

--- a/tests/Teams/AdaptiveCards/Bots/AdaptiveCardsBot.cs
+++ b/tests/Teams/AdaptiveCards/Bots/AdaptiveCardsBot.cs
@@ -85,7 +85,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             }
         }
 
-        protected override async Task<TaskModuleTaskInfo> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected override async Task<TaskModuleResponse> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             var reply = MessageFactory.Text("OnTeamsTaskModuleFetchAsync TaskModuleRequest: " + JsonConvert.SerializeObject(taskModuleRequest));
             await turnContext.SendActivityAsync(reply, cancellationToken);
@@ -94,19 +94,32 @@ namespace Microsoft.BotBuilderSamples.Bots
             adaptiveCard.Body.Add(new AdaptiveTextBlock("This is an Adaptive Card within a Task Module"));
             adaptiveCard.Actions.Add(new AdaptiveSubmitAction { Type = "Action.Submit", Title = "Action.Submit", Data = new JObject { { "submitLocation", "taskModule" } } });
 
-            return new TaskModuleTaskInfo()
+            return new TaskModuleResponse
             {
-                Card = adaptiveCard.ToAttachment(),
-                Height = 200,
-                Width = 400,
-                Title = "Task Module Example",
+                Task = new TaskModuleContinueResponse
+                {
+                    Value = new TaskModuleTaskInfo()
+                    {
+                        Card = adaptiveCard.ToAttachment(),
+                        Height = 200,
+                        Width = 400,
+                        Title = "Task Module Example",
+                    },
+                },
             };
         }
 
-        protected override async Task<TaskModuleResponseBase> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected override async Task<TaskModuleResponse> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             await turnContext.SendActivityAsync(MessageFactory.Text($"OnTeamsTaskModuleSubmitAsync value: { JsonConvert.SerializeObject(taskModuleRequest) }"), cancellationToken);
-            return new TaskModuleMessageResponse { Value = "Thanks!" };
+
+            return new TaskModuleResponse
+            {
+                Task = new TaskModuleMessageResponse()
+                {
+                    Value = "Thanks!",
+                },
+            };
         }
 
         protected override async Task<InvokeResponse> OnTeamsCardActionInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)

--- a/tests/Teams/MessagingExtensionAuth/Bots/MessagingExtensionAuthBot.cs
+++ b/tests/Teams/MessagingExtensionAuth/Bots/MessagingExtensionAuthBot.cs
@@ -92,7 +92,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             };
         }
 
-        protected override async Task<TaskModuleTaskInfo> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected override async Task<TaskModuleResponse> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             // When a user has successfully signed in, the bot receives the Magic Code from Azure Bot Service in
             // the Activity.Value. Use the magic code to obtain the user token.
@@ -100,7 +100,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             if (data != null && data["state"] != null)
             {
                 var tokenResponse = await (turnContext.Adapter as IUserTokenProvider).GetUserTokenAsync(turnContext, _connectionName, data["state"].ToString(), cancellationToken: cancellationToken);
-                return CreateSignedInTaskModuleTaskInfo(tokenResponse.Token);
+                return new TaskModuleResponse() { Task = new TaskModuleContinueResponse( CreateSignedInTaskModuleTaskInfo(tokenResponse.Token) ) };
             }
             else
             {

--- a/tests/Teams/MessagingExtensionAuth/Bots/MessagingExtensionAuthBot.cs
+++ b/tests/Teams/MessagingExtensionAuth/Bots/MessagingExtensionAuthBot.cs
@@ -54,7 +54,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             }
         }
 
-        protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
+        protected override async Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionFetchTaskAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             var tokenResponse = await (turnContext.Adapter as IUserTokenProvider).GetUserTokenAsync(turnContext, _connectionName, string.Empty, cancellationToken: cancellationToken);
             if (tokenResponse == null || string.IsNullOrEmpty(tokenResponse.Token))

--- a/tests/Teams/Roster/AdapterWithErrorHandler.cs
+++ b/tests/Teams/Roster/AdapterWithErrorHandler.cs
@@ -12,6 +12,13 @@ namespace Microsoft.BotBuilderSamples
         public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger)
             : base(configuration, logger)
         {
+            var allowedTeamsTenantId = configuration.GetValue<string>("AllowedTeamsTenantId");
+            if (!string.IsNullOrEmpty(allowedTeamsTenantId))
+            {
+                var teamsTenantFilterMiddleware = new TeamsTenantFilteringMiddleware(allowedTeamsTenantId);
+                Use(teamsTenantFilterMiddleware);
+            }
+
             OnTurnError = async (turnContext, exception) =>
             {
                 // Log any leaked exception from the application.

--- a/tests/Teams/Roster/TeamsTenantFilteringMiddleware.cs
+++ b/tests/Teams/Roster/TeamsTenantFilteringMiddleware.cs
@@ -5,10 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema.Teams;
 
-namespace Microsoft.Bot.Builder.Teams
+namespace Microsoft.BotBuilderSamples
 {
     /// <summary>
     /// Filters request based on provided tenant list.
@@ -20,6 +21,15 @@ namespace Microsoft.Bot.Builder.Teams
         /// The tenant map.
         /// </summary>
         private readonly HashSet<string> tenantMap;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsTenantFilteringMiddleware"/> class.
+        /// </summary>
+        /// <param name="allowedTenantId">The allowed tenant.</param>
+        public TeamsTenantFilteringMiddleware(string allowedTenantId)
+            :this(new string[] { allowedTenantId })
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsTenantFilteringMiddleware"/> class.
@@ -59,6 +69,8 @@ namespace Microsoft.Bot.Builder.Teams
         {
             if (!turnContext.Activity.ChannelId.Equals(Channels.Msteams, StringComparison.OrdinalIgnoreCase))
             {
+                // If the goal is to NOT process messages from other channels, comment out the following line
+                // and message processing will be 'short circuited'.
                 await next(cancellationToken).ConfigureAwait(false);
                 return;
             }

--- a/tests/Teams/Roster/appsettings.json
+++ b/tests/Teams/Roster/appsettings.json
@@ -1,4 +1,5 @@
 {
   "MicrosoftAppId": "",
-  "MicrosoftAppPassword": ""
+  "MicrosoftAppPassword": "",
+  "AllowedTeamsTenantId": ""
 }

--- a/tests/Teams/TaskModule/Bots/TaskModuleBot.cs
+++ b/tests/Teams/TaskModule/Bots/TaskModuleBot.cs
@@ -25,26 +25,38 @@ namespace Microsoft.BotBuilderSamples.Bots
             await turnContext.SendActivityAsync(reply);
         }
 
-        protected override async Task<TaskModuleTaskInfo> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected override async Task<TaskModuleResponse> OnTeamsTaskModuleFetchAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             var reply = MessageFactory.Text("OnTeamsTaskModuleFetchAsync TaskModuleRequest: " + JsonConvert.SerializeObject(taskModuleRequest));
             await turnContext.SendActivityAsync(reply);
 
-            return new TaskModuleTaskInfo()
+            return new TaskModuleResponse
             {
-                Card = this.GetTaskModuleAdaptiveCard(),
-                Height = 200,
-                Width = 400,
-                Title = "Adaptive Card: Inputs",
+                Task = new TaskModuleContinueResponse
+                {
+                    Value = new TaskModuleTaskInfo()
+                    {
+                        Card = this.GetTaskModuleAdaptiveCard(),
+                        Height = 200,
+                        Width = 400,
+                        Title = "Adaptive Card: Inputs",
+                    },
+                },
             };
         }
 
-        protected override async Task<TaskModuleResponseBase> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
+        protected override async Task<TaskModuleResponse> OnTeamsTaskModuleSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TaskModuleRequest taskModuleRequest, CancellationToken cancellationToken)
         {
             var reply = MessageFactory.Text("OnTeamsTaskModuleFetchAsync Value: " + JsonConvert.SerializeObject(taskModuleRequest));
             await turnContext.SendActivityAsync(reply);
 
-            return new TaskModuleMessageResponse() { Value = "Thanks!" };
+            return new TaskModuleResponse
+            {
+                Task = new TaskModuleMessageResponse()
+                {
+                    Value = "Thanks!",
+                },
+            };
         }
 
         private Attachment GetTaskModuleHeroCard()


### PR DESCRIPTION
Fixes: 
https://github.com/microsoft/botbuilder-dotnet/issues/2737
and
https://github.com/microsoft/botbuilder-dotnet/issues/2718


•	Remove the tenant filtering middleware from the product, and add to samples
	-Removed TeamsTenantFilteringMiddleware from the product and added it to Roster bot as an example.
	
•	Bot message preview edit/send return value should be bad request if malformed
	-now returning BadRequest

•	File consent should be bad request if malformed
	-now returning BadRequest

•	OnTeamsMessagingExtensionFetchTaskAsync should take a MessagingExtensionAction and not MessagingExtensionQuery 
	-Changed parameter type

•	In TeamACtivityHandler we should check whether there is an InvokeResponse activity on the turnstate and if there is don’t overwrite it.
	- added check of TurnState for existing InvokeResponse

•	OnSigninVerifyStateAsync should be void (create invoke response internally, if not present in turnstate)
	- Changed return type to void, added test

•	Change TeamsActivityHandler's task/fetch and task/submit return types to TaskModuleResponse