### PR TITLE
Added a flag to control the bubbling of cancellation events

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelAllDialogs.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/CancelAllDialogs.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             if (dc.Parent == null)
             {
-                return await dc.CancelAllDialogsAsync(EventName, eventValue, cancellationToken).ConfigureAwait(false);
+                return await dc.CancelAllDialogsAsync(true, EventName, eventValue, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                var turnResult = await dc.Parent.CancelAllDialogsAsync(EventName, eventValue, cancellationToken).ConfigureAwait(false);
+                var turnResult = await dc.Parent.CancelAllDialogsAsync(true, EventName, eventValue, cancellationToken).ConfigureAwait(false);
                 turnResult.ParentEnded = true;
                 return turnResult;
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -319,12 +319,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <seealso cref="EndDialogAsync(object, CancellationToken)"/>
         public async Task<DialogTurnResult> CancelAllDialogsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return await this.CancelAllDialogsAsync(eventName: null, eventValue: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await this.CancelAllDialogsAsync(false, eventName: null, eventValue: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Deletes any existing dialog stack thus cancelling all dialogs on the stack.
         /// </summary>
+        /// <param name="cancelParents">If true the cancelation will bubble up through any parent dialogs as well.</param>
         /// <param name="eventName">The event.</param>
         /// <param name="eventValue">The event value.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
@@ -340,7 +341,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// `ResumeDialogAsync`, then the parent will end, too, and the result is passed to the next
         /// parent context.</remarks>
         /// <seealso cref="EndDialogAsync(object, CancellationToken)"/>
-        public async Task<DialogTurnResult> CancelAllDialogsAsync(string eventName, object eventValue = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<DialogTurnResult> CancelAllDialogsAsync(bool cancelParents, string eventName = null, object eventValue = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (eventValue is CancellationToken)
             {
@@ -375,7 +376,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else
                     {
-                        dialogContext = dialogContext.Parent;
+                        dialogContext = cancelParents ? dialogContext.Parent : null;
                     }
 
                     notify = true;


### PR DESCRIPTION
Fixes #2531 

The default is "false" which preserves the current 4.5 behavior.