### PR TITLE
Implements auth changes required to handle skills

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -2,17 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
-using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -42,11 +38,24 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
         public AppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
+        : this(channelAuthTenant, customHttpClient, logger, null)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppCredentials"/> class.
+        /// </summary>
+        /// <param name="channelAuthTenant">Optional. The oauth token tenant.</param>
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        /// <param name="oAuthScope">The scope for the token.</param>
+        public AppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null, string oAuthScope = null)
+        {
+            OAuthScope = string.IsNullOrWhiteSpace(oAuthScope) ? AuthenticationConstants.ToChannelFromBotOAuthScope : oAuthScope;
             authenticator = BuildAuthenticator();
-            this.ChannelAuthTenant = channelAuthTenant;
-            this.CustomHttpClient = customHttpClient;
-            this.Logger = logger;
+            ChannelAuthTenant = channelAuthTenant;
+            CustomHttpClient = customHttpClient;
+            Logger = logger;
         }
 
         /// <summary>
@@ -102,7 +111,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// The OAuth scope to use.
         /// </value>
-        public virtual string OAuthScope => AuthenticationConstants.ToChannelFromBotOAuthScope;
+        public virtual string OAuthScope { get; }
 
         /// <summary>
         /// Gets or sets the channel auth token tenant for this credential.

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -45,35 +45,18 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>True, if the token was issued by the Emulator. Otherwise, false.</returns>
         public static bool IsTokenFromEmulator(string authHeader)
         {
-            // The Auth Header generally looks like this:
-            // "Bearer eyJ0e[...Big Long String...]XAiO"
-            if (string.IsNullOrWhiteSpace(authHeader))
+            if (!JwtTokenValidation.IsValidToken(authHeader))
             {
-                // No token. Can't be an emulator token.
                 return false;
             }
 
-            string[] parts = authHeader?.Split(' ');
-            if (parts.Length != 2)
-            {
-                // Emulator tokens MUST have exactly 2 parts. If we don't have 2 parts, it's not an emulator token
-                return false;
-            }
-
-            string authScheme = parts[0];
-            string bearerToken = parts[1];
-
-            // We now have an array that should be:
+            // We know is a valid token, split it and work with it:
             // [0] = "Bearer"
             // [1] = "[Big Long String]"
-            if (authScheme != "Bearer")
-            {
-                // The scheme from the emulator MUST be "Bearer"
-                return false;
-            }
+            var bearerToken = authHeader.Split(' ')[1];
 
             // Parse the Big Long String into an actual token.
-            JwtSecurityToken token = new JwtSecurityToken(bearerToken);
+            var token = new JwtSecurityToken(bearerToken);
 
             // Is there an Issuer?
             if (string.IsNullOrWhiteSpace(token.Issuer))
@@ -148,7 +131,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     openIdMetadataUrl,
                     AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.
@@ -207,7 +190,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException($"Unknown Emulator Token version '{tokenVersion}'.");
             }
 
-            if (!await credentials.IsValidAppIdAsync(appID))
+            if (!await credentials.IsValidAppIdAsync(appID).ConfigureAwait(false))
             {
                 throw new UnauthorizedAccessException($"Invalid AppId passed on token: {appID}");
             }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// identity for the request.</remarks>
         public static async Task<ClaimsIdentity> AuthenticateRequest(IActivity activity, string authHeader, ICredentialProvider credentials, IChannelProvider provider, HttpClient httpClient = null)
         {
-            return await AuthenticateRequest(activity, authHeader, credentials, provider, new AuthenticationConfiguration(), httpClient);
+            return await AuthenticateRequest(activity, authHeader, credentials, provider, new AuthenticationConfiguration(), httpClient).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(authConfig));
             }
 
-            if (string.IsNullOrWhiteSpace(authHeader))
+            if (String.IsNullOrWhiteSpace(authHeader))
             {
                 var isAuthDisabled = await credentials.IsAuthenticationDisabledAsync().ConfigureAwait(false);
                 if (isAuthDisabled)
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException();
             }
 
-            var claimsIdentity = await ValidateAuthHeader(authHeader, credentials, provider, activity.ChannelId, authConfig, activity.ServiceUrl, httpClient ?? _httpClient);
+            var claimsIdentity = await ValidateAuthHeader(authHeader, credentials, provider, activity.ChannelId, authConfig, activity.ServiceUrl, httpClient ?? _httpClient).ConfigureAwait(false);
 
             AppCredentials.TrustServiceUrl(activity.ServiceUrl);
 
@@ -123,12 +123,12 @@ namespace Microsoft.Bot.Connector.Authentication
 
             if (SkillValidation.IsSkillToken(authHeader))
             {
-                return await SkillValidation.AuthenticateChannelToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig);
+                return await SkillValidation.AuthenticateChannelToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig).ConfigureAwait(false);
             }
 
             if (EmulatorValidation.IsTokenFromEmulator(authHeader))
             {
-                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig);
+                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig).ConfigureAwait(false);
             }
 
             if (channelProvider == null || channelProvider.IsPublicAzure())
@@ -136,10 +136,10 @@ namespace Microsoft.Bot.Connector.Authentication
                 // No empty or null check. Empty can point to issues. Null checks only.
                 if (serviceUrl != null)
                 {
-                    return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, authConfig);
+                    return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
                 }
 
-                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig);
+                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig).ConfigureAwait(false);
             }
 
             if (channelProvider.IsGovernment())
@@ -161,7 +161,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </remarks>
         /// <param name="claims">A list of <see cref="Claim"/> instances.</param>
         /// <returns>The value of the appId claim if found (null if it can't find a suitable claim)</returns>
-        public static string GetAppId(IEnumerable<Claim> claims)
+        public static string GetAppIdFromClaims(IEnumerable<Claim> claims)
         {
             var claimsList = claims.ToList();
             string appId = null;
@@ -184,6 +184,39 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             return appId;
+        }
+
+        /// <summary>
+        /// Internal helper to check if the token has the shape we expect "Bearer [big long string]"
+        /// </summary>
+        /// <param name="authHeader">A string containing the token header.</param>
+        /// <returns>True if the token is valid, false if not.</returns>
+        internal static bool IsValidToken(string authHeader)
+        {
+            if (string.IsNullOrWhiteSpace(authHeader))
+            {
+                // No token, not valid.
+                return false;
+            }
+
+            var parts = authHeader.Split(' ');
+            if (parts.Length != 2)
+            {
+                // Tokens MUST have exactly 2 parts. If we don't have 2 parts, it's not a valid token
+                return false;
+            }
+
+            // We now have an array that should be:
+            // [0] = "Bearer"
+            // [1] = "[Big Long String]"
+            var authScheme = parts[0];
+            if (!authScheme.Equals("Bearer", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // The scheme MUST be "Bearer"
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(authConfig));
             }
 
-            if (String.IsNullOrWhiteSpace(authHeader))
+            if (string.IsNullOrWhiteSpace(authHeader))
             {
                 var isAuthDisabled = await credentials.IsAuthenticationDisabledAsync().ConfigureAwait(false);
                 if (isAuthDisabled)
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// identity for the request.</remarks>
         public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, AuthenticationConfiguration authConfig, string serviceUrl = null, HttpClient httpClient = null)
         {
-            if (String.IsNullOrEmpty(authHeader))
+            if (string.IsNullOrEmpty(authHeader))
             {
                 throw new ArgumentNullException(nameof(authHeader));
             }

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="appId">The Microsoft app ID.</param>
         /// <param name="password">The Microsoft app password.</param>
         public MicrosoftAppCredentials(string appId, string password)
-            : this(appId, password, null)
+            : this(appId, password, null, null, null, null)
         {
         }
 
@@ -74,6 +74,19 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="appId">The Microsoft app ID.</param>
         /// <param name="password">The Microsoft app password.</param>
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        /// <param name="oAuthScope">The scope for the token.</param>
+        public MicrosoftAppCredentials(string appId, string password, HttpClient customHttpClient, ILogger logger,  string oAuthScope)
+            : this(appId, password, null, customHttpClient, logger, oAuthScope)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicrosoftAppCredentials"/> class.
+        /// </summary>
+        /// <param name="appId">The Microsoft app ID.</param>
+        /// <param name="password">The Microsoft app password.</param>
         /// <param name="channelAuthTenant">Optional. The oauth token tenant.</param>
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         public MicrosoftAppCredentials(string appId, string password, string channelAuthTenant, HttpClient customHttpClient)
@@ -90,10 +103,24 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
         public MicrosoftAppCredentials(string appId, string password, string channelAuthTenant, HttpClient customHttpClient, ILogger logger = null)
-            : base(channelAuthTenant)
+            : this(appId, password, channelAuthTenant, customHttpClient, logger, null)
         {
-            this.MicrosoftAppId = appId;
-            this.MicrosoftAppPassword = password;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicrosoftAppCredentials"/> class.
+        /// </summary>
+        /// <param name="appId">The Microsoft app ID.</param>
+        /// <param name="password">The Microsoft app password.</param>
+        /// <param name="channelAuthTenant">Optional. The oauth token tenant.</param>
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        /// <param name="oAuthScope">The scope for the token.</param>
+        public MicrosoftAppCredentials(string appId, string password, string channelAuthTenant, HttpClient customHttpClient, ILogger logger = null, string oAuthScope = null)
+            : base(channelAuthTenant, customHttpClient, logger, oAuthScope)
+        {
+            MicrosoftAppId = appId;
+            MicrosoftAppPassword = password;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/OAuthConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/OAuthConfiguration.cs
@@ -1,4 +1,7 @@
-﻿namespace Microsoft.Bot.Connector.Authentication
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Connector.Authentication
 {
     /// <summary>
     /// Configuration for OAuth client credential authentication.

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,9 +11,9 @@ namespace Microsoft.Bot.Connector.Authentication
     {
         public static async Task<TResult> Run<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
         {
-            RetryParams retry = RetryParams.StopRetrying;
-            List<Exception> exceptions = new List<Exception>();
-            int currentRetryCount = 0;
+            RetryParams retry;
+            var exceptions = new List<Exception>();
+            var currentRetryCount = 0;
 
             do
             {
@@ -30,8 +33,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     currentRetryCount++;
                     await Task.Delay(retry.RetryAfter.WithJitter()).ConfigureAwait(false);
                 }
-            }
-            while (retry.ShouldRetry);
+            } while (retry.ShouldRetry);
 
             throw new AggregateException("Failed to acquire token for client credentials.", exceptions);
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// Validates JWT tokens sent to and from a Skill.
+    /// </summary>
+    public class SkillValidation
+    {
+        /// <summary>
+        /// TO SKILL FROM BOT and TO BOT FROM SKILL: Token validation parameters when connecting a bot to a skill.
+        /// </summary>
+        private static readonly TokenValidationParameters _tokenValidationParameters =
+            new TokenValidationParameters()
+            {
+                ValidateIssuer = true,
+                ValidIssuers = new[]
+                {
+                    "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/", // Auth v3.1, 1.0 token
+                    "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0", // Auth v3.1, 2.0 token
+                    "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/", // Auth v3.2, 1.0 token
+                    "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0", // Auth v3.2, 2.0 token
+                    "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/", // Auth for US Gov, 1.0 token
+                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0", // Auth for US Gov, 2.0 token
+                },
+                ValidateAudience = false, // Audience validation takes place manually in code.
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5),
+                RequireSignedTokens = true,
+            };
+
+        /// <summary>
+        /// Determines if a given Auth header is from from a skill to bot or bot to skill request.
+        /// </summary>
+        /// <param name="authHeader">Bearer Token, in the "Bearer [Long String]" Format.</param>
+        /// <returns>True, if the token was issued for a skill to bot communication. Otherwise, false.</returns>
+        public static bool IsSkillToken(string authHeader)
+        {
+            if (string.IsNullOrWhiteSpace(authHeader))
+            {
+                // No token. Can't be an emulator token.
+                return false;
+            }
+
+            var parts = authHeader.Split(' ');
+            if (parts.Length != 2)
+            {
+                // Skill tokens MUST have exactly 2 parts. If we don't have 2 parts, it's not a skill token
+                return false;
+            }
+
+            // We now have an array that should be:
+            // [0] = "Bearer"
+            // [1] = "[Big Long String]"
+            var authScheme = parts[0];
+            var bearerToken = parts[1];
+            if (!authScheme.Equals("Bearer", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // The scheme MUST be "Bearer"
+                return false;
+            }
+
+            // Parse the Big Long String into an actual token.
+            var token = new JwtSecurityToken(bearerToken);
+
+            return IsSkillClaim(token.Claims);
+        }
+
+        /// <summary>
+        /// Checks if the given list of claims represents a skill.
+        /// </summary>
+        /// <remarks>
+        /// A skill claim should contain:
+        ///     An <see cref="AuthenticationConstants.VersionClaim"/> claim.
+        ///     An <see cref="AuthenticationConstants.AudienceClaim"/> claim.
+        ///     An <see cref="AuthenticationConstants.AppIdClaim"/> claim (v1) or an a <see cref="AuthenticationConstants.AuthorizedParty"/> claim (v2).
+        /// And the appId claim should be different than the audience claim.
+        /// </remarks>
+        /// <param name="claims">A list of claims.</param>
+        /// <returns>True if the list of claims is a skill claim, false if is not.</returns>
+        public static bool IsSkillClaim(IEnumerable<Claim> claims)
+        {
+            var claimsList = claims.ToList();
+
+            var version = claimsList.FirstOrDefault(claim => claim.Type == AuthenticationConstants.VersionClaim);
+            if (string.IsNullOrWhiteSpace(version?.Value))
+            {
+                // Must have a version claim.
+                return false;
+            }
+
+            var audience = claimsList.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim)?.Value;
+            if (string.IsNullOrWhiteSpace(audience) || AuthenticationConstants.ToBotFromChannelTokenIssuer.Equals(audience, StringComparison.InvariantCulture))
+            {
+                // The audience is https://api.botframework.com and not an appId.
+                return false;
+            }
+
+            var appId = JwtTokenValidation.GetAppId(claimsList);
+            if (string.IsNullOrWhiteSpace(appId))
+            {
+                return false;
+            }
+
+            // Skill claims must contain and app ID and the AppID must be different than the audience.
+            return appId != audience;
+        }
+
+        /// <summary>
+        /// Validates that the incoming Auth Header is a token sent from a bot to a skill or from a skill to a bot.
+        /// </summary>
+        /// <param name="authHeader">The raw HTTP header in the format: "Bearer [longString]".</param>
+        /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
+        /// <param name="channelProvider">The channelService value that distinguishes public Azure from US Government Azure.</param>
+        /// <param name="httpClient">
+        /// Authentication of tokens requires calling out to validate Endorsements and related documents. The
+        /// HttpClient is used for making those calls. Those calls generally require TLS connections, which are expensive to
+        /// setup and teardown, so a shared HttpClient is recommended.
+        /// </param>
+        /// <param name="channelId">The ID of the channel to validate.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <returns>A <see cref="ClaimsIdentity"/> instance if the validation is successful.</returns>
+        public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+        {
+            if (authConfig == null)
+            {
+                throw new ArgumentNullException(nameof(authConfig));
+            }
+
+            var openIdMetadataUrl = channelProvider != null && channelProvider.IsGovernment() ?
+                GovernmentAuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl : 
+                AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl;
+
+            var tokenExtractor = new JwtTokenExtractor(
+                httpClient,
+                _tokenValidationParameters,
+                openIdMetadataUrl,
+                AuthenticationConstants.AllowedSigningAlgorithms);
+
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements);
+
+            await ValidateIdentity(identity, credentials).ConfigureAwait(false);
+
+            return identity;
+        }
+
+        internal static async Task ValidateIdentity(ClaimsIdentity identity, ICredentialProvider credentials)
+        {
+            if (identity == null)
+            {
+                // No valid identity. Not Authorized.
+                throw new UnauthorizedAccessException("Invalid Identity");
+            }
+
+            if (!identity.IsAuthenticated)
+            {
+                // The token is in some way invalid. Not Authorized.
+                throw new UnauthorizedAccessException("Token Not Authenticated");
+            }
+
+            var versionClaim = identity.Claims.FirstOrDefault(c => c.Type == AuthenticationConstants.VersionClaim);
+            if (versionClaim == null)
+            {
+                // No version claim
+                throw new UnauthorizedAccessException($"'{AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.");
+            }
+
+            // Look for the "aud" claim, but only if issued from the Bot Framework
+            var audienceClaim = identity.Claims.FirstOrDefault(c => c.Type == AuthenticationConstants.AudienceClaim)?.Value;
+            if (string.IsNullOrWhiteSpace(audienceClaim))
+            {
+                // Claim is not present or doesn't have a value. Not Authorized.
+                throw new UnauthorizedAccessException($"'{AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.");
+            }
+
+            if (!await credentials.IsValidAppIdAsync(audienceClaim))
+            {
+                // The AppId is not valid. Not Authorized.
+                throw new UnauthorizedAccessException($"Invalid audience.");
+            }
+            
+            var appId = JwtTokenValidation.GetAppId(identity.Claims);
+            if (string.IsNullOrWhiteSpace(appId))
+            {
+                // Invalid appId
+                throw new UnauthorizedAccessException($"Invalid appId.");
+            }
+
+            // TODO: check the appId against the registered skill client IDs.
+            // Check the AppId and ensure that only works against my whitelist authConfig can have info on how to get the
+            // whitelist AuthenticationConfiguration
+            // We may need to add a ClaimsIdentityValidator delegate or class that allows the dev to inject a custom validator.
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
     public static class TimeSpanExtensions
     {
-        private static Random random = new Random();
+        private static readonly Random _random = new Random();
 
         public static TimeSpan WithJitter(this TimeSpan delay, double multiplier = 0.1)
         {
@@ -12,7 +15,7 @@ namespace Microsoft.Bot.Connector.Authentication
             // random noise. The reason for this is that if there are multiple threads about to retry
             // at the same time, it can overload the server again and trigger throttling again.
             // By adding a bit of random noise, we distribute requests a across time.
-            return delay + TimeSpan.FromMilliseconds(random.NextDouble() * delay.TotalMilliseconds * 0.1);
+            return delay + TimeSpan.FromMilliseconds(_random.NextDouble() * delay.TotalMilliseconds * 0.1);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Internals.cs
+++ b/libraries/Microsoft.Bot.Connector/Internals.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Connector.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Connector.Tests")]
+#endif

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/AppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/AppCredentialsTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests.Authentication
+{
+    public class AppCredentialsTests
+    {
+        [Fact]
+        public void ConstructorTests()
+        {
+            var shouldDefaultToChannelScope = new TestAppCredentials("irrelevant", null, null);
+            Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, shouldDefaultToChannelScope.OAuthScope);
+
+            var shouldDefaultToCustomScope = new TestAppCredentials("irrelevant", null, null, "customScope");
+            Assert.Equal("customScope", shouldDefaultToCustomScope.OAuthScope);
+        }
+
+        private class TestAppCredentials : AppCredentials
+        {
+            public TestAppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
+                : base(channelAuthTenant, customHttpClient, logger)
+            {
+            }
+
+            public TestAppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null, string oAuthScope = null)
+                : base(channelAuthTenant, customHttpClient, logger, oAuthScope)
+            {
+            }
+
+            protected override Lazy<AdalAuthenticator> BuildAuthenticator()
+            {
+                return new Mock<Lazy<AdalAuthenticator>>().Object;
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -460,30 +460,30 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void GetAppIdTests()
+        public void GetAppIdFromClaimsTests()
         {
             var v1Claims = new List<Claim>();
             var v2Claims = new List<Claim>();
             var appId = Guid.NewGuid().ToString();
 
             // Empty list
-            Assert.Null(JwtTokenValidation.GetAppId(v1Claims));
+            Assert.Null(JwtTokenValidation.GetAppIdFromClaims(v1Claims));
 
             // AppId there but no version (assumes v1)
             v1Claims.Add(new Claim(AuthenticationConstants.AppIdClaim, appId));
-            Assert.Equal(appId, JwtTokenValidation.GetAppId(v1Claims));
+            Assert.Equal(appId, JwtTokenValidation.GetAppIdFromClaims(v1Claims));
 
             // AppId there with v1 version
             v1Claims.Add(new Claim(AuthenticationConstants.VersionClaim, "1.0"));
-            Assert.Equal(appId, JwtTokenValidation.GetAppId(v1Claims));
+            Assert.Equal(appId, JwtTokenValidation.GetAppIdFromClaims(v1Claims));
 
             // v2 version but no azp
             v2Claims.Add(new Claim(AuthenticationConstants.VersionClaim, "2.0"));
-            Assert.Null(JwtTokenValidation.GetAppId(v2Claims));
+            Assert.Null(JwtTokenValidation.GetAppIdFromClaims(v2Claims));
 
             // v2 version with azp
             v2Claims.Add(new Claim(AuthenticationConstants.AuthorizedParty, appId));
-            Assert.Equal(appId, JwtTokenValidation.GetAppId(v2Claims));
+            Assert.Equal(appId, JwtTokenValidation.GetAppIdFromClaims(v2Claims));
         }
 
         private async Task JwtTokenValidation_ValidateAuthHeader_WithChannelService_Succeeds(string appId, string pwd, string channelService)

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/MicrosoftAppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/MicrosoftAppCredentialsTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests.Authentication
+{
+    public class MicrosoftAppCredentialsTests
+    {
+        [Fact]
+        public void ConstructorTests()
+        {
+            var defaultScopeCase1 = new MicrosoftAppCredentials("someApp", "somePassword");
+            Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, defaultScopeCase1.OAuthScope);
+
+            using (var customHttpClient = new HttpClient())
+            {
+                // Use with default scope
+                var defaultScopeCase2 = new MicrosoftAppCredentials("someApp", "somePassword", customHttpClient);
+                Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, defaultScopeCase2.OAuthScope);
+
+                var logger = new Mock<ILogger>().Object;
+                var defaultScopeCase3 = new MicrosoftAppCredentials("someApp", "somePassword", customHttpClient, logger);
+                Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, defaultScopeCase3.OAuthScope);
+
+                var defaultScopeCase4 = new MicrosoftAppCredentials("someApp", "somePassword", "someTenant", customHttpClient);
+                Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, defaultScopeCase4.OAuthScope);
+
+                var defaultScopeCase5 = new MicrosoftAppCredentials("someApp", "somePassword", "someTenant", customHttpClient, logger);
+                Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, defaultScopeCase5.OAuthScope);
+
+                // Use custom scope
+                var customScopeCase1 = new MicrosoftAppCredentials("someApp", "somePassword", customHttpClient, logger, "customScope");
+                Assert.Equal("customScope", customScopeCase1.OAuthScope);
+
+                var customScopeCase2 = new MicrosoftAppCredentials("someApp", "somePassword", "someTenant", customHttpClient, logger, "customScope");
+                Assert.Equal("customScope", customScopeCase2.OAuthScope);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/SkillValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/SkillValidationTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Bot.Connector.Tests.Authentication
+{
+    public class SkillValidationTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public SkillValidationTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void IsSkillClaimTest()
+        {
+            var claims = new List<Claim>();
+            var audience = Guid.NewGuid().ToString();
+            var appId = Guid.NewGuid().ToString();
+            
+            // Empty list of claims
+            Assert.False(SkillValidation.IsSkillClaim(claims));
+
+            // No Audience claim
+            claims.Add(new Claim(AuthenticationConstants.VersionClaim, "1.0"));
+            Assert.False(SkillValidation.IsSkillClaim(claims));
+
+            // Emulator Audience claim
+            claims.Add(new Claim(AuthenticationConstants.AudienceClaim, AuthenticationConstants.ToBotFromChannelTokenIssuer));
+            Assert.False(SkillValidation.IsSkillClaim(claims));
+
+            // No AppId claim
+            claims.RemoveAt(claims.Count -1);
+            claims.Add(new Claim(AuthenticationConstants.AudienceClaim, audience));
+            Assert.False(SkillValidation.IsSkillClaim(claims));
+
+            // AppId != Audience
+            claims.Add(new Claim(AuthenticationConstants.AppIdClaim, audience));
+            Assert.False(SkillValidation.IsSkillClaim(claims));
+
+            // All checks pass, should be good now
+            claims.RemoveAt(claims.Count -1);
+            claims.Add(new Claim(AuthenticationConstants.AppIdClaim, appId));
+            Assert.True(SkillValidation.IsSkillClaim(claims));
+        }
+
+        [Theory]
+        [InlineData(false, "Null string", null)]
+        [InlineData(false, "Empty string", "")]
+        [InlineData(false, "No token part", "Bearer")]
+        [InlineData(false, "No bearer part", "ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ")]
+        [InlineData(false, "Invalid scheme", "Potato ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ")]
+        [InlineData(false, "To bot v2 from webchat", "Bearer ew0KICAiYWxnIjogIlJTMjU2IiwNCiAgImtpZCI6ICJKVzNFWGRudy13WTJFcUxyV1RxUTJyVWtCLWciLA0KICAieDV0IjogIkpXM0VYZG53LXdZMkVxTHJXVHFRMnJVa0ItZyIsDQogICJ0eXAiOiAiSldUIg0KfQ.ew0KICAic2VydmljZXVybCI6ICJodHRwczovL2RpcmVjdGxpbmUuYm90ZnJhbWV3b3JrLmNvbS8iLA0KICAibmJmIjogMTU3MTE5MDM0OCwNCiAgImV4cCI6IDE1NzExOTA5NDgsDQogICJpc3MiOiAiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsDQogICJhdWQiOiAiNGMwMDM5ZTUtNjgxNi00OGU4LWIzMTMtZjc3NjkxZmYxYzVlIg0KfQ.cEVHmQCTjL9HVHGk91sja5CqjgvM7B-nArkOg4bE83m762S_le94--GBb0_7aAy6DCdvkZP0d4yWwbpfOkukEXixCDZQM2kWPcOo6lz_VIuXxHFlZAGrTvJ1QkBsg7vk-6_HR8XSLJQZoWrVhE-E_dPj4GPBKE6s1aNxYytzazbKRAEYa8Cn4iVtuYbuj4XfH8PMDv5aC0APNvfgTGk-BlIiP6AGdo4JYs62lUZVSAYg5VLdBcJYMYcKt-h2n1saeapFDVHx_tdpRuke42M4RpGH_wzICeWC5tTExWEkQWApU85HRA5zzk4OpTv17Ct13JCvQ7cD5x9RK5f7CMnbhQ")]
+        [InlineData(false, "To bot v1 token from emulator", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzMzYzQyMS1mN2QzLTRiNmMtOTkyYi0zNmU3ZTZkZTg3NjEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwiaWF0IjoxNTcxMTg5ODczLCJuYmYiOjE1NzExODk4NzMsImV4cCI6MTU3MTE5Mzc3MywiYWlvIjoiNDJWZ1lLaWJGUDIyMUxmL0NjL1Yzai8zcGF2RUFBPT0iLCJhcHBpZCI6IjRjMzNjNDIxLWY3ZDMtNGI2Yy05OTJiLTM2ZTdlNmRlODc2MSIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2Q2ZDQ5NDIwLWYzOWItNGRmNy1hMWRjLWQ1OWE5MzU4NzFkYi8iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJOdXJ3bTVOQnkwR2duT3dKRnFVREFBIiwidmVyIjoiMS4wIn0.GcKs3XZ_4GONVsAoPYI7otqUZPoNN8pULUnlJMxQa-JKXRKV0KtvTAdcMsfYudYxbz7HwcNYerFT1q3RZAimJFtfF4x_sMN23yEVxsQmYQrsf2YPmEsbCfNiEx0YEoWUdS38R1N0Iul2P_P_ZB7XreG4aR5dT6lY5TlXbhputv9pi_yAU7PB1aLuB05phQme5NwJEY22pUfx5pe1wVHogI0JyNLi-6gdoSL63DJ32tbQjr2DNYilPVtLsUkkz7fTky5OKd4p7FmG7P5EbEK4H5j04AGe_nIFs-X6x_FIS_5OSGK4LGA2RPnqa-JYpngzlNWVkUbnuH10AovcAprgdg")]
+        [InlineData(false, "To bot v2 token from emulator", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzAwMzllNS02ODE2LTQ4ZTgtYjMxMy1mNzc2OTFmZjFjNWUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiL3YyLjAiLCJpYXQiOjE1NzExODkwMTEsIm5iZiI6MTU3MTE4OTAxMSwiZXhwIjoxNTcxMTkyOTExLCJhaW8iOiI0MlZnWUxnYWxmUE90Y2IxaEoxNzJvbmxIc3ZuQUFBPSIsImF6cCI6IjRjMDAzOWU1LTY4MTYtNDhlOC1iMzEzLWY3NzY5MWZmMWM1ZSIsImF6cGFjciI6IjEiLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJucEVxVTFoR1pVbXlISy1MUVdJQ0FBIiwidmVyIjoiMi4wIn0.CXcPx7LfatlRsOX4QG-jaC-guwcY3PFxpFICqwfoOTxAjHpeJNFXOpFeA3Qb5VKM6Yw5LyA9eraL5QDJB_4uMLCCKErPXMyoSm8Hw-GGZkHgFV5ciQXSXhE-IfOinqHE_0Lkt_VLR2q6ekOncnJeCR111QCqt3D8R0Ud0gvyLv_oONxDtqg7HUgNGEfioB-BDnBsO4RN7NGrWQFbyPxPmhi8a_Xc7j5Bb9jeiiIQbVaWkIrrPN31aWY1tEZLvdN0VluYlOa0EBVrzpXXZkIyWx99mpklg0lsy7mRyjuM1xydmyyGkzbiCKtODOanf8UwTjkTg5XTIluxe79_hVk2JQ")]
+        [InlineData(true, "To skill valid v1 token", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzMzYzQyMS1mN2QzLTRiNmMtOTkyYi0zNmU3ZTZkZTg3NjEiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9kNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIvIiwiaWF0IjoxNTcxMTg5NjMwLCJuYmYiOjE1NzExODk2MzAsImV4cCI6MTU3MTE5MzUzMCwiYWlvIjoiNDJWZ1lJZzY1aDFXTUVPd2JmTXIwNjM5V1lLckFBPT0iLCJhcHBpZCI6IjRjMDAzOWU1LTY4MTYtNDhlOC1iMzEzLWY3NzY5MWZmMWM1ZSIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2Q2ZDQ5NDIwLWYzOWItNGRmNy1hMWRjLWQ1OWE5MzU4NzFkYi8iLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJhWlpOUTY3RjRVNnNmY3d0S0R3RUFBIiwidmVyIjoiMS4wIn0.Yogk9fptxxJKO8jRkk6FrlLQsAulNNgoa0Lqv2JPkswyyizse8kcwQhxOaZOotY0UBduJ-pCcrejk6k4_O_ZReYXKz8biL9Q7Z02cU9WUMvuIGpAhttz8v0VlVSyaEJVJALc5B-U6XVUpZtG9LpE6MVror_0WMnT6T9Ijf9SuxUvdVCcmAJyZuoqudodseuFI-jtCpImEapZp0wVN4BUodrBacMbTeYjdZyAbNVBqF5gyzDztMKZR26HEz91gqulYZvJJZOJO6ejnm0j62s1tqvUVRBywvnSOon-MV0Xt2Vm0irhv6ipzTXKwWhT9rGHSLj0g8r6NqWRyPRFqLccvA")]
+        [InlineData(true, "To skill valid v2 token", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImFQY3R3X29kdlJPb0VOZzNWb09sSWgydGlFcyJ9.eyJhdWQiOiI0YzAwMzllNS02ODE2LTQ4ZTgtYjMxMy1mNzc2OTFmZjFjNWUiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZDZkNDk0MjAtZjM5Yi00ZGY3LWExZGMtZDU5YTkzNTg3MWRiL3YyLjAiLCJpYXQiOjE1NzExODk3NTUsIm5iZiI6MTU3MTE4OTc1NSwiZXhwIjoxNTcxMTkzNjU1LCJhaW8iOiI0MlZnWUpnZDROZkZKeG1tMTdPaVMvUk8wZll2QUE9PSIsImF6cCI6IjRjMzNjNDIxLWY3ZDMtNGI2Yy05OTJiLTM2ZTdlNmRlODc2MSIsImF6cGFjciI6IjEiLCJ0aWQiOiJkNmQ0OTQyMC1mMzliLTRkZjctYTFkYy1kNTlhOTM1ODcxZGIiLCJ1dGkiOiJMc2ZQME9JVkNVS1JzZ1IyYlFBQkFBIiwidmVyIjoiMi4wIn0.SggsEbEyXDYcg6EdhK-RA1y6S97z4hwEccXc6a3ymnHP-78frZ3N8rPLsqLoK5QPGA_cqOXsX1zduA4vlFSy3MfTV_npPfsyWa1FIse96-2_3qa9DIP8bhvOHXEVZeq-r-0iF972waFyPPC_KVYWnIgAcunGhFWvLhhOUx9dPgq7824qTq45ma1rOqRoYbhhlRn6PJDymIin5LeOzDGJJ8YVLnFUgntc6_4z0P_fnuMktzar88CUTtGvR4P7XNJhS8v9EwYQujglsJNXg7LNcwV7qOxDYWJtT_UMuMAts9ctD6FkuTGX_-6FTqmdUPPUS4RWwm4kkl96F_dXnos9JA")]
+        public void IsSkillTokenTest(bool expected, string testCaseName, string token)
+        {
+            _output.WriteLine(testCaseName);
+            Assert.Equal(expected, SkillValidation.IsSkillToken(token));
+        }
+
+        [Fact]
+        public async Task IdentityValidationTests()
+        {
+            var mockCredentials = new Mock<ICredentialProvider>();
+            var audience = Guid.NewGuid().ToString();
+            var appId = Guid.NewGuid().ToString();
+            var mockIdentity = new Mock<ClaimsIdentity>();
+            var claims = new List<Claim>();
+
+            // Null identity
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await SkillValidation.ValidateIdentity(null, mockCredentials.Object));
+            Assert.Equal("Invalid Identity", exception.Message);
+
+            // not authenticated identity
+            mockIdentity.Setup(x => x.IsAuthenticated).Returns(false);
+            exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+            Assert.Equal("Token Not Authenticated", exception.Message);
+
+            // No version claims
+            mockIdentity.Setup(x => x.IsAuthenticated).Returns(true);
+            mockIdentity.Setup(x => x.Claims).Returns(claims);
+            exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+            Assert.Equal($"'{AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.", exception.Message);
+
+            // No audience claim
+            claims.Add(new Claim(AuthenticationConstants.VersionClaim, "1.0"));
+            exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+            Assert.Equal($"'{AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.", exception.Message);
+
+            // Invalid AppId in audience
+            claims.Add(new Claim(AuthenticationConstants.AudienceClaim, audience));
+            mockCredentials.Setup(x => x.IsValidAppIdAsync(It.IsAny<string>())).Returns(Task.FromResult(false));
+            exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+            Assert.Equal("Invalid audience.", exception.Message);
+
+            // Invalid AppId in in appId or azp
+            mockCredentials.Setup(x => x.IsValidAppIdAsync(It.IsAny<string>())).Returns(Task.FromResult(true));
+            exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+            Assert.Equal("Invalid appId.", exception.Message);
+
+            // All checks pass (no exception)
+            claims.Add(new Claim(AuthenticationConstants.AppIdClaim, appId));
+            await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object);
+        }
+    }
+}

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Mocks/MockAppCredentials.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Mocks/MockAppCredentials.cs
@@ -2,25 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using FluentAssertions;
 using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
-using Microsoft.Rest;
-using Moq;
-using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.Mocks
 {
     internal class MockAppCredentials : AppCredentials
     {
+        public MockAppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
+            : base(channelAuthTenant, customHttpClient, logger)
+        {
+        }
+
         protected override Lazy<AdalAuthenticator> BuildAuthenticator()
         {
             return new Lazy<AdalAuthenticator>();


### PR DESCRIPTION
Relates to #2743 
 
Added constructor overload to AppCredentials and MicrosoftAppCredentals that allow the developer to set a custom OAuthScope (this helps with skill authentication where the audience will be the calling bot).
Added code to validate skill request tokens
Adds missing (c) to OAuthConfiguration, Retry and TimeSpanaExtensios.
Added InternalsVisibleTo to facilitate unit testing.