### PR TITLE
fix ObjectPath.GetValue to handle nested property paths

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -472,36 +472,28 @@ namespace Microsoft.Bot.Builder.Dialogs
         private static IEnumerable<string> MatchBrackets(string path)
         {
             StringBuilder sb = new StringBuilder();
-            int inside = 0;
+            int nest = 0;
             for (int i = 0; i < path.Length; i++)
             {
                 char ch = path[i];
-                if (inside == 0)
+                if (ch == '[')
                 {
-                    if (ch == '[')
-                    {
-                        inside++;
-                        sb.Append(ch);
-                    }
+                    nest++;
                 }
-                else
+                else if (ch == ']')
                 {
-                    if (ch == '[')
-                    {
-                        inside++;
-                    }
-                    else if (ch == ']')
-                    {
-                        inside--;
-                    }
+                    nest--;
+                }
 
+                if (nest > 0)
+                {
                     sb.Append(ch);
-
-                    if (inside == 0)
-                    {
-                        yield return sb.ToString();
-                        sb.Clear();
-                    }
+                }
+                else if (sb.Length > 0)
+                {
+                    sb.Append(ch);
+                    yield return sb.ToString();
+                    sb.Clear();
                 }
             }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     objIndex = "options",
                     options = new Options()
                     {
-                        Age = 15,
+                        Age = 1,
                         FirstName = "joe",
                         LastName = "blow",
                         Bool = false,
@@ -409,11 +409,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar.numIndex]", out int number2));
                 Assert.AreEqual(3, number2);
 
+                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar[bar.objIndex].Age]", out int number3));
+                Assert.AreEqual(2, number3);
+
                 Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "bar.options[bar.strIndex]", out string name));
                 Assert.AreEqual("joe", name);
 
                 Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar[bar.objIndex].Age", out int age));
-                Assert.AreEqual(15, age);
+                Assert.AreEqual(1, age);
             }
 
             // now try with JObject

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
@@ -372,6 +372,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
                 bar = new
                 {
+                    numIndex = 2,
+                    strIndex = "FirstName",
+                    objIndex = "options",
                     options = new Options()
                     {
                         Age = 15,
@@ -380,7 +383,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                         Bool = false,
                     },
                     numbers = new int[] { 1, 2, 3, 4, 5 }
-                }
+                },
             };
 
             // set with anonymous object
@@ -402,6 +405,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
                 Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[1]", out int number));
                 Assert.AreEqual(2, number);
+
+                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar.numIndex]", out int number2));
+                Assert.AreEqual(3, number2);
+
+                Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "bar.options[bar.strIndex]", out string name));
+                Assert.AreEqual("joe", name);
+
+                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar[bar.objIndex].Age", out int age));
+                Assert.AreEqual(15, age);
             }
 
             // now try with JObject


### PR DESCRIPTION
Example:  "dialog[user.name].Age"

fix for #2757 
