### PR TITLE
Fix regressions in Debugger support

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
@@ -105,6 +106,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
             // Dialogs
             yield return new TypeRegistration<AdaptiveDialog>("Microsoft.AdaptiveDialog");
+            yield return new TypeRegistration<QnAMakerDialog>("Microsoft.QnAMakerDialog");
         }
 
         public override IEnumerable<JsonConverter> GetConverters(ISourceMap sourceMap, IRefResolver refResolver, Stack<string> paths)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
@@ -164,8 +165,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             }
         }
 
-        private static bool PathEquals(string one, string two) =>
-            Path.Equals(Path.GetFullPath(one), Path.GetFullPath(two));
+        private static bool PathEquals(string one, string two)
+        {
+            var ext1 = Path.GetExtension(one).ToLower();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // we want to be case insensitive on windows
+                one = one.ToLower();
+                two = two.ToLower();
+            }
+
+            // if it's resource path, we only care about resource name
+            if (ext1 == ".dialog" || ext1 == ".lg" || ext1 == ".lu")
+            {
+                return Path.GetFileName(one) == Path.GetFileName(two);
+            }
+
+            return Path.Equals(Path.GetFullPath(one), Path.GetFullPath(two));
+        }
 
         private bool TryUpdate(Row row, KeyValuePair<object, SourceRange> sourceItem)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using static Microsoft.Bot.Builder.Dialogs.DialogContext;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
@@ -355,7 +356,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
         private async Task SendAsync(Protocol.Message message, CancellationToken cancellationToken)
         {
-            var token = JToken.FromObject(message, new JsonSerializer() { NullValueHandling = NullValueHandling.Include });
+            var token = JToken.FromObject(message, new JsonSerializer()
+            {
+                NullValueHandling = NullValueHandling.Include,
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            });
             await SendAsync(token, cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
* Debugger requires camelcase serialization when communicating with vscode debugger
* VSCode sends different case drive letter then IIS has.  
** Added support to only use file name for resources, (.dialog, .lg, etc.) 
** made path case insensitive on windows platform.