### PR TITLE
Fix for #2776: 'null' response to Invoke when using AspNetCore integration package

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                 {
                     response.StatusCode = invokeResponse.Status;
 
-                    if (response.Body != null)
+                    if (invokeResponse.Body != null)
                     {
                         response.ContentType = "application/json";
                         using (var memoryStream = new MemoryStream())


### PR DESCRIPTION
Fixed issue where the body of invokes with no response was 'null' rather than an empty body. This was causing all the `TeamsActivityHandler` delegates that didn't have a payload response to an invoke to fail in-flight on returning to Teams as one of the intermediaries attempts to parse the body as JSON if present. 