### PR TITLE
SkillHostAdapter Constructor updates

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Skills/Integration.AspNet.Core/BotFrameworkHttpSkillsServer.cs
+++ b/libraries/Microsoft.Bot.Builder.Skills/Integration.AspNet.Core/BotFrameworkHttpSkillsServer.cs
@@ -24,74 +24,75 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Skills
             new ChannelRoute
             {
                 Method = ChannelApiMethods.GetActivityMembers,
-                Pattern = new Regex(@"/GET:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>.*)/members", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/GET:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>.*)/members", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.ReplyToActivity,
-                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>[^\s/]*)?", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>[^\s/]*)?", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.UpdateActivity,
-                Pattern = new Regex(@"/PUT:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>[^\s/]*)?", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/PUT:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>[^\s/]*)?", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.DeleteActivity,
-                Pattern = new Regex(@"/DELETE:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>[^\s/]*)?", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/DELETE:/v3/conversations/(?<conversationId>[^\s/]*)/activities/(?<activityId>[^\s/]*)?", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.SendToConversation,
-                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/activities", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/activities", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.SendConversationHistory,
-                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/activities/history", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/activities/history", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.DeleteConversationMember,
-                Pattern = new Regex(@"/DELETE:/v3/conversations/(?<conversationId>[^\s/]*)/members/(?<memberId>.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/DELETE:/v3/conversations/(?<conversationId>[^\s/]*)/members/(?<memberId>.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.UploadAttachment,
-                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/attachments", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/POST:/v3/conversations/(?<conversationId>[^\s/]*)/attachments", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.GetConversationMembers,
-                Pattern = new Regex(@"/GET:/v3/conversations/(?<conversationId>[^\s/]*)/members", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/GET:/v3/conversations/(?<conversationId>[^\s/]*)/members", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.GetConversationPagedMembers,
-                Pattern = new Regex(@"/GET:/v3/conversations/(?<conversationId>[^\s/]*)/pagedmember", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/GET:/v3/conversations/(?<conversationId>[^\s/]*)/pagedmember", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.GetConversations,
-                Pattern = new Regex(@"/GET:/v3/conversations/", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                Pattern = new Regex(@"/GET:/v3/conversations/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             },
             new ChannelRoute
             {
                 Method = ChannelApiMethods.CreateConversation,
-                Pattern = new Regex(@"/POST:/v3/conversations/", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            },
+                Pattern = new Regex(@"/POST:/v3/conversations/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+            }
         };
 
-        private readonly BotFrameworkSkillHostAdapter _skillAdapter;
         private readonly ConfigurationChannelProvider _channelProvider;
         private readonly ConfigurationCredentialProvider _credentialsProvider;
+
+        private readonly BotFrameworkSkillHostAdapter _skillAdapter;
 
         public BotFrameworkHttpSkillsServer(BotFrameworkSkillHostAdapter skillAdapter, IConfiguration configuration)
         {
             // adapter to use for calling back to channel
             _skillAdapter = skillAdapter;
-            
+
             // _botAppId = configuration.GetValue<string>("MicrosoftAppId");
             _credentialsProvider = new ConfigurationCredentialProvider(configuration);
             _channelProvider = new ConfigurationChannelProvider(configuration);
@@ -129,75 +130,75 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Skills
                 // grab the auth header from the inbound http request
                 var authHeader = httpRequest.Headers["Authorization"];
                 var claimsIdentity = await JwtTokenValidation.ValidateAuthHeader(authHeader, _credentialsProvider, _channelProvider, "unknown").ConfigureAwait(false);
-                
+
                 switch (route.Method)
                 {
                     // [Route("/v3/conversations")]
                     case ChannelApiMethods.CreateConversation:
                         var parameters = HttpHelper.ReadRequest<ConversationParameters>(httpRequest);
-                        result = await _skillAdapter.CreateConversationAsync(claimsIdentity, route.Parameters["conversationId"].Value, parameters, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.CreateConversationAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, parameters, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/activities/{activityId}")]
                     case ChannelApiMethods.DeleteActivity:
                         // TODO: ask Tom why we use the value from the route and not from the activity here.
-                        await _skillAdapter.DeleteActivityAsync(claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["activityId"].Value, cancellationToken).ConfigureAwait(false);
+                        await _skillAdapter.DeleteActivityAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["activityId"].Value, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/members/{memberId}")]
                     case ChannelApiMethods.DeleteConversationMember:
-                        await _skillAdapter.DeleteConversationMemberAsync(claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["memberId"].Value, cancellationToken).ConfigureAwait(false);
+                        await _skillAdapter.DeleteConversationMemberAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["memberId"].Value, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/activities/{activityId}/members")]
                     case ChannelApiMethods.GetActivityMembers:
-                        result = await _skillAdapter.GetActivityMembersAsync(claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["activityId"].Value, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.GetActivityMembersAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["activityId"].Value, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/members")]
                     case ChannelApiMethods.GetConversationMembers:
-                        result = await _skillAdapter.GetConversationMembersAsync(claimsIdentity, route.Parameters["conversationId"].Value, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.GetConversationMembersAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/pagedmembers")]
                     case ChannelApiMethods.GetConversationPagedMembers:
                         var pageSize = string.IsNullOrWhiteSpace(route.Parameters["pageSize"].Value) ? -1 : int.Parse(route.Parameters["pageSize"].Value, CultureInfo.InvariantCulture);
-                        result = await _skillAdapter.GetConversationPagedMembersAsync(claimsIdentity, route.Parameters["conversationId"].Value, pageSize, route.Parameters["continuationToken"].Value, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.GetConversationPagedMembersAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, pageSize, route.Parameters["continuationToken"].Value, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations")]
                     case ChannelApiMethods.GetConversations:
-                        result = await _skillAdapter.GetConversationsAsync(claimsIdentity, route.Parameters["conversationId"].Value, cancellationToken: cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.GetConversationsAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, cancellationToken: cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/activities/{activityId}")]
                     case ChannelApiMethods.ReplyToActivity:
                         var replyToActivity = HttpHelper.ReadRequest<Activity>(httpRequest);
-                        result = await _skillAdapter.ReplyToActivityAsync(claimsIdentity, replyToActivity.Conversation.Id, route.Parameters["activityId"].Value, replyToActivity, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.ReplyToActivityAsync(bot, claimsIdentity, replyToActivity.Conversation.Id, route.Parameters["activityId"].Value, replyToActivity, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/activities/history")]
                     case ChannelApiMethods.SendConversationHistory:
                         var history = HttpHelper.ReadRequest<Transcript>(httpRequest);
-                        result = await _skillAdapter.SendConversationHistoryAsync(claimsIdentity, route.Parameters["conversationId"].Value, history, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.SendConversationHistoryAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, history, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/activities")]
                     case ChannelApiMethods.SendToConversation:
                         var sendToConversationActivity = HttpHelper.ReadRequest<Activity>(httpRequest);
-                        result = await _skillAdapter.SendToConversationAsync(claimsIdentity, sendToConversationActivity.Conversation.Id, sendToConversationActivity, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.SendToConversationAsync(bot, claimsIdentity, sendToConversationActivity.Conversation.Id, sendToConversationActivity, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/activities/{activityId}")]
                     case ChannelApiMethods.UpdateActivity:
                         var updateActivity = HttpHelper.ReadRequest<Activity>(httpRequest);
-                        result = await _skillAdapter.UpdateActivityAsync(claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["activityId"].Value, updateActivity, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.UpdateActivityAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, route.Parameters["activityId"].Value, updateActivity, cancellationToken).ConfigureAwait(false);
                         break;
 
                     // [Route("/v3/conversations/{conversationId}/attachments")]
                     case ChannelApiMethods.UploadAttachment:
                         var uploadAttachment = HttpHelper.ReadRequest<AttachmentData>(httpRequest);
-                        result = await _skillAdapter.UploadAttachmentAsync(claimsIdentity, route.Parameters["conversationId"].Value, uploadAttachment, cancellationToken).ConfigureAwait(false);
+                        result = await _skillAdapter.UploadAttachmentAsync(bot, claimsIdentity, route.Parameters["conversationId"].Value, uploadAttachment, cancellationToken).ConfigureAwait(false);
                         break;
 
                     default:
@@ -214,7 +215,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Skills
             HttpHelper.WriteResponse(httpResponse, statusCode, result);
         }
 
-        private RouteResult GetRoute(HttpRequest httpRequest)
+        private static RouteResult GetRoute(HttpRequest httpRequest)
         {
             var path = $"/{httpRequest.Method}:{httpRequest.Path}";
             foreach (var route in _routes)
@@ -225,7 +226,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Skills
                     var result = new RouteResult
                     {
                         Method = route.Method,
-                        Parameters = match.Groups,
+                        Parameters = match.Groups
                     };
 
                     return result;

--- a/libraries/Microsoft.Bot.Builder.Skills/SkillHostAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Skills/SkillHostAdapter.cs
@@ -21,10 +21,9 @@ namespace Microsoft.Bot.Builder.Skills
         public const string InvokeActivityName = "SkillEvents.ChannelApiInvoke";
         private readonly ILogger _logger;
 
-        protected SkillHostAdapter(BotAdapter adapter, IBot bot, ILogger logger = null)
+        protected SkillHostAdapter(BotAdapter adapter, ILogger logger = null)
         {
             ChannelAdapter = adapter;
-            Bot = bot;
             _logger = logger ?? NullLogger.Instance;
 
             // make sure there is a channel api middleware
@@ -43,14 +42,6 @@ namespace Microsoft.Bot.Builder.Skills
         public BotAdapter ChannelAdapter { get; }
 
         /// <summary>
-        /// Gets the callback to invoke bot logic.
-        /// </summary>
-        /// <value>
-        /// The callback to invoke bot logic.
-        /// </value>
-        public IBot Bot { get; }
-
-        /// <summary>
         /// Forwards an activity to a skill.
         /// </summary>
         /// <param name="turnContext">turnContext.</param>
@@ -65,25 +56,26 @@ namespace Microsoft.Bot.Builder.Skills
         /// </summary>
         /// <remarks>
         /// List the Conversations in which this bot has participated.
-        ///
+        /// 
         /// GET from this method with a skip token
-        ///
+        /// 
         /// The return value is a ConversationsResult, which contains an array of
         /// ConversationMembers and a skip token.  If the skip token is not empty, then
         /// there are further values to be returned. Call this method again with the
         /// returned token to get more values.
-        ///
+        /// 
         /// Each ConversationMembers object contains the ID of the conversation and an
         /// array of ChannelAccounts that describe the members of the conversation.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>conversationId.</param> 
         /// <param name='continuationToken'>skip or continuation token.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for ConversationsResult.</returns>
-        public virtual Task<ConversationsResult> GetConversationsAsync(ClaimsIdentity claimsIdentity, string conversationId, string continuationToken = default, CancellationToken cancellationToken = default)
+        public virtual Task<ConversationsResult> GetConversationsAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, string continuationToken = default, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ConversationsResult>(claimsIdentity, ChannelApiMethods.GetConversations, conversationId, continuationToken);
+            return InvokeChannelApiAsync<ConversationsResult>(bot, claimsIdentity, ChannelApiMethods.GetConversations, conversationId, continuationToken);
         }
 
         /// <summary>
@@ -112,14 +104,15 @@ namespace Microsoft.Bot.Builder.Skills
         ///
         /// end. 
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>conversationId.</param> 
         /// <param name='parameters'>Parameters to create the conversation from.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a conversation resource response.</returns>
-        public virtual Task<ConversationResourceResponse> CreateConversationAsync(ClaimsIdentity claimsIdentity, string conversationId, ConversationParameters parameters, CancellationToken cancellationToken = default)
+        public virtual Task<ConversationResourceResponse> CreateConversationAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, ConversationParameters parameters, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ConversationResourceResponse>(claimsIdentity, ChannelApiMethods.CreateConversation, conversationId, parameters);
+            return InvokeChannelApiAsync<ConversationResourceResponse>(bot, claimsIdentity, ChannelApiMethods.CreateConversation, conversationId, parameters);
         }
 
         /// <summary>
@@ -140,14 +133,15 @@ namespace Microsoft.Bot.Builder.Skills
         ///
         /// Use SendToConversation in all other cases.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>conversationId.</param> 
         /// <param name='activity'>Activity to send.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a resource response.</returns>
-        public virtual Task<ResourceResponse> SendToConversationAsync(ClaimsIdentity claimsIdentity, string conversationId, Activity activity, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> SendToConversationAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, Activity activity, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ResourceResponse>(claimsIdentity, ChannelApiMethods.SendToConversation, conversationId, activity);
+            return InvokeChannelApiAsync<ResourceResponse>(bot, claimsIdentity, ChannelApiMethods.SendToConversation, conversationId, activity);
         }
 
         /// <summary>
@@ -162,14 +156,15 @@ namespace Microsoft.Bot.Builder.Skills
         /// duplicate activities and the timestamps are used by the client to render
         /// the activities in the right order.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='transcript'>Transcript of activities.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a resource response.</returns>
-        public virtual Task<ResourceResponse> SendConversationHistoryAsync(ClaimsIdentity claimsIdentity, string conversationId, Transcript transcript, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> SendConversationHistoryAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, Transcript transcript, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ResourceResponse>(claimsIdentity, ChannelApiMethods.SendConversationHistory, conversationId, transcript);
+            return InvokeChannelApiAsync<ResourceResponse>(bot, claimsIdentity, ChannelApiMethods.SendConversationHistory, conversationId, transcript);
         }
 
         /// <summary>
@@ -184,15 +179,16 @@ namespace Microsoft.Bot.Builder.Skills
         /// For example, you can remove buttons after someone has clicked "Approve"
         /// button.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='activityId'>activityId to update.</param>
         /// <param name='activity'>replacement Activity.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a resource response.</returns>
-        public virtual Task<ResourceResponse> UpdateActivityAsync(ClaimsIdentity claimsIdentity, string conversationId, string activityId, Activity activity, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> UpdateActivityAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, string activityId, Activity activity, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ResourceResponse>(claimsIdentity, ChannelApiMethods.UpdateActivity, conversationId, activityId, activity);
+            return InvokeChannelApiAsync<ResourceResponse>(bot, claimsIdentity, ChannelApiMethods.UpdateActivity, conversationId, activityId, activity);
         }
 
         /// <summary>
@@ -213,15 +209,16 @@ namespace Microsoft.Bot.Builder.Skills
         ///
         /// Use SendToConversation in all other cases.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='activityId'>activityId the reply is to (OPTIONAL).</param>
         /// <param name='activity'>Activity to send.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a resource response.</returns>
-        public virtual Task<ResourceResponse> ReplyToActivityAsync(ClaimsIdentity claimsIdentity, string conversationId, string activityId, Activity activity, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> ReplyToActivityAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, string activityId, Activity activity, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ResourceResponse>(claimsIdentity, ChannelApiMethods.ReplyToActivity, conversationId, activityId, activity);
+            return InvokeChannelApiAsync<ResourceResponse>(bot, claimsIdentity, ChannelApiMethods.ReplyToActivity, conversationId, activityId, activity);
         }
 
         /// <summary>
@@ -233,14 +230,15 @@ namespace Microsoft.Bot.Builder.Skills
         /// Some channels allow you to delete an existing activity, and if successful
         /// this method will remove the specified activity.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='activityId'>activityId to delete.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a resource response.</returns>
-        public virtual Task DeleteActivityAsync(ClaimsIdentity claimsIdentity, string conversationId, string activityId, CancellationToken cancellationToken = default)
+        public virtual Task DeleteActivityAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, string activityId, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync(claimsIdentity, ChannelApiMethods.DeleteActivity, conversationId, activityId);
+            return InvokeChannelApiAsync(bot, claimsIdentity, ChannelApiMethods.DeleteActivity, conversationId, activityId);
         }
 
         /// <summary>
@@ -252,13 +250,14 @@ namespace Microsoft.Bot.Builder.Skills
         /// This REST API takes a ConversationId and returns an array of ChannelAccount
         /// objects representing the members of the conversation.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a response.</returns>
-        public virtual Task<IList<ChannelAccount>> GetConversationMembersAsync(ClaimsIdentity claimsIdentity, string conversationId, CancellationToken cancellationToken = default)
+        public virtual Task<IList<ChannelAccount>> GetConversationMembersAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<IList<ChannelAccount>>(claimsIdentity, ChannelApiMethods.GetConversationMembers, conversationId);
+            return InvokeChannelApiAsync<IList<ChannelAccount>>(bot, claimsIdentity, ChannelApiMethods.GetConversationMembers, conversationId);
         }
 
         /// <summary>
@@ -283,15 +282,16 @@ namespace Microsoft.Bot.Builder.Skills
         /// A response to a request that has a continuation token from a prior request
         /// may rarely return members from a previous request.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='pageSize'>Suggested page size.</param>
         /// <param name='continuationToken'>Continuation Token.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task for a response.</returns>
-        public virtual Task<PagedMembersResult> GetConversationPagedMembersAsync(ClaimsIdentity claimsIdentity, string conversationId, int? pageSize = default, string continuationToken = default, CancellationToken cancellationToken = default)
+        public virtual Task<PagedMembersResult> GetConversationPagedMembersAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, int? pageSize = default, string continuationToken = default, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<PagedMembersResult>(claimsIdentity, ChannelApiMethods.GetConversationPagedMembers, conversationId, pageSize, continuationToken);
+            return InvokeChannelApiAsync<PagedMembersResult>(bot, claimsIdentity, ChannelApiMethods.GetConversationPagedMembers, conversationId, pageSize, continuationToken);
         }
 
         /// <summary>
@@ -305,14 +305,15 @@ namespace Microsoft.Bot.Builder.Skills
         /// member
         /// of the conversation, the conversation will also be deleted.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='memberId'>ID of the member to delete from this conversation.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task.</returns>
-        public virtual Task DeleteConversationMemberAsync(ClaimsIdentity claimsIdentity, string conversationId, string memberId, CancellationToken cancellationToken = default)
+        public virtual Task DeleteConversationMemberAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, string memberId, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync(claimsIdentity, ChannelApiMethods.DeleteConversationMember, conversationId, memberId);
+            return InvokeChannelApiAsync(bot, claimsIdentity, ChannelApiMethods.DeleteConversationMember, conversationId, memberId);
         }
 
         /// <summary>
@@ -325,14 +326,15 @@ namespace Microsoft.Bot.Builder.Skills
         /// of ChannelAccount objects representing the members of the particular
         /// activity in the conversation.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='activityId'>Activity ID.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task with result.</returns>
-        public virtual Task<IList<ChannelAccount>> GetActivityMembersAsync(ClaimsIdentity claimsIdentity, string conversationId, string activityId, CancellationToken cancellationToken = default)
+        public virtual Task<IList<ChannelAccount>> GetActivityMembersAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, string activityId, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<IList<ChannelAccount>>(claimsIdentity, ChannelApiMethods.GetActivityMembers, conversationId, activityId);
+            return InvokeChannelApiAsync<IList<ChannelAccount>>(bot, claimsIdentity, ChannelApiMethods.GetActivityMembers, conversationId, activityId);
         }
 
         /// <summary>
@@ -347,22 +349,23 @@ namespace Microsoft.Bot.Builder.Skills
         /// The response is a ResourceResponse which contains an AttachmentId which is
         /// suitable for using with the attachments API.
         /// </remarks>
+        /// <param name="bot">The <see cref="IBot"/> instance.</param>
         /// <param name="claimsIdentity">claimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.</param>
         /// <param name='conversationId'>Conversation ID.</param>
         /// <param name='attachmentUpload'>Attachment data.</param>
         /// <param name='cancellationToken'>The cancellation token.</param>
         /// <returns>task with result.</returns>
-        public virtual Task<ResourceResponse> UploadAttachmentAsync(ClaimsIdentity claimsIdentity, string conversationId, AttachmentData attachmentUpload, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> UploadAttachmentAsync(IBot bot, ClaimsIdentity claimsIdentity, string conversationId, AttachmentData attachmentUpload, CancellationToken cancellationToken = default)
         {
-            return InvokeChannelApiAsync<ResourceResponse>(claimsIdentity, ChannelApiMethods.UploadAttachment, conversationId, attachmentUpload);
+            return InvokeChannelApiAsync<ResourceResponse>(bot, claimsIdentity, ChannelApiMethods.UploadAttachment, conversationId, attachmentUpload);
         }
 
-        protected async Task InvokeChannelApiAsync(ClaimsIdentity claimsIdentity, string method, string conversationId, params object[] args)
+        protected async Task InvokeChannelApiAsync(IBot bot, ClaimsIdentity claimsIdentity, string method, string conversationId, params object[] args)
         {
-            await InvokeChannelApiAsync<object>(claimsIdentity, method, conversationId, args).ConfigureAwait(false);
+            await InvokeChannelApiAsync<object>(bot, claimsIdentity, method, conversationId, args).ConfigureAwait(false);
         }
 
-        protected async Task<T> InvokeChannelApiAsync<T>(ClaimsIdentity claimsIdentity, string method, string conversationId, params object[] args)
+        protected async Task<T> InvokeChannelApiAsync<T>(IBot bot, ClaimsIdentity claimsIdentity, string method, string conversationId, params object[] args)
         {
             var skillConversation = new SkillConversation(conversationId);
 
@@ -400,16 +403,8 @@ namespace Microsoft.Bot.Builder.Skills
             };
             channelApiInvokeActivity.Value = channelApiArgs;
 
-            // We call our adapter using the BotAppId claim, so turnContext has the bot claims
-            // var claimsIdentity = new ClaimsIdentity(new List<Claim>
-            // {
-            //     new Claim(AuthenticationConstants.AudienceClaim, this.BotAppId),
-            //     new Claim(AuthenticationConstants.AppIdClaim, this.BotAppId),
-            //     new Claim(AuthenticationConstants.ServiceUrlClaim, skillConversation.ServiceUrl),
-            // });
-
             // send up to the bot to process it...
-            await ChannelAdapter.ProcessActivityAsync(claimsIdentity, (Activity)channelApiInvokeActivity, Bot.OnTurnAsync, CancellationToken.None).ConfigureAwait(false);
+            await ChannelAdapter.ProcessActivityAsync(claimsIdentity, (Activity)channelApiInvokeActivity, bot.OnTurnAsync, CancellationToken.None).ConfigureAwait(false);
 
             if (channelApiArgs.Exception != null)
             {

--- a/tests/Microsoft.Bot.Builder.Skills.Tests/Microsoft.Bot.Builder.Skills.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Skills.Tests/Microsoft.Bot.Builder.Skills.Tests.csproj
@@ -7,22 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\Microsoft.Bot.Builder.Dialogs.Adaptive.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs.Declarative\Microsoft.Bot.Builder.Dialogs.Declarative.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs\Microsoft.Bot.Builder.Dialogs.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.LanguageGeneration\Microsoft.Bot.Builder.LanguageGeneration.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Skills\Microsoft.Bot.Builder.Skills.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Expressions\Microsoft.Bot.Expressions.csproj" />
-    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.Bot.Builder.Skills.Tests/SkillAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Skills.Tests/SkillAdapterTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#pragma warning disable SA1402 // File may only contain a single type
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,38 +13,37 @@ using Microsoft.Bot.Builder.Skills.Adapters;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Skills.Tests
 {
-    [TestClass]
     public class SkillAdapterTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public void TestSkillAdapterInjectsMiddleware()
         {
-            var botAdapter = CreateAdapter();
+            var botAdapter = CreateAdapter("TestSkillAdapterInjectsMiddleware");
 
-            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new CallbackBot(), new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration(), configuration: new ConfigurationBuilder().Build());
+            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration(), configuration: new ConfigurationBuilder().Build());
 
-            Assert.AreEqual(1, botAdapter.MiddlewareSet.Where(s => s is ChannelApiMiddleware).Count(), "Should have injected ChannelApiMiddleware into adapter");
+            Assert.Equal(1, botAdapter.MiddlewareSet.Count(s => s is ChannelApiMiddleware));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestSkillAdapterApiCalls()
         {
             var activityId = Guid.NewGuid().ToString("N");
             var botId = Guid.NewGuid().ToString("N");
-            var botAdapter = CreateAdapter();
+            var botAdapter = CreateAdapter("TestSkillAdapterApiCalls");
             var skillAccount = ObjectPath.Clone(botAdapter.Conversation.Bot);
             var skillId = "testSkill";
             skillAccount.Properties["SkillId"] = skillId;
 
-            var middleware = new AssertInvokeMiddleware(botAdapter, skillId, activityId);
+            var middleware = new AssertInvokeMiddleware(botAdapter, activityId);
             botAdapter.Use(middleware);
-            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new CallbackBot(), new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration(), configuration: new ConfigurationBuilder().Build());
+            var bot = new CallbackBot();
+            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration(), configuration: new ConfigurationBuilder().Build());
 
             var sc = new SkillConversation()
             {
@@ -58,36 +56,36 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             claimsIdentity.AddClaim(new Claim(AuthenticationConstants.AppIdClaim, botId));
             claimsIdentity.AddClaim(new Claim(AuthenticationConstants.ServiceUrlClaim, botAdapter.Conversation.ServiceUrl));
 
-            object result = await skillAdapter.CreateConversationAsync(claimsIdentity, skillConversationId, new ConversationParameters());
-            Assert.IsInstanceOfType(result, typeof(ConversationResourceResponse));
-            Assert.AreEqual(middleware.NewResourceId, ((ConversationResourceResponse)result).Id);
+            object result = await skillAdapter.CreateConversationAsync(bot, claimsIdentity, skillConversationId, new ConversationParameters());
+            Assert.IsType<ConversationResourceResponse>(result);
+            Assert.Equal(middleware.NewResourceId, ((ConversationResourceResponse)result).Id);
 
-            await skillAdapter.DeleteActivityAsync(claimsIdentity, skillConversationId, activityId);
+            await skillAdapter.DeleteActivityAsync(bot, claimsIdentity, skillConversationId, activityId);
 
-            await skillAdapter.DeleteConversationMemberAsync(claimsIdentity, skillConversationId, "user2");
+            await skillAdapter.DeleteConversationMemberAsync(bot, claimsIdentity, skillConversationId, "user2");
 
-            result = await skillAdapter.GetActivityMembersAsync(claimsIdentity, skillConversationId, activityId);
-            Assert.IsInstanceOfType(result, typeof(IList<ChannelAccount>));
+            result = await skillAdapter.GetActivityMembersAsync(bot, claimsIdentity, skillConversationId, activityId);
+            Assert.IsAssignableFrom<IList<ChannelAccount>>(result);
 
-            result = await skillAdapter.GetConversationMembersAsync(claimsIdentity, skillConversationId);
-            Assert.IsInstanceOfType(result, typeof(IList<ChannelAccount>));
+            result = await skillAdapter.GetConversationMembersAsync(bot, claimsIdentity, skillConversationId);
+            Assert.IsAssignableFrom<IList<ChannelAccount>>(result);
 
-            result = await skillAdapter.GetConversationPagedMembersAsync(claimsIdentity, skillConversationId);
-            Assert.IsInstanceOfType(result, typeof(PagedMembersResult));
+            result = await skillAdapter.GetConversationPagedMembersAsync(bot, claimsIdentity, skillConversationId);
+            Assert.IsType<PagedMembersResult>(result);
 
-            result = await skillAdapter.GetConversationPagedMembersAsync(claimsIdentity, skillConversationId, 10);
-            Assert.IsInstanceOfType(result, typeof(PagedMembersResult));
+            result = await skillAdapter.GetConversationPagedMembersAsync(bot, claimsIdentity, skillConversationId, 10);
+            Assert.IsType<PagedMembersResult>(result);
 
             var pagedMembersResult = (PagedMembersResult)result;
-            result = await skillAdapter.GetConversationPagedMembersAsync(claimsIdentity, skillConversationId, continuationToken: pagedMembersResult.ContinuationToken);
-            Assert.IsInstanceOfType(result, typeof(PagedMembersResult));
+            result = await skillAdapter.GetConversationPagedMembersAsync(bot, claimsIdentity, skillConversationId, continuationToken: pagedMembersResult.ContinuationToken);
+            Assert.IsType<PagedMembersResult>(result);
 
-            result = await skillAdapter.GetConversationsAsync(claimsIdentity, skillConversationId);
-            Assert.IsInstanceOfType(result, typeof(ConversationsResult));
+            result = await skillAdapter.GetConversationsAsync(bot, claimsIdentity, skillConversationId);
+            Assert.IsType<ConversationsResult>(result);
 
             var conversationsResult = (ConversationsResult)result;
-            result = await skillAdapter.GetConversationsAsync(claimsIdentity, skillConversationId, continuationToken: conversationsResult.ContinuationToken);
-            Assert.IsInstanceOfType(result, typeof(ConversationsResult));
+            result = await skillAdapter.GetConversationsAsync(bot, claimsIdentity, skillConversationId, continuationToken: conversationsResult.ContinuationToken);
+            Assert.IsType<ConversationsResult>(result);
 
             var msgActivity = Activity.CreateMessageActivity();
             msgActivity.Conversation = botAdapter.Conversation.Conversation;
@@ -95,34 +93,35 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             msgActivity.Recipient = botAdapter.Conversation.User;
             msgActivity.Text = "yo";
 
-            result = await skillAdapter.SendToConversationAsync(claimsIdentity, skillConversationId, (Activity)msgActivity);
-            Assert.IsInstanceOfType(result, typeof(ResourceResponse));
-            Assert.AreEqual(middleware.NewResourceId, ((ResourceResponse)result).Id);
+            result = await skillAdapter.SendToConversationAsync(bot, claimsIdentity, skillConversationId, (Activity)msgActivity);
+            Assert.IsType<ResourceResponse>(result);
+            Assert.Equal(middleware.NewResourceId, ((ResourceResponse)result).Id);
             msgActivity.Id = ((ResourceResponse)result).Id;
 
-            result = await skillAdapter.ReplyToActivityAsync(claimsIdentity, skillConversationId, activityId, (Activity)msgActivity);
-            Assert.IsInstanceOfType(result, typeof(ResourceResponse));
-            Assert.AreEqual(middleware.NewResourceId, ((ResourceResponse)result).Id);
-            result = await skillAdapter.SendConversationHistoryAsync(claimsIdentity, skillConversationId, new Transcript());
-            Assert.IsInstanceOfType(result, typeof(ResourceResponse));
-            Assert.AreEqual(middleware.NewResourceId, ((ResourceResponse)result).Id);
+            result = await skillAdapter.ReplyToActivityAsync(bot, claimsIdentity, skillConversationId, activityId, (Activity)msgActivity);
+            Assert.IsType<ResourceResponse>(result);
+            Assert.Equal(middleware.NewResourceId, ((ResourceResponse)result).Id);
 
-            result = await skillAdapter.UpdateActivityAsync(claimsIdentity, skillConversationId, activityId, (Activity)msgActivity);
-            Assert.IsInstanceOfType(result, typeof(ResourceResponse));
-            Assert.AreEqual(middleware.NewResourceId, ((ResourceResponse)result).Id);
+            result = await skillAdapter.SendConversationHistoryAsync(bot, claimsIdentity, skillConversationId, new Transcript());
+            Assert.IsType<ResourceResponse>(result);
+            Assert.Equal(middleware.NewResourceId, ((ResourceResponse)result).Id);
 
-            result = await skillAdapter.UploadAttachmentAsync(claimsIdentity, skillConversationId, new AttachmentData());
-            Assert.IsInstanceOfType(result, typeof(ResourceResponse));
-            Assert.AreEqual(middleware.NewResourceId, ((ResourceResponse)result).Id);
+            result = await skillAdapter.UpdateActivityAsync(bot, claimsIdentity, skillConversationId, activityId, (Activity)msgActivity);
+            Assert.IsType<ResourceResponse>(result);
+            Assert.Equal(middleware.NewResourceId, ((ResourceResponse)result).Id);
+
+            result = await skillAdapter.UploadAttachmentAsync(bot, claimsIdentity, skillConversationId, new AttachmentData());
+            Assert.IsType<ResourceResponse>(result);
+            Assert.Equal(middleware.NewResourceId, ((ResourceResponse)result).Id);
         }
 
-        private TestAdapter CreateAdapter()
+        private TestAdapter CreateAdapter(string conversationName)
         {
             var storage = new MemoryStorage();
             var convoState = new ConversationState(storage);
             var userState = new UserState(storage);
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName));
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(conversationName));
             adapter
                 .UseStorage(storage)
                 .UseState(userState, convoState)
@@ -132,106 +131,104 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
         private class CallbackBot : IBot
         {
-            private readonly BotCallbackHandler callback;
+            private readonly BotCallbackHandler _callback;
 
             public CallbackBot(BotCallbackHandler callback = null)
             {
-                this.callback = callback;
+                _callback = callback;
             }
 
             public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
             {
-                return callback != null ? callback(turnContext, cancellationToken) : Task.CompletedTask;
+                return _callback != null ? _callback(turnContext, cancellationToken) : Task.CompletedTask;
             }
         }
 
         private class AssertInvokeMiddleware : IMiddleware
         {
-            private readonly TestAdapter adapter;
-            private readonly string expectedActivityId;
-            private string skillId;
+            private readonly TestAdapter _adapter;
+            private readonly string _expectedActivityId;
 
-            public AssertInvokeMiddleware(TestAdapter adapter, string skillId, string activityId)
+            public AssertInvokeMiddleware(TestAdapter adapter, string activityId)
             {
-                this.adapter = adapter;
-                this.skillId = skillId;
-                this.expectedActivityId = activityId;
-                this.NewResourceId = Guid.NewGuid().ToString("n");
+                _adapter = adapter;
+                _expectedActivityId = activityId;
+                NewResourceId = Guid.NewGuid().ToString("n");
             }
 
             public string NewResourceId { get; }
 
             public Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
             {
-                Assert.AreEqual(ActivityTypes.Invoke, turnContext.Activity.Type);
-                Assert.AreEqual(adapter.Conversation.Conversation.Id, turnContext.Activity.Conversation.Id);
-                Assert.AreEqual(adapter.Conversation.ServiceUrl, turnContext.Activity.ServiceUrl);
-                Assert.AreEqual(adapter.Conversation.User.Id, turnContext.Activity.From.Id);
-                Assert.AreEqual(adapter.Conversation.Bot.Id, turnContext.Activity.Recipient.Id);
+                Assert.Equal(ActivityTypes.Invoke, turnContext.Activity.Type);
+                Assert.Equal(_adapter.Conversation.Conversation.Id, turnContext.Activity.Conversation.Id);
+                Assert.Equal(_adapter.Conversation.ServiceUrl, turnContext.Activity.ServiceUrl);
+                Assert.Equal(_adapter.Conversation.User.Id, turnContext.Activity.From.Id);
+                Assert.Equal(_adapter.Conversation.Bot.Id, turnContext.Activity.Recipient.Id);
 
                 var invoke = turnContext.Activity.AsInvokeActivity();
-                Assert.AreEqual(SkillHostAdapter.InvokeActivityName, invoke.Name);
+                Assert.Equal(SkillHostAdapter.InvokeActivityName, invoke.Name);
                 var apiArgs = invoke.Value as ChannelApiArgs;
-                Assert.IsNotNull(apiArgs);
+                Assert.NotNull(apiArgs);
 
                 switch (apiArgs.Method)
                 {
                     // ReplyToActivity(conversationId, activityId, activity).
                     case ChannelApiMethods.ReplyToActivity:
-                        Assert.AreEqual(2, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(string));
-                        Assert.IsInstanceOfType(apiArgs.Args[1], typeof(Activity));
+                        Assert.Equal(2, apiArgs.Args.Length);
+                        Assert.IsType<string>(apiArgs.Args[0]);
+                        Assert.IsType<Activity>(apiArgs.Args[1]);
                         apiArgs.Result = new ResourceResponse(id: NewResourceId);
                         break;
 
                     // SendToConversation(activity).
                     case ChannelApiMethods.SendToConversation:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(Activity));
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<Activity>(apiArgs.Args[0]);
                         apiArgs.Result = new ResourceResponse(id: NewResourceId);
                         break;
 
                     // UpdateActivity(activity).
                     case ChannelApiMethods.UpdateActivity:
-                        Assert.AreEqual(2, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(string));
-                        Assert.IsInstanceOfType(apiArgs.Args[1], typeof(Activity));
-                        Assert.AreEqual(this.expectedActivityId, (string)apiArgs.Args[0]);
+                        Assert.Equal(2, apiArgs.Args.Length);
+                        Assert.IsType<string>(apiArgs.Args[0]);
+                        Assert.IsType<Activity>(apiArgs.Args[1]);
+                        Assert.Equal(_expectedActivityId, (string)apiArgs.Args[0]);
                         apiArgs.Result = new ResourceResponse(id: NewResourceId);
                         break;
 
                     // DeleteActivity(conversationId, activityId).
                     case ChannelApiMethods.DeleteActivity:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(string));
-                        Assert.AreEqual(this.expectedActivityId, apiArgs.Args[0]);
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<string>(apiArgs.Args[0]);
+                        Assert.Equal(_expectedActivityId, apiArgs.Args[0]);
                         break;
 
                     // SendConversationHistory(conversationId, history).
                     case ChannelApiMethods.SendConversationHistory:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(Transcript));
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<Transcript>(apiArgs.Args[0]);
                         apiArgs.Result = new ResourceResponse(id: NewResourceId);
                         break;
 
                     // GetConversationMembers(conversationId).
                     case ChannelApiMethods.GetConversationMembers:
-                        Assert.AreEqual(0, apiArgs.Args.Length);
+                        Assert.Empty(apiArgs.Args);
                         apiArgs.Result = new List<ChannelAccount>();
                         break;
 
                     // GetConversationPageMembers(conversationId, (int)pageSize, continuationToken).
                     case ChannelApiMethods.GetConversationPagedMembers:
-                        Assert.AreEqual(2, apiArgs.Args.Length);
+                        Assert.Equal(2, apiArgs.Args.Length);
 
                         if (apiArgs.Args[0] != null)
                         {
-                            Assert.AreEqual(10, ((int?)apiArgs.Args[0]).Value);
+                            Assert.Equal(10, ((int?)apiArgs.Args[0]).Value);
                         }
 
                         if (apiArgs.Args[1] != null)
                         {
-                            Assert.AreEqual("continue please", (string)apiArgs.Args[1]);
+                            Assert.Equal("continue please", (string)apiArgs.Args[1]);
                         }
 
                         apiArgs.Result = new PagedMembersResult()
@@ -243,40 +240,40 @@ namespace Microsoft.Bot.Builder.Skills.Tests
 
                     // DeleteConversationMember(conversationId, memberId).
                     case ChannelApiMethods.DeleteConversationMember:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(string));
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<string>(apiArgs.Args[0]);
                         break;
 
                     // GetActivityMembers(conversationId, activityId).
                     case ChannelApiMethods.GetActivityMembers:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(string));
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<string>(apiArgs.Args[0]);
                         apiArgs.Result = new List<ChannelAccount>();
                         break;
 
                     // UploadAttachment(conversationId, attachmentData).
                     case ChannelApiMethods.UploadAttachment:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(AttachmentData));
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<AttachmentData>(apiArgs.Args[0]);
                         apiArgs.Result = new ResourceResponse(id: NewResourceId);
                         break;
 
                     // CreateConversation([FromBody] ConversationParameters parameters)
                     case ChannelApiMethods.CreateConversation:
-                        Assert.AreEqual(1, apiArgs.Args.Length);
-                        Assert.IsInstanceOfType(apiArgs.Args[0], typeof(ConversationParameters));
+                        Assert.Single(apiArgs.Args);
+                        Assert.IsType<ConversationParameters>(apiArgs.Args[0]);
                         apiArgs.Result = new ConversationResourceResponse(id: NewResourceId);
                         break;
 
                     // GetConversations(string continuationToken = null)
                     case ChannelApiMethods.GetConversations:
-                        Assert.IsTrue(apiArgs.Args.Length == 0 || apiArgs.Args.Length == 1);
+                        Assert.True(apiArgs.Args.Length == 0 || apiArgs.Args.Length == 1);
                         if (apiArgs.Args.Length == 1)
                         {
                             if (apiArgs.Args[0] != null)
                             {
-                                Assert.IsInstanceOfType(apiArgs.Args[0], typeof(string));
-                                Assert.AreEqual("continue please", (string)apiArgs.Args[0]);
+                                Assert.IsType<string>(apiArgs.Args[0]);
+                                Assert.Equal("continue please", (string)apiArgs.Args[0]);
                             }
                         }
 
@@ -284,8 +281,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
                         break;
 
                     default:
-                        Assert.Fail($"Unknown ChannelApi method {apiArgs.Method}");
-                        break;
+                        throw new XunitException($"Unknown ChannelApi method {apiArgs.Method}");
                 }
 
                 // return next(cancellationToken);

--- a/tests/Microsoft.Bot.Builder.Skills.Tests/SkillConversationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Skills.Tests/SkillConversationTests.cs
@@ -1,23 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#pragma warning disable SA1402 // File may only contain a single type
 using System;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Skills.Tests
 {
-    [TestClass]
     public class SkillConversationTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public void TestSkillConversationEncoding()
         {
-            var sc = new SkillConversation
+            var sc = new SkillConversation()
             {
                 ConversationId = Guid.NewGuid().ToString("N"),
                 ServiceUrl = "http://test.com/xyz?id=1&id=2"
@@ -25,88 +21,68 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             var skillConversationId = sc.GetSkillConversationId();
 
             var sc2 = new SkillConversation(skillConversationId);
-            Assert.AreEqual(sc.ConversationId, sc2.ConversationId);
-            Assert.AreEqual(sc.ServiceUrl, sc2.ServiceUrl);
+            Assert.Equal(sc.ConversationId, sc2.ConversationId);
+            Assert.Equal(sc.ServiceUrl, sc2.ServiceUrl);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSkillConversationTestNullId()
         {
-            try
+            Assert.Throws<ArgumentNullException>(() =>
             {
-                var sc = new SkillConversation
+                var sc = new SkillConversation()
                 {
                     ConversationId = null,
                     ServiceUrl = "http://test.com/xyz?id=1&id=2"
                 };
                 var cid = sc.GetSkillConversationId();
-                Assert.Fail("Should have thrown on null");
-            }
-            catch (Exception)
-            {
-            }
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSkillConversationNullUrl()
         {
-            try
+            Assert.Throws<ArgumentNullException>(() =>
             {
-                var sc = new SkillConversation
+                var sc = new SkillConversation()
                 {
                     ConversationId = Guid.NewGuid().ToString("N"),
                     ServiceUrl = null
                 };
                 var cid = sc.GetSkillConversationId();
-                Assert.Fail("Should have thrown on null");
-            }
-            catch (Exception)
-            {
-            }
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSkillConversationNullCtor()
         {
-            try
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 var sc = new SkillConversation(null);
                 var cid = sc.GetSkillConversationId();
-                Assert.Fail("Should have thrown on null");
-            }
-            catch (Exception)
-            {
-            }
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSkillConversationEmptyCtor()
         {
-            try
+            Assert.Throws<NullReferenceException>(() =>
             {
                 var sc = new SkillConversation(string.Empty);
                 var cid = sc.GetSkillConversationId();
-                Assert.Fail("Should have thrown on empty");
-            }
-            catch (Exception)
-            {
-            }
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void TestSkillConversationBogusPayload()
         {
-            try
+            Assert.Throws<IndexOutOfRangeException>(() =>
             {
                 var test = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new object[0])));
 
                 var sc = new SkillConversation(test);
                 var cid = sc.GetSkillConversationId();
-                Assert.Fail("Should have thrown on bogusity");
-            }
-            catch (Exception)
-            {
-            }
+            });
         }
     }
 }


### PR DESCRIPTION
Removed IBot from the BotFrameworkSkillHostAdapter/SkillHostAdapter constructos (and the related property) and updated the code to use the IBot instance passed in the BotFrameworkHttpSkillsServer.ProcessAsync()

Updated unit tests project to use XUnit.

Relates to #2774 