### PR TITLE
Fix objectPath array syntax 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -12,6 +12,9 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Helper methods for working with dynamic json objects.
+    /// </summary>
     public static class ObjectPath
     {
         private const string SingleQuote = "\'";
@@ -24,21 +27,42 @@ namespace Microsoft.Bot.Builder.Dialogs
             NullValueHandling = NullValueHandling.Ignore,
         };
 
-        public static bool HasValue(object obj, string pathExpression)
+        /// <summary>
+        /// Does an object have a subpath.
+        /// </summary>
+        /// <param name="obj">object.</param>
+        /// <param name="path">path to evaluate.</param>
+        /// <returns>true if the path is there.</returns>
+        public static bool HasValue(object obj, string path)
         {
-            return TryGetPathValue<object>(obj, pathExpression, out var value);
+            return TryGetPathValue<object>(obj, path, out var value);
         }
 
-        public static T GetPathValue<T>(object obj, string pathExpression)
+        /// <summary>
+        /// Get the value for a path relative to an object.
+        /// </summary>
+        /// <typeparam name="T">type to return.</typeparam>
+        /// <param name="obj">object to start with.</param>
+        /// <param name="path">path to evaluate.</param>
+        /// <returns>value or default(T).</returns>
+        public static T GetPathValue<T>(object obj, string path)
         {
-            if (TryGetPathValue<T>(obj, pathExpression, out var value))
+            if (TryGetPathValue<T>(obj, path, out var value))
             {
                 return value;
             }
 
-            throw new KeyNotFoundException(pathExpression);
+            throw new KeyNotFoundException(path);
         }
 
+        /// <summary>
+        /// Get the value for a path relative to an object.
+        /// </summary>
+        /// <typeparam name="T">type to return.</typeparam>
+        /// <param name="obj">object to start with.</param>
+        /// <param name="path">path to evaluate.</param>
+        /// <param name="defaultValue">default value to use if any part of the path is missing.</param>
+        /// <returns>value or default(T).</returns>
         public static T GetPathValue<T>(object obj, string path, T defaultValue)
         {
             if (TryGetPathValue<T>(obj, path, out var value))
@@ -49,7 +73,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             return defaultValue;
         }
 
-        public static bool TryGetPathValue<T>(object obj, string pathExpression, out T value)
+        /// <summary>
+        /// Get the value for a path relative to an object.
+        /// </summary>
+        /// <typeparam name="T">type to return.</typeparam>
+        /// <param name="obj">object to start with.</param>
+        /// <param name="path">path to evaluate.</param>
+        /// <param name="value">value for the path.</param>
+        /// <returns>true if successful.</returns>
+        public static bool TryGetPathValue<T>(object obj, string path, out T value)
         {
             value = default(T);
 
@@ -58,106 +90,126 @@ namespace Microsoft.Bot.Builder.Dialogs
                 return false;
             }
 
-            if (pathExpression == null)
+            if (path == null)
             {
                 return false;
             }
 
-            if (pathExpression == string.Empty)
+            if (path == string.Empty)
             {
                 value = MapValueTo<T>(obj);
                 return true;
             }
 
-            foreach (string bracket in MatchBrackets(pathExpression))
+            if (!TryResolveBracketValues(obj, ref path))
             {
-                string bracketPath = bracket.Substring(1, bracket.Length - 2);
-
-                // if it's not a number, or quoted string
-                if (!int.TryParse(bracketPath, out int index) &&
-                    !(bracketPath.StartsWith(SingleQuote) && bracketPath.EndsWith(SingleQuote)) &&
-                    !(bracketPath.StartsWith(DoubleQuote) && bracketPath.EndsWith(DoubleQuote)))
-                {
-                    // then evaluate the path (NOTE: this is where nested [] will get resolved recursively)
-                    if (TryGetPathValue<string>(obj, bracketPath, out string bracketValue))
-                    {
-                        if (int.TryParse(bracketValue, out index))
-                        {
-                            // if it's an intent we keep array syntax [#]
-                            pathExpression = pathExpression.Replace(bracket, $"[{index}]");
-                        }
-                        else
-                        {
-                            // otherwise we replace with found property, meaning user[name] => user['tom']
-                            pathExpression = pathExpression.Replace(bracket, $"['{bracketValue}']");
-                        }
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
+                return false;
             }
 
             // at this point we have clean dotted path with numerical array indexers: user[user.name][user.age] ==> user['tom'][52]
-            string[] segments = SplitNonQuotedPath(pathExpression).Select(s => s.ToLower()).ToArray();
             dynamic current = obj;
-            for (var i = 0; i < segments.Length; i++)
+            var segments = SplitSegments(path).ToArray();
+            for (int i = 0; i < segments.Length - 1; i++)
             {
-                current = ResolveSegment(current, segments[i]);
+                var segment = segments[i];
+                var nextSegment = segments[i + 1];
+                current = ResolveSegment(current, segment, nextSegment);
                 if (current == null)
                 {
                     return false;
                 }
             }
 
+            current = ResolveSegment(current, segments.Last(), null);
+            if (current == null)
+            {
+                return false;
+            }
+
             value = MapValueTo<T>(current);
             return true;
         }
 
-        public static void SetPathValue(object obj, string pathExpression, object value, bool json = true)
+        /// <summary>
+        /// Given an object evaluate a path to set the value.
+        /// </summary>
+        /// <param name="obj">object to start with.</param>
+        /// <param name="path">path to evaluate.</param>
+        /// <param name="value">value to store.</param>
+        /// <param name="json">if true, sets the value as primitive JSON objects.</param>
+        public static void SetPathValue(object obj, string path, object value, bool json = true)
         {
-            string[] segments = pathExpression.Split('.').Select(segment => segment.ToLower()).ToArray();
-            dynamic current = obj;
-
-            for (var i = 0; i < segments.Length - 1; i++)
+            if (!TryResolveBracketValues(obj, ref path))
             {
-                dynamic next = ResolveSegment(current, segments[i], addMissing: true);
-                current = next;
+                return;
             }
 
-            SetObjectProperty(current, segments.Last(), value);
+            string[] segments = SplitSegments(path).ToArray();
+            dynamic current = obj;
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                var segment = segments[i];
+                var nextSegment = segments[i + 1];
+                current = ResolveSegment(current, segment, nextSegment, addMissing: true);
+            }
+
+            var lastSegment = segments.Last();
+            SetObjectProperty(current, lastSegment, value);
         }
 
-        public static void RemovePathValue(object obj, string pathExpression)
+        public static void RemovePathValue(object obj, string path)
         {
-            string[] segments = pathExpression.Split('.').Select(segment => segment.ToLower()).ToArray();
+            if (!TryResolveBracketValues(obj, ref path))
+            {
+                return;
+            }
+
+            string[] segments = SplitSegments(path).ToArray();
             dynamic next = obj;
             for (var i = 0; i < segments.Length - 1; i++)
             {
-                next = ResolveSegment(next, segments[i], addMissing: true);
+                var segment = segments[i];
+                var nextSegment = segments[i + 1];
+                next = ResolveSegment(next, segment, nextSegment);
+
+                if (next == null)
+                {
+                    return;
+                }
             }
 
             if (next != null)
             {
-                var segment = segments.Last();
-                int iIndexerStart = segment.IndexOf('[');
-                if (iIndexerStart > 0)
+                var lastSegment = segments.Last();
+                if (IsArraySegment(lastSegment))
                 {
-                    var index = int.Parse(segment.Substring(iIndexerStart + 1).TrimEnd(']'));
-                    segment = segment.Substring(0, iIndexerStart);
-                    next = ObjectPath.GetObjectProperty(next, segment);
-                    next[index] = null;
+                    var indexArgs = GetIndexArg(lastSegment);
+                    if (int.TryParse(indexArgs, out int index))
+                    {
+                        next[index] = null;
+                        return;
+                    }
+                    else
+                    {
+                        try
+                        {
+                            next.Remove(indexArgs);
+                        }
+                        catch (Exception)
+                        {
+                            ObjectPath.SetObjectProperty(next, indexArgs, null);
+                        }
+                    }
                 }
                 else
                 {
                     try
                     {
-                        next.Remove(segment);
+                        next.Remove(lastSegment);
                     }
                     catch (Exception)
                     {
-                        ObjectPath.SetObjectProperty(next, segment, null);
+                        ObjectPath.SetObjectProperty(next, lastSegment, null);
                     }
                 }
             }
@@ -200,6 +252,13 @@ namespace Microsoft.Bot.Builder.Dialogs
             return (T)Assign(startObject, overlayObject, typeof(T));
         }
 
+        /// <summary>
+        /// Equivalent to javascripts ObjectPath.Assign, creates a new object from startObject overlaying any non-null values from the overlay object.
+        /// </summary>
+        /// <param name="startObject">intial object of any type.</param>
+        /// <param name="overlayObject">overlay object of any type.</param>
+        /// <param name="type">type to output.</param>
+        /// <returns>merged object.</returns>
         public static object Assign(object startObject, object overlayObject, Type type)
         {
             if (startObject != null && overlayObject != null)
@@ -233,6 +292,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             return (Type)Activator.CreateInstance(type);
         }
 
+        /// <summary>
+        /// Convert a generic object to a typed object.
+        /// </summary>
+        /// <typeparam name="T">type to convert to.</typeparam>
+        /// <param name="val">value to convert.</param>
+        /// <returns>converted value.</returns>
         public static T MapValueTo<T>(object val)
         {
             if (val is JValue)
@@ -269,8 +334,19 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
+        /// <summary>
+        /// Get a property or array element from an object.
+        /// </summary>
+        /// <param name="obj">object.</param>
+        /// <param name="property">property or array segment to get relative to the object.</param>
+        /// <returns>the value or null if not found.</returns>
         private static object GetObjectProperty(object obj, string property)
         {
+            if (obj == null)
+            {
+                return null;
+            }
+
             if (obj is IDictionary<string, object> dict)
             {
                 var key = dict.Keys.Where(k => k.ToLower() == property.ToLower()).FirstOrDefault();
@@ -297,10 +373,63 @@ namespace Microsoft.Bot.Builder.Dialogs
             return null;
         }
 
+        /// <summary>
+        /// Given an object, set a property or array element on it with a value.
+        /// </summary>
+        /// <param name="obj">object to modify.</param>
+        /// <param name="property">property or array segment to put the value in.</param>
+        /// <param name="value">value to store.</param>
+        /// <param name="json">if true, value will be normalized to JSON primitive objects.</param>
         private static void SetObjectProperty(object obj, string property, object value, bool json = true)
         {
             object val;
 
+            val = GetNormalizedValue(value, json);
+
+            if (IsArraySegment(property))
+            {
+                property = GetIndexArg(property);
+                if (int.TryParse(property, out int index))
+                {
+                    var jar = obj as JArray;
+                    for (int i = jar.Count; i <= index; i++)
+                    {
+                        jar.Add(null);
+                    }
+
+                    jar[index] = JToken.FromObject(val);
+                    return;
+                }
+            }
+
+            if (obj is IDictionary<string, object> dict)
+            {
+                dict[property] = val;
+                return;
+            }
+
+            if (obj is JObject jobj)
+            {
+                jobj[property] = (val != null) ? JToken.FromObject(val) : null;
+                return;
+            }
+
+            var prop = obj.GetType().GetProperty(property);
+            if (prop != null)
+            {
+                prop.SetValue(obj, val);
+            }
+        }
+
+        /// <summary>
+        /// Normalize value as json objects.
+        /// </summary>
+        /// <param name="value">value to normalize.</param>
+        /// <param name="json">normalize as json objects.</param>
+        /// <returns>normalized value.</returns>
+        private static object GetNormalizedValue(object value, bool json)
+        {
+            object val;
             if (json)
             {
                 if (value is JToken || value is JObject || value is JArray)
@@ -328,49 +457,14 @@ namespace Microsoft.Bot.Builder.Dialogs
                 val = value;
             }
 
-            int iIndexerStart = property.IndexOf('[');
-            if (iIndexerStart > 0)
-            {
-                var index = int.Parse(property.Substring(iIndexerStart + 1).TrimEnd(']'));
-                property = property.Substring(0, iIndexerStart);
-
-                dynamic array = GetObjectProperty(obj, property);
-                if (array == null)
-                {
-                    SetObjectProperty(obj, property, new JArray());
-                    array = GetObjectProperty(obj, property);
-                }
-
-                // expand nodes
-                for (int i = ((ICollection)array).Count; i <= index; i++)
-                {
-                    array.Add(null);
-                }
-
-                array[index] = JToken.FromObject(val);
-            }
-            else
-            {
-                if (obj is IDictionary<string, object> dict)
-                {
-                    dict[property] = val;
-                    return;
-                }
-
-                if (obj is JObject jobj)
-                {
-                    jobj[property] = (val != null) ? JToken.FromObject(val) : null;
-                    return;
-                }
-
-                var prop = obj.GetType().GetProperty(property);
-                if (prop != null)
-                {
-                    prop.SetValue(obj, val);
-                }
-            }
+            return val;
         }
 
+        /// <summary>
+        /// Given an object and a property segment, remove the property segment from the object.
+        /// </summary>
+        /// <param name="obj">object.</param>
+        /// <param name="property">property or arraysegment.</param>
         private static void RemoveObjectProperty(object obj, string property)
         {
             if (obj is IDictionary<string, object> dict)
@@ -408,42 +502,52 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
-        private static dynamic ResolveSegment(dynamic node, string segment, bool addMissing = false)
+        /// <summary>
+        /// Is the segment an array segment [xxxx].
+        /// </summary>
+        /// <param name="segment">segment.</param>
+        /// <returns>true if it has [].</returns>
+        private static bool IsArraySegment(string segment)
         {
-            dynamic next;
-            int iIndexerStart = segment.IndexOf('[');
-            if (iIndexerStart > 0)
-            {
-                var indexArg = segment.Substring(iIndexerStart + 1).TrimEnd(']');
-                segment = segment.Substring(0, iIndexerStart);
+            return segment.StartsWith("[") && segment.EndsWith("]");
+        }
 
-                next = GetObjectProperty(node, segment);
+        /// <summary>
+        /// Get the indexArg from an array segment ['foo'] => foo, [0] => 0.
+        /// </summary>
+        /// <param name="segment">segment.</param>
+        /// <returns>normalized array argument as a string.</returns>
+        private static string GetIndexArg(string segment)
+        {
+            return segment.TrimStart('[').TrimEnd(']').Trim('\'', '\"');
+        }
+
+        /// <summary>
+        /// Given a node and a segment (and nextSegment if we are adding mising elemets) return the subproperty/element.
+        /// </summary>
+        /// <param name="node">current node.</param>
+        /// <param name="segment">oath segment.</param>
+        /// <param name="nextSegment">next segment (so we can initialize with JArray or JObject appropriately).</param>
+        /// <param name="addMissing">if true, missing path members will be initialized appropriately.</param>
+        /// <returns>leaf node.</returns>
+        private static dynamic ResolveSegment(dynamic node, string segment, string nextSegment, bool addMissing = false)
+        {
+            // if it is a [0] or a ['string'] or a ["string"]
+            if (IsArraySegment(segment))
+            {
+                var indexArg = GetIndexArg(segment);
+
                 if (int.TryParse(indexArg, out int index))
                 {
-                    if (next == null)
-                    {
-                        // then no array
-                        if (addMissing)
-                        {
-                            var missing = new JArray();
-                            SetObjectProperty(node, segment, missing);
-                            next = GetObjectProperty(node, segment);
-                        }
-                        else
-                        {
-                            return null;
-                        }
-                    }
-
-                    if (((ICollection)next).Count <= index)
+                    if (((ICollection)node).Count <= index)
                     {
                         // then array is too small
                         if (addMissing)
                         {
                             // expand nodes
-                            for (int i = ((ICollection)next).Count; i <= index; i++)
+                            for (int i = ((ICollection)node).Count; i <= index; i++)
                             {
-                                ((JArray)next)[i] = null;
+                                ((JArray)node)[i] = null;
                             }
                         }
                         else
@@ -452,32 +556,43 @@ namespace Microsoft.Bot.Builder.Dialogs
                         }
                     }
 
-                    next = next[index];
+                    // return x[0]
+                    return node[index];
                 }
                 else
                 {
-                    // x.y.z['val'] will have next == z so next.GetObjectProperty(val)
-                    next = GetObjectProperty(next, indexArg?.Trim('\'', '\"'));
+                    // return x['string']
+                    return GetObjectProperty(node, indexArg);
                 }
             }
             else
             {
-                next = GetObjectProperty(node, segment);
+                dynamic next = GetObjectProperty(node, segment);
                 if (next == null)
                 {
                     if (addMissing)
                     {
+                        if (IsArraySegment(nextSegment))
+                        {
+                            var indexArg = GetIndexArg(nextSegment);
+                            if (int.TryParse(indexArg, out int index))
+                            {
+                                SetObjectProperty(node, segment, new JArray());
+                                return GetObjectProperty(node, segment);
+                            }
+                        }
+
                         SetObjectProperty(node, segment, new JObject());
-                        next = GetObjectProperty(node, segment);
+                        return GetObjectProperty(node, segment);
                     }
                 }
-            }
 
-            return next;
+                return next;
+            }
         }
 
         /// <summary>
-        /// Given a path this will enumerate paired brackets
+        /// Given a path this will enumerate paired brackets, which is used to do the SplitSegments 
         /// x[y[z]].blah[p] => "[y[z]]","[p]".
         /// </summary>
         /// <param name="path">path.</param>
@@ -512,21 +627,46 @@ namespace Microsoft.Bot.Builder.Dialogs
             yield break;
         }
 
-        private static IEnumerable<string> SplitNonQuotedPath(string path)
+        /// <summary>
+        /// Split path x.y.z[user.name][13] => "x","y","z","[user.name]","13".
+        /// </summary>
+        /// <param name="path">path to split.</param>
+        /// <returns>split segments.</returns>
+        private static IEnumerable<string> SplitSegments(string path)
         {
             StringBuilder sb = new StringBuilder();
-            bool inQuote = false;
+            bool inBracket = false;
             foreach (char ch in path)
             {
-                if (!inQuote)
+                if (!inBracket)
                 {
-                    if (ch == '\'' || ch == '\"')
+                    if (ch == '[')
                     {
-                        inQuote = true;
+                        yield return sb.ToString();
+                        sb.Clear();
                         sb.Append(ch);
+                        inBracket = true;
                     }
                     else if (ch == '.')
                     {
+                        if (sb.Length > 0)
+                        {
+                            yield return sb.ToString();
+                        }
+
+                        sb.Clear();
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
+                }
+                else if (inBracket)
+                {
+                    if (ch == ']')
+                    {
+                        inBracket = false;
+                        sb.Append(ch);
                         yield return sb.ToString();
                         sb.Clear();
                     }
@@ -535,18 +675,53 @@ namespace Microsoft.Bot.Builder.Dialogs
                         sb.Append(ch);
                     }
                 }
-                else if (inQuote)
-                {
-                    if (ch == '\'' || ch == '\"')
-                    {
-                        inQuote = false;
-                    }
+            }
 
-                    sb.Append(ch);
+            if (sb.Length > 0)
+            {
+                yield return sb.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Given an root object and property path, resolve any nested bracket values.  conversation[user.name][user.age] => conversation['joe'][32]
+        /// </summary>
+        /// <param name="obj">root object.</param>
+        /// <param name="propertyPath">property path to resolve.</param>
+        /// <returns>true if it was able to resolve all nested references.</returns>
+        private static bool TryResolveBracketValues(object obj, ref string propertyPath)
+        {
+            foreach (string bracket in MatchBrackets(propertyPath))
+            {
+                string bracketPath = bracket.Substring(1, bracket.Length - 2);
+
+                // if it's not a number, or quoted string
+                if (!int.TryParse(bracketPath, out int index) &&
+                    !(bracketPath.StartsWith(SingleQuote) && bracketPath.EndsWith(SingleQuote)) &&
+                    !(bracketPath.StartsWith(DoubleQuote) && bracketPath.EndsWith(DoubleQuote)))
+                {
+                    // then evaluate the path (NOTE: this is where nested [] will get resolved recursively)
+                    if (TryGetPathValue<string>(obj, bracketPath, out string bracketValue))
+                    {
+                        if (int.TryParse(bracketValue, out index))
+                        {
+                            // if it's an intent we keep array syntax [#]
+                            propertyPath = propertyPath.Replace(bracket, $"[{index}]");
+                        }
+                        else
+                        {
+                            // otherwise we replace with found property, meaning user[name] => user['tom']
+                            propertyPath = propertyPath.Replace(bracket, $"['{bracketValue}']");
+                        }
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
             }
 
-            yield return sb.ToString();
+            return true;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -684,7 +684,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
-        /// Given an root object and property path, resolve any nested bracket values.  conversation[user.name][user.age] => conversation['joe'][32]
+        /// Given an root object and property path, resolve any nested bracket values.  conversation[user.name][user.age] => conversation['joe'][32].
         /// </summary>
         /// <param name="obj">root object.</param>
         /// <param name="propertyPath">property path to resolve.</param>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -228,7 +228,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        [Ignore] // NOTE: This needs to be revisited
         public void TestComplexPathExpressions()
         {
             var dialogs = new DialogSet();
@@ -238,10 +237,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             // complex type paths
             state.SetValue("user.name", "joe");
             state.SetValue("conversation.stuff[user.name]", "test");
-            var value = state.GetValue<string>("conversation.stuff.joe");
-            Assert.AreEqual("test", value, "complex set should set");
-            value = state.GetValue<string>("conversation.stuff[user.name]");
-            Assert.AreEqual("test", value, "complex get should get");
+            state.SetValue("conversation.stuff['frank']", "test2");
+            state.SetValue("conversation.stuff[\"susan\"]", "test3");
+            state.SetValue("conversation.stuff['Jo.Bob']", "test4");
+            Assert.AreEqual("test", state.GetValue<string>("conversation.stuff.joe"), "complex set should set");
+            Assert.AreEqual("test", state.GetValue<string>("conversation.stuff[user.name]"), "complex get should get");
+            Assert.AreEqual("test2", state.GetValue<string>("conversation.stuff['frank']"), "complex get should get");
+            Assert.AreEqual("test3", state.GetValue<string>("conversation.stuff[\"susan\"]"), "complex get should get");
+            Assert.AreEqual("test4", state.GetValue<string>("conversation.stuff[\"Jo.Bob\"]"), "complex get should get");
         }
 
         [TestMethod]


### PR DESCRIPTION
to handle cross memory scope references and nested bracket syntax across Get/Set/RemovePath() calls
