### PR TITLE
DM should be using ConversationState/UserState directly 

### DIFF
--- a/libraries/Microsoft.Bot.Builder/AdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/AdapterExtensions.cs
@@ -31,42 +31,18 @@ namespace Microsoft.Bot.Builder
                 throw new ArgumentNullException(nameof(botAdapter));
             }
 
-            if (userState == null || conversationState == null)
+            if (userState == null)
             {
-                var storageMiddleware = botAdapter.MiddlewareSet.Where(mw => mw is RegisterClassMiddleware<IStorage>).Cast<RegisterClassMiddleware<IStorage>>().FirstOrDefault();
-                if (storageMiddleware == null)
-                {
-                    throw new ArgumentNullException("There is no IStorage registered in the middleware");
-                }
-
-                if (userState == null)
-                {
-                    var userStateMiddleware = botAdapter.MiddlewareSet.Where(mw => mw is RegisterClassMiddleware<UserState>).Cast<RegisterClassMiddleware<UserState>>().FirstOrDefault();
-                    if (userStateMiddleware != null)
-                    {
-                        userState = userStateMiddleware.Service;
-                    }
-                    else
-                    {
-                        userState = new UserState(storageMiddleware.Service);
-                        botAdapter.Use(new RegisterClassMiddleware<UserState>(userState));
-                    }
-                }
-
-                if (conversationState == null)
-                {
-                    var conversationStateMiddleware = botAdapter.MiddlewareSet.Where(mw => mw is RegisterClassMiddleware<ConversationState>).Cast<RegisterClassMiddleware<ConversationState>>().FirstOrDefault();
-                    if (conversationStateMiddleware != null)
-                    {
-                        conversationState = conversationStateMiddleware.Service;
-                    }
-                    else
-                    {
-                        conversationState = new ConversationState(storageMiddleware.Service);
-                        botAdapter.Use(new RegisterClassMiddleware<ConversationState>(conversationState));
-                    }
-                }
+                throw new ArgumentNullException(nameof(userState));
             }
+
+            if (conversationState == null)
+            {
+                throw new ArgumentNullException(nameof(conversationState));
+            }
+
+            botAdapter.Use(new RegisterClassMiddleware<UserState>(userState));
+            botAdapter.Use(new RegisterClassMiddleware<ConversationState>(conversationState));
 
             if (auto)
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -45,8 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         private TestFlow CreateFlow(string locale)
         {
-            var convoState = new ConversationState(new MemoryStorage());
-            var userState = new UserState(new MemoryStorage());
+            TypeFactory.Configuration = this.Configuration;
             var dialog = new AdaptiveDialog();
             dialog.Triggers.AddRange(new List<OnCondition>()
             {
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .UseAdaptiveDialogs()
                 .UseLanguageGeneration(resourceExplorer)
                 .Use(new RegisterClassMiddleware<IConfiguration>(this.Configuration))
-                .Use(new AutoSaveStateMiddleware(convoState, userState))
+                .UseState(new UserState(new MemoryStorage()), new ConversationState(new MemoryStorage()))
                 .Use(new TranscriptLoggerMiddleware(new FileTranscriptLogger()));
 
             DialogManager dm = new DialogManager(dialog);


### PR DESCRIPTION
Fixes #2823 
Current code was doing it's own custom storage
* removed custom storage, replaced to use PropertyAccessors
* removed RunAsync() (can add in the future)
* added unit tests
** OnError works to clear conversationState
** Expiration works to clear conversationState
* Cleaned up UseState()
