### PR TITLE
Refactor MemoryScopes to be self-contained 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -91,14 +91,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </value>
         public string DefaultResultProperty { get; set; } = "dialog.result";
 
-        /// <summary>
-        /// Gets the dialogs which make up the AdaptiveDialog.
-        /// </summary>
-        /// <value>
-        /// The dialogs which make up the AdaptiveDialog.
-        /// </value>
-        public DialogSet Dialogs => base.Dialogs;
-
         public override IBotTelemetryClient TelemetryClient
         {
             get
@@ -109,7 +101,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             set
             {
                 var client = value ?? new NullBotTelemetryClient();
-                base.Dialogs.TelemetryClient = client;
+                this.Dialogs.TelemetryClient = client;
                 base.TelemetryClient = client;
             }
         }
@@ -190,7 +182,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 // We need to mockup a DialogContext so that we can call RepromptDialog
                 // for the active step
-                var stepDc = new DialogContext(base.Dialogs, turnContext, state.Actions[0]);
+                var stepDc = new DialogContext(this.Dialogs, turnContext, state.Actions[0]);
                 await stepDc.RepromptDialogAsync(cancellationToken).ConfigureAwait(false);
             }
         }
@@ -208,7 +200,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
             if (state.Actions != null && state.Actions.Any())
             {
-                var ctx = new SequenceContext(base.Dialogs, dc, state.Actions.First(), state.Actions, changeKey, base.Dialogs);
+                var ctx = new SequenceContext(this.Dialogs, dc, state.Actions.First(), state.Actions, changeKey, this.Dialogs);
                 ctx.Parent = dc;
                 return ctx;
             }
@@ -622,7 +614,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 state.Actions = new List<ActionState>();
             }
 
-            var sequenceContext = new SequenceContext(dc.Dialogs, dc, new DialogState { DialogStack = dc.Stack }, state.Actions, changeKey, base.Dialogs);
+            var sequenceContext = new SequenceContext(dc.Dialogs, dc, new DialogState { DialogStack = dc.Stack }, state.Actions, changeKey, this.Dialogs);
             sequenceContext.Parent = dc.Parent;
             return sequenceContext;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
         }
 
-        protected DialogSet Dialogs { get; set; } = new DialogSet();
+        public DialogSet Dialogs { get; set; } = new DialogSet();
 
         public abstract DialogContext CreateChildContext(DialogContext dc);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Bot.Builder.Dialogs
             // create property accessors
             var lastAccessProperty = conversationState.CreateProperty<DateTime>(LASTACCESS);
             var dialogsProperty = conversationState.CreateProperty<DialogState>(DIALOGS);
-            var userScope = userState.CreateProperty<object>($"{ScopePath.USER}{nameof(MemoryScope)}");
-            var conversationScope = conversationState.CreateProperty<object>($"{ScopePath.CONVERSATION}{nameof(MemoryScope)}");
+            var userScope = userState.CreateProperty<object>($"{ScopePath.USER}{nameof(TurnMemoryScope)}");
+            var conversationScope = conversationState.CreateProperty<object>($"{ScopePath.CONVERSATION}{nameof(TurnMemoryScope)}");
 
             var lastAccess = await lastAccessProperty.GetAsync(context, () => DateTime.UtcNow, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -99,11 +99,6 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // get dialog stack 
             DialogState dialogState = await dialogsProperty.GetAsync(context, () => new DialogState(), cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            var namedScopes = MemoryScope.GetScopesMemory(context);
-            namedScopes[ScopePath.USER] = await userScope.GetAsync(context, () => new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase), cancellationToken: cancellationToken).ConfigureAwait(false);
-            namedScopes[ScopePath.CONVERSATION] = await conversationScope.GetAsync(context, () => new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase), cancellationToken: cancellationToken).ConfigureAwait(false);
-            namedScopes[ScopePath.TURN] = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
 
             // Create DialogContext
             var dc = new DialogContext(this.dialogSet, context, dialogState);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -80,10 +80,6 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // create property accessors
             var lastAccessProperty = conversationState.CreateProperty<DateTime>(LASTACCESS);
-            var dialogsProperty = conversationState.CreateProperty<DialogState>(DIALOGS);
-            var userScope = userState.CreateProperty<object>($"{ScopePath.USER}{nameof(TurnMemoryScope)}");
-            var conversationScope = conversationState.CreateProperty<object>($"{ScopePath.CONVERSATION}{nameof(TurnMemoryScope)}");
-
             var lastAccess = await lastAccessProperty.GetAsync(context, () => DateTime.UtcNow, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // Check for expired conversation
@@ -98,6 +94,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             await lastAccessProperty.SetAsync(context, lastAccess, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // get dialog stack 
+            var dialogsProperty = conversationState.CreateProperty<DialogState>(DIALOGS);
             DialogState dialogState = await dialogsProperty.GetAsync(context, () => new DialogState(), cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // Create DialogContext

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             var result = new JObject();
 
-            foreach (var scope in MemoryScopes.Where(ms => ms.IsReadOnly == false))
+            foreach (var scope in MemoryScopes.Where(ms => ms.IncludeInSnapshot == false))
             {
                 var memory = scope.GetMemory(dialogContext);
                 if (memory != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             var result = new JObject();
 
-            foreach (var scope in MemoryScopes.Where(ms => ms.IncludeInSnapshot == false))
+            foreach (var scope in MemoryScopes.Where(ms => ms.IncludeInSnapshot == true))
             {
                 var memory = scope.GetMemory(dialogContext);
                 if (memory != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// </value>
         public static List<MemoryScope> MemoryScopes { get; } = new List<MemoryScope>
         {
-            new MemoryScope(ScopePath.USER),
-            new MemoryScope(ScopePath.CONVERSATION),
-            new MemoryScope(ScopePath.TURN),
+            new UserMemoryScope(),
+            new ConversationMemoryScope(),
+            new TurnMemoryScope(),
             new SettingsMemoryScope(),
             new DialogMemoryScope(),
             new ClassMemoryScope(),

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/BotStateMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/BotStateMemoryScope.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         where T : BotState
     {
         public BotStateMemoryScope(string name)
-            : base(name, false)
+            : base(name)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/BotStateMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/BotStateMemoryScope.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
+{
+    /// <summary>
+    /// BotStateMemoryScope represents a BotState scoped memory.
+    /// </summary>
+    /// <remarks>This relies on the BotState object being accessible from turnContext.TurnState.Get&lt;T&gt().</remarks>
+    /// <typeparam name="T">botState type.</typeparam>
+    public class BotStateMemoryScope<T> : MemoryScope
+        where T : BotState
+    {
+        public BotStateMemoryScope(string name)
+            : base(name, false)
+        {
+        }
+
+        /// <summary>
+        /// Get the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">dc.</param>
+        /// <returns>memory for the scope.</returns>
+        public override object GetMemory(DialogContext dc)
+        {
+            var property = GetBotStateProperty(dc);
+            
+            // NOTE: the BotState should already be in memory, this is accessing the in-memory cache, which means it should complete without blocking
+            return property.GetAsync(dc.Context, () => new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase)).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">dc.</param>
+        /// <param name="memory">memory.</param>
+        public override void SetMemory(DialogContext dc, object memory)
+        {
+            var property = GetBotStateProperty(dc);
+
+            // NOTE: the BotState should already be in memory, this is accessing the in-memory cache, which means it should complete without blocking
+            property.SetAsync(dc.Context, memory).GetAwaiter().GetResult();
+        }
+
+        private IStatePropertyAccessor<object> GetBotStateProperty(DialogContext dc)
+        {
+            if (dc == null)
+            {
+                throw new ArgumentNullException(nameof(dc));
+            }
+
+            var conversationState = dc.Context.TurnState.Get<T>();
+            if (conversationState == null)
+            {
+                throw new ArgumentNullException($"There is no {typeof(T).Name} registered in TurnContext.TurnState.Get<{typeof(T).Name}>().  Have you registered {typeof(T).Name}?");
+            }
+
+            return conversationState.CreateProperty<object>(this.GetType().Name);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ClassMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ClassMemoryScope.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         public ClassMemoryScope()
             : base(ScopePath.CLASS)
         {
-            this.IsReadOnly = true;
+            this.IncludeInSnapshot = false;
         }
 
         public override object GetMemory(DialogContext dc)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ConversationMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ConversationMemoryScope.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
+{
+    /// <summary>
+    /// ConversationMemoryScope represents Conversation scoped memory. 
+    /// </summary>
+    /// <remarks>This relies on the ConversationState object being accessible from turnContext.TurnState.Get&lt;ConversationState&gt().</remarks>
+    public class ConversationMemoryScope : BotStateMemoryScope<ConversationState>
+    {
+        public ConversationMemoryScope()
+            : base(ScopePath.CONVERSATION)
+        {
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
@@ -8,15 +8,10 @@ using System.Data;
 namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
 {
     /// <summary>
-    /// MemoryScope represents a named memory scope stored in TurnState["MemoryScopes"]
-    /// It is responsible for using the DialogContext to bind to the object for it. 
-    /// The default MemoryScope is stored in TurnState[MEMORYSCOPESKEY][Name]
-    /// Example: User memory scope is tracked in dc.Context.TurnState.MemoryScopes.User.
+    /// MemoryScope represents a named memory scope abstract class.
     /// </summary>
-    public class MemoryScope
+    public abstract class MemoryScope
     {
-        private const string MEMORYSCOPESKEY = "MemoryScopes";
-
         public MemoryScope(string name, bool isReadOnly = false)
         {
             this.IsReadOnly = isReadOnly;
@@ -44,68 +39,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// </summary>
         /// <param name="dc">dc.</param>
         /// <returns>memory for the scope.</returns>
-        public virtual object GetMemory(DialogContext dc)
-        {
-            if (dc == null)
-            {
-                throw new ArgumentNullException(nameof(dc));
-            }
-
-            var scopesMemory = GetScopesMemory(dc.Context);
-            if (!scopesMemory.TryGetValue(this.Name, out object memory))
-            {
-                memory = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-                scopesMemory[this.Name] = memory;
-            }
-
-            return memory;
-        }
+        public abstract object GetMemory(DialogContext dc);
 
         /// <summary>
         /// Changes the backing object for the memory scope.
         /// </summary>
         /// <param name="dc">dc.</param>
         /// <param name="memory">memory.</param>
-        public virtual void SetMemory(DialogContext dc, object memory)
-        {
-            if (this.IsReadOnly)
-            {
-                throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
-            }
-
-            if (dc == null)
-            {
-                throw new ArgumentNullException(nameof(dc));
-            }
-
-            if (memory == null)
-            {
-                throw new ArgumentNullException(nameof(memory));
-            }
-
-            var namedScopes = GetScopesMemory(dc.Context);
-            namedScopes[this.Name] = memory;
-        }
-
-        /// <summary>
-        /// Get Turn Scopes memory.
-        /// </summary>
-        /// <param name="context">turn context.</param>
-        /// <returns>scopes object.</returns>
-        internal static Dictionary<string, object> GetScopesMemory(ITurnContext context)
-        {
-            Dictionary<string, object> namedScopes;
-            if (!context.TurnState.TryGetValue(MEMORYSCOPESKEY, out object val))
-            {
-                namedScopes = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-                context.TurnState[MEMORYSCOPESKEY] = namedScopes;
-            }
-            else
-            {
-                namedScopes = (Dictionary<string, object>)val;
-            }
-
-            return namedScopes;
-        }
+        public abstract void SetMemory(DialogContext dc, object memory);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public abstract class MemoryScope
     {
-        public MemoryScope(string name, bool isReadOnly = false)
+        public MemoryScope(string name)
         {
-            this.IsReadOnly = isReadOnly;
+            this.IncludeInSnapshot = true;
             this.Name = name;
         }
 
@@ -27,12 +27,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this memory scope mutable.
+        /// Gets or sets a value indicating whether this memory should be included in snapshot.
         /// </summary>
         /// <value>
-        /// A value indicating whether this memory scope mutable.
+        /// True or false.
         /// </value>
-        public bool IsReadOnly { get; protected set; }
+        public bool IncludeInSnapshot { get; protected set; }
 
         /// <summary>
         /// Get the backing memory for this scope.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            if (!dc.Context.TurnState.TryGetValue(this.Name, out object settings))
+            if (!dc.Context.TurnState.TryGetValue(nameof(SettingsMemoryScope), out object settings))
             {
                 var configuration = dc.Context.TurnState.Get<IConfiguration>();
                 if (configuration != null)
                 {
                     settings = LoadSettings(configuration);
-                    dc.Context.TurnState[this.Name] = settings;
+                    dc.Context.TurnState[nameof(SettingsMemoryScope)] = settings;
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
@@ -16,8 +16,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         private Dictionary<string, object> emptySettings = new Dictionary<string, object>();
 
         public SettingsMemoryScope()
-            : base(ScopePath.SETTINGS, isReadOnly: true)
+            : base(ScopePath.SETTINGS)
         {
+            this.IncludeInSnapshot = false;
         }
 
         public override object GetMemory(DialogContext dc)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
@@ -27,18 +27,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            var namedScopes = GetScopesMemory(dc.Context);
-            if (!namedScopes.TryGetValue(ScopePath.SETTINGS, out object settings))
+            if (!dc.Context.TurnState.TryGetValue(this.Name, out object settings))
             {
                 var configuration = dc.Context.TurnState.Get<IConfiguration>();
                 if (configuration != null)
                 {
                     settings = LoadSettings(configuration);
-                    namedScopes[ScopePath.SETTINGS] = settings;
+                    dc.Context.TurnState[this.Name] = settings;
                 }
             }
 
             return settings ?? emptySettings;
+        }
+
+        public override void SetMemory(DialogContext dc, object memory)
+        {
+            throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     public class TurnMemoryScope : MemoryScope
     {
         public TurnMemoryScope()
-            : base(ScopePath.TURN, true)
+            : base(ScopePath.TURN)
         {
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// <param name="memory">memory.</param>
         public override void SetMemory(DialogContext dc, object memory)
         {
-            throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
+            throw new NotSupportedException("You cannot change the root object a turn memory");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
+{
+    /// <summary>
+    /// TurnMemoryScope represents memory scoped to the current turn.
+    /// </summary>
+    public class TurnMemoryScope : MemoryScope
+    {
+        public TurnMemoryScope()
+            : base(ScopePath.TURN, false)
+        {
+        }
+
+        /// <summary>
+        /// Get the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">dc.</param>
+        /// <returns>memory for the scope.</returns>
+        public override object GetMemory(DialogContext dc)
+        {
+            if (dc == null)
+            {
+                throw new ArgumentNullException(nameof(dc));
+            }
+
+            if (!dc.Context.TurnState.TryGetValue(this.Name, out object memory))
+            {
+                memory = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
+                dc.Context.TurnState[this.Name] = memory;
+            }
+
+            return memory;
+        }
+
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">dc.</param>
+        /// <param name="memory">memory.</param>
+        public override void SetMemory(DialogContext dc, object memory)
+        {
+            if (this.IsReadOnly)
+            {
+                throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
+            }
+
+            if (dc == null)
+            {
+                throw new ArgumentNullException(nameof(dc));
+            }
+
+            if (memory == null)
+            {
+                throw new ArgumentNullException(nameof(memory));
+            }
+
+            dc.Context.TurnState[this.Name] = memory;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
@@ -29,7 +29,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            return dc.Context.TurnState;
+            if (!dc.Context.TurnState.TryGetValue(nameof(TurnMemoryScope), out object val))
+            {
+                val = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                dc.Context.TurnState[nameof(TurnMemoryScope)] = val;
+            }
+
+            return val;
         }
 
         /// <summary>
@@ -39,7 +45,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// <param name="memory">memory.</param>
         public override void SetMemory(DialogContext dc, object memory)
         {
-            throw new NotSupportedException("You cannot change the root object a turn memory");
+            if (dc == null)
+            {
+                throw new ArgumentNullException(nameof(dc));
+            }
+
+            dc.Context.TurnState[nameof(TurnMemoryScope)] = memory;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     public class TurnMemoryScope : MemoryScope
     {
         public TurnMemoryScope()
-            : base(ScopePath.TURN, false)
+            : base(ScopePath.TURN, true)
         {
         }
 
@@ -29,13 +29,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            if (!dc.Context.TurnState.TryGetValue(this.Name, out object memory))
-            {
-                memory = new Dictionary<string, object>(StringComparer.InvariantCultureIgnoreCase);
-                dc.Context.TurnState[this.Name] = memory;
-            }
-
-            return memory;
+            return dc.Context.TurnState;
         }
 
         /// <summary>
@@ -45,22 +39,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// <param name="memory">memory.</param>
         public override void SetMemory(DialogContext dc, object memory)
         {
-            if (this.IsReadOnly)
-            {
-                throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
-            }
-
-            if (dc == null)
-            {
-                throw new ArgumentNullException(nameof(dc));
-            }
-
-            if (memory == null)
-            {
-                throw new ArgumentNullException(nameof(memory));
-            }
-
-            dc.Context.TurnState[this.Name] = memory;
+            throw new NotSupportedException("You cannot set the memory for a readonly memory scope");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/UserMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/UserMemoryScope.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
+{
+    /// <summary>
+    /// UserMemoryScope represents User scoped memory.
+    /// </summary>
+    /// <remarks>This relies on the UserState object being accessible from turnContext.TurnState.Get&lt;UserState&gt().</remarks>
+    public class UserMemoryScope : BotStateMemoryScope<UserState>
+    {
+        public UserMemoryScope()
+            : base(ScopePath.USER)
+        {
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Builder
         /// Initializes a new instance of the <see cref="TurnContextStateCollection"/> class.
         /// </summary>
         public TurnContextStateCollection()
+            : base(StringComparer.InvariantCultureIgnoreCase)
         {
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SettingsStateTests.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Types;
@@ -32,19 +34,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         [TestMethod]
         public async Task DialogContextState_SettingsTest()
         {
-            await CreateFlow("en-us")
-                .Send("howdy")
-                    .AssertReply("00000000-0000-0000-0000-000000000000")
-                .Send("howdy")
-                    .AssertReply("00000000-0000-0000-0000-000000000000")
-                .Send("howdy")
-                    .AssertReply("00000000-0000-0000-0000-000000000000")
-                .StartTestAsync();
-        }
-
-        private TestFlow CreateFlow(string locale)
-        {
-            TypeFactory.Configuration = this.Configuration;
             var dialog = new AdaptiveDialog();
             dialog.Triggers.AddRange(new List<OnCondition>()
             {
@@ -57,6 +46,65 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                         },
                     }),
             });
+            await CreateFlow("en-us", dialog)
+                .Send("howdy")
+                    .AssertReply("00000000-0000-0000-0000-000000000000")
+                .Send("howdy")
+                    .AssertReply("00000000-0000-0000-0000-000000000000")
+                .Send("howdy")
+                    .AssertReply("00000000-0000-0000-0000-000000000000")
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TestTurnStateAcrossBoundaries()
+        {
+            var rootDialog = new AdaptiveDialog(nameof(AdaptiveDialog))
+            {
+                Recognizer = new RegexRecognizer()
+                {
+                    Intents = new List<IntentPattern>
+                    {
+                        new IntentPattern() { Intent = "Test", Pattern = "test" }
+                    }
+                },
+                Triggers = new List<OnCondition>()
+                {
+                    new OnIntent()
+                    {
+                        Intent = "Test",
+                        Actions = new List<Dialog>()
+                        {
+                            new SetProperty() { Property = "dialog.name", Value = "'foo'" },
+                            new TextInput() { Prompt = new ActivityTemplate("what is your name?"), Property = "dialog.name" },
+                            new SendActivity() { Activity = new ActivityTemplate("{turn.recognized.intent}") }
+                        }
+                    }
+                }
+            };
+            var rootDialog2 = new AdaptiveDialog()
+            {
+                Triggers = new List<OnCondition>()
+                {
+                    new OnBeginDialog()
+                    {
+                        Actions = new List<Dialog>()
+                        {
+                            new BeginDialog() { Dialog = rootDialog }
+                        }
+                    }
+                }
+            };
+
+            await CreateFlow("en-us", rootDialog)
+                .Send("test")
+                    .AssertReply("Test")
+            .StartTestAsync();
+        }
+
+        private TestFlow CreateFlow(string locale, Dialog dialog)
+        {
+            TypeFactory.Configuration = this.Configuration;
 
             var resourceExplorer = new ResourceExplorer();
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -101,15 +101,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await CreateDialogContext(async (context, ct) =>
             {
                 JObject snapshot = context.State.GetMemorySnapshot();
-                foreach (var memoryScope in DialogStateManager.MemoryScopes.Where(ms => ms.Name != "dialog" && ms.Name != "this"))
+                foreach (var memoryScope in DialogStateManager.MemoryScopes)
                 {
                     if (memoryScope.IncludeInSnapshot)
                     {
-                        Assert.IsNull(snapshot.Property(memoryScope.Name));
+                        Assert.IsNotNull(snapshot.Property(memoryScope.Name));
                     }
                     else
                     {
-                        Assert.IsNotNull(snapshot.Property(memoryScope.Name));
+                        Assert.IsNull(snapshot.Property(memoryScope.Name));
                     }
                 }
             })

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -66,16 +66,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                     }
 
-                    if (!memoryScope.IsReadOnly)
+                    try
                     {
-                        try
-                        {
-                            memoryScope.SetMemory(null, new object());
-                            Assert.Fail($"Should have thrown exception with null dc for SetMemory {memoryScope.Name}");
-                        }
-                        catch (ArgumentNullException)
-                        {
-                        }
+                        memoryScope.SetMemory(null, new object());
+                        Assert.Fail($"Should have thrown exception with null dc for SetMemory {memoryScope.Name}");
+                    }
+                    catch (Exception)
+                    {
                     }
                 }
             })
@@ -106,7 +103,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 JObject snapshot = context.State.GetMemorySnapshot();
                 foreach (var memoryScope in DialogStateManager.MemoryScopes.Where(ms => ms.Name != "dialog" && ms.Name != "this"))
                 {
-                    if (memoryScope.IsReadOnly)
+                    if (memoryScope.IncludeInSnapshot)
                     {
                         Assert.IsNull(snapshot.Property(memoryScope.Name));
                     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -36,45 +37,49 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         public TestContext TestContext { get; set; }
 
-        [TestMethod]
-        public void TestMemoryScopeNullChecks()
+        public TestFlow CreateDialogContext(Func<DialogContext, CancellationToken, Task> handler)
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            foreach (var memoryScope in DialogStateManager.MemoryScopes)
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName));
+            adapter
+                .UseStorage(new MemoryStorage())
+                .UseState(new UserState(new MemoryStorage()), new ConversationState(new MemoryStorage()));
+            DialogManager dm = new DialogManager(new LamdaDialog(handler));
+            return new TestFlow(adapter, (context, ct) =>
             {
-                try
-                {
-                    memoryScope.GetMemory(null);
-                    Assert.Fail($"Should have thrown exception with null for {memoryScope.Name}");
-                }
-                catch (ArgumentNullException)
-                {
-                }
+                return dm.OnTurnAsync(context, ct);
+            }).SendConversationUpdate();
+        }
 
-                if (!memoryScope.IsReadOnly)
+        [TestMethod]
+        public async Task TestMemoryScopeNullChecks()
+        {
+            await CreateDialogContext(async (context, ct) =>
+            {
+                foreach (var memoryScope in DialogStateManager.MemoryScopes)
                 {
                     try
                     {
-                        memoryScope.SetMemory(null, new object());
-                        Assert.Fail($"Should have thrown exception with null dc for SetMemory {memoryScope.Name}");
+                        memoryScope.GetMemory(null);
+                        Assert.Fail($"Should have thrown exception with null for {memoryScope.Name}");
                     }
                     catch (ArgumentNullException)
                     {
                     }
 
-                    try
+                    if (!memoryScope.IsReadOnly)
                     {
-                        memoryScope.SetMemory(dc, null);
-                        Assert.Fail($"Should have thrown exception with null memory for SetMemory {memoryScope.Name}");
-                    }
-                    catch (ArgumentNullException)
-                    {
+                        try
+                        {
+                            memoryScope.SetMemory(null, new object());
+                            Assert.Fail($"Should have thrown exception with null dc for SetMemory {memoryScope.Name}");
+                        }
+                        catch (ArgumentNullException)
+                        {
+                        }
                     }
                 }
-            }
+            })
+            .StartTestAsync();
         }
 
         [TestMethod]
@@ -94,24 +99,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        public void TestMemorySnapshot()
+        public async Task TestMemorySnapshot()
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            JObject snapshot = state.GetMemorySnapshot();
-            foreach (var memoryScope in DialogStateManager.MemoryScopes.Where(ms => ms.Name != "dialog" && ms.Name != "this"))
+            await CreateDialogContext(async (context, ct) =>
             {
-                if (memoryScope.IsReadOnly)
+                JObject snapshot = context.State.GetMemorySnapshot();
+                foreach (var memoryScope in DialogStateManager.MemoryScopes.Where(ms => ms.Name != "dialog" && ms.Name != "this"))
                 {
-                    Assert.IsNull(snapshot.Property(memoryScope.Name));
+                    if (memoryScope.IsReadOnly)
+                    {
+                        Assert.IsNull(snapshot.Property(memoryScope.Name));
+                    }
+                    else
+                    {
+                        Assert.IsNotNull(snapshot.Property(memoryScope.Name));
+                    }
                 }
-                else
-                {
-                    Assert.IsNotNull(snapshot.Property(memoryScope.Name));
-                }
-            }
+            })
+            .StartTestAsync();
         }
 
         [TestMethod]
@@ -144,189 +149,181 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        public void TestSimpleValues()
+        public async Task TestSimpleValues()
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            // simple value types
-            state.SetValue("UseR.nuM", 15);
-            state.SetValue("uSeR.NuM", 25);
-            Assert.AreEqual(25, state.GetValue<int>("user.num"));
-
-            state.SetValue("UsEr.StR", "string1");
-            state.SetValue("usER.STr", "string2");
-            Assert.AreEqual("string2", state.GetValue<string>("USer.str"));
-
-            // simple value types
-            state.SetValue("ConVErsation.nuM", 15);
-            state.SetValue("ConVErSation.NuM", 25);
-            Assert.AreEqual(25, state.GetValue<int>("conversation.num"));
-
-            state.SetValue("ConVErsation.StR", "string1");
-            state.SetValue("CoNVerSation.STr", "string2");
-            Assert.AreEqual("string2", state.GetValue<string>("conversation.str"));
-
-            // simple value types
-            state.SetValue("tUrn.nuM", 15);
-            state.SetValue("turN.NuM", 25);
-            Assert.AreEqual(25, state.GetValue<int>("turn.num"));
-
-            state.SetValue("tuRn.StR", "string1");
-            state.SetValue("TuRn.STr", "string2");
-            Assert.AreEqual("string2", state.GetValue<string>("turn.str"));
-        }
-
-        [TestMethod]
-        public void TestEntitiesRetrieval()
-        {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            var array = new JArray();
-            array.Add("test1");
-            array.Add("test2");
-            array.Add("test3");
-
-            var array2 = new JArray();
-            array2.Add("testx");
-            array2.Add("testy");
-            array2.Add("testz");
-
-            var arrayarray = new JArray();
-            arrayarray.Add(array2);
-            arrayarray.Add(array);
-
-            state.SetValue("turn.recognized.entities.single", array);
-            state.SetValue("turn.recognized.entities.double", arrayarray);
-
-            Assert.AreEqual("test1", state.GetValue<string>("@single"));
-            Assert.AreEqual("testx", state.GetValue<string>("@double"));
-            Assert.AreEqual("test1", state.GetValue<string>("turn.recognized.entities.single.First()"));
-            Assert.AreEqual("testx", state.GetValue<string>("turn.recognized.entities.double.First()"));
-        }
-
-        [TestMethod]
-        public void TestComplexValuePaths()
-        {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            // complex type paths
-            state.SetValue("UseR.fOo", foo);
-            Assert.AreEqual("bob", state.GetValue<string>("user.foo.SuBname.name"));
-
-            // complex type paths
-            state.SetValue("ConVerSation.FOo", foo);
-            Assert.AreEqual("bob", state.GetValue<string>("conversation.foo.SuBname.name"));
-
-            // complex type paths
-            state.SetValue("TurN.fOo", foo);
-            Assert.AreEqual("bob", state.GetValue<string>("TuRN.foo.SuBname.name"));
-        }
-
-        [TestMethod]
-        public void TestComplexPathExpressions()
-        {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            // complex type paths
-            state.SetValue("user.name", "joe");
-            state.SetValue("conversation.stuff[user.name]", "test");
-            state.SetValue("conversation.stuff['frank']", "test2");
-            state.SetValue("conversation.stuff[\"susan\"]", "test3");
-            state.SetValue("conversation.stuff['Jo.Bob']", "test4");
-            Assert.AreEqual("test", state.GetValue<string>("conversation.stuff.joe"), "complex set should set");
-            Assert.AreEqual("test", state.GetValue<string>("conversation.stuff[user.name]"), "complex get should get");
-            Assert.AreEqual("test2", state.GetValue<string>("conversation.stuff['frank']"), "complex get should get");
-            Assert.AreEqual("test3", state.GetValue<string>("conversation.stuff[\"susan\"]"), "complex get should get");
-            Assert.AreEqual("test4", state.GetValue<string>("conversation.stuff[\"Jo.Bob\"]"), "complex get should get");
-        }
-
-        [TestMethod]
-        public void TestGetValue()
-        {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            // complex type paths
-            state.SetValue("user.name.first", "joe");
-            Assert.AreEqual("joe", state.GetValue<string>("user.name.first"));
-
-            Assert.AreEqual(null, state.GetValue<string>("user.xxx"));
-            Assert.AreEqual("default", state.GetValue<string>("user.xxx", () => "default"));
-
-            foreach (var key in state.Keys)
+            await CreateDialogContext(async (dc, ct) =>
             {
-                Assert.AreEqual(state.GetValue<object>(key), state[key]);
-            }
+                // simple value types
+                dc.State.SetValue("UseR.nuM", 15);
+                dc.State.SetValue("uSeR.NuM", 25);
+                Assert.AreEqual(25, dc.State.GetValue<int>("user.num"));
+
+                dc.State.SetValue("UsEr.StR", "string1");
+                dc.State.SetValue("usER.STr", "string2");
+                Assert.AreEqual("string2", dc.State.GetValue<string>("USer.str"));
+
+                // simple value types
+                dc.State.SetValue("ConVErsation.nuM", 15);
+                dc.State.SetValue("ConVErSation.NuM", 25);
+                Assert.AreEqual(25, dc.State.GetValue<int>("conversation.num"));
+
+                dc.State.SetValue("ConVErsation.StR", "string1");
+                dc.State.SetValue("CoNVerSation.STr", "string2");
+                Assert.AreEqual("string2", dc.State.GetValue<string>("conversation.str"));
+
+                // simple value types
+                dc.State.SetValue("tUrn.nuM", 15);
+                dc.State.SetValue("turN.NuM", 25);
+                Assert.AreEqual(25, dc.State.GetValue<int>("turn.num"));
+
+                dc.State.SetValue("tuRn.StR", "string1");
+                dc.State.SetValue("TuRn.STr", "string2");
+                Assert.AreEqual("string2", dc.State.GetValue<string>("turn.str"));
+            }).StartTestAsync();
         }
 
         [TestMethod]
-        public void TestGetValueT()
+        public async Task TestEntitiesRetrieval()
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                var array = new JArray();
+                array.Add("test1");
+                array.Add("test2");
+                array.Add("test3");
 
-            // complex type paths
-            state.SetValue("UseR.fOo", foo);
-            Assert.AreEqual(state.GetValue<Foo>("user.foo").SubName.Name, "bob");
+                var array2 = new JArray();
+                array2.Add("testx");
+                array2.Add("testy");
+                array2.Add("testz");
 
-            // complex type paths
-            state.SetValue("ConVerSation.FOo", foo);
-            Assert.AreEqual(state.GetValue<Foo>("conversation.foo").SubName.Name, "bob");
+                var arrayarray = new JArray();
+                arrayarray.Add(array2);
+                arrayarray.Add(array);
 
-            // complex type paths
-            state.SetValue("TurN.fOo", foo);
-            Assert.AreEqual(state.GetValue<Foo>("turn.foo").SubName.Name, "bob");
+                dc.State.SetValue("turn.recognized.entities.single", array);
+                dc.State.SetValue("turn.recognized.entities.double", arrayarray);
+
+                Assert.AreEqual("test1", dc.State.GetValue<string>("@single"));
+                Assert.AreEqual("testx", dc.State.GetValue<string>("@double"));
+                Assert.AreEqual("test1", dc.State.GetValue<string>("turn.recognized.entities.single.First()"));
+                Assert.AreEqual("testx", dc.State.GetValue<string>("turn.recognized.entities.double.First()"));
+            }).StartTestAsync();
         }
 
         [TestMethod]
-        public void TestHashResolver()
+        public async Task TestComplexValuePaths()
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                // complex type paths
+                dc.State.SetValue("UseR.fOo", foo);
+                Assert.AreEqual("bob", dc.State.GetValue<string>("user.foo.SuBname.name"));
 
-            // test HASH
-            state.SetValue($"turn.recognized.intents.test", "intent1");
-            state.SetValue($"#test2", "intent2");
+                // complex type paths
+                dc.State.SetValue("ConVerSation.FOo", foo);
+                Assert.AreEqual("bob", dc.State.GetValue<string>("conversation.foo.SuBname.name"));
 
-            Assert.AreEqual("intent1", state.GetValue<string>("turn.recognized.intents.test"));
-            Assert.AreEqual("intent1", state.GetValue<string>("#test"));
-            Assert.AreEqual("intent2", state.GetValue<string>("turn.recognized.intents.test2"));
-            Assert.AreEqual("intent2", state.GetValue<string>("#test2"));
+                // complex type paths
+                dc.State.SetValue("TurN.fOo", foo);
+                Assert.AreEqual("bob", dc.State.GetValue<string>("TuRN.foo.SuBname.name"));
+            }).StartTestAsync();
         }
 
         [TestMethod]
-        public void TestEntityResolvers()
+        public async Task TestComplexPathExpressions()
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                // complex type paths
+                dc.State.SetValue("user.name", "joe");
+                dc.State.SetValue("conversation.stuff[user.name]", "test");
+                dc.State.SetValue("conversation.stuff['frank']", "test2");
+                dc.State.SetValue("conversation.stuff[\"susan\"]", "test3");
+                dc.State.SetValue("conversation.stuff['Jo.Bob']", "test4");
+                Assert.AreEqual("test", dc.State.GetValue<string>("conversation.stuff.joe"), "complex set should set");
+                Assert.AreEqual("test", dc.State.GetValue<string>("conversation.stuff[user.name]"), "complex get should get");
+                Assert.AreEqual("test2", dc.State.GetValue<string>("conversation.stuff['frank']"), "complex get should get");
+                Assert.AreEqual("test3", dc.State.GetValue<string>("conversation.stuff[\"susan\"]"), "complex get should get");
+                Assert.AreEqual("test4", dc.State.GetValue<string>("conversation.stuff[\"Jo.Bob\"]"), "complex get should get");
+            }).StartTestAsync();
+        }
 
-            // test @ and @@
-            var testEntities = new string[] { "entity1", "entity2" };
-            var testEntities2 = new string[] { "entity3", "entity4" };
-            state.SetValue($"turn.recognized.entities.test", testEntities);
-            state.SetValue($"@@test2", testEntities2);
+        [TestMethod]
+        public async Task TestGetValue()
+        {
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                // complex type paths
+                dc.State.SetValue("user.name.first", "joe");
+                Assert.AreEqual("joe", dc.State.GetValue<string>("user.name.first"));
 
-            Assert.AreEqual(testEntities.First(), state.GetValue<string>("turn.recognized.entities.test[0]"));
-            Assert.AreEqual(testEntities.First(), state.GetValue<string>("@test"));
-            Assert.IsTrue(testEntities.SequenceEqual(state.GetValue<string[]>("turn.recognized.entities.test")));
-            Assert.IsTrue(testEntities.SequenceEqual(state.GetValue<string[]>("@@test")));
+                Assert.AreEqual(null, dc.State.GetValue<string>("user.xxx"));
+                Assert.AreEqual("default", dc.State.GetValue<string>("user.xxx", () => "default"));
 
-            Assert.AreEqual(testEntities2.First(), state.GetValue<string>("turn.recognized.entities.test2[0]"));
-            Assert.AreEqual(testEntities2.First(), state.GetValue<string>("@test2"));
-            Assert.IsTrue(testEntities2.SequenceEqual(state.GetValue<string[]>("turn.recognized.entities.test2")));
-            Assert.IsTrue(testEntities2.SequenceEqual(state.GetValue<string[]>("@@test2")));
+                foreach (var key in dc.State.Keys)
+                {
+                    Assert.AreEqual(dc.State.GetValue<object>(key), dc.State[key]);
+                }
+            }).StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TestGetValueT()
+        {
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                // complex type paths
+                dc.State.SetValue("UseR.fOo", foo);
+                Assert.AreEqual(dc.State.GetValue<Foo>("user.foo").SubName.Name, "bob");
+
+                // complex type paths
+                dc.State.SetValue("ConVerSation.FOo", foo);
+                Assert.AreEqual(dc.State.GetValue<Foo>("conversation.foo").SubName.Name, "bob");
+
+                // complex type paths
+                dc.State.SetValue("TurN.fOo", foo);
+                Assert.AreEqual(dc.State.GetValue<Foo>("turn.foo").SubName.Name, "bob");
+            }).StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TestHashResolver()
+        {
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                // test HASH
+                dc.State.SetValue($"turn.recognized.intents.test", "intent1");
+                dc.State.SetValue($"#test2", "intent2");
+
+                Assert.AreEqual("intent1", dc.State.GetValue<string>("turn.recognized.intents.test"));
+                Assert.AreEqual("intent1", dc.State.GetValue<string>("#test"));
+                Assert.AreEqual("intent2", dc.State.GetValue<string>("turn.recognized.intents.test2"));
+                Assert.AreEqual("intent2", dc.State.GetValue<string>("#test2"));
+            }).StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task TestEntityResolvers()
+        {
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                // test @ and @@
+                var testEntities = new string[] { "entity1", "entity2" };
+                var testEntities2 = new string[] { "entity3", "entity4" };
+                dc.State.SetValue($"turn.recognized.entities.test", testEntities);
+                dc.State.SetValue($"@@test2", testEntities2);
+
+                Assert.AreEqual(testEntities.First(), dc.State.GetValue<string>("turn.recognized.entities.test[0]"));
+                Assert.AreEqual(testEntities.First(), dc.State.GetValue<string>("@test"));
+                Assert.IsTrue(testEntities.SequenceEqual(dc.State.GetValue<string[]>("turn.recognized.entities.test")));
+                Assert.IsTrue(testEntities.SequenceEqual(dc.State.GetValue<string[]>("@@test")));
+
+                Assert.AreEqual(testEntities2.First(), dc.State.GetValue<string>("turn.recognized.entities.test2[0]"));
+                Assert.AreEqual(testEntities2.First(), dc.State.GetValue<string>("@test2"));
+                Assert.IsTrue(testEntities2.SequenceEqual(dc.State.GetValue<string[]>("turn.recognized.entities.test2")));
+                Assert.IsTrue(testEntities2.SequenceEqual(dc.State.GetValue<string[]>("@@test2")));
+            }).StartTestAsync();
         }
 
         public class D2Dialog : Dialog
@@ -373,7 +370,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             public IEnumerable<Dialog> GetDependencies()
             {
-                return Dialogs.GetDialogs();
+                return this.Dialogs.GetDialogs();
             }
 
             public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
@@ -507,14 +504,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        public void TestExpressionSet()
+        public async Task TestExpressionSet()
         {
-            var dialogs = new DialogSet();
-            var dc = new DialogContext(dialogs, new TurnContext(new TestAdapter(), new Schema.Activity()), (DialogState)new DialogState());
-            DialogStateManager state = new DialogStateManager(dc);
-
-            state.SetValue($"turn.x.y.z", null);
-            Assert.AreEqual(null, state.GetValue<object>("turn.x.y.z"));
+            await CreateDialogContext(async (dc, ct) =>
+            {
+                dc.State.SetValue($"turn.x.y.z", null);
+                Assert.AreEqual(null, dc.State.GetValue<object>("turn.x.y.z"));
+            }).StartTestAsync();
         }
 
         internal class TestDialog : Dialog

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/LamdaDialog.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/LamdaDialog.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    public class LamdaDialog : Dialog
+    {
+        private Func<DialogContext, CancellationToken, Task> handler;
+
+        public LamdaDialog(Func<DialogContext, CancellationToken, Task> handler)
+        {
+            this.handler = handler;
+        }
+
+        public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
+        {
+            await this.handler(dc, cancellationToken);
+            return await dc.EndDialogAsync();
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     {
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            foreach (var scope in DialogStateManager.MemoryScopes.Where(ms => !(ms is DialogMemoryScope) && ms.IsReadOnly == false).Select(ms => ms.Name))
+            foreach (var scope in DialogStateManager.MemoryScopes.Where(ms => !(ms is DialogMemoryScope) && ms.IncludeInSnapshot == true).Select(ms => ms.Name))
             {
                 var path = $"{scope}.test";
                 Assert.IsNull(dc.State.GetValue<string>(path), $"{path} should be null");


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/2842
MemoryScopes were being initialized by external DM, which is not optimal
* it makes it harder to add new scopes
* it adds a hard dependency on the implementation of User and Converation scopes
This delta adds unit test for the issue, but implements BotStateMemoryScope with User and Conversation versions of it which are self contained.
User and Conversation state were being copied into the TurnState, but there was no real reason to do this.
Turn memory scope was always being intialized even if it was already there.

This cleanup allows for
* more BotState based scopes to be easily added (such as Tenant, etc)
* Better encapsulation
* Ability for customers to replace memory scopes (such as User and Conversation) with their own implementations.
To test this I needed to update the DialogStateMemory tests to properly create a DialogContext for executing within, as the UserState/ConversationState memory scopes need actualy UserState and ConversationState accessible off of the turn context.