### PR TITLE
Trim the whitespace of structured-lg

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public override object VisitStructuredTemplateBody([NotNull] LGFileParser.StructuredTemplateBodyContext context)
         {
             var result = new JObject();
-            var typeName = context.structuredBodyNameLine().STRUCTURED_CONTENT().GetText();
+            var typeName = context.structuredBodyNameLine().STRUCTURED_CONTENT().GetText().Trim();
             result["$type"] = typeName;
 
             var bodys = context.structuredBodyContentLine().STRUCTURED_CONTENT();

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var idToStringDict = new Dictionary<string, string>();
             var stb = context.structuredTemplateBody();
             var result = new JObject();
-            var typeName = stb.structuredBodyNameLine().STRUCTURED_CONTENT().GetText();
+            var typeName = stb.structuredBodyNameLine().STRUCTURED_CONTENT().GetText().Trim();
             result["$type"] = typeName;
             var expandedResult = new List<JObject>();
             expandedResult.Add(result);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/MessageGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/MessageGeneratorTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dynamic data = new JObject();
             data.title = "titleContent";
             data.text = "textContent";
-
+            
             var activity = await mg.Generate(context, "[HerocardWithCardAction]", data: data) as Activity;
             AssertCardActionActivity(activity);
 
@@ -114,6 +114,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             data.connectionName = "MyConnection";
             activity = await mg.Generate(context, "[OAuthCardTemplate]", data: data) as Activity;
             AssertOAuthCardActivity(activity);
+
+            activity = await mg.Generate(context, "[SuggestedActionsReference]", data: data) as Activity;
+            AssertSuggestedActionsReferenceActivity(activity);
         }
 
         [TestMethod]
@@ -178,11 +181,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             data.connectionName = "MyConnection";
             activity = ActivityGenerator.GenerateFromLG(engine.EvaluateTemplate("OAuthCardTemplate", data));
             AssertOAuthCardActivity(activity);
+
+            activity = ActivityGenerator.GenerateFromLG(engine.EvaluateTemplate("SuggestedActionsReference", data));
+            AssertSuggestedActionsReferenceActivity(activity);
         }
 
         private static string GetProjectFolder()
         {
             return AppContext.BaseDirectory.Substring(0, AppContext.BaseDirectory.IndexOf("bin"));
+        }
+
+        private void AssertSuggestedActionsReferenceActivity(dynamic activity)
+        {
+            Assert.AreEqual(ActivityTypes.Message, activity.Type);
+            Assert.AreEqual("textContent", activity.Text);
+           
+            Assert.AreEqual(activity.SuggestedActions.Actions.Count, 5);
+            Assert.AreEqual(activity.SuggestedActions.Actions[0].Text, "Add todo");
+            Assert.AreEqual(activity.SuggestedActions.Actions[1].Text, "View Todo");
+            Assert.AreEqual(activity.SuggestedActions.Actions[2].Text, "Remove Todo");
+            Assert.AreEqual(activity.SuggestedActions.Actions[3].Text, "Cancel");
+            Assert.AreEqual(activity.SuggestedActions.Actions[4].Text, "Help");
         }
 
         private void AssertMessageActivityAll(Activity activity)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/MessageGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/MessageGeneratorTests.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dynamic data = new JObject();
             data.title = "titleContent";
             data.text = "textContent";
-            
             var activity = await mg.Generate(context, "[HerocardWithCardAction]", data: data) as Activity;
             AssertCardActionActivity(activity);
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
@@ -154,6 +154,17 @@
     key = value
 ]
 
+# SuggestedActionsReference(text)
+[Activity 
+    Text = {text}
+    @{WelcomeActions()}
+]
+
+# WelcomeActions
+[Activity
+    SuggestedActions = Add todo | View Todo | Remove Todo | Cancel | Help
+]
+
 # adaptivecardjson
 - ```
 {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
@@ -155,7 +155,7 @@
 ]
 
 # SuggestedActionsReference(text)
-[Activity 
+[  Activity 
     Text = {text}
     @{WelcomeActions()}
 ]


### PR DESCRIPTION
Trim the whitespace of structured-lg. For example:
```
# template
[     Activity       -> type will be parsed as 'Activity', but not '    Activity    ';       
   text = 'hi'
]
```