### PR TITLE
Skill bug fixes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Skills/Adapters/BotFrameworkSkillHostAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Skills/Adapters/BotFrameworkSkillHostAdapter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -15,11 +14,11 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest.TransientFaultHandling;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Skills.Adapters
 {
@@ -66,7 +65,6 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
         /// <param name="connectorClientRetryPolicy">Retry policy for retrying HTTP operations.</param>
         /// <param name="customHttpClient">The HTTP client.</param>
         /// <param name="logger">The ILogger implementation this adapter should use.</param>
-        /// <param name="configuration">configuration.</param>
         /// <remarks>Use a <see cref="MiddlewareSet"/> object to add multiple middleware
         /// components in the constructor. Use the Use(<see cref="IMiddleware"/>) method to
         /// add additional middleware to the adapter after construction.
@@ -77,9 +75,8 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             IChannelProvider channelProvider = null,
             RetryPolicy connectorClientRetryPolicy = null,
             HttpClient customHttpClient = null,
-            ILogger logger = null,
-            IConfiguration configuration = null)
-            : this(adapter, credentialProvider, new AuthenticationConfiguration(), channelProvider, connectorClientRetryPolicy, customHttpClient, logger, configuration)
+            ILogger logger = null)
+            : this(adapter, credentialProvider, new AuthenticationConfiguration(), channelProvider, connectorClientRetryPolicy, customHttpClient, logger)
         {
         }
 
@@ -94,7 +91,6 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
         /// <param name="connectorClientRetryPolicy">Retry policy for retrying HTTP operations.</param>
         /// <param name="customHttpClient">The HTTP client.</param>
         /// <param name="logger">The ILogger implementation this adapter should use.</param>
-        /// <param name="configuration">configuration.</param>
         /// <exception cref="ArgumentNullException">throw ArgumentNullException.</exception>
         /// <remarks>Use a <see cref="MiddlewareSet"/> object to add multiple middleware
         /// components in the constructor. Use the Use(<see cref="IMiddleware"/>) method to
@@ -107,8 +103,7 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             IChannelProvider channelProvider = null,
             RetryPolicy connectorClientRetryPolicy = null,
             HttpClient customHttpClient = null,
-            ILogger logger = null,
-            IConfiguration configuration = null)
+            ILogger logger = null)
             : base(adapter, logger)
         {
             _credentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
@@ -117,8 +112,6 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             _connectorClientRetryPolicy = connectorClientRetryPolicy;
             _logger = logger ?? NullLogger.Instance;
             _authConfiguration = authConfig ?? throw new ArgumentNullException(nameof(authConfig));
-
-            LoadFromConfiguration(configuration);
 
             // DefaultRequestHeaders are not thread safe so set them up here because this adapter should be a singleton.
             ConnectorClient.AddDefaultRequestHeaders(_httpClient);
@@ -135,7 +128,6 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
         /// <param name="connectorClientRetryPolicy">Retry policy for retrying HTTP operations.</param>
         /// <param name="customHttpClient">The HTTP client.</param>
         /// <param name="logger">The ILogger implementation this adapter should use.</param>
-        /// <param name="configuration">configuration.</param>
         /// <exception cref="ArgumentNullException">throw ArgumentNullException.</exception>
         /// <remarks>Use a <see cref="MiddlewareSet"/> object to add multiple middleware
         /// components in the constructor. Use the Use(<see cref="IMiddleware"/>) method to
@@ -148,8 +140,7 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             IChannelProvider channelProvider = null,
             RetryPolicy connectorClientRetryPolicy = null,
             HttpClient customHttpClient = null,
-            ILogger logger = null,
-            IConfiguration configuration = null)
+            ILogger logger = null)
             : base(adapter, logger)
         {
             _appCredentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
@@ -159,43 +150,8 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             _logger = logger ?? NullLogger.Instance;
             _authConfiguration = authConfig ?? throw new ArgumentNullException(nameof(authConfig));
 
-            LoadFromConfiguration(configuration);
-
             // DefaultRequestHeaders are not thread safe so set them up here because this adapter should be a singleton.
             ConnectorClient.AddDefaultRequestHeaders(_httpClient);
-        }
-
-        public List<BotFrameworkSkill> Skills { get; } = new List<BotFrameworkSkill>();
-
-        /// <summary>
-        /// Gets or sets the /v3/conversations endpoint that will handle responses from the skill..
-        /// </summary>
-        /// <value>
-        /// The callback URL that will be used by the skills to communicate back to the bot.
-        /// </value>
-        public Uri SkillHostEndpoint { get; set; }
-
-        /// <summary>
-        /// Forwards an activity to a skill (bot).
-        /// </summary>
-        /// <remarks>NOTE: Forwarding an activity to a skill will flush UserState and ConversationState changes so that skill has accurate state.</remarks>
-        /// <param name="turnContext">turnContext.</param>
-        /// <param name="skillId">skillId of the skill to forward the activity to.</param>
-        /// <param name="activity">activity to forward.</param>
-        /// <param name="cancellationToken">cancellation Token.</param>
-        /// <returns>Async task with optional invokeResponse.</returns>
-        public override async Task<InvokeResponse> ForwardActivityAsync(ITurnContext turnContext, string skillId, Activity activity, CancellationToken cancellationToken)
-        {
-            _logger.LogInformation($"Received request to forward activity to skill id {skillId}.");
-
-            // Get the skill information for the skillId
-            var skill = Skills.FirstOrDefault(s => s.Id == skillId);
-            if (skill == null)
-            {
-                throw new ArgumentException($"Skill:{skillId} isn't a registered skill");
-            }
-
-            return await ForwardActivityAsync(turnContext, skill, SkillHostEndpoint, activity, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -208,8 +164,10 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
         /// <param name="activity">activity to forward.</param>
         /// <param name="cancellationToken">cancellation Token.</param>
         /// <returns>Async task with optional invokeResponse.</returns>
-        public async Task<InvokeResponse> ForwardActivityAsync(ITurnContext turnContext, BotFrameworkSkill skill, Uri skillHostEndpoint, Activity activity, CancellationToken cancellationToken)
+        public override async Task<InvokeResponse> ForwardActivityAsync(ITurnContext turnContext, BotFrameworkSkill skill, Uri skillHostEndpoint, Activity activity, CancellationToken cancellationToken)
         {
+            _logger.LogInformation($"Received request to forward activity to skill id {skill.Id}.");
+
             // Pull the current claims identity from TurnState (it is stored there on the way in).
             var identity = (ClaimsIdentity)turnContext.TurnState.Get<IIdentity>(BotIdentityKey);
             if (identity.AuthenticationType.Equals("anonymous", StringComparison.InvariantCultureIgnoreCase))
@@ -224,7 +182,7 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
                 throw new InvalidOperationException("Unable to get the audience from the current request identity");
             }
 
-            var appCredentials = await GetAppCredentialsAsync(botAppId, skill.AppId, cancellationToken).ConfigureAwait(false);
+            var appCredentials = await GetAppCredentialsAsync(botAppId, skill.AppId).ConfigureAwait(false);
             if (appCredentials == null)
             {
                 throw new InvalidOperationException("Unable to get appCredentials to connect to the skill");
@@ -236,25 +194,32 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             // POST to skill 
             using (var client = new HttpClient())
             {
+                // Create a deep clone of the activity so we can update it without impacting the original activity.
+                var activityClone = JObject.FromObject(activity).ToObject<Activity>();
+
                 // TODO use SkillConversation class here instead of hard coded encoding...
                 // Encode original bot service URL and ConversationId in the new conversation ID so we can unpack it later.
                 // var skillConversation = new SkillConversation() { ServiceUrl = activity.ServiceUrl, ConversationId = activity.Conversation.Id };
                 // activity.Conversation.Id = skillConversation.GetSkillConversationId()
-                activity.Conversation.Id = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new[]
+                activityClone.Conversation.Id = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new[]
                 {
-                    activity.Conversation.Id,
-                    activity.ServiceUrl
+                    activityClone.Conversation.Id,
+                    activityClone.ServiceUrl
                 })));
-                activity.ServiceUrl = skillHostEndpoint.ToString();
-                activity.Recipient.Properties["skillId"] = skill.Id;
-                using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
+                activityClone.ServiceUrl = skillHostEndpoint.ToString();
+                activityClone.Recipient.Properties["skillId"] = skill.Id;
+                using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activityClone, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
                 {
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
                     var response = await client.PostAsync($"{skill.SkillEndpoint}", jsonContent, cancellationToken).ConfigureAwait(false);
                     var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     if (content.Length > 0)
                     {
-                        return JsonConvert.DeserializeObject<InvokeResponse>(content);
+                        return new InvokeResponse()
+                        {
+                            Status = (int)response.StatusCode,
+                            Body = JsonConvert.DeserializeObject(content)
+                        };
                     }
                 }
             }
@@ -268,9 +233,8 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
         /// </summary>
         /// <param name="appId">The application identifier (AAD Id for the bot).</param>
         /// <param name="oAuthScope">The scope for the token, skills will use the Skill App Id. </param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>App credentials.</returns>
-        private async Task<AppCredentials> GetAppCredentialsAsync(string appId, string oAuthScope = null, CancellationToken cancellationToken = default)
+        private async Task<AppCredentials> GetAppCredentialsAsync(string appId, string oAuthScope = null)
         {
             if (appId == null)
             {
@@ -298,22 +262,6 @@ namespace Microsoft.Bot.Builder.Skills.Adapters
             // Cache the credentials for later use
             _appCredentialMap[cacheKey] = appCredentials;
             return appCredentials;
-        }
-
-        private void LoadFromConfiguration(IConfiguration configuration)
-        {
-            var section = configuration?.GetSection("BotFrameworkSkills");
-            var skills = section?.Get<BotFrameworkSkill[]>();
-            if (skills != null)
-            {
-                Skills.AddRange(skills);
-            }
-
-            var skillHostEndpoint = configuration?.GetValue<string>(nameof(SkillHostEndpoint));
-            if (!string.IsNullOrWhiteSpace(skillHostEndpoint))
-            {
-                SkillHostEndpoint = new Uri(skillHostEndpoint);
-            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Skills/SkillHostAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Skills/SkillHostAdapter.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Skills.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -45,11 +47,12 @@ namespace Microsoft.Bot.Builder.Skills
         /// Forwards an activity to a skill.
         /// </summary>
         /// <param name="turnContext">turnContext.</param>
-        /// <param name="skillId">skillId of the skill to forward the activity to.</param>
+        /// <param name="skill">A <see cref="BotFrameworkSkill"/> instance with the skill information.</param>
+        /// <param name="skillHostEndpoint">The callback Url for the skill host.</param>
         /// <param name="activity">activity to forward.</param>
         /// <param name="cancellationToken">cancellation Token.</param>
         /// <returns>Async task with optional InvokeResponse.</returns>
-        public abstract Task<InvokeResponse> ForwardActivityAsync(ITurnContext turnContext, string skillId, Activity activity, CancellationToken cancellationToken);
+        public abstract Task<InvokeResponse> ForwardActivityAsync(ITurnContext turnContext, BotFrameworkSkill skill, Uri skillHostEndpoint, Activity activity, CancellationToken cancellationToken);
 
         /// <summary>
         /// GetConversationsAsync() API for Skill.
@@ -367,6 +370,8 @@ namespace Microsoft.Bot.Builder.Skills
 
         protected async Task<T> InvokeChannelApiAsync<T>(IBot bot, ClaimsIdentity claimsIdentity, string method, string conversationId, params object[] args)
         {
+            _logger.LogInformation($"InvokeChannelApiAsync(). Invoking method \"{method}\"");
+
             var skillConversation = new SkillConversation(conversationId);
 
             var channelApiInvokeActivity = Activity.CreateInvokeActivity();

--- a/tests/Microsoft.Bot.Builder.Skills.Tests/SkillAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Skills.Tests/SkillAdapterTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Skills.Adapters;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Xunit;
 using Xunit.Sdk;
 
@@ -25,7 +24,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
         {
             var botAdapter = CreateAdapter("TestSkillAdapterInjectsMiddleware");
 
-            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration(), configuration: new ConfigurationBuilder().Build());
+            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration());
 
             Assert.Equal(1, botAdapter.MiddlewareSet.Count(s => s is ChannelApiMiddleware));
         }
@@ -43,7 +42,7 @@ namespace Microsoft.Bot.Builder.Skills.Tests
             var middleware = new AssertInvokeMiddleware(botAdapter, activityId);
             botAdapter.Use(middleware);
             var bot = new CallbackBot();
-            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration(), configuration: new ConfigurationBuilder().Build());
+            var skillAdapter = new BotFrameworkSkillHostAdapter(botAdapter, new MicrosoftAppCredentials(string.Empty, string.Empty), new AuthenticationConfiguration());
 
             var sc = new SkillConversation()
             {


### PR DESCRIPTION
Relates to #2774 
Fixes issue handling InvokeActivities
Added code to create a deep clone of the Activity in ForwardToSkill in order to avoid issues related to manipulating the activity during the forward operation
Removes functionality to load Skills information from config in BotFramworkSkillHostAdapter and ForwardToSkill overload that was using it.
Updated ForwardToSkill abstract method in SkillHostAdapter.
Fixed several compilation warnings by removing unused parameters (we can add them back later).

FYI @lzc850612 