### PR TITLE
Fix library compat issues.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Condition=" '$(IsBuildServer)' != '' " Version="$(PreviewPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />
     <PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
@@ -26,7 +26,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -20,13 +20,13 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
   </ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>    
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0-preview5.19227.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -16,9 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.3" />
   </ItemGroup>
 

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.3" />
   </ItemGroup>
 

--- a/tests/Microsoft.Bot.Expressions.Tests/Microsoft.Bot.Expressions.Tests.csproj
+++ b/tests/Microsoft.Bot.Expressions.Tests/Microsoft.Bot.Expressions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.3.0-rc2" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -9,7 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />


### PR DESCRIPTION
For more info see: 

https://github.com/microsoft/BotBuilder-Samples/issues/1524
and
https://github.com/aspnet/Universe/issues/1180

Without this change, I cannot build some of the test projects from a clean repo pull.

`dotnet --info`
![image](https://user-images.githubusercontent.com/11055362/68347993-8a6d9100-00ad-11ea-8e39-a9b631290b9b.png)

Note this recommendation: 

> When referencing the Microsoft.AspNetCore.App or Microsoft.AspNetCore.All packages, do not specify their version.

has a known issue on 2.1:

> Known issue: the .NET Core 2.1 SDK only supported this syntax when the project also uses Microsoft.NET.Sdk.Web. This is resolved in the .NET Core 2.2 SDK.

from:
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#recommendation
