### PR TITLE
ChoicePrompt handles null locales [4.6 cherry-pick]

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -122,12 +122,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(options));
             }
 
-            // Determine culture
-            var culture = MapToNearestLanguage(turnContext.Activity.Locale ?? DefaultLocale);
-            if (string.IsNullOrEmpty(culture) || !_choiceDefaults.ContainsKey(culture))
-            {
-                culture = English.Locale;
-            }
+            var culture = DetermineCulture(turnContext.Activity);
 
             // Format prompt to send
             IMessageActivity prompt;
@@ -174,7 +169,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var activity = turnContext.Activity;
                 var utterance = activity.Text;
                 var opt = RecognizerOptions ?? new FindChoicesOptions();
-                opt.Locale = MapToNearestLanguage(activity.Locale ?? opt.Locale ?? DefaultLocale ?? English.Locale);
+                opt.Locale = DetermineCulture(activity, opt);
                 var results = ChoiceRecognizers.RecognizeChoices(utterance, choices, opt);
                 if (results != null && results.Count > 0)
                 {
@@ -184,6 +179,17 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             return Task.FromResult(result);
+        }
+
+        private string DetermineCulture(Activity activity, FindChoicesOptions opt = null)
+        {
+            var culture = MapToNearestLanguage(activity.Locale ?? opt?.Locale ?? DefaultLocale ?? English.Locale);
+            if (string.IsNullOrEmpty(culture) || !_choiceDefaults.ContainsKey(culture))
+            {
+                culture = English.Locale;
+            }
+
+            return culture;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -101,6 +101,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
         /// <summary>
         /// Use Recognizers-Text to normalize various potential Locale strings to a standard.
         /// </summary>
+        /// <remarks>
+        /// This is mostly a copy/paste from https://github.com/microsoft/Recognizers-Text/blob/master/.NET/Microsoft.Recognizers.Text/Culture.cs#L66
+        /// This doesn't directly use Recognizers-Text's MapToNearestLanguage because if they add language support before we do, it will break our prompts.
+        /// </remarks>
         /// <param name="cultureCode">Represents locale. Examples: "en-US, en-us, EN".</param>
         /// <returns>Normalized locale.</returns>
         public static string MapToNearestLanguage(string cultureCode) => Culture.MapToNearestLanguage(cultureCode);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Linq;
 using Microsoft.Recognizers.Text;
 
 namespace Microsoft.Bot.Builder.Dialogs.Prompts
@@ -10,6 +12,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
     /// </summary>
     public static class PromptCultureModels
     {
+        private static readonly string[] SupportedLocales = GetSupportedCultures().Select(c => c.Locale).ToArray();
+
         public static PromptCultureModel Chinese =>
             new PromptCultureModel
             {
@@ -107,7 +111,35 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
         /// </remarks>
         /// <param name="cultureCode">Represents locale. Examples: "en-US, en-us, EN".</param>
         /// <returns>Normalized locale.</returns>
-        public static string MapToNearestLanguage(string cultureCode) => Culture.MapToNearestLanguage(cultureCode);
+        public static string MapToNearestLanguage(string cultureCode)
+        {
+            cultureCode = cultureCode.ToLowerInvariant();
+
+            if (SupportedLocales.All(o => o != cultureCode))
+            {
+                // Handle cases like EnglishOthers with cultureCode "en-*"
+                var fallbackCultureCodes = SupportedLocales
+                    .Where(o => o.EndsWith("*", StringComparison.Ordinal) &&
+                                cultureCode.StartsWith(o.Split('-').First(), StringComparison.Ordinal)).ToList();
+
+                if (fallbackCultureCodes.Count == 1)
+                {
+                    return fallbackCultureCodes.First();
+                }
+
+                // If there is no cultureCode like "-*", map only the prefix
+                // For example, "es-mx" will be mapped to "es-es"
+                fallbackCultureCodes = SupportedLocales
+                    .Where(o => cultureCode.StartsWith(o.Split('-').First(), StringComparison.Ordinal)).ToList();
+
+                if (fallbackCultureCodes.Any())
+                {
+                    return fallbackCultureCodes.First();
+                }
+            }
+
+            return cultureCode;
+        }
 
         public static PromptCultureModel[] GetSupportedCultures() => new PromptCultureModel[]
         {


### PR DESCRIPTION
Per standup this morning, this is a PR against 4.6, replacing [this PR](https://github.com/microsoft/botbuilder-dotnet/pull/2943)

---

Fixes: #2942 

# Changes

* `ChoicePrompt`: Ensures that locale defaults to English and handles mapping to the nearest locale more gracefully
* `PromptCultureModels`: Implements our own version of [Recognizers-Text's `MapToNearestLanguage`](https://github.com/microsoft/Recognizers-Text/blob/7b20c1bbbfdebc3a801fbc61b094706ceebd7acf/.NET/Microsoft.Recognizers.Text/Culture.cs#L66) -- They added a bunch of other supported languages that will break this without doing this.
* `ChoicePromptTests`: Added a test to specifically set the Locale to null

# Other Notes

* ConfirmPrompt already handled this fine and had tests for it
* I'll also work on some tests for PromptCultureModels, but I figured this should get out the door, first.
* Since Recognizers-Text added a bunch of supported languages, I'll see about adding them here in a future PR

## Workarounds until this is Merged

* Downgrade to < 4.6, or
* set `DefaultLocale` on `ChoicePrompt`