### PR TITLE
Adds ClaimValidator to AuthtentcationConfiguration

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder
             ILogger logger = null)
         {
             CredentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
-            this.ChannelProvider = channelProvider;
+            ChannelProvider = channelProvider;
             _httpClient = customHttpClient ?? _defaultHttpClient;
             _connectorClientRetryPolicy = connectorClientRetryPolicy;
             Logger = logger ?? NullLogger.Instance;

--- a/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
@@ -6,25 +6,37 @@ using System.Net.Http;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
+using Microsoft.Rest.TransientFaultHandling;
 
 namespace Microsoft.Bot.Builder.Streaming
 {
     public class BotFrameworkHttpAdapterBase : BotFrameworkAdapter, IStreamingActivityProcessor
     {
+        public BotFrameworkHttpAdapterBase(
+            ICredentialProvider credentialProvider,
+            AuthenticationConfiguration authConfig,
+            IChannelProvider channelProvider = null,
+            RetryPolicy connectorClientRetryPolicy = null,
+            HttpClient customHttpClient = null,
+            IMiddleware middleware = null,
+            ILogger logger = null)
+            : base(credentialProvider, authConfig, channelProvider, connectorClientRetryPolicy, customHttpClient, middleware, logger)
+        {
+        }
+        
         public BotFrameworkHttpAdapterBase(ICredentialProvider credentialProvider = null, IChannelProvider channelProvider = null, ILogger<BotFrameworkHttpAdapterBase> logger = null)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, null, null, logger)
+            : this(credentialProvider ?? new SimpleCredentialProvider(), new AuthenticationConfiguration(), channelProvider, null, null, null, logger)
         {
         }
 
         public BotFrameworkHttpAdapterBase(ICredentialProvider credentialProvider, IChannelProvider channelProvider, HttpClient httpClient, ILogger<BotFrameworkHttpAdapterBase> logger)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, httpClient, null, logger)
+            : this(credentialProvider ?? new SimpleCredentialProvider(), new AuthenticationConfiguration(), channelProvider, null, httpClient, null, logger)
         {
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -12,6 +12,31 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </remarks>
     public class AuthenticationConfiguration
     {
-        public string[] RequiredEndorsements { get; set; } = new string[] { };
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationConfiguration"/> class.
+        /// </summary>
+        public AuthenticationConfiguration()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationConfiguration"/> class.
+        /// </summary>
+        /// <param name="claimsValidator">A <see cref="ClaimsValidator"/> instance used to validate claims.</param>
+        public AuthenticationConfiguration(ClaimsValidator claimsValidator)
+        {
+            ClaimsValidator = claimsValidator;
+        }
+
+        public string[] RequiredEndorsements { get; set; } = { };
+
+        /// <summary>
+        /// Gets an <see cref="ClaimsValidator"/> instance used to validate the identity claims.
+        /// </summary>
+        /// <value>
+        /// An <see cref="ClaimsValidator"/> instance used to validate the identity claims.
+        /// </value>
+        public virtual ClaimsValidator ClaimsValidator { get; }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -12,31 +12,14 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </remarks>
     public class AuthenticationConfiguration
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthenticationConfiguration"/> class.
-        /// </summary>
-        public AuthenticationConfiguration()
-            : this(null)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthenticationConfiguration"/> class.
-        /// </summary>
-        /// <param name="claimsValidator">A <see cref="ClaimsValidator"/> instance used to validate claims.</param>
-        public AuthenticationConfiguration(ClaimsValidator claimsValidator)
-        {
-            ClaimsValidator = claimsValidator;
-        }
-
         public string[] RequiredEndorsements { get; set; } = { };
 
         /// <summary>
-        /// Gets an <see cref="ClaimsValidator"/> instance used to validate the identity claims.
+        /// Gets or sets an <see cref="ClaimsValidator"/> instance used to validate the identity claims.
         /// </summary>
         /// <value>
         /// An <see cref="ClaimsValidator"/> instance used to validate the identity claims.
         /// </value>
-        public virtual ClaimsValidator ClaimsValidator { get; }
+        public virtual ClaimsValidator ClaimsValidator { get; set; } = null;
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/ClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ClaimsValidator.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// An interface used to validate identity <see cref="Claim"/>.
+    /// </summary>
+    public abstract class ClaimsValidator
+    {
+        /// <summary>
+        /// Validates a list of <see cref="Claim"/>.
+        /// </summary>
+        /// <param name="claims">The list of claims to validate.</param>
+        /// <returns>true if the validation is successful, false if not.</returns>
+        public abstract Task<bool> ValidateClaimsAsync(List<Claim> claims);
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/ClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ClaimsValidator.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="claims">The list of claims to validate.</param>
         /// <returns>true if the validation is successful, false if not.</returns>
-        public abstract Task<bool> ValidateClaimsAsync(List<Claim> claims);
+        public abstract Task<bool> ValidateClaimsAsync(IList<Claim> claims);
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/ClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ClaimsValidator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -13,10 +14,11 @@ namespace Microsoft.Bot.Connector.Authentication
     public abstract class ClaimsValidator
     {
         /// <summary>
-        /// Validates a list of <see cref="Claim"/>.
+        /// Validates a list of <see cref="Claim"/> and should throw an exception if the validation fails.
         /// </summary>
         /// <param name="claims">The list of claims to validate.</param>
         /// <returns>true if the validation is successful, false if not.</returns>
-        public abstract Task<bool> ValidateClaimsAsync(IList<Claim> claims);
+        /// <exception cref="UnauthorizedAccessException">Throw this exception if the validation fails.</exception>
+        public abstract Task ValidateClaimsAsync(IList<Claim> claims);
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -119,39 +119,17 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(authConfig));
             }
 
-            httpClient = httpClient ?? _httpClient;
+            httpClient ??= _httpClient;
 
-            if (SkillValidation.IsSkillToken(authHeader))
-            {
-                return await SkillValidation.AuthenticateChannelToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig).ConfigureAwait(false);
-            }
+            var identity = await AuthenticateToken(authHeader, credentials, channelProvider, channelId, authConfig, serviceUrl, httpClient);
 
-            if (EmulatorValidation.IsTokenFromEmulator(authHeader))
-            {
-                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig).ConfigureAwait(false);
-            }
+            await ValidateClaimsAsync(authConfig, identity.Claims).ConfigureAwait(false);
 
-            if (channelProvider == null || channelProvider.IsPublicAzure())
-            {
-                // No empty or null check. Empty can point to issues. Null checks only.
-                if (serviceUrl != null)
-                {
-                    return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
-                }
-
-                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig).ConfigureAwait(false);
-            }
-
-            if (channelProvider.IsGovernment())
-            {
-                return await GovernmentChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
-            }
-
-            return await EnterpriseChannelValidation.AuthenticateChannelToken(authHeader, credentials, channelProvider, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
+            return identity;
         }
 
         /// <summary>
-        /// Helper method to get the AppId from a token claims list.
+        /// Gets the AppId from a claims list.
         /// </summary>
         /// <remarks>
         /// In v1 tokens the AppId is in the the <see cref="AuthenticationConstants.AppIdClaim"/> claim.
@@ -187,6 +165,22 @@ namespace Microsoft.Bot.Connector.Authentication
         }
 
         /// <summary>
+        /// Validates the identity claims against the <see cref="ClaimsValidator"/> in <see cref="AuthenticationConfiguration"/> if present. 
+        /// </summary>
+        /// <param name="authConfig">An <see cref="AuthenticationConfiguration"/> instance.</param>
+        /// <param name="claims">The list of claims to validate.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <exception cref="UnauthorizedAccessException">If the validation returns false.</exception>
+        internal static async Task ValidateClaimsAsync(AuthenticationConfiguration authConfig, IEnumerable<Claim> claims)
+        {
+            if (authConfig.ClaimsValidator != null && !await authConfig.ClaimsValidator.ValidateClaimsAsync(new List<Claim>(claims)).ConfigureAwait(false))
+            {
+                // Invalid appId
+                throw new UnauthorizedAccessException("Invalid claims.");
+            }
+        }
+
+        /// <summary>
         /// Internal helper to check if the token has the shape we expect "Bearer [big long string]".
         /// </summary>
         /// <param name="authHeader">A string containing the token header.</param>
@@ -217,6 +211,40 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Authenticates the auth header token from the request.
+        /// </summary>
+        private static async Task<ClaimsIdentity> AuthenticateToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, AuthenticationConfiguration authConfig, string serviceUrl, HttpClient httpClient)
+        {
+            if (SkillValidation.IsSkillToken(authHeader))
+            {
+                return await SkillValidation.AuthenticateChannelToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig).ConfigureAwait(false);
+            }
+
+            if (EmulatorValidation.IsTokenFromEmulator(authHeader))
+            {
+                return await EmulatorValidation.AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, authConfig).ConfigureAwait(false);
+            }
+
+            if (channelProvider == null || channelProvider.IsPublicAzure())
+            {
+                // No empty or null check. Empty can point to issues. Null checks only.
+                if (serviceUrl != null)
+                {
+                    return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
+                }
+
+                return await ChannelValidation.AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig).ConfigureAwait(false);
+            }
+
+            if (channelProvider.IsGovernment())
+            {
+                return await GovernmentChannelValidation.AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
+            }
+
+            return await EnterpriseChannelValidation.AuthenticateChannelToken(authHeader, credentials, channelProvider, serviceUrl, httpClient, channelId, authConfig).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>The value of the appId claim if found (null if it can't find a suitable claim).</returns>
         public static string GetAppIdFromClaims(IEnumerable<Claim> claims)
         {
-            var claimsList = claims.ToList();
+            var claimsList = claims as List<Claim> ?? claims.ToList();
             string appId = null;
 
             // Depending on Version, the is either in the
@@ -173,7 +173,8 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <exception cref="UnauthorizedAccessException">If the validation returns false.</exception>
         internal static async Task ValidateClaimsAsync(AuthenticationConfiguration authConfig, IEnumerable<Claim> claims)
         {
-            if (authConfig.ClaimsValidator != null && !await authConfig.ClaimsValidator.ValidateClaimsAsync(new List<Claim>(claims)).ConfigureAwait(false))
+            var claimsList = claims as IList<Claim> ?? claims.ToList();
+            if (authConfig.ClaimsValidator != null && !await authConfig.ClaimsValidator.ValidateClaimsAsync(claimsList).ConfigureAwait(false))
             {
                 // Invalid appId
                 throw new UnauthorizedAccessException("Invalid claims.");

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -141,7 +141,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>The value of the appId claim if found (null if it can't find a suitable claim).</returns>
         public static string GetAppIdFromClaims(IEnumerable<Claim> claims)
         {
-            var claimsList = claims as List<Claim> ?? claims.ToList();
+            if (claims == null)
+            {
+                throw new ArgumentNullException(nameof(claims));
+            }
+
+            var claimsList = claims as IList<Claim> ?? claims.ToList();
             string appId = null;
 
             // Depending on Version, the is either in the
@@ -173,11 +178,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <exception cref="UnauthorizedAccessException">If the validation returns false.</exception>
         internal static async Task ValidateClaimsAsync(AuthenticationConfiguration authConfig, IEnumerable<Claim> claims)
         {
-            var claimsList = claims as IList<Claim> ?? claims.ToList();
-            if (authConfig.ClaimsValidator != null && !await authConfig.ClaimsValidator.ValidateClaimsAsync(claimsList).ConfigureAwait(false))
+            if (authConfig.ClaimsValidator != null)
             {
-                // Invalid appId
-                throw new UnauthorizedAccessException("Invalid claims.");
+                // Call the validation method if defined (it should throw an exception if the validation fails)
+                var claimsList = claims as IList<Claim> ?? claims.ToList();
+                await authConfig.ClaimsValidator.ValidateClaimsAsync(claimsList).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(authConfig));
             }
 
-            httpClient ??= _httpClient;
+            httpClient = httpClient ?? _httpClient;
 
             var identity = await AuthenticateToken(authHeader, credentials, channelProvider, channelId, authConfig, serviceUrl, httpClient);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// TO SKILL FROM BOT and TO BOT FROM SKILL: Token validation parameters when connecting a bot to a skill.
         /// </summary>
         private static readonly TokenValidationParameters _tokenValidationParameters =
-            new TokenValidationParameters()
+            new TokenValidationParameters
             {
                 ValidateIssuer = true,
                 ValidIssuers = new[]
@@ -31,12 +31,12 @@ namespace Microsoft.Bot.Connector.Authentication
                     "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/", // Auth v3.2, 1.0 token
                     "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0", // Auth v3.2, 2.0 token
                     "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/", // Auth for US Gov, 1.0 token
-                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0", // Auth for US Gov, 2.0 token
+                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0" // Auth for US Gov, 2.0 token
                 },
                 ValidateAudience = false, // Audience validation takes place manually in code.
                 ValidateLifetime = true,
                 ClockSkew = TimeSpan.FromMinutes(5),
-                RequireSignedTokens = true,
+                RequireSignedTokens = true
             };
 
         /// <summary>
@@ -141,12 +141,12 @@ namespace Microsoft.Bot.Connector.Authentication
 
             var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
 
-            await ValidateIdentity(identity, credentials).ConfigureAwait(false);
+            await ValidateIdentityAsync(identity, credentials).ConfigureAwait(false);
 
             return identity;
         }
 
-        internal static async Task ValidateIdentity(ClaimsIdentity identity, ICredentialProvider credentials)
+        internal static async Task ValidateIdentityAsync(ClaimsIdentity identity, ICredentialProvider credentials)
         {
             if (identity == null)
             {
@@ -178,20 +178,15 @@ namespace Microsoft.Bot.Connector.Authentication
             if (!await credentials.IsValidAppIdAsync(audienceClaim).ConfigureAwait(false))
             {
                 // The AppId is not valid. Not Authorized.
-                throw new UnauthorizedAccessException($"Invalid audience.");
+                throw new UnauthorizedAccessException("Invalid audience.");
             }
-            
+
             var appId = JwtTokenValidation.GetAppIdFromClaims(identity.Claims);
             if (string.IsNullOrWhiteSpace(appId))
             {
                 // Invalid appId
-                throw new UnauthorizedAccessException($"Invalid appId.");
+                throw new UnauthorizedAccessException("Invalid appId.");
             }
-
-            // TODO: check the appId against the registered skill client IDs.
-            // Check the AppId and ensure that only works against my whitelist authConfig can have info on how to get the
-            // whitelist AuthenticationConfiguration
-            // We may need to add a ClaimsIdentityValidator delegate or class that allows the dev to inject a custom validator.
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/TestBotHttpAdapter.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/TestBotHttpAdapter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder.TestBot.Json
             UserState userState, 
             ConversationState conversationState, 
             ResourceExplorer resourceExplorer)
-            : base(credentialProvider)
+            : base(configuration, credentialProvider)
         {
             this.UseStorage(storage);
             this.UseState(userState, conversationState);

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -497,14 +497,14 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             await JwtTokenValidation.ValidateClaimsAsync(defaultAuthConfig, claims);
 
             var mockValidator = new Mock<ClaimsValidator>();
-            var authConfigWithClaimsValidator = new AuthenticationConfiguration(mockValidator.Object);
+            var authConfigWithClaimsValidator = new AuthenticationConfiguration() { ClaimsValidator = mockValidator.Object };
 
-            // Configure IClaimsValidator to fail
-            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Returns(Task.FromResult(true));
+            // ClaimsValidator configured but no exception should pass.
+            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Returns(Task.CompletedTask);
             await JwtTokenValidation.ValidateClaimsAsync(authConfigWithClaimsValidator, claims);
 
             // Configure IClaimsValidator to fail
-            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Returns(Task.FromResult(false));
+            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Throws(new UnauthorizedAccessException("Invalid claims."));
             var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
                 async () => await JwtTokenValidation.ValidateClaimsAsync(authConfigWithClaimsValidator, claims));
             Assert.Equal("Invalid claims.", exception.Message);

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -8,6 +8,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Bot.Connector.Tests.Authentication
@@ -484,6 +485,29 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             // v2 version with azp
             v2Claims.Add(new Claim(AuthenticationConstants.AuthorizedParty, appId));
             Assert.Equal(appId, JwtTokenValidation.GetAppIdFromClaims(v2Claims));
+        }
+
+        [Fact]
+        public async Task ValidateClaimsTest()
+        {
+            var claims = new List<Claim>();
+            var defaultAuthConfig = new AuthenticationConfiguration();
+
+            // No validator should pass.
+            await JwtTokenValidation.ValidateClaimsAsync(defaultAuthConfig, claims);
+
+            var mockValidator = new Mock<ClaimsValidator>();
+            var authConfigWithClaimsValidator = new AuthenticationConfiguration(mockValidator.Object);
+
+            // Configure IClaimsValidator to fail
+            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Returns(Task.FromResult(true));
+            await JwtTokenValidation.ValidateClaimsAsync(authConfigWithClaimsValidator, claims);
+
+            // Configure IClaimsValidator to fail
+            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Returns(Task.FromResult(false));
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await JwtTokenValidation.ValidateClaimsAsync(authConfigWithClaimsValidator, claims));
+            Assert.Equal("Invalid claims.", exception.Message);
         }
 
         private async Task JwtTokenValidation_ValidateAuthHeader_WithChannelService_Succeeds(string appId, string pwd, string channelService)

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/SkillValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/SkillValidationTests.cs
@@ -79,47 +79,47 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             var appId = Guid.NewGuid().ToString();
             var mockIdentity = new Mock<ClaimsIdentity>();
             var claims = new List<Claim>();
-
+            
             // Null identity
             var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await SkillValidation.ValidateIdentity(null, mockCredentials.Object));
+                async () => await SkillValidation.ValidateIdentityAsync(null, mockCredentials.Object));
             Assert.Equal("Invalid Identity", exception.Message);
 
             // not authenticated identity
             mockIdentity.Setup(x => x.IsAuthenticated).Returns(false);
             exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+                async () => await SkillValidation.ValidateIdentityAsync(mockIdentity.Object, mockCredentials.Object));
             Assert.Equal("Token Not Authenticated", exception.Message);
 
             // No version claims
             mockIdentity.Setup(x => x.IsAuthenticated).Returns(true);
             mockIdentity.Setup(x => x.Claims).Returns(claims);
             exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+                async () => await SkillValidation.ValidateIdentityAsync(mockIdentity.Object, mockCredentials.Object));
             Assert.Equal($"'{AuthenticationConstants.VersionClaim}' claim is required on skill Tokens.", exception.Message);
 
             // No audience claim
             claims.Add(new Claim(AuthenticationConstants.VersionClaim, "1.0"));
             exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+                async () => await SkillValidation.ValidateIdentityAsync(mockIdentity.Object, mockCredentials.Object));
             Assert.Equal($"'{AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.", exception.Message);
 
             // Invalid AppId in audience
             claims.Add(new Claim(AuthenticationConstants.AudienceClaim, audience));
             mockCredentials.Setup(x => x.IsValidAppIdAsync(It.IsAny<string>())).Returns(Task.FromResult(false));
             exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+                async () => await SkillValidation.ValidateIdentityAsync(mockIdentity.Object, mockCredentials.Object));
             Assert.Equal("Invalid audience.", exception.Message);
 
             // Invalid AppId in in appId or azp
             mockCredentials.Setup(x => x.IsValidAppIdAsync(It.IsAny<string>())).Returns(Task.FromResult(true));
             exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object));
+                async () => await SkillValidation.ValidateIdentityAsync(mockIdentity.Object, mockCredentials.Object));
             Assert.Equal("Invalid appId.", exception.Message);
 
-            // All checks pass (no exception)
+            // All checks pass (no exception thrown)
             claims.Add(new Claim(AuthenticationConstants.AppIdClaim, appId));
-            await SkillValidation.ValidateIdentity(mockIdentity.Object, mockCredentials.Object);
+            await SkillValidation.ValidateIdentityAsync(mockIdentity.Object, mockCredentials.Object);
         }
     }
 }


### PR DESCRIPTION
Relates to: https://github.com/microsoft/botbuilder-dotnet/issues/2970

Added ClaimsValidator to AuthtentcationConfiguration and updated validation sequence in JwtokenValidation to use it.
Updated BotFrameworkHttpAdapter and BotFrameworkHttpAdapterBase to surface constructor parameters from BotFrameworkAdapter so they can be used.
Refactored BotFrameworkHttpAdapter and BotFrameworkHttpAdapterBase to have only one constructor call base and the other ones to use this. to make it easier to maintain and have consistent execution paths.