### PR TITLE
[Slack Adapter] Consolidate Newtonsoft Json version

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Microsoft.Bot.Builder.Adapters.Slack.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Microsoft.Bot.Builder.Adapters.Slack.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SlackAPI" Version="1.1.2" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(IsBuildServer)' == '' " Version="4.6.0-local" />

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 };
             }
 
-            return JsonConvert.DeserializeObject<SlackRequestBody>(requestBody, new UnixDateTimeConverter());
+            return JsonConvert.DeserializeObject<SlackRequestBody>(requestBody, new SlackUnixTimeConverter());
         }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackUnixTimeConverter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackUnixTimeConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    public class SlackUnixTimeConverter : DateTimeConverterBase
+    {
+        private static readonly DateTime _epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null) 
+            { 
+                return null; 
+            }
+
+            return _epoch.AddMilliseconds((long)reader.Value / 1000d);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteRawValue(((DateTime)value - _epoch).TotalMilliseconds + "000");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Remove specific Converter reference so we can get rid of Newtonsoft v11 requirement, and use v10.0.3 as with the rest of the projects. Reported in Issue #2858.

## Details
Implemented a custom converter (**SlackUnixTimeConverter**) to handle the special format Slack [handles timestamps for certain values](https://github.com/slackhq/slack-api-docs/issues/7#issuecomment-67913241).

**Modified files**
- Microsoft.Bot.Builder.Adapters.Slack.csproj
- SlackHelper.cs
- SlackUnixTimeConverter.cs (added)