### PR TITLE
[DO NOT MERGE] AdaptiveCardPrompt

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException("AdaptiveCardPrompt requires a card in `AdaptiveCardPromptSettings.card`");
             }
 
-            this._validator = validator;
+            _validator = validator;
 
             _requiredInputIds = settings.RequiredInputIds ?? null;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var data = JObject.FromObject(context.Activity.Value);
 
                 // Validate it comes from the correct card - This is only a worry while the prompt/dialog has not ended
-                if (!string.IsNullOrEmpty(_promptId) && data["promptId"].ToString() != _promptId)
+                if (!string.IsNullOrEmpty(_promptId) && data["promptId"]?.ToString() != _promptId)
                 {
                     return Task.FromResult(new PromptRecognizerResult<AdaptiveCardPromptResult>() 
                     { 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    public enum AdaptiveCardPromptErrors
+    {
+        /// <summary>
+        /// Error presented if developer specifies AdaptiveCardPromptSettings.promptId,
+        /// but user submits adaptive card input on a card where the ID does not match.
+        /// This error will also be present if developer AdaptiveCardPromptSettings.promptId,
+        /// but forgets to add the promptId to every <submit>.data.promptId in your Adaptive Card.
+        /// </summary>
+        UserInputDoesNotMatchCardId,
+        
+        /// <summary>
+        /// Error presented if developer specifies AdaptiveCardPromptSettings.requiredIds,
+        /// but user does not submit input for all required input id's on the adaptive card.
+        /// </summary>
+        MissingRequiredIds,
+
+        /// <summary>
+        /// Error presented if user enters plain text instead of using Adaptive Card's input fields.
+        /// </summary>
+        UserUsedTextInput
+    }
+
+    /// <summary>
+    /// Waits for Adaptive Card Input to be received.
+    /// </summary>
+    /// <remarks>
+    /// This prompt is similar to ActivityPrompt but provides features specific to Adaptive Cards:
+    ///   * Optionally allow specified input fields to be required
+    ///   * Optionally ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
+    ///   * Provides ability to handle variety of common user errors related to Adaptive Cards
+    /// DO NOT USE WITH CHANNELS THAT DON'T SUPPORT ADAPTIVE CARDS.
+    /// </remarks>
+    public class AdaptiveCardPrompt : Dialog
+    {
+        private const string PersistedOptions = "options";
+        private const string PersistedState = "state";
+
+        private readonly PromptValidator<object> _validator;
+        private readonly string[] _requiredInputIds;
+        private readonly string _promptId;
+        private readonly Attachment _card;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdaptiveCardPrompt"/> class.
+        /// </summary>
+        /// <param name="dialogId">Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.</param>
+        /// <param name="validator">(optional) Validator that will be called each time a new activity is received.</param>
+        /// <param name="settings">(optional) Additional settings for AdaptiveCardPrompt behavior.</param>
+        public AdaptiveCardPrompt(string dialogId, AdaptiveCardPromptSettings settings, PromptValidator<object> validator = null)
+            : base(dialogId)
+        {
+            if (settings == null || settings.Card == null)
+            {
+                throw new ArgumentException("AdaptiveCardPrompt requires a card in `AdaptiveCardPromptSettings.card`");
+            }
+
+            this._validator = validator;
+
+            _requiredInputIds = settings.RequiredInputIds ?? null;
+
+            ThrowIfNotAdaptiveCard(settings.Card);
+            _card = settings.Card;
+
+            _promptId = settings.PromptId;
+        }
+
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            // Initialize prompt state
+            var state = dc.ActiveDialog.State;
+            state[PersistedOptions] = options;
+            state[PersistedState] = new Dictionary<string, object>
+            {
+                { Prompt<int>.AttemptCountKey, 0 },
+            };
+
+            // Send initial prompt
+            await OnPromptAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions], false, cancellationToken).ConfigureAwait(false);
+
+            return Dialog.EndOfTurn;
+        }
+
+        // Override ContinueDialogAsync so that we can catch Activity.Value (which is ignored, by default)
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken)
+        {
+            // Perform base recognition
+            var instance = dc.ActiveDialog;
+            var state = (IDictionary<string, object>)instance.State[PersistedState];
+            var options = (PromptOptions)instance.State[PersistedOptions];
+            var recognized = await OnRecognizeAsync(dc.Context, cancellationToken).ConfigureAwait(false);
+
+            // Increment attempt count
+            // Convert.ToInt32 For issue https://github.com/Microsoft/botbuilder-dotnet/issues/1859
+            state[Prompt<int>.AttemptCountKey] = Convert.ToInt32(state[Prompt<int>.AttemptCountKey]) + 1;
+
+            var isValid = false;
+            if (_validator != null)
+            {
+                var promptContext = new PromptValidatorContext<object>(dc.Context, recognized, state, options);
+                isValid = await _validator(promptContext, cancellationToken).ConfigureAwait(false);
+            } 
+            else if (recognized.Succeeded)
+            {
+                isValid = true;
+            }
+
+            // Return recognized value or re-prompt
+            if (isValid)
+            {
+                return await dc.EndDialogAsync(recognized.Value).ConfigureAwait(false);
+            }
+            else
+            {
+                // Re-prompt
+                if (!dc.Context.Responded)
+                {
+                    await OnPromptAsync(dc.Context, state, options, true, cancellationToken).ConfigureAwait(false);
+                }
+
+                return Dialog.EndOfTurn;
+            }
+        }
+
+        protected virtual async Task OnPromptAsync(ITurnContext context, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken)
+        {
+            // Since card is passed in via AdaptiveCardPromptSettings, PromptOptions may not be used.
+            // Ensure we're working with RetryPrompt, as applicable
+            var prompt = isRetry && options.RetryPrompt != null ? options.RetryPrompt : options.Prompt;
+
+            // Clone the correct prompt so that we don't affect the one saved in state
+            var jsonSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
+            var clonedPrompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt, jsonSettings));
+
+            // Add Adaptive Card as last attachment (user input should go last), keeping any others
+            clonedPrompt.Attachments.Add(_card);
+
+            await context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected virtual async Task<AdaptiveCardPromptRecognizerResult<object>> OnRecognizeAsync(ITurnContext context, CancellationToken cancellationToken)
+        {
+            // Ignore user input that doesn't come from adaptive card
+            if (string.IsNullOrWhiteSpace(context.Activity.Text) && context.Activity.Value != null)
+            {
+                var value = JObject.FromObject(context.Activity.Value);
+
+                // Validate it comes from the correct card - This is only a worry while the prompt/dialog has not ended
+                if (value["promptId"].ToString() != _promptId)
+                {
+                    return new AdaptiveCardPromptRecognizerResult<object>() { Succeeded = false, Value = value, Error = AdaptiveCardPromptErrors.UserInputDoesNotMatchCardId };
+                }
+
+                // Check for required input data, if specified in AdaptiveCardPromptSettings
+                var missingIds = new List<string>();
+                foreach (var id in _requiredInputIds)
+                {
+                    if (value[id] == null || string.IsNullOrWhiteSpace(value[id].ToString()))
+                    {
+                        missingIds.Add(id);
+                    }
+                }
+
+                // User did not submit inputs that were required
+                if (missingIds.Count > 0)
+                {
+                    return new AdaptiveCardPromptRecognizerResult<object>()
+                    { 
+                        Succeeded = false,
+                        Value = value,
+                        Error = AdaptiveCardPromptErrors.MissingRequiredIds,
+                        MissingIds = missingIds
+                    };
+                }
+
+                return new AdaptiveCardPromptRecognizerResult<object>() { Succeeded = true, Value = context.Activity.Value };
+            }
+            else
+            {
+                // User used text input instead of card input
+                return new AdaptiveCardPromptRecognizerResult<object>() { Succeeded = false, Error = AdaptiveCardPromptErrors.UserUsedTextInput };
+            }
+        }
+
+        private void ThrowIfNotAdaptiveCard(Attachment cardAttachment)
+        {
+            var adaptiveCardType = "application/vnd.microsoft.card.adaptive";
+
+            if (cardAttachment == null || cardAttachment.Content == null)
+            {
+                throw new NullReferenceException($"No Adaptive Card provided. Include in the constructor or PromptOptions.Prompt.Attachments[0]");
+            }
+            else if (string.IsNullOrEmpty(cardAttachment.ContentType) || cardAttachment.ContentType != adaptiveCardType)
+            {
+                throw new ArgumentException($"Attachment is not a valid Adaptive Card.\n" +
+                                    "Ensure card.contentType is '${ adaptiveCardType }'\n" +
+                                    "and card.content contains the card json");
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPrompt.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPromptRecognizerResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPromptRecognizerResult.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    /// <summary>
+    /// Additional items to include on PromptRecognizerResult, as necessary.
+    /// </summary>
+    /// <typeparam name="T">Type returned by recognizer.</typeparam>
+    public class AdaptiveCardPromptRecognizerResult<T> : PromptRecognizerResult<T>
+    {
+        /// <summary>
+        /// Gets or sets Error enum.
+        /// </summary>
+        /// <value>
+        /// If not recognized.succeeded, include reason why, if known.
+        /// </value>
+        public AdaptiveCardPromptErrors Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets array of missing required Ids.
+        /// </summary>
+        /// <value>
+        /// Array of requiredIds that were not included with user input.
+        /// </value>
+        public List<string> MissingIds { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPromptResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPromptResult.cs
@@ -1,14 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Bot.Builder.Dialogs
 {
     /// <summary>
-    /// Additional items to include on PromptRecognizerResult, as necessary.
+    /// Represents a result from adaptive card input.
     /// </summary>
     /// <typeparam name="T">Type returned by recognizer.</typeparam>
-    public class AdaptiveCardPromptRecognizerResult<T> : PromptRecognizerResult<T>
+    public class AdaptiveCardPromptResult
     {
+        /// <summary>
+        /// Gets or sets the Value of the Adaptive Card input.
+        /// </summary>
+        /// <value>
+        /// The value of the user's input from the Adaptive Card.
+        /// </value>
+        public object Data { get; set; }
+
         /// <summary>
         /// Gets or sets Error enum.
         /// </summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPromptSettings.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/AdaptiveCardPromptSettings.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    /// <summary>
+    /// Settings to control the behavior of AdaptiveCardPrompt.
+    /// </summary>
+    public class AdaptiveCardPromptSettings
+    {
+        /// <summary>
+        /// Gets or sets the card to send the user. Required.
+        /// </summary>
+        /// <remarks>
+        /// Add the card here. Do not pass it in to `Prompt.Attachments` or it will show twice.
+        /// </remarks>
+        /// <value>
+        /// An Adaptive Card. Can be input here or in constructor.
+        /// </value>
+        public Attachment Card { get; set; }
+
+        /// <summary>
+        /// Gets or sets the array of strings matching IDs of required input fields.
+        /// </summary>
+        /// <value>
+        /// The message sent (if not null) when user uses text input instead of Adaptive Card Input.
+        /// </value>
+        /// <remarks>
+        /// The ID strings must exactly match those used in the Adaptive Card JSON Input IDs
+        /// For JSON:
+        /// ```json
+        /// {
+        ///   "type": "Input.Text",
+        ///   "id": "myCustomId",
+        /// },
+        /// ```
+        ///   You would use `"myCustomId"` if you want that to be a required input.
+        /// </remarks>
+        public string[] RequiredInputIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID specific to this prompt.
+        /// If used, you MUST add this promptId to every data.promptId in your Adaptive Card.
+        /// </summary>
+        /// <value>
+        /// The ID specific to this prompt.
+        /// </value>
+        /// <remarks>
+        /// Card input is only accepted if SubmitAction.data.promptId matches the promptId.
+        /// Does not change between reprompts.
+        /// </remarks>
+        public string PromptId { get; set; }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/AdaptiveCardPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/AdaptiveCardPromptTests.cs
@@ -1,0 +1,1024 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    [TestClass]
+    public class AdaptiveCardPromptTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AdaptiveCardPromptWithEmptyIdShouldFail()
+        {
+            var emptyId = string.Empty;
+            var textPrompt = new AdaptiveCardPrompt(emptyId);
+        }
+
+        [TestMethod]
+        public async Task ShouldCallAdaptiveCardPromptUsingDcPrompt()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt");
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+
+            // MUST use lambda because test is async and simulatedInput changes after prompt displayed. Ref won't work because async.
+            .AssertReply((activity) =>
+            {
+                Assert.AreEqual($"You said: {simulatedInput.Value.ToString()}", (activity as Activity).Text);
+            })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldCallAdaptiveCardPromptUsingDcBeginDialog()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt");
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.BeginDialogAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+
+            // MUST use lambda because test is async and simulatedInput changes after prompt displayed. Ref won't work because async.
+            .AssertReply((activity) =>
+            {
+                Assert.AreEqual($"You said: {simulatedInput.Value.ToString()}", (activity as Activity).Text);
+            })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldCreateANewPromptIdForEachOnPromptCall()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt");
+            var simulatedInput = GetSimulatedInput();
+            var usedIds = new HashSet<string>();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync(GetPromptIdFromObject(content));
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+
+            // MUST use lambda because test is async and simulatedInput changes after prompt displayed. Ref won't work because async.
+            .AssertReply((activity) =>
+            {
+                var promptId = (activity as Activity).Text;
+                Assert.IsFalse(usedIds.Contains(promptId));
+                usedIds.Add(promptId);
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+
+            // MUST use lambda because test is async and simulatedInput changes after prompt displayed. Ref won't work because async.
+            .AssertReply((activity) =>
+            {
+                var promptId = (activity as Activity).Text;
+                Assert.IsFalse(usedIds.Contains(promptId));
+            })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldUseRetryPromptIfGivenAndAttemptsBeforeCardRedisplayedAllows()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings() { AttemptsBeforeCardRedisplayed = 1 });
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Attachments = GetAttachmentsWithCard() },
+                        RetryPrompt = new Activity { Text = "RETRY", Attachments = GetAttachmentsWithCard() },
+                    };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                })
+            .Send(GetInvalidSimulatedInput())
+            .AssertReply("Please fill out the Adaptive Card")
+
+            // Must be lambda to avoid type check. RetryPrompt type is null
+            .AssertReply((activity) => Assert.AreEqual("RETRY", (activity as Activity).Text))
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldAllowForCustomPromptIdThatDoesntChangeOnReprompt()
+        {
+            var customId = "custom";
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings() { AttemptsBeforeCardRedisplayed = 1, PromptId = customId });
+            var simulatedInput = GetSimulatedInput();
+            UpdateSimulatedInputWithPromptId(simulatedInput, null, customId);
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = new Activity { Attachments = GetAttachmentsWithCard() },
+                    };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync(GetPromptIdFromObject(content));
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                })
+            .Send(simulatedInput)
+            .AssertReply(customId)
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task PromptCanBeTextOnlyActivityIfCardPassedInConstructor()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings() { Card = GetCard() });
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = MessageFactory.Text("STRING"),
+                    };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync(GetPromptIdFromObject(content));
+                }
+            })
+            .Send("hello")
+            .AssertReply("STRING")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException))]
+        public async Task ShouldThrowIfNoAttachmentPassedInConstructorOrSet()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt");
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = MessageFactory.Text("STRING"),
+                    };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+            })
+            .Send("hello")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public async Task ShouldThrowIfCardIsNotAValidAdaptiveCard()
+        {
+            var card = GetCard();
+            card.ContentType = "InvalidCard";
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings() { Card = card });
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions
+                    {
+                        Prompt = MessageFactory.Text("STRING"),
+                    };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+            })
+            .Send("hello")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldAcceptACustomValidatorThatHandlesValidContext()
+        {
+            var usedValidator = false;
+
+            Task<bool> Validator(PromptValidatorContext<object> promptContext, CancellationToken cancellationToken)
+            {
+                usedValidator = true;
+                return Task.FromResult(true);
+            }
+
+            var prompt = new AdaptiveCardPrompt("prompt", Validator);
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+
+            // MUST use lambda because test is async and simulatedInput changes after prompt displayed. Ref won't work because async.
+            .AssertReply((activity) =>
+            {
+                Assert.AreEqual($"You said: {simulatedInput.Value.ToString()}", (activity as Activity).Text);
+            })
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task ShouldAcceptACustomValidatorThatHandlesInalidContext()
+        {
+            var usedValidator = false;
+
+            async Task<bool> Validator(PromptValidatorContext<object> promptContext, CancellationToken cancellationToken)
+            {
+                usedValidator = true;
+                await promptContext.Context.SendActivityAsync("FAILED");
+                return false;
+            }
+
+            var prompt = new AdaptiveCardPrompt("prompt", Validator);
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+            .AssertReply("FAILED")
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task ShouldTrackTheNumberOfAttempts()
+        {
+            var attempts = 0;
+
+            Task<bool> Validator(PromptValidatorContext<object> promptContext, CancellationToken cancellationToken)
+            {
+                attempts = promptContext.AttemptCount;
+                return Task.FromResult(false);
+            }
+
+            var prompt = new AdaptiveCardPrompt("prompt", Validator, new AdaptiveCardPromptSettings() { AttemptsBeforeCardRedisplayed = 99 });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
+                {
+                    await turnContext.SendActivityAsync("Invalid Response");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .StartTestAsync();
+            Assert.AreEqual(3, attempts);
+        }
+
+        [TestMethod]
+        public async Task ShouldRecognizeCardInput()
+        {
+            var usedValidator = false;
+
+            Task<bool> Validator(PromptValidatorContext<object> promptContext, CancellationToken cancellationToken)
+            {
+                usedValidator = true;
+                Assert.IsTrue(promptContext.Recognized.Succeeded);
+                return Task.FromResult(true);
+            }
+
+            var prompt = new AdaptiveCardPrompt("prompt", Validator);
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                    Assert.IsTrue(simulatedInput.Value != null && string.IsNullOrEmpty(simulatedInput.Text));
+                })
+            .Send(simulatedInput)
+            .AssertReply((activity) =>
+            {
+                Assert.AreEqual($"You said: {simulatedInput.Value.ToString()}", (activity as Activity).Text);
+            })
+            .StartTestAsync();
+            Assert.IsTrue(usedValidator);
+        }
+
+        [TestMethod]
+        public async Task ShouldNotRecognizeTextInputAndShouldDisplayCustomInputFailMessage()
+        {
+            // Note: Validator isn't used if !recognized.succeeded
+            var failMessage = "Test input fail message";
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings() { InputFailMessage = failMessage });
+            var invalidSimulatedInput = GetInvalidSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(invalidSimulatedInput, prompt);
+                })
+            .Send(invalidSimulatedInput)
+            .AssertReply(failMessage)
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldNotSuccessfullyRecognizeIfInputComesFromCardWithWrongId()
+        {
+            // Note: Validator isn't used if !recognized.succeeded
+            var prompt = new AdaptiveCardPrompt("prompt");
+            var simulatedInput = GetSimulatedInput();
+            UpdateSimulatedInputWithPromptId(simulatedInput, null, "wrongId");
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
+                {
+                    await turnContext.SendActivityAsync("Invalid Response");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                })
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldNotSuccessfullyRecognizeAndShouldUseCustomMissingIdsMessage()
+        {
+            // Note: Validator isn't used if !recognized.succeeded
+            var missingIdsMessage = "Test Missing Ids";
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings()
+            {
+                MissingRequiredInputsMessage = missingIdsMessage,
+                RequiredInputIds = new List<string>() { "test1", "test2", "test3" },
+            });
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+            .AssertReply($"{missingIdsMessage}: test1, test2, test3")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldSuccessfullyRecognizeIfAllRequiredIdsSupplied()
+        {
+            // Note: Validator isn't used if !recognized.succeeded
+            var missingIdsMessage = "Test Missing Ids";
+            var simulatedInput = GetSimulatedInput();
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings()
+            {
+                MissingRequiredInputsMessage = missingIdsMessage,
+                RequiredInputIds = (simulatedInput.Value as JObject).Properties().Select(p => p.Name).ToList(),
+            });
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    var content = results.Result;
+                    await turnContext.SendActivityAsync($"You said: {content.ToString()}");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    UpdateSimulatedInputWithPromptId(simulatedInput, prompt);
+                })
+            .Send(simulatedInput)
+
+            // MUST use lambda because test is async and simulatedInput changes after prompt displayed. Ref won't work because async.
+            .AssertReply((activity) =>
+            {
+                Assert.AreEqual($"You said: {simulatedInput.Value.ToString()}", (activity as Activity).Text);
+            })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldRedisplayCardOnlyWhenAttemptCountDivisibleByAttemptsBeforeCardRedisplayed()
+        {
+            var prompt = new AdaptiveCardPrompt("prompt", null, new AdaptiveCardPromptSettings() { AttemptsBeforeCardRedisplayed = 5 });
+
+            var simulatedInput = GetSimulatedInput();
+            UpdateSimulatedInputWithPromptId(simulatedInput, null, "invalidId");
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
+                {
+                    await turnContext.SendActivityAsync("Invalid Response");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                })
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .Send(simulatedInput)
+            .AssertReply("Invalid Response")
+            .Send(simulatedInput)
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                })
+            .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task ShouldAppropriatelyAddPromptIdToCardInAllNestedJsonOccurrences()
+        {
+            // Assert card doesn't already have promptIds
+            var cardBefore = JObject.FromObject(GetCard().Content);
+            Assert.IsTrue(string.IsNullOrEmpty(cardBefore["selectAction"]["data"]?.ToString()) || string.IsNullOrEmpty(cardBefore["selectAction"]["data"]["promptId"]?.ToString()));
+            Assert.IsTrue(string.IsNullOrEmpty(cardBefore["actions"][0]["data"]?.ToString()) || string.IsNullOrEmpty(cardBefore["actions"][0]["data"]["promptId"]?.ToString()));
+            Assert.IsTrue(string.IsNullOrEmpty(cardBefore["actions"][1]["card"]["actions"][0]["data"]?.ToString()) || string.IsNullOrEmpty(cardBefore["actions"][1]["card"]["actions"][0]["data"]["promptId"]?.ToString()));
+            Assert.IsTrue(string.IsNullOrEmpty(cardBefore["actions"][2]["card"]["actions"][0]["data"]?.ToString()) || string.IsNullOrEmpty(cardBefore["actions"][2]["card"]["actions"][0]["data"]["promptId"]?.ToString()));
+            Assert.IsTrue(string.IsNullOrEmpty(cardBefore["actions"][3]["card"]["actions"][0]["data"]?.ToString()) || string.IsNullOrEmpty(cardBefore["actions"][3]["card"]["actions"][0]["data"]["promptId"]?.ToString()));
+
+            var prompt = new AdaptiveCardPrompt("prompt");
+
+            var simulatedInput = GetSimulatedInput();
+
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+
+            // Create and add custom activity prompt to DialogSet.
+            dialogs.Add(prompt);
+
+            // Create mock Activity for testing.
+            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    var options = new PromptOptions { Prompt = new Activity { Attachments = GetAttachmentsWithCard() } };
+                    await dc.PromptAsync("prompt", options, cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
+                {
+                    await turnContext.SendActivityAsync("Invalid Response");
+                }
+            })
+            .Send("hello")
+            .AssertReply(
+                (activity) =>
+                {
+                    AssertActivityHasCard(activity);
+                    var expectedId = prompt.PromptId;
+                    var cardAfter = (activity as Activity).Attachments[0].Content as JObject;
+                    Assert.AreEqual(expectedId, cardAfter["selectAction"]["data"]["promptId"].ToString());
+                    Assert.AreEqual(expectedId, cardAfter["actions"][0]["data"]["promptId"].ToString());
+                    Assert.AreEqual(expectedId, cardAfter["actions"][1]["card"]["actions"][0]["data"]["promptId"].ToString());
+                    Assert.AreEqual(expectedId, cardAfter["actions"][2]["card"]["actions"][0]["data"]["promptId"].ToString());
+                    Assert.AreEqual(expectedId, cardAfter["actions"][3]["card"]["actions"][0]["data"]["promptId"].ToString());
+                })
+            .StartTestAsync();
+        }
+
+        private Attachment GetCard()
+        {
+            var cardPath = Path.Combine("../../../", "adaptiveCard.json");
+            var cardJson = File.ReadAllText(cardPath);
+            var cardAttachment = new Attachment()
+            {
+                ContentType = "application/vnd.microsoft.card.adaptive",
+                Content = JsonConvert.DeserializeObject(cardJson),
+            };
+            return cardAttachment;
+        }
+
+        private List<Attachment> GetAttachmentsWithCard() => new List<Attachment>() { GetCard() };
+
+        private Activity GetSimulatedInput() => new Activity()
+        {
+            Type = ActivityTypes.Message,
+            Value = JObject.FromObject(new
+            {
+                foodChoice = "Steak",
+                steakOther = "some details",
+                steakTemp = "rare",
+            }),
+        };
+
+        private Activity GetInvalidSimulatedInput() => new Activity()
+        {
+            Type = ActivityTypes.Message,
+            Text = "Invalid Adaptive Card Input",
+        };
+
+        private void UpdateSimulatedInputWithPromptId(Activity simulatedInput, AdaptiveCardPrompt prompt = null, string promptId = null)
+        {
+            var jsonValue = JObject.FromObject(simulatedInput.Value ?? new { });
+
+            if (prompt != null)
+            {
+                jsonValue["promptId"] = prompt.PromptId;
+            }
+            else if (promptId != null)
+            {
+                jsonValue["promptId"] = promptId;
+            }
+            else { throw new Exception("Must provide either prompt or promptId"); }
+
+            simulatedInput.Value = JsonConvert.DeserializeObject(jsonValue.ToString());
+        }
+
+        private string GetPromptIdFromObject(object obj) => JObject.FromObject(obj)["promptId"].ToString();
+
+        private void AssertActivityHasCard(IActivity activity) => Assert.AreEqual("application/vnd.microsoft.card.adaptive", (activity as Activity).Attachments[0].ContentType);
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/adaptiveCard.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/adaptiveCard.json
@@ -1,0 +1,189 @@
+﻿{
+  "type": "AdaptiveCard",
+  "selectAction": {
+    "type": "Action.Submit",
+    "title": "Test",
+    "data": {
+      "promptId": "custom"
+    }
+  },
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": "Your registration is almost complete"
+    },
+    {
+      "type": "TextBlock",
+      "text": "What type of food do you prefer?",
+      "wrap": true
+    },
+    {
+      "type": "ImageSet",
+      "images": [
+        {
+          "type": "Image",
+          "url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg",
+          "size": "Medium"
+        },
+        {
+          "type": "Image",
+          "url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg",
+          "size": "Medium"
+        },
+        {
+          "type": "Image",
+          "url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg",
+          "size": "Medium"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": "Submit",
+      "data": {
+        "promptId": "custom"
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Steak",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "text": "How would you like your steak prepared?",
+            "wrap": true
+          },
+          {
+            "type": "Input.ChoiceSet",
+            "id": "SteakTemp",
+            "choices": [
+              {
+                "title": "Rare",
+                "value": "rare"
+              },
+              {
+                "title": "Medium-Rare",
+                "value": "medium-rare"
+              },
+              {
+                "title": "Well-done",
+                "value": "well-done"
+              }
+            ],
+            "style": "expanded"
+          },
+          {
+            "type": "Input.Text",
+            "id": "SteakOther",
+            "placeholder": "Any other preparation requests?",
+            "isMultiline": true
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK",
+            "data": {
+              "FoodChoice": "Steak",
+              "promptId": "custom"
+            }
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Chicken",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "text": "Do you have any allergies?",
+            "wrap": true
+          },
+          {
+            "type": "Input.ChoiceSet",
+            "id": "ChickenAllergy",
+            "choices": [
+              {
+                "title": "I'm allergic to peanuts",
+                "value": "peanut"
+              }
+            ],
+            "style": "expanded",
+            "isMultiSelect": true
+          },
+          {
+            "type": "Input.Text",
+            "id": "ChickenOther",
+            "placeholder": "Any other preparation requests?",
+            "isMultiline": true
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK",
+            "data": {
+              "FoodChoice": "Chicken",
+              "promptId": "custom"
+            }
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    },
+    {
+      "type": "Action.ShowCard",
+      "title": "Tofu",
+      "card": {
+        "type": "AdaptiveCard",
+        "body": [
+          {
+            "type": "TextBlock",
+            "size": "Medium",
+            "text": "Would you like it prepared vegan?",
+            "wrap": true
+          },
+          {
+            "type": "Input.Toggle",
+            "id": "Vegetarian",
+            "title": "Please prepare it vegan",
+            "valueOn": "vegan",
+            "valueOff": "notVegan",
+            "wrap": false
+          },
+          {
+            "type": "Input.Text",
+            "id": "VegOther",
+            "placeholder": "Any other preparation requests?",
+            "isMultiline": true
+          }
+        ],
+        "actions": [
+          {
+            "type": "Action.Submit",
+            "title": "OK",
+            "data": {
+              "FoodChoice": "Vegetarian",
+              "promptId": "custom"
+            }
+          }
+        ],
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+      }
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0"
+}


### PR DESCRIPTION
Full context: https://github.com/microsoft/botframework-sdk/issues/5396

Summary:

Adds an AdaptiveCardPrompt that allows developers to easily gather user input from adaptive cards. Provides the following benefits over using `ActivityPrompt`:

* Optionally allow specified input fields to be required
* Optionally ensures input is only valid if it comes from the appropriate card (not one shown previous to prompt)
* Provides ability to handle variety of common user errors related to Adaptive Cards

If the intent is to get AdaptiveCardPrompt Samples in R7 and then AdaptiveCardPrompt merged into the SDK in R8, we should probably attack this in the following order:

1. Moderate review of this PR, [or JS version](https://github.com/microsoft/botbuilder-js/pull/1431), primarily focused on design
2. Make edits to both Node and C# versions
3. Add the "moderately-reviewed" version to the samples, merge samples for R7
4. Rigorous review of this PR and C# version
5. Merge for R8

## Testing

18 unit tests included and passing