### PR TITLE
fix expression escape issue

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 {
     public class Evaluator : LGFileParserBaseVisitor<object>
     {
-        public static readonly Regex ExpressionRecognizeRegex = new Regex(@"@{(((\'([^'\r\n])*?\')|(\""([^""\r\n])*?\""))|[^\r\n{}'""])*?}", RegexOptions.Compiled);
+        public static readonly Regex ExpressionRecognizeRegex = new Regex(@"(?<!\\)@{(((\'([^'\r\n])*?\')|(\""([^""\r\n])*?\""))|[^\r\n{}'""])*?}", RegexOptions.Compiled);
         public static readonly Regex EscapeSeperatorRegex = new Regex(@"(?<!\\)\|", RegexOptions.Compiled);
         private readonly Stack<EvaluationTarget> evaluationTargetStack = new Stack<EvaluationTarget>();
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/StructuredTemplate.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/StructuredTemplate.lg
@@ -21,9 +21,10 @@
 
 
 > You can use '\' as an escape character
+> \@{GetAge()} would not be evaluated as expression, would be parsed as '@{getAge()}' string
 # AskForAge.prompt3
 [Activity
-        Text = @{GetAge()}
+        Text = \@{GetAge()}
         Suggestions = 10 \| cards | 20 \| cards
 ]
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -792,8 +792,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             evaled = engine.EvaluateTemplate("AskForAge.prompt3");
 
             Assert.IsTrue(
-                JToken.DeepEquals(JObject.Parse("{\"$type\":\"Activity\",\"text\":\"how old are you?\",\"suggestions\":[\"10 | cards\",\"20 | cards\"]}"), evaled as JObject)
-                || JToken.DeepEquals(JObject.Parse("{\"$type\":\"Activity\",\"text\":\"what's your age?\",\"suggestions\":[\"10 | cards\",\"20 | cards\"]}"), evaled as JObject));
+                JToken.DeepEquals(JObject.Parse("{\"$type\":\"Activity\",\"text\":\"@{GetAge()}\",\"suggestions\":[\"10 | cards\",\"20 | cards\"]}"), evaled as JObject));
 
             evaled = engine.EvaluateTemplate("T1");
 


### PR DESCRIPTION
in LG, expression should be described as @{expression}
but now, if you just want to escape it, use a \ in front of expression, like  \\@{expression}, 
so it will be evaluated as string '@{expression}'