### PR TITLE
Fix multi-lang resource generator enumerate locale blindly

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
             // load all LG resources
             foreach (var resource in this.resourceExplorer.GetResources("lg"))
-            {
+            {   
                 LanguageGenerators[resource.Id] = GetTemplateEngineLanguageGenerator(resource);
             }
 
@@ -60,15 +60,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
                 var resourceName = Path.GetFileName(PathUtils.NormalizePath(id));
 
-                var resource = resources.FirstOrDefault(u => MultiLanguageResourceLoader.ParseLGFileName(u.Id).prefix == MultiLanguageResourceLoader.ParseLGFileName(resourceName).prefix);
+                var resource = resources.FirstOrDefault(u => MultiLanguageResourceLoader.ParseLGFileName(u.Id).prefix.ToLower() == MultiLanguageResourceLoader.ParseLGFileName(resourceName).prefix.ToLower());
                 if (resource == null)
                 {
-                    return (string.Empty, resourceName);
+                    return (string.Empty, resource.Id);
                 }
                 else
                 {
                     var content = resource.ReadTextAsync().GetAwaiter().GetResult();
-                    return (content, resourceName);
+                    return (content, resource.Id);
                 }
             };
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -40,12 +40,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         {
             this.Id = id ?? DEFAULTLABEL;
             var (_, locale) = MultiLanguageResourceLoader.ParseLGFileName(id);
-                
+            var fallbackLocale = MultiLanguageResourceLoader.FallbackLocale(locale, resourceMapping.Keys.ToList());
+
             foreach (var mapping in resourceMapping)    
             {
                 // if no locale present in id, enumarate every locale found
                 // if locale is present, use that one
-                if (string.Equals(locale, string.Empty) || string.Equals(locale, mapping.Key))
+                if (string.Equals(fallbackLocale, string.Empty) || string.Equals(fallbackLocale, mapping.Key))
                 {
                     var engine = new TemplateEngine().AddText(lgText ?? string.Empty, Id, LanguageGeneratorManager.ResourceExplorerResolver(mapping.Key, resourceMapping));
                     multiLangEngines.Add(mapping.Key, engine);
@@ -62,10 +63,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         {
             filePath = PathUtils.NormalizePath(filePath);
             this.Id = Path.GetFileName(filePath);
-            foreach (var mappingItem in resourceMapping)
+
+            var (_, locale) = MultiLanguageResourceLoader.ParseLGFileName(Id);
+            var fallbackLocale = MultiLanguageResourceLoader.FallbackLocale(locale, resourceMapping.Keys.ToList());
+
+            foreach (var mapping in resourceMapping)
             {
-                var engine = new TemplateEngine().AddFile(filePath, LanguageGeneratorManager.ResourceExplorerResolver(mappingItem.Key, resourceMapping));
-                multiLangEngines.Add(mappingItem.Key, engine);
+                // if no locale present in id, enumarate every locale found
+                // if locale is present, use that one
+                if (string.Equals(fallbackLocale, string.Empty) || string.Equals(fallbackLocale, mapping.Key))
+                {
+                    var engine = new TemplateEngine().AddFile(filePath, LanguageGeneratorManager.ResourceExplorerResolver(mapping.Key, resourceMapping));
+                    multiLangEngines.Add(mapping.Key, engine);
+                }
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
         private readonly Dictionary<string, TemplateEngine> multiLangEngines = new Dictionary<string, TemplateEngine>();
 
-        private TemplateEngine engine;
+        private TemplateEngine engine;      
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplateEngineLanguageGenerator"/> class.
@@ -39,12 +39,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         public TemplateEngineLanguageGenerator(string lgText, string id, Dictionary<string, IList<IResource>> resourceMapping)
         {
             this.Id = id ?? DEFAULTLABEL;
-            foreach (var mappingItem in resourceMapping)
+            var (_, locale) = MultiLanguageResourceLoader.ParseLGFileName(id);
+                
+            foreach (var mapping in resourceMapping)    
             {
-                var engine = new TemplateEngine().AddText(lgText ?? string.Empty, Id, LanguageGeneratorManager.ResourceExplorerResolver(mappingItem.Key, resourceMapping));
-                multiLangEngines.Add(mappingItem.Key, engine);
+                // if no locale present in id, enumarate every locale found
+                // if locale is present, use that one
+                if (string.Equals(locale, string.Empty) || string.Equals(locale, mapping.Key))
+                {
+                    var engine = new TemplateEngine().AddText(lgText ?? string.Empty, Id, LanguageGeneratorManager.ResourceExplorerResolver(mapping.Key, resourceMapping));
+                    multiLangEngines.Add(mapping.Key, engine);
+                }
             }
-        }
+        }   
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplateEngineLanguageGenerator"/> class.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             result = await generator.Generate(GetTurnContext(locale: "en-us"), templateContent, null);
             Assert.AreEqual("from b.en-us.lg", result);
+            result = await generator.Generate(GetTurnContext(locale: "en-us"), "@{templatec()}", null);
+            Assert.AreEqual("from c.en.lg", result);
 
             // fallback to en
             result = await generator.Generate(GetTurnContext(locale: "en-gb"), templateContent, null);
@@ -75,11 +77,13 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             result = await generator.Generate(GetTurnContext(locale: "en"), templateContent, null);
             Assert.AreEqual("from b.en.lg", result);
+            var ex = Assert.ThrowsException<AggregateException>(() => generator.Generate(GetTurnContext(locale: "en"), "@{templatec()}", null).Wait());
+            Assert.IsTrue(ex.Message.Contains("templatec does not have an evaluator"));
 
             templateContent = "@{templateben()}";
 
             // imported will not fallback when not found
-            var ex = Assert.ThrowsException<AggregateException>(() => generator.Generate(GetTurnContext(locale: "en-us"), templateContent, null).Wait());
+            ex = Assert.ThrowsException<AggregateException>(() => generator.Generate(GetTurnContext(locale: "en-us"), templateContent, null).Wait());
             Assert.IsTrue(ex.Message.Contains("templateben does not have an evaluator"));
 
             templateContent = "@{templateben-us()}";
@@ -102,24 +106,32 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 Assert.AreEqual("from a.lg", text, "template should be there");
                 text = await lg.Generate(turnContext, "@{templateb()}", null);
                 Assert.AreEqual("from b.lg", text, "template should be there");
+                var ex = Assert.ThrowsException<AggregateException>(() => lg.Generate(turnContext, "@{templatec()}", null).Wait());
+                Assert.IsTrue(ex.Message.Contains("templatec does not have an evaluator"));
 
                 turnContext.Activity.Locale = "en-us";
                 text = await lg.Generate(turnContext, "@{templatea()}", null);
                 Assert.AreEqual("from a.en-US.lg", text, "template should be there");
                 text = await lg.Generate(turnContext, "@{templateb()}", null);
                 Assert.AreEqual("from b.en-us.lg", text, "template should be there");
+                text = await lg.Generate(turnContext, "@{templatec()}", null);
+                Assert.AreEqual("from c.en.lg", text, "template should be there");
 
                 turnContext.Activity.Locale = "en";
                 text = await lg.Generate(turnContext, "@{templatea()}", null);
                 Assert.AreEqual("from a.lg", text, "template should be there");
                 text = await lg.Generate(turnContext, "@{templateb()}", null);
                 Assert.AreEqual("from b.en.lg", text, "template should be there");
+                ex = Assert.ThrowsException<AggregateException>(() => lg.Generate(turnContext, "@{templatec()}", null).Wait());
+                Assert.IsTrue(ex.Message.Contains("templatec does not have an evaluator"));
 
                 turnContext.Activity.Locale = "foo";
                 text = await lg.Generate(turnContext, "@{templatea()}", null);
                 Assert.AreEqual("from a.lg", text, "template should be there");
                 text = await lg.Generate(turnContext, "@{templateb()}", null);
                 Assert.AreEqual("from b.lg", text, "template should be there");
+                ex = Assert.ThrowsException<AggregateException>(() => lg.Generate(turnContext, "@{templatec()}", null).Wait());
+                Assert.IsTrue(ex.Message.Contains("templatec does not have an evaluator"));
             })
             .Send("hello")
             .StartTestAsync();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/b.en-us.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/b.en-us.lg
@@ -1,4 +1,6 @@
-﻿# templateb
+﻿﻿[import](c.lg)
+
+# templateb
 - from b.en-us.lg
 
 # templateben-us

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/c.en.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/c.en.lg
@@ -1,0 +1,2 @@
+﻿﻿# templatec
+- from c.en.lg


### PR DESCRIPTION
Currently, to support flexible multi-language support. We try to enumerate every entry lg + every locale found, which is too wide. 

If the entry is "foo.en_us.lg" and refers to "bar.lg", we should only looking for "bar.en_us.lg" or other language fallback. We should not try to create other locales found, because the file id already tells the locale