### PR TITLE
DialogSet dependencies not initialized correctly when created each turn

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
@@ -1,8 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1515 // Single-line comment should be preceded by blank line
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
@@ -21,6 +33,66 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         public async Task Rule_Reprompt()
         {
             await TestUtils.RunTestScript("Rule_Reprompt.test.dialog");
+        }
+
+        [TestMethod]
+        public async Task DialogManager_InitDialogsEnsureDependencies()
+        {
+            TestScript CreateTestScript()
+            {
+                return new TestScript()
+                    .Send("hi")
+                        .AssertReply("You said 'hi'")
+                        .AssertReply("Enter age")
+                    .Send("10")
+                        .AssertReply("You said 10");
+            }
+
+            Dialog CreateDialog()
+            {
+                return new AdaptiveDialog()
+                {
+                    Recognizer = new CustomRecognizer(),
+                    Triggers = new List<Adaptive.Conditions.OnCondition>()
+                    {
+                        new OnUnknownIntent()
+                        {
+                            Actions = new List<Dialog>()
+                            {
+                                new SendActivity("You said '@{turn.activity.text}'"),
+                                new TextInput()
+                                {
+                                    Prompt = new ActivityTemplate("Enter age"),
+                                    Property = "dialog.age"
+                                },
+                                new SendActivity("You said @{dialog.age}")
+                            }
+                        }
+                    }
+                };
+            }
+
+            var script = CreateTestScript();
+            script.Dialog = CreateDialog();
+            await script.ExecuteAsync();
+
+            // create new dialog manager and new dialog each turn should be the same as when it's static
+            await CreateTestScript()
+                .ExecuteAsync(callback: (context, ct) => new DialogManager(CreateDialog()).OnTurnAsync(context, ct));
+        }
+    }
+
+    public class CustomRecognizer : IRecognizer
+    {
+        public Task<RecognizerResult> RecognizeAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new RecognizerResult());
+        }
+
+        public Task<T> RecognizeAsync<T>(ITurnContext turnContext, CancellationToken cancellationToken)
+            where T : IRecognizerConvert, new()
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Adaptive Dialog needs to have dialog set initialized before dialogcontext is created.  When dialogs are static this is a small issue, but when you create the dialog tree on each this will cause inconsistent dialogset collections.

Fix for #3031 
