### PR TITLE
Add KeySuffix and CompatibilityMode to CosmosDbPartitionedStorage

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
@@ -10,8 +10,9 @@ namespace Microsoft.Bot.Builder.Azure
 {
     public static class CosmosDbKeyEscape
     {
-        // Per the CosmosDB Docs, there is a max key length of 255.
-        // https://docs.microsoft.com/en-us/azure/cosmos-db/faq#table
+        // Older libraries had a max key length of 255.
+        // The limit is now 1023. In this library, 255 remains the default for backwards compat.
+        // https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
         public const int MaxKeyLength = 255;
 
         // The list of illegal characters for Cosmos DB Keys comes from this list on
@@ -34,18 +35,39 @@ namespace Microsoft.Bot.Builder.Azure
         /// <returns>An escaped key that can be used safely with CosmosDB.</returns>
         public static string EscapeKey(string key)
         {
+            return TruncateKeyIfNeeded(EscapeKey(key, string.Empty, MaxKeyLength), MaxKeyLength);
+        }
+
+        /// <summary>
+        /// Converts the key into a DocumentID that can be used safely with Cosmos DB.
+        /// The following characters are restricted and cannot be used in the Id property: '/', '\', '?', and '#'.
+        /// More information at <see cref="Microsoft.Azure.Documents.Resource.Id"/>.
+        /// 
+        /// Note: if (key + suffix).length > maxKeyLegth, key length exceeded exception is thrown.
+        /// </summary>
+        /// <param name="key">The key to escape.</param>
+        /// <param name="suffix">The string to add at the end of all row keys.</param>
+        /// <param name="maxKeyLength ">Maximum Length allowed for the escaped key. Default value of <see cref="MaxKeyLength"/>.</param>
+        /// <returns>An escaped key that can be used safely with CosmosDB.</returns>
+        public static string EscapeKey(string key, string suffix, int maxKeyLength = MaxKeyLength)
+        {
             if (string.IsNullOrWhiteSpace(key))
             {
                 throw new ArgumentNullException(nameof(key));
             }
 
+            if (maxKeyLength < MaxKeyLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxKeyLength), $"Cannot be < {MaxKeyLength}");
+            }
+
             var firstIllegalCharIndex = key.IndexOfAny(_illegalKeys);
 
-            // If there are no illegal characters, and tkey is within length costraints,
+            // If there are no illegal characters, and the key is within length costraints,
             // return immediately and avoid any further processing/allocations
             if (firstIllegalCharIndex == -1)
             {
-                return TruncateKeyIfNeeded(key);
+                return ThrowOrTruncateIfNeeded($"{key}{suffix}", maxKeyLength, !string.IsNullOrWhiteSpace(suffix));
             }
 
             // Allocate a builder that assumes that all remaining characters might be replaced to avoid any extra allocations
@@ -75,16 +97,39 @@ namespace Microsoft.Bot.Builder.Azure
                 }
             }
 
-            var sanitizedKey = sanitizedKeyBuilder.ToString();
-            return TruncateKeyIfNeeded(sanitizedKey);
+            if (!string.IsNullOrWhiteSpace(suffix)) 
+            {
+                sanitizedKeyBuilder.Append(suffix);
+            }
+
+            return ThrowOrTruncateIfNeeded(sanitizedKeyBuilder.ToString(), maxKeyLength, !string.IsNullOrWhiteSpace(suffix));
         }
 
-        private static string TruncateKeyIfNeeded(string key)
+        private static string ThrowOrTruncateIfNeeded(string sanitizedkey, int maxKeyLength, bool suffixUsed)
         {
-            if (key.Length > MaxKeyLength)
+            // Only throw InvalidOperationException if default max key length (255) is NOT in use, OR if a suffix is in use.
+            // (NOTE: this dual behavior is cryptic, but present in order to support previous 
+            //  CosmosDb versions which defaulted to truncating everything after MaxKeyLength 255)
+            if (suffixUsed || maxKeyLength != MaxKeyLength)
+            {
+                if (sanitizedkey.Length > maxKeyLength)
+                {
+                    throw new InvalidOperationException($"CosmosDb row key length of {sanitizedkey.Length} exceeded {maxKeyLength}");
+                }
+
+                return sanitizedkey;
+            }
+
+            // Default path is to turncate keys > maxKeyLength.
+            return TruncateKeyIfNeeded(sanitizedkey, maxKeyLength);
+        }
+
+        private static string TruncateKeyIfNeeded(string key, int maxKeyLength)
+        {
+            if (key.Length > maxKeyLength)
             {
                 var hash = key.GetHashCode().ToString("x");
-                key = key.Substring(0, MaxKeyLength - hash.Length) + hash;
+                key = key.Substring(0, maxKeyLength - hash.Length) + hash;
             }
 
             return key;

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <returns>An escaped key that can be used safely with CosmosDB.</returns>
         public static string EscapeKey(string key)
         {
-            return TruncateKeyIfNeeded(EscapeKey(key, string.Empty, MaxKeyLength), MaxKeyLength);
+            return EscapeKey(key, string.Empty, MaxKeyLength);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Azure
     {
         // Older libraries had a max key length of 255.
         // The limit is now 1023. In this library, 255 remains the default for backwards compat.
-        // To override this behavior, and use the longer limit, set CosmosDbPartitionedStorageOptions.TruncateKeysForCompatibility to false.
+        // To override this behavior, and use the longer limit, set CosmosDbPartitionedStorageOptions.CompatibilityMode to false.
         // https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
         public const int MaxKeyLength = 255;
 
@@ -46,12 +46,13 @@ namespace Microsoft.Bot.Builder.Azure
         /// </summary>
         /// <param name="key">The key to escape.</param>
         /// <param name="suffix">The string to add at the end of all row keys.</param>
-        /// <param name="truncateKeysForCompatibility ">True if keys should be truncated in order to support
-        /// previous CosmosDb max key length of 255. This behavior can be overridden by setting
-        /// <see cref="CosmosDbPartitionedStorageOptions.TruncateKeysForCompatibility"/> to false.
+        /// <param name="compatibilityMode ">True if running in compatability mode and keys should
+        /// be truncated in order to support previous CosmosDb max key length of 255. 
+        /// This behavior can be overridden by setting
+        /// <see cref="CosmosDbPartitionedStorageOptions.CompatibilityMode"/> to false.
         /// </param>
         /// <returns>An escaped key that can be used safely with CosmosDB.</returns>
-        public static string EscapeKey(string key, string suffix, bool truncateKeysForCompatibility)
+        public static string EscapeKey(string key, string suffix, bool compatibilityMode)
         {
             if (string.IsNullOrWhiteSpace(key))
             {
@@ -64,7 +65,7 @@ namespace Microsoft.Bot.Builder.Azure
             // return immediately and avoid any further processing/allocations
             if (firstIllegalCharIndex == -1)
             {
-                return TruncateKeyIfNeeded($"{key}{suffix}", truncateKeysForCompatibility);
+                return TruncateKeyIfNeeded($"{key}{suffix}", compatibilityMode);
             }
 
             // Allocate a builder that assumes that all remaining characters might be replaced to avoid any extra allocations
@@ -99,7 +100,7 @@ namespace Microsoft.Bot.Builder.Azure
                 sanitizedKeyBuilder.Append(suffix);
             }
 
-            return TruncateKeyIfNeeded(sanitizedKeyBuilder.ToString(), truncateKeysForCompatibility);
+            return TruncateKeyIfNeeded(sanitizedKeyBuilder.ToString(), compatibilityMode);
         }
 
         private static string TruncateKeyIfNeeded(string key, bool truncateKeysForCompatibility)

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -57,12 +57,17 @@ namespace Microsoft.Bot.Builder.Azure
 
             if (!string.IsNullOrWhiteSpace(cosmosDbStorageOptions.KeySuffix))
             {
+                if (cosmosDbStorageOptions.TruncateKeysForCompatibility)
+                {
+                    throw new ArgumentException($"TruncateKeysForCompatibility cannot be 'true' while using a KeySuffix.", nameof(cosmosDbStorageOptions.TruncateKeysForCompatibility));
+                }
+
                 // In order to reduce key complexity, we do not allow invalid characters in a KeySuffix
                 // If the KeySuffix has invalid characters, the EscapeKey will not match
                 var suffixEscaped = CosmosDbKeyEscape.EscapeKey(cosmosDbStorageOptions.KeySuffix);
                 if (!cosmosDbStorageOptions.KeySuffix.Equals(suffixEscaped, StringComparison.Ordinal))
                 {
-                    throw new ArgumentException($"Cnnot use invalid Row Key characters: {cosmosDbStorageOptions.KeySuffix}", nameof(cosmosDbStorageOptions.KeySuffix));
+                    throw new ArgumentException($"Cannot use invalid Row Key characters: {cosmosDbStorageOptions.KeySuffix}", nameof(cosmosDbStorageOptions.KeySuffix));
                 }
             }
 
@@ -107,7 +112,7 @@ namespace Microsoft.Bot.Builder.Azure
             {
                 try
                 {
-                    var escapedKey = CosmosDbKeyEscape.EscapeKey(key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.MaxKeyLength);
+                    var escapedKey = CosmosDbKeyEscape.EscapeKey(key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.TruncateKeysForCompatibility);
 
                     var readItemResponse = await _container.ReadItemAsync<DocumentStoreItem>(
                             escapedKey,
@@ -170,7 +175,7 @@ namespace Microsoft.Bot.Builder.Azure
 
                 var documentChange = new DocumentStoreItem
                 {
-                    Id = CosmosDbKeyEscape.EscapeKey(change.Key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.MaxKeyLength),
+                    Id = CosmosDbKeyEscape.EscapeKey(change.Key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.TruncateKeysForCompatibility),
                     RealId = change.Key,
                     Document = json,
                 };
@@ -213,7 +218,7 @@ namespace Microsoft.Bot.Builder.Azure
 
             foreach (var key in keys)
             {
-                var escapedKey = CosmosDbKeyEscape.EscapeKey(key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.MaxKeyLength);
+                var escapedKey = CosmosDbKeyEscape.EscapeKey(key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.TruncateKeysForCompatibility);
 
                 try
                 {

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Azure
                 var suffixEscaped = CosmosDbKeyEscape.EscapeKey(cosmosDbStorageOptions.KeySuffix);
                 if (!cosmosDbStorageOptions.KeySuffix.Equals(suffixEscaped, StringComparison.Ordinal))
                 {
-                    throw new ArgumentException($"Cnnot use invalid Row Key characters: {_cosmosDbStorageOptions.KeySuffix}", nameof(cosmosDbStorageOptions.KeySuffix));
+                    throw new ArgumentException($"Cnnot use invalid Row Key characters: {cosmosDbStorageOptions.KeySuffix}", nameof(cosmosDbStorageOptions.KeySuffix));
                 }
             }
 
@@ -171,7 +171,7 @@ namespace Microsoft.Bot.Builder.Azure
                 var documentChange = new DocumentStoreItem
                 {
                     Id = CosmosDbKeyEscape.EscapeKey(change.Key, _cosmosDbStorageOptions.KeySuffix, _cosmosDbStorageOptions.MaxKeyLength),
-                    RealId = $"{change.Key}{_cosmosDbStorageOptions.KeySuffix}",
+                    RealId = change.Key,
                     Document = json,
                 };
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Azure.Cosmos;
-using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.Client;
 
 namespace Microsoft.Bot.Builder.Azure
 {
@@ -64,22 +61,28 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Gets or sets the suffix to be added to every key. <see cref="CosmosDbKeyEscape.EscapeKey"/>.
         /// 
-        /// Note: When KeySuffix is used, keys will NOT be truncated but an exception will be thrown if
-        /// the key length is longer than <see cref="MaxKeyLength"/>.
+        /// Note: <see cref="TruncateKeysForCompatibility"/> must be set to 'false' to use a KeySuffix.
+        /// When KeySuffix is used, keys will NOT be truncated but an exception will be thrown if
+        /// the key length is longer than allowed by CosmosDb.
         /// </summary>
         /// <value>
-        /// String containing valid CosmosDb key characters. (e.g. not: '\\', '?', '/', '#', '*').
+        /// String containing only valid CosmosDb key characters. (e.g. not: '\\', '?', '/', '#', '*').
         /// </value>
         public string KeySuffix { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum row key length to use for <see cref="CosmosDbPartitionedStorage"/>.
+        /// Gets or sets a value indicating whether or not keys longer than 255 should be truncated.
+        /// Early versions of CosmosDb had a key length limit of 255.  Keys longer than this were
+        /// truncated in <see cref="CosmosDbKeyEscape"/>.  This remains the default behavior, but
+        /// can be overridden by setting TruncateKeysForCompatibility to false.
+        /// 
+        /// Note: TruncateKeysForCompatibility cannot be 'true' if KeySuffix is used.
         /// </summary>
         /// <value>
-        /// Currently, max key length for cosmosdb is now 1023:
+        /// Currently, max key length for cosmosdb is 1023:
         /// https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
-        /// Default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
+        /// The default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
         /// </value>
-        public int MaxKeyLength { get; set; } = CosmosDbKeyEscape.MaxKeyLength;
+        public bool TruncateKeysForCompatibility { get; set; } = true;
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Gets or sets the suffix to be added to every key. <see cref="CosmosDbKeyEscape.EscapeKey"/>.
         /// 
-        /// Note: <see cref="TruncateKeysForCompatibility"/> must be set to 'false' to use a KeySuffix.
+        /// Note: <see cref="CompatibilityMode"/> must be set to 'false' to use a KeySuffix.
         /// When KeySuffix is used, keys will NOT be truncated but an exception will be thrown if
         /// the key length is longer than allowed by CosmosDb.
         /// </summary>
@@ -71,18 +71,19 @@ namespace Microsoft.Bot.Builder.Azure
         public string KeySuffix { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not keys longer than 255 should be truncated.
+        /// Gets or sets a value indicating whether or not to run in Compatibility Mode.
         /// Early versions of CosmosDb had a key length limit of 255.  Keys longer than this were
         /// truncated in <see cref="CosmosDbKeyEscape"/>.  This remains the default behavior, but
-        /// can be overridden by setting TruncateKeysForCompatibility to false.
+        /// can be overridden by setting CompatibilityMode to false.  This setting will also allow
+        /// for using older collections where no PartitionKey was specified.
         /// 
-        /// Note: TruncateKeysForCompatibility cannot be 'true' if KeySuffix is used.
+        /// Note: CompatibilityMode cannot be 'true' if KeySuffix is used.
         /// </summary>
         /// <value>
         /// Currently, max key length for cosmosdb is 1023:
         /// https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
         /// The default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
         /// </value>
-        public bool TruncateKeysForCompatibility { get; set; } = true;
+        public bool CompatibilityMode { get; set; } = true;
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -60,5 +60,26 @@ namespace Microsoft.Bot.Builder.Azure
         /// Container throughput. Defaults to 400.
         /// </value>
         public int ContainerThroughput { get; set; } = 400;
+
+        /// <summary>
+        /// Gets or sets the suffix to be added to every key. <see cref="CosmosDbKeyEscape.EscapeKey"/>.
+        /// 
+        /// Note: When KeySuffix is used, keys will NOT be truncated but an exception will be thrown if
+        /// the key length is longer than <see cref="MaxKeyLength"/>.
+        /// </summary>
+        /// <value>
+        /// String containing valid CosmosDb key characters. (e.g. not: '\\', '?', '/', '#', '*').
+        /// </value>
+        public string KeySuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum row key length to use for <see cref="CosmosDbPartitionedStorage"/>.
+        /// </summary>
+        /// <value>
+        /// Currently, max key length for cosmosdb is now 1024:
+        /// https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
+        /// Default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
+        /// </value>
+        public int MaxKeyLength { get; set; } = CosmosDbKeyEscape.MaxKeyLength;
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// Gets or sets the maximum row key length to use for <see cref="CosmosDbPartitionedStorage"/>.
         /// </summary>
         /// <value>
-        /// Currently, max key length for cosmosdb is now 1024:
+        /// Currently, max key length for cosmosdb is now 1023:
         /// https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
         /// Default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
         /// </value>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -104,5 +104,41 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             Assert.AreNotEqual(escaped1, escaped2);
         }
+
+        [TestMethod]
+        public void Long_Key_Should_Not_Be_Truncated_With_False_TruncateKeysForCompatibility()
+        {
+            var tooLongKey = new string('a', CosmosDbKeyEscape.MaxKeyLength + 1);
+
+            var sanitizedKey = CosmosDbKeyEscape.EscapeKey(tooLongKey, string.Empty, false);
+            Assert.AreEqual(CosmosDbKeyEscape.MaxKeyLength + 1, sanitizedKey.Length, "Key should not have been truncated");
+
+            // The resulting key should be identical
+            Assert.AreEqual(tooLongKey, sanitizedKey);
+        }
+
+        [TestMethod]
+        public void Long_Key_With_Illegal_Characters_Should_Not_Be_Truncated_With_False_TruncateKeysForCompatibility()
+        {
+            var longKeyWithIllegalCharacters = "?test?" + new string('A', 1000);
+            var sanitizedKey = CosmosDbKeyEscape.EscapeKey(longKeyWithIllegalCharacters, string.Empty, false);
+
+            // Verify the key was NOT truncated
+            Assert.AreEqual(1010, sanitizedKey.Length, "Key should not have been truncated");
+
+            // Make sure the escaping still happened
+            Assert.IsTrue(sanitizedKey.StartsWith("*3ftest*3f"));
+        }
+
+        [TestMethod]
+        public void KeySuffix_Is_Added_To_End_of_Key()
+        {
+            var suffix = "test suffix";
+            var key = "this is a test";
+            var sanitizedKey = CosmosDbKeyEscape.EscapeKey(key, suffix, false);
+
+            // Verify the suffix was added to the end of the key
+            Assert.AreEqual(sanitizedKey, $"{key}{suffix}", "Suffix was not added to end of key");
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public void Long_Key_Should_Not_Be_Truncated_With_False_TruncateKeysForCompatibility()
+        public void Long_Key_Should_Not_Be_Truncated_With_False_CompatibilityMode()
         {
             var tooLongKey = new string('a', CosmosDbKeyEscape.MaxKeyLength + 1);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [TestMethod]
-        public void Long_Key_With_Illegal_Characters_Should_Not_Be_Truncated_With_False_TruncateKeysForCompatibility()
+        public void Long_Key_With_Illegal_Characters_Should_Not_Be_Truncated_With_False_CompatibilityMode()
         {
             var longKeyWithIllegalCharacters = "?test?" + new string('A', 1000);
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(longKeyWithIllegalCharacters, string.Empty, false);

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -155,7 +155,18 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 ContainerId = "testId",
                 DatabaseId = "testDb",
                 CosmosDbEndpoint = "testEndpoint",
-                KeySuffix = "?#*test"
+                KeySuffix = "?#*test",
+                TruncateKeysForCompatibility = false
+            }));
+
+            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                AuthKey = "testAuthKey",
+                ContainerId = "testId",
+                DatabaseId = "testDb",
+                CosmosDbEndpoint = "testEndpoint",
+                KeySuffix = "thisisatest",
+                TruncateKeysForCompatibility = true
             }));
         }
 
@@ -350,16 +361,6 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     .StartTestAsync();
             }
         }
-
-        //// NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
-        //[TestMethod]
-        //public async Task ThrowsOn()
-        //{
-        //    if (CheckEmulator())
-        //    {
-
-        //    }
-        //}
 
         public bool CheckEmulator()
         {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 DatabaseId = "testDb",
                 CosmosDbEndpoint = "testEndpoint",
                 KeySuffix = "?#*test",
-                TruncateKeysForCompatibility = false
+                CompatibilityMode = false
             }));
 
             Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 DatabaseId = "testDb",
                 CosmosDbEndpoint = "testEndpoint",
                 KeySuffix = "thisisatest",
-                TruncateKeysForCompatibility = true
+                CompatibilityMode = true
             }));
         }
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -147,6 +147,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 DatabaseId = "testDb",
                 CosmosDbEndpoint = "testEndpoint",
             }));
+
+            // Invalid Row Key characters in KeySuffix
+            Assert.ThrowsException<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                AuthKey = "testAuthKey",
+                ContainerId = "testId",
+                DatabaseId = "testDb",
+                CosmosDbEndpoint = "testEndpoint",
+                KeySuffix = "?#*test"
+            }));
         }
 
         // NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
@@ -340,6 +350,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     .StartTestAsync();
             }
         }
+
+        //// NOTE: THESE TESTS REQUIRE THAT THE COSMOS DB EMULATOR IS INSTALLED AND STARTED !!!!!!!!!!!!!!!!!
+        //[TestMethod]
+        //public async Task ThrowsOn()
+        //{
+        //    if (CheckEmulator())
+        //    {
+
+        //    }
+        //}
 
         public bool CheckEmulator()
         {


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/2766 CosmosDbPartitionedStorage should support a custom user provided suffix for id

and

https://github.com/microsoft/botbuilder-dotnet/issues/2765 CosmosDbPartitionedStorage should work with existing collections created by CosmosDbStorage