### PR TITLE
OAuthPrompt Updates for Skills

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -702,17 +702,6 @@ namespace Microsoft.Bot.Builder
             }
 
             var activity = turnContext.Activity;
-            var serviceUrl = activity.ServiceUrl;
-
-            // Clone the conversation information
-            var conversation = JsonConvert.DeserializeObject<ConversationAccount>(JsonConvert.SerializeObject(activity.Conversation));
-
-            if (turnContext.TurnState.Get<ClaimsIdentity>("BotIdentity") is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims))
-            {
-                conversation.Id = turnContext.Activity.Conversation.Id;
-                serviceUrl = turnContext.Activity.ServiceUrl;
-            }
-
             var tokenExchangeState = new TokenExchangeState()
             {
                 ConnectionName = connectionName,
@@ -721,8 +710,8 @@ namespace Microsoft.Bot.Builder
                     ActivityId = activity.Id,
                     Bot = activity.Recipient,       // Activity is from the user to the bot
                     ChannelId = activity.ChannelId,
-                    Conversation = conversation,
-                    ServiceUrl = serviceUrl,
+                    Conversation = activity.Conversation,
+                    ServiceUrl = activity.ServiceUrl,
                     User = activity.From,
                 },
                 MsAppId = (CredentialProvider as MicrosoftAppCredentials)?.MicrosoftAppId,


### PR DESCRIPTION
Relates to https://github.com/microsoft/botframework-sdk/issues/5654

Removes special handling for sign in link generation for skills and adds code to force magic code in OAuthPrompt for skills

In R7 skills that use the OAuthPrompt will still require a magic code, we will look into removing the need for magic code in R8.