### PR TITLE
AppCredentials construction: Enable extension of credential construction

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1018,7 +1018,7 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// Logic to build an <see cref="AppCreentials"/> object to be used to acquire tokens
+        /// Logic to build an <see cref="AppCredentials"/> object to be used to acquire tokens
         /// for this HttpClient.
         /// </summary>
         /// <param name="appId">The application id.</param>
@@ -1026,7 +1026,10 @@ namespace Microsoft.Bot.Builder
         /// <returns>The app credentials to be used to acquire tokens.</returns>
         protected virtual async Task<AppCredentials> BuildCredentialsAsync(string appId, string oAuthScope = null)
         {
+            // Get the password from the credential provider
             var appPassword = await CredentialProvider.GetAppPasswordAsync(appId).ConfigureAwait(false);
+
+            // Construct an AppCredentials using the app + password combination. If government, we create a government specific credential.
             return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
         }
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <summary>
-        /// Logic to build an <see cref="AppCreentials"/> object to be used to acquire tokens
+        /// Logic to build an <see cref="AppCredentials"/> object to be used to acquire tokens
         /// for this HttpClient.
         /// </summary>
         /// <param name="appId">The application id.</param>


### PR DESCRIPTION
AppCredentials construction: Enable extension of credential construction by sublcassing of adapter and http client. Side effect: promoting 4 private members to protected.

Instead of building new functionality for custom credentials in the adapter (and adding more constructors to the problem), we allow subclasses to customize how credentials are created. This enables scenarios like multitenant bots with custom creds, etc.

All the lines changed only boil down to 1) refactoring the creation of the AppCredentials to a protected virtual method, 2) promoting 4 private members to protected for subclasses to be able to access them. We make them properties since our policy does not allow protected members :)