### PR TITLE
remove unused overload in JwtTokenExtractor

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
@@ -195,11 +195,6 @@ namespace Microsoft.Bot.Connector.Authentication
             return false;
         }
 
-        private async Task<ClaimsPrincipal> ValidateTokenAsync(string jwtToken, string channelId)
-        {
-            return await ValidateTokenAsync(jwtToken, channelId, new string[] { }).ConfigureAwait(false);
-        }
-
         private async Task<ClaimsPrincipal> ValidateTokenAsync(string jwtToken, string channelId, string[] requiredEndorsements)
         {
             if (requiredEndorsements == null)


### PR DESCRIPTION
The overload is private and has no references.