### PR TITLE
[Skills] update ForwardController to use config for botId and skillId

### DIFF
--- a/tests/Microsoft.Bot.Builder.TestProtocol/Controllers/ForwardController.cs
+++ b/tests/Microsoft.Bot.Builder.TestProtocol/Controllers/ForwardController.cs
@@ -20,12 +20,16 @@ namespace Microsoft.Bot.Builder.TestProtocol.Controllers
         private readonly Uri _toUri;
         private readonly Uri _serviceUrl;
         private readonly SkillConversationIdFactoryBase _factory;
+        private readonly String _botId;
+        private readonly String _skillId;
 
         public ForwardController(BotFrameworkHttpClient client, IConfiguration configuration, SkillConversationIdFactoryBase factory)
         {
             _client = client;
             _toUri = new Uri(configuration["Next"]);
             _serviceUrl = new Uri(configuration["ServiceUrl"]);
+            _botId = configuration["MicrosofAppId"];
+            _skillId = configuration["SkillId"];
             _factory = factory;
         }
 
@@ -34,7 +38,7 @@ namespace Microsoft.Bot.Builder.TestProtocol.Controllers
         {
             var inboundActivity = await HttpHelper.ReadRequestAsync<Activity>(Request);
             var nextConversationId = await _factory.CreateSkillConversationIdAsync(inboundActivity.GetConversationReference(), CancellationToken.None);
-            await _client.PostActivityAsync(null, null, _toUri, _serviceUrl, nextConversationId, inboundActivity);
+            await _client.PostActivityAsync(_botId, _skillId, _toUri, _serviceUrl, nextConversationId, inboundActivity);
 
             // ALTERNATIVE API IDEA...
             //var inboundConversationReference = inboundActivity.GetConversationReference();

--- a/tests/Microsoft.Bot.Builder.TestProtocol/appsettings.json
+++ b/tests/Microsoft.Bot.Builder.TestProtocol/appsettings.json
@@ -2,5 +2,6 @@
   "MicrosoftAppId": "",
   "MicrosoftAppPassword": "",
   "Next": "http://localhost:3978/api/mybot",
-  "ServiceUrl": "http://localhost:3428/api/connector"
+  "ServiceUrl": "http://localhost:3428/api/connector",
+  "SkillId": ""
 }


### PR DESCRIPTION
_Minor nits_

## Specific Changes
- Update ForwardController to obtain botId and skillId from IConfiguration and store as private readonly members
- PostAsync uses _botId and _skillId when it forwards an activity to the skill.
- Add "SkillId" to the appsettings.json.