### PR TITLE
Change Functional tests to use attribute instead of compiler directive

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -9,11 +9,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
+    //    #if !FUNCTIONALTESTS
+    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
+    //#endif
     [TestClass]
-    #if !FUNCTIONALTESTS
-    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    #endif
-
+    [TestCategory("FunctionalTests")]
     public class DirectLineClientTests
     {
         private static string directLineSecret = null;

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -9,9 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
-    //    #if !FUNCTIONALTESTS
-    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    //#endif
     [TestClass]
     [TestCategory("FunctionalTests")]
     public class DirectLineClientTests

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineSpeechTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineSpeechTests.cs
@@ -20,12 +20,8 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 {
     [TestClass]
 
-    // When the active Ignore tag is removed un-comment this one so these tests remain gated behind the FUNCTIONALTESTS flag.
-    //#if !FUNCTIONALTESTS
-    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    //#endif
+    [TestCategory("FunctionalTests")]
     [Ignore("DirectLine Speech tests require updates to the REST API and CLI to be able to properly provision a bot.")]
-
     public class DirectLineSpeechTests
     {
         private static readonly string SoundFileMessage = "Tell me a joke";

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/GetTokenRefreshTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/GetTokenRefreshTests.cs
@@ -10,10 +10,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
+    //    #if !FUNCTIONALTESTS
+    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
+    //#endif
     [TestClass]
-    #if !FUNCTIONALTESTS
-    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    #endif
+    [TestCategory("FunctionalTests")]
     public class GetTokenRefreshTests
     {
         private string testAppId = null;

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/GetTokenRefreshTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/GetTokenRefreshTests.cs
@@ -10,9 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
-    //    #if !FUNCTIONALTESTS
-    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    //#endif
     [TestClass]
     [TestCategory("FunctionalTests")]
     public class GetTokenRefreshTests

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/JwtTokenExtractorTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/JwtTokenExtractorTests.cs
@@ -13,10 +13,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
+    //    #if !FUNCTIONALTESTS
+    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
+    //#endif
     [TestClass]
-    #if !FUNCTIONALTESTS
-    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    #endif
+    [TestCategory("FunctionalTests")]
     public class JwtTokenExtractorTests
     {
         private const string KeyId = "CtfQC8Le-8NsC7oC2zQkZpcrfOc";

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/JwtTokenExtractorTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/JwtTokenExtractorTests.cs
@@ -13,9 +13,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
-    //    #if !FUNCTIONALTESTS
-    //    [Ignore("These integration tests run only when FUNCTIONALTESTS is defined")]
-    //#endif
     [TestClass]
     [TestCategory("FunctionalTests")]
     public class JwtTokenExtractorTests

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -19,7 +19,7 @@ steps:
     projects: |
      Tests/**/*Tests.csproj
      
-    arguments: '-v n  --configuration release --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+    arguments: '-v n  --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: eq(variables['BuildConfiguration'],'Release-Windows')
 
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
Added attribute [TestCategory("FunctionalTests")] to functional tests. Builds then reference that attribute for running tests instead of compiling different versions.