### PR TITLE
[Webex adapter] Add support for room messages

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -70,22 +70,25 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 else
                 {
                     // transform activity into the webex message format
-                    string personIdOrEmail;
+                    string recipientId;
+                    var target = MessageTarget.PersonId;
 
-                    if (activity.GetChannelData<WebhookEventData>()?.MessageData.PersonEmail != null)
+                    if (activity.Conversation?.Id != null)
                     {
-                        personIdOrEmail = activity.GetChannelData<WebhookEventData>()?.MessageData.PersonEmail;
+                        recipientId = activity.Conversation.Id;
+                        target = MessageTarget.SpaceId;
+                    }
+                    else if (activity.Conversation == null && activity.Recipient.Id != null)
+                    {
+                        recipientId = activity.Recipient.Id;
+                    }
+                    else if (activity.GetChannelData<WebhookEventData>()?.MessageData.PersonEmail != null)
+                    {
+                        recipientId = activity.GetChannelData<WebhookEventData>()?.MessageData.PersonEmail;
                     }
                     else
                     {
-                        if (activity.Recipient?.Id != null)
-                        {
-                            personIdOrEmail = activity.Recipient.Id;
-                        }
-                        else
-                        {
-                            throw new Exception("No Person or Email to send the message");
-                        }
+                        throw new Exception("No Person, Email or Room to send the message");
                     }
 
                     string responseId;
@@ -94,7 +97,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                     {
                         if (activity.Attachments[0].ContentType == "application/vnd.microsoft.card.adaptive")
                         {
-                            responseId = await _webexClient.CreateMessageWithAttachmentsAsync(personIdOrEmail, activity.Text, activity.Attachments, cancellationToken).ConfigureAwait(false);
+                            responseId = await _webexClient.CreateMessageWithAttachmentsAsync(recipientId, activity.Text, activity.Attachments, MessageTextType.Text, target, cancellationToken).ConfigureAwait(false);
                         }
                         else
                         {
@@ -106,13 +109,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                                 files.Add(file);
                             }
 
-                            responseId = await _webexClient.CreateMessageAsync(personIdOrEmail, activity.Text, files.Count > 0 ? files : null, cancellationToken).ConfigureAwait(false);
+                            responseId = await _webexClient.CreateMessageAsync(recipientId, activity.Text, files.Count > 0 ? files : null, MessageTextType.Text, target, cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
                     {
                         responseId = await _webexClient
-                            .CreateMessageAsync(personIdOrEmail, activity.Text, cancellationToken: cancellationToken)
+                            .CreateMessageAsync(recipientId, activity.Text, target: target, cancellationToken: cancellationToken)
                             .ConfigureAwait(false);
                     }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                         recipientId = activity.Conversation.Id;
                         target = MessageTarget.SpaceId;
                     }
-                    else if (activity.Conversation == null && activity.Recipient.Id != null)
+                    else if (activity.Conversation == null && activity.Recipient?.Id != null)
                     {
                         recipientId = activity.Recipient.Id;
                     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -191,9 +191,26 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <param name="files">List of files attached to the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageAsync(string toPersonOrEmail, string text, IList<Uri> files = null, CancellationToken cancellationToken = default)
+        public virtual async Task<string> CreateDirectMessageAsync(string toPersonOrEmail, string text, IList<Uri> files = null, CancellationToken cancellationToken = default)
         {
             var webexResponse = await _api.CreateDirectMessageAsync(toPersonOrEmail, text, files, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            return webexResponse.Data.Id;
+        }
+
+        /// <summary>
+        /// Wraps Webex API's CreateMessageAsync method.
+        /// </summary>
+        /// <param name="recipient">Target id of the message.</param>
+        /// <param name="text">Text of the message.</param>
+        /// <param name="files">List of files attached to the message.</param>
+        /// <param name="messageType">Type of message. It can be Text or Markdown.</param>
+        /// <param name="target">Target for the message.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
+        /// <returns>The created message id.</returns>
+        public virtual async Task<string> CreateMessageAsync(string recipient, string text, IList<Uri> files = null, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
+        {
+            var webexResponse = await _api.CreateMessageAsync(recipient, text, files, target, messageType, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return webexResponse.Data.Id;
         }
@@ -212,12 +229,14 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         /// <summary>
         /// Creates a message with attachments.
         /// </summary>
-        /// <param name="toPersonOrEmail">Id or email of message recipient.</param>
+        /// <param name="recipient">PersonId, email or roomId of the message.</param>
         /// <param name="text">Text of the message.</param>
         /// <param name="attachments">List of attachments attached to the message.</param>
+        /// <param name="messageType">Type of the message. It can be Text or Markdown.</param>
+        /// <param name="target">Target for the message.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The created message id.</returns>
-        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string toPersonOrEmail, string text, IList<Attachment> attachments, CancellationToken cancellationToken)
+        public virtual async Task<string> CreateMessageWithAttachmentsAsync(string recipient, string text, IList<Attachment> attachments, MessageTextType messageType = MessageTextType.Text, MessageTarget target = MessageTarget.PersonId, CancellationToken cancellationToken = default)
         {
             Message result;
 
@@ -230,7 +249,8 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
 
             var request = new WebexMessageRequest
             {
-                ToPersonId = toPersonOrEmail,
+                RoomId = target == MessageTarget.SpaceId ? recipient : null,
+                ToPersonId = target == MessageTarget.SpaceId ? null : recipient,
                 Text = text ?? string.Empty,
                 Attachments = attachmentsContent.Count > 0 ? attachmentsContent : null,
             };

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 ChannelId = "webex",
                 Conversation = new ConversationAccount
                 {
-                    Id = payload.MessageData.SpaceId,
+                    Id = payload.SpaceMembershipData.SpaceId,
                 },
                 From = new ChannelAccount
                 {

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Bots/EchoBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Bots/EchoBot.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+using Thrzn41.WebexTeams.Version1;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Bots
 {
@@ -42,7 +43,8 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Bots
 
         protected override async Task OnEventActivityAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
         {
-            Activity activity = null;
+            Activity activity;
+
             if (turnContext.Activity.Value != null)
             {
                 var inputs = (Dictionary<string, string>)turnContext.Activity.Value;
@@ -50,6 +52,17 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.TestBot.Bots
 
                 activity = MessageFactory.Text($"How are you doing {name}?");
                 await turnContext.SendActivityAsync(activity, cancellationToken);
+            }
+
+            if (turnContext.Activity.TryGetChannelData(out WebhookEventData eventData))
+            {
+                if (eventData.ResourceName == "memberships" && eventData.EventTypeName == "created")
+                {
+                    activity = MessageFactory.Text("Hello! I'm the WebexTestBot, nice to meet you");
+                    activity.Conversation = new ConversationAccount { Id = eventData.SpaceData.Id };
+
+                    await turnContext.SendActivityAsync(activity, cancellationToken);
+                }
             }
         }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -251,7 +250,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Uri>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Uri>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             // Create a new Webex Adapter with the mocked classes and get the responses
             var webexAdapter = new WebexAdapter(webexApi.Object);
@@ -275,7 +274,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Uri>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Uri>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             // Create a new Webex Adapter with the mocked classes and get the responses
             var webexAdapter = new WebexAdapter(webexApi.Object);
@@ -302,7 +301,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         {
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Attachment>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Attachment>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             var webexAdapter = new WebexAdapter(webexApi.Object);
 
@@ -327,7 +326,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         {
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Attachment>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageWithAttachmentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Attachment>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             var webexAdapter = new WebexAdapter(webexApi.Object);
 
@@ -349,7 +348,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
-            webexApi.Setup(x => x.CreateMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Uri>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
+            webexApi.Setup(x => x.CreateMessageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<Uri>>(), It.IsAny<MessageTextType>(), It.IsAny<MessageTarget>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResponseId));
 
             // Create a new Webex Adapter with the mocked classes and get the responses
             var webexAdapter = new WebexAdapter(webexApi.Object);


### PR DESCRIPTION
## Description
Add support for messages sent from a room and reply to them in the room instead of in a private conversation.

## Details
- Update **WebexAdapter** class to handle the roomId and the new method's signature on _CreateMessageAsync_ method
- Update **WebexClientWrapper** class to call the _CreateMessageAsync_ instead of the _CreateDirectMessageAsync_ method.
- Update **WebexHelper** class to get the SpaceId from the message.
- Update the **WebexTestBot** to handle the membership event and send a message when the bot is added to a room.
- Update unit tests for the new method signature.

### Testing
![WebexRoomMessage](https://user-images.githubusercontent.com/44245136/70562899-09059480-1b6c-11ea-8477-b64e66548e6c.gif)

