### PR TITLE
Delete compiler directive from functional tests YAML build

### DIFF
--- a/build/yaml/botbuilder-dotnet-functional-tests-setup.yml
+++ b/build/yaml/botbuilder-dotnet-functional-tests-setup.yml
@@ -8,7 +8,7 @@ variables:
   BuildConfiguration: Debug-Windows
   BuildPlatform: any cpu
   IsBuildServer: true # Consumed by projects in Microsoft.Bot.Builder.sln.
-  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false -p:DefineConstants="FUNCTIONALTESTS"
+  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   Parameters.solution: Microsoft.Bot.Builder.sln
   PreviewPackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
   ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.


### PR DESCRIPTION
Delete no-longer-used compiler directive from the functional tests YAML build. Specifically, delete msbuild argument  -p:DefineConstants="FUNCTIONALTESTS"

This is build cleanup from PR #3124.