### PR TITLE
Additional Language Support for Confirm/Choice Prompts

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -14,6 +14,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
     {
         private static readonly string[] SupportedLocales = GetSupportedCultures().Select(c => c.Locale).ToArray();
 
+        public static PromptCultureModel Bulgarian =>
+            new PromptCultureModel
+            {
+                InlineOr = " или ",
+                InlineOrMore = ", или ",
+                Locale = Culture.Bulgarian,
+                NoInLanguage = "Не",
+                Separator = ", ",
+                YesInLanguage = "да",
+            };
+
         public static PromptCultureModel Chinese =>
             new PromptCultureModel
             {
@@ -69,6 +80,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Ja",
             };
 
+        public static PromptCultureModel Hindi =>
+            new PromptCultureModel
+            {
+                InlineOr = " या ",
+                InlineOrMore = ", या ",
+                Locale = Culture.Hindi,
+                NoInLanguage = "नहीं",
+                Separator = ", ",
+                YesInLanguage = "हां",
+            };
+
+        public static PromptCultureModel Italian =>
+            new PromptCultureModel
+            {
+                InlineOr = " o ",
+                InlineOrMore = " o ",
+                Locale = Culture.Italian,
+                NoInLanguage = "No",
+                Separator = ", ",
+                YesInLanguage = "Si",
+            };
+
         public static PromptCultureModel Japanese =>
             new PromptCultureModel
             {
@@ -78,6 +111,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 NoInLanguage = "いいえ",
                 Separator = "、 ",
                 YesInLanguage = "はい",
+            };
+
+        public static PromptCultureModel Korean =>
+            new PromptCultureModel
+            {
+                InlineOr = " 또는 ",
+                InlineOrMore = " 또는 ",
+                Locale = Culture.Korean,
+                NoInLanguage = "아니",
+                Separator = ", ",
+                YesInLanguage = "예",
             };
 
         public static PromptCultureModel Portuguese =>
@@ -100,6 +144,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 NoInLanguage = "No",
                 Separator = ", ",
                 YesInLanguage = "Sí",
+            };
+
+        public static PromptCultureModel Swedish =>
+            new PromptCultureModel
+            {
+                InlineOr = " eller ",
+                InlineOrMore = " eller ",
+                Locale = Culture.Swedish,
+                NoInLanguage = "Nej",
+                Separator = ", ",
+                YesInLanguage = "Ja",
+            };
+
+        public static PromptCultureModel Turkish =>
+            new PromptCultureModel
+            {
+                InlineOr = " veya ",
+                InlineOrMore = " veya ",
+                Locale = Culture.Turkish,
+                NoInLanguage = "Hayır",
+                Separator = ", ",
+                YesInLanguage = "Evet",
             };
 
         /// <summary>
@@ -143,14 +209,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
 
         public static PromptCultureModel[] GetSupportedCultures() => new PromptCultureModel[]
         {
+            Bulgarian,
             Chinese,
             Dutch,
             English,
             French,
             German,
+            Hindi,
+            Italian,
             Japanese,
+            Korean,
             Portuguese,
             Spanish,
+            Swedish,
+            Turkish
         };
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -882,14 +882,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             var testLocales = new TestLocale[]
             {
+                new TestLocale(Bulgarian),
                 new TestLocale(Chinese),
                 new TestLocale(Dutch),
                 new TestLocale(English),
                 new TestLocale(French),
                 new TestLocale(German),
+                new TestLocale(Hindi),
+                new TestLocale(Italian),
                 new TestLocale(Japanese),
+                new TestLocale(Korean),
                 new TestLocale(Portuguese),
                 new TestLocale(Spanish),
+                new TestLocale(Swedish),
+                new TestLocale(Turkish),
             };
 
             foreach (var locale in testLocales)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptLocTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ConfirmPromptLocTests.cs
@@ -19,22 +19,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public TestContext TestContext { get; set; }
 
         [TestMethod]
+        [DataRow(null, Culture.Bulgarian, "(1) да или (2) Не", "да", "1")]
+        [DataRow(null, Culture.Bulgarian, "(1) да или (2) Не", "Не", "0")]
+        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "是的", "1")]
+        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "不", "0")]
         [DataRow(null, Culture.Dutch, "(1) Ja of (2) Nee", "Ja", "1")]
         [DataRow(null, Culture.Dutch, "(1) Ja of (2) Nee", "Nee", "0")]
-        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "Sí", "1")]
-        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "No", "0")]
         [DataRow(null, Culture.English, "(1) Yes or (2) No", "Yes", "1")]
         [DataRow(null, Culture.English, "(1) Yes or (2) No", "No", "0")]
         [DataRow(null, Culture.French, "(1) Oui ou (2) Non", "Oui", "1")]
         [DataRow(null, Culture.French, "(1) Oui ou (2) Non", "Non", "0")]
         [DataRow(null, Culture.German, "(1) Ja oder (2) Nein", "Ja", "1")]
         [DataRow(null, Culture.German, "(1) Ja oder (2) Nein", "Nein", "0")]
+        [DataRow(null, Culture.Hindi, "(1) हां या (2) नहीं", "हां", "1")]
+        [DataRow(null, Culture.Hindi, "(1) हां या (2) नहीं", "नहीं", "0")]
+        [DataRow(null, Culture.Italian, "(1) Si o (2) No", "Si", "1")]
+        [DataRow(null, Culture.Italian, "(1) Si o (2) No", "No", "0")]
         [DataRow(null, Culture.Japanese, "(1) はい または (2) いいえ", "はい", "1")]
         [DataRow(null, Culture.Japanese, "(1) はい または (2) いいえ", "いいえ", "0")]
+        [DataRow(null, Culture.Korean, "(1) 예 또는 (2) 아니", "예", "1")]
+        [DataRow(null, Culture.Korean, "(1) 예 또는 (2) 아니", "아니", "0")]
         [DataRow(null, Culture.Portuguese, "(1) Sim ou (2) Não", "Sim", "1")]
         [DataRow(null, Culture.Portuguese, "(1) Sim ou (2) Não", "Não", "0")]
-        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "是的", "1")]
-        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "不", "0")]
+        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "Sí", "1")]
+        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "No", "0")]
+        [DataRow(null, Culture.Swedish, "(1) Ja eller (2) Nej", "Ja", "1")]
+        [DataRow(null, Culture.Swedish, "(1) Ja eller (2) Nej", "Nej", "0")]
+        [DataRow(null, Culture.Turkish, "(1) Evet veya (2) Hayır", "Evet", "1")]
+        [DataRow(null, Culture.Turkish, "(1) Evet veya (2) Hayır", "Hayır", "0")]
         public async Task ConfirmPrompt_Activity_Locale_Default(string activityLocale, string defaultLocale, string prompt, string utterance, string expectedResponse)
         {
             await ConfirmPrompt_Locale_Impl(activityLocale, defaultLocale, prompt, utterance, expectedResponse);
@@ -50,22 +62,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        [DataRow(null, Culture.Bulgarian, "(1) да или (2) Не", "1", "1")]
+        [DataRow(null, Culture.Bulgarian, "(1) да или (2) Не", "2", "0")]
+        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "1", "1")]
+        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "2", "0")]
         [DataRow(null, Culture.Dutch, "(1) Ja of (2) Nee", "1", "1")]
         [DataRow(null, Culture.Dutch, "(1) Ja of (2) Nee", "2", "0")]
-        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "1", "1")]
-        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "2", "0")]
         [DataRow(null, Culture.English, "(1) Yes or (2) No", "1", "1")]
         [DataRow(null, Culture.English, "(1) Yes or (2) No", "2", "0")]
         [DataRow(null, Culture.French, "(1) Oui ou (2) Non", "1", "1")]
         [DataRow(null, Culture.French, "(1) Oui ou (2) Non", "2", "0")]
         [DataRow(null, Culture.German, "(1) Ja oder (2) Nein", "1", "1")]
         [DataRow(null, Culture.German, "(1) Ja oder (2) Nein", "2", "0")]
+        [DataRow(null, Culture.Hindi, "(1) हां या (2) नहीं", "1", "1")]
+        [DataRow(null, Culture.Hindi, "(1) हां या (2) नहीं", "2", "0")]
+        [DataRow(null, Culture.Italian, "(1) Si o (2) No", "1", "1")]
+        [DataRow(null, Culture.Italian, "(1) Si o (2) No", "2", "0")]
         [DataRow(null, Culture.Japanese, "(1) はい または (2) いいえ", "1", "1")]
         [DataRow(null, Culture.Japanese, "(1) はい または (2) いいえ", "2", "0")]
+        [DataRow(null, Culture.Korean, "(1) 예 또는 (2) 아니", "1", "1")]
+        [DataRow(null, Culture.Korean, "(1) 예 또는 (2) 아니", "2", "0")]
         [DataRow(null, Culture.Portuguese, "(1) Sim ou (2) Não", "1", "1")]
         [DataRow(null, Culture.Portuguese, "(1) Sim ou (2) Não", "2", "0")]
-        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "1", "1")]
-        [DataRow(null, Culture.Chinese, "(1) 是的 要么 (2) 不", "2", "0")]
+        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "1", "1")]
+        [DataRow(null, Culture.Spanish, "(1) Sí o (2) No", "2", "0")]
+        [DataRow(null, Culture.Swedish, "(1) Ja eller (2) Nej", "1", "1")]
+        [DataRow(null, Culture.Swedish, "(1) Ja eller (2) Nej", "2", "0")]
+        [DataRow(null, Culture.Turkish, "(1) Evet veya (2) Hayır", "1", "1")]
+        [DataRow(null, Culture.Turkish, "(1) Evet veya (2) Hayır", "2", "0")]
         public async Task ConfirmPrompt_Activity_Locale_Default_Number(string activityLocale, string defaultLocale, string prompt, string utterance, string expectedResponse)
         {
             await ConfirmPrompt_Locale_Impl(activityLocale, defaultLocale, prompt, utterance, expectedResponse);
@@ -81,22 +105,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        [DataRow(Culture.Bulgarian, null, "(1) да или (2) Не", "да", "1")]
+        [DataRow(Culture.Bulgarian, null, "(1) да или (2) Не", "Не", "0")]
+        [DataRow(Culture.Chinese, null, "(1) 是的 要么 (2) 不", "是的", "1")]
+        [DataRow(Culture.Chinese, null, "(1) 是的 要么 (2) 不", "不", "0")]
         [DataRow(Culture.Dutch, null, "(1) Ja of (2) Nee", "Ja", "1")]
         [DataRow(Culture.Dutch, null, "(1) Ja of (2) Nee", "Nee", "0")]
-        [DataRow(Culture.Spanish, null, "(1) Sí o (2) No", "Sí", "1")]
-        [DataRow(Culture.Spanish, null, "(1) Sí o (2) No", "No", "0")]
         [DataRow(Culture.English, null, "(1) Yes or (2) No", "Yes", "1")]
         [DataRow(Culture.English, null, "(1) Yes or (2) No", "No", "0")]
         [DataRow(Culture.French, null, "(1) Oui ou (2) Non", "Oui", "1")]
         [DataRow(Culture.French, null, "(1) Oui ou (2) Non", "Non", "0")]
         [DataRow(Culture.German, null, "(1) Ja oder (2) Nein", "Ja", "1")]
         [DataRow(Culture.German, null, "(1) Ja oder (2) Nein", "Nein", "0")]
+        [DataRow(Culture.Hindi, null, "(1) हां या (2) नहीं", "हां", "1")]
+        [DataRow(Culture.Hindi, null, "(1) हां या (2) नहीं", "नहीं", "0")]
+        [DataRow(Culture.Italian, null, "(1) Si o (2) No", "Si", "1")]
+        [DataRow(Culture.Italian, null, "(1) Si o (2) No", "No", "0")]
         [DataRow(Culture.Japanese, null, "(1) はい または (2) いいえ", "はい", "1")]
         [DataRow(Culture.Japanese, null, "(1) はい または (2) いいえ", "いいえ", "0")]
+        [DataRow(Culture.Korean, null, "(1) 예 또는 (2) 아니", "예", "1")]
+        [DataRow(Culture.Korean, null, "(1) 예 또는 (2) 아니", "아니", "0")]
         [DataRow(Culture.Portuguese, null, "(1) Sim ou (2) Não", "Sim", "1")]
         [DataRow(Culture.Portuguese, null, "(1) Sim ou (2) Não", "Não", "0")]
-        [DataRow(Culture.Chinese, null, "(1) 是的 要么 (2) 不", "是的", "1")]
-        [DataRow(Culture.Chinese, null, "(1) 是的 要么 (2) 不", "不", "0")]
+        [DataRow(Culture.Spanish, null, "(1) Sí o (2) No", "Sí", "1")]
+        [DataRow(Culture.Spanish, null, "(1) Sí o (2) No", "No", "0")]
+        [DataRow(Culture.Swedish, null, "(1) Ja eller (2) Nej", "Ja", "1")]
+        [DataRow(Culture.Swedish, null, "(1) Ja eller (2) Nej", "Nej", "0")]
+        [DataRow(Culture.Turkish, null, "(1) Evet veya (2) Hayır", "Evet", "1")]
+        [DataRow(Culture.Turkish, null, "(1) Evet veya (2) Hayır", "Hayır", "0")]
         public async Task ConfirmPrompt_Activity_Locale_Activity(string activityLocale, string defaultLocale, string prompt, string utterance, string expectedResponse)
         {
             await ConfirmPrompt_Locale_Impl(activityLocale, defaultLocale, prompt, utterance, expectedResponse);
@@ -232,14 +268,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             var testLocales = new TestLocale[]
             {
+                new TestLocale(Bulgarian, "(1) да или (2) Не", "да", "Не"),
                 new TestLocale(Chinese, "(1) 是的 要么 (2) 不", "是的", "不"),
                 new TestLocale(Dutch, "(1) Ja of (2) Nee", "Ja", "Nee"),
                 new TestLocale(English, "(1) Yes or (2) No", "Yes", "No"),
                 new TestLocale(French, "(1) Oui ou (2) Non", "Oui", "Non"),
                 new TestLocale(German, "(1) Ja oder (2) Nein", "Ja", "Nein"),
+                new TestLocale(Hindi, "(1) हां या (2) नहीं", "हां", "नहीं"),
+                new TestLocale(Italian, "(1) Si o (2) No", "Si", "No"),
                 new TestLocale(Japanese, "(1) はい または (2) いいえ", "はい", "いいえ"),
+                new TestLocale(Korean, "(1) 예 또는 (2) 아니", "예", "아니"),
                 new TestLocale(Portuguese, "(1) Sim ou (2) Não", "Sim", "Não"),
                 new TestLocale(Spanish, "(1) Sí o (2) No", "Sí", "No"),
+                new TestLocale(Swedish, "(1) Ja eller (2) Nej", "Ja", "Nej"),
+                new TestLocale(Turkish, "(1) Evet veya (2) Hayır", "Evet", "Hayır")
             };
 
             foreach (var locale in testLocales)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptCultureModelsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptCultureModelsTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Bot.Builder.Dialogs.Prompts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.Bot.Builder.Dialogs.Prompts.PromptCultureModels;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    [TestClass]
+    [TestCategory("Prompts")]
+    [TestCategory("Prompt Culture Models Tests")]
+    public class PromptCultureModelsTests
+    {
+        [TestMethod]
+        [DynamicData(nameof(GetLocaleVariationTest), DynamicDataSourceType.Method)]
+        public void ShouldCorrectlyMapToNearesLanguage(string localeVariation, string expectedResult)
+        {
+            var result = MapToNearestLanguage(localeVariation);
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public void ShouldReturnAllSupportedCultures()
+        {
+            var expected = new PromptCultureModel[]
+            {
+                Bulgarian,
+                Chinese,
+                Dutch,
+                English,
+                French,
+                German,
+                Hindi,
+                Italian,
+                Japanese,
+                Korean,
+                Portuguese,
+                Spanish,
+                Swedish,
+                Turkish
+            };
+
+            var supportedCultures = GetSupportedCultures();
+
+            Assert.IsTrue(expected.All(expectedCulture =>
+            {
+                return supportedCultures.Any(supportedCulture => expectedCulture.Locale == supportedCulture.Locale);
+            }));
+
+            Assert.IsTrue(supportedCultures.All(supportedCulture =>
+            {
+                return expected.Any(expectedCulture => supportedCulture.Locale == expectedCulture.Locale);
+            }));
+        }
+
+        private static IEnumerable<object[]> GetLocaleVariationTest()
+        {
+            var testLocales = new TestLocale[]
+            {
+                new TestLocale(Bulgarian),
+                new TestLocale(Chinese),
+                new TestLocale(Dutch),
+                new TestLocale(English),
+                new TestLocale(French),
+                new TestLocale(German),
+                new TestLocale(Hindi),
+                new TestLocale(Italian),
+                new TestLocale(Japanese),
+                new TestLocale(Korean),
+                new TestLocale(Portuguese),
+                new TestLocale(Spanish),
+                new TestLocale(Swedish),
+                new TestLocale(Turkish)
+            };
+
+            foreach (var locale in testLocales)
+            {
+                yield return new object[] { locale.ValidLocale, locale.Culture.Locale };
+                yield return new object[] { locale.CapEnding, locale.Culture.Locale };
+                yield return new object[] { locale.TitleEnding, locale.Culture.Locale };
+                yield return new object[] { locale.CapTwoLetter, locale.Culture.Locale };
+                yield return new object[] { locale.LowerTwoLetter, locale.Culture.Locale };
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestLocale.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TestLocale.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         public string InlineOrMore => Culture.InlineOrMore;
 
-        private PromptCultureModel Culture { get; }
+        public PromptCultureModel Culture { get; }
 
         private string GetCapEnding(string validLocale)
         {


### PR DESCRIPTION
Recognizers-Text [added support for a few additional languages](https://github.com/microsoft/Recognizers-Text/blob/7b20c1bbbfdebc3a801fbc61b094706ceebd7acf/.NET/Microsoft.Recognizers.Text/Culture.cs#L25) that we don't currently support in our Confirm and Choice prompts:

* Bulgarian
* Hindi
* Italian
* Korean
* Swedish
* Turkish

This PR adds support for those, ensures they get test coverage, and also adds test coverage for `PromptCultureModels`.

*Notes:* 

* I skipped adding Arabic support because it is read Right to Left, which makes prompt support tricker.
* Recognizers-Text JS SDK currently has only added Italian, but I don't believe there's a reason our C#/Node SDKs need to have matching language support
* I'm also far from a polyglot, so most of the translations were provided by [cough]Google Translate[cough]*

# Need to Decide Before Merge

English is really the only language that uses the Oxford/Serial comma. I.e, in this sentence:

> Yes, no, or maybe

...the second comma is the Oxford/Serial comma. Most other languages would write it as:

> Yes, no or maybe

In our SDK, this is the `InlineOrMore` property:

```csharp
public static PromptCultureModel Spanish =>
    new PromptCultureModel
    {
        InlineOr = " o ",
        InlineOrMore = ", o ",
        Locale = Culture.Spanish,
        NoInLanguage = "No",
        Separator = ", ",
        YesInLanguage = "Sí",
    };
```

..without the Oxford comma, `InlineOrMore` would look the same as `InlineOr`.

The languages that I added **do not** have the Oxford comma (as appropriate). However, many of the current languages we have support for **do** use the comma in our SDK, although would likely not in real life. 

- [ ] **Should those commas be removed in the SDK, or would that possibly create backwards-compat issues?**