### PR TITLE
[Facebook Adapter] Add typing indicator support

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                 {
                     var message = FacebookHelper.ActivityToFacebook(activity);
 
-                    if (message.Message.Attachment != null)
+                    if (message.Message?.Attachment != null)
                     {
                         message.Message.Text = null;
                     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// <param name="turnContext">The TurnContext that will send the activities.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A task.</returns>
-        public static async Task SendMessage(IActivity activity, ITurnContext turnContext, CancellationToken cancellationToken)
+        public static async Task SendActivityWithTypingIndicatorAsync(IActivity activity, ITurnContext turnContext, CancellationToken cancellationToken)
         {
             var typingActivity = GenerateTypingActivity(turnContext.Activity.Conversation.Id);
             await turnContext.SendActivitiesAsync(new[] { typingActivity, activity }, cancellationToken).ConfigureAwait(false);

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
@@ -173,20 +173,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
             return attachmentsList;
         }
-
-        /// <summary>
-        /// Sends a message that will display a typing indicator as a placeholder while the message arrives.
-        /// </summary>
-        /// <param name="activity">The activity with the actual message to be sent.</param>
-        /// <param name="turnContext">The TurnContext that will send the activities.</param>
-        /// <param name="cancellationToken">A cancellation token for the task.</param>
-        /// <returns>A task.</returns>
-        public static async Task SendActivityWithTypingIndicatorAsync(IActivity activity, ITurnContext turnContext, CancellationToken cancellationToken)
-        {
-            var typingActivity = GenerateTypingActivity(turnContext.Activity.Conversation.Id);
-            await turnContext.SendActivitiesAsync(new[] { typingActivity, activity }, cancellationToken).ConfigureAwait(false);
-        }
-
+        
         /// <summary>
         /// Writes the HttpResponse.
         /// </summary>
@@ -222,11 +209,11 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         }
 
         /// <summary>
-        /// Generates a sender_action = typing_on to be sent in advance to the actual message.
+        /// Generates an activity that displays a typing indicator.
         /// </summary>
         /// <param name="recipientId">The id of the recipient of the message.</param>
-        /// <returns>An activity with sender_action = typing_on.</returns>
-        private static Activity GenerateTypingActivity(string recipientId)
+        /// <returns>An activity with sender_action equal to 'typing_on'.</returns>
+        public static Activity GenerateTypingActivity(string recipientId)
         {
             var activity = new Activity()
             {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// <summary>
         /// Gets or sets the sender action.
         /// </summary>
-        /// <value>The sender action.</value>
+        /// <value>The sender action (typing_on, typing_off, mark_seen).</value>
         [JsonProperty(PropertyName = "sender_action")]
         public string SenderAction { get; set; }
 
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// Gets or sets a value indicating whether the message was received while in Standby mode.
         /// </summary>
         /// <value>Value indicating whether the message was received while in Standby mode.</value>
-        [JsonProperty(PropertyName = "standby")]
+        [JsonIgnore]
         public bool IsStandby { get; set; }
 
         /// <summary>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                         content: attachment.Content);
 
                     activity.Attachments.Add(image);
-                    await turnContext.SendActivityAsync(activity, cancellationToken);
+                    await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
                 }
             }
             else if (turnContext.Activity.GetChannelData<FacebookMessage>().IsStandby)
@@ -103,7 +103,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                         break;
                 }
 
-                await turnContext.SendActivityAsync(activity, cancellationToken);
+                await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
             }
         }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                         content: attachment.Content);
 
                     activity.Attachments.Add(image);
-                    await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
+                    await FacebookHelper.SendActivityWithTypingIndicatorAsync(activity, turnContext, cancellationToken);
                 }
             }
             else if (turnContext.Activity.GetChannelData<FacebookMessage>().IsStandby)
@@ -103,7 +103,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                         break;
                 }
 
-                await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
+                await FacebookHelper.SendActivityWithTypingIndicatorAsync(activity, turnContext, cancellationToken);
             }
         }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Bots/PrimaryBot.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                         content: attachment.Content);
 
                     activity.Attachments.Add(image);
-                    await FacebookHelper.SendActivityWithTypingIndicatorAsync(activity, turnContext, cancellationToken);
+
+                    // Generate an activity with typing indicator, then send it along the other to display the indicator
+                    // while the attachment is retrieved
+                    var typingActivity = FacebookHelper.GenerateTypingActivity(turnContext.Activity.Conversation.Id);
+                    await turnContext.SendActivitiesAsync(new[] { typingActivity, activity }, cancellationToken).ConfigureAwait(false);
                 }
             }
             else if (turnContext.Activity.GetChannelData<FacebookMessage>().IsStandby)
@@ -53,7 +57,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
             {
                 IActivity activity;
 
-                switch (turnContext.Activity.Text)
+                var messageText = turnContext.Activity.Text.ToLowerInvariant();
+
+                switch (messageText)
                 {
                     case "button template":
                         activity = MessageFactory.Attachment(CreateTemplateAttachment(Directory.GetCurrentDirectory() + @"/Resources/ButtonTemplatePayload.json"));
@@ -64,19 +70,19 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                     case "generic template":
                         activity = MessageFactory.Attachment(CreateTemplateAttachment(Directory.GetCurrentDirectory() + @"/Resources/GenericTemplatePayload.json"));
                         break;
-                    case "Hello button":
+                    case "hello button":
                         activity = MessageFactory.Text("Hello Human!");
                         break;
-                    case "Goodbye button":
+                    case "goodbye button":
                         activity = MessageFactory.Text("Goodbye Human!");
                         break;
-                    case "Chatting":
+                    case "chatting":
                         activity = MessageFactory.Text("Hello! How can I help you?");
                         break;
                     case "handover template":
                         activity = MessageFactory.Attachment(CreateTemplateAttachment(Directory.GetCurrentDirectory() + @"/Resources/HandoverTemplatePayload.json"));
                         break;
-                    case "Handover":
+                    case "handover":
                         activity = MessageFactory.Text("Redirecting...");
                         activity.Type = ActivityTypes.Event;
                         ((IEventActivity)activity).Name = HandoverConstants.PassThreadControl;
@@ -85,7 +91,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                     case "bot template":
                         activity = MessageFactory.Attachment(CreateTemplateAttachment(Directory.GetCurrentDirectory() + @"/Resources/HandoverBotsTemplatePayload.json"));
                         break;
-                    case "SecondaryBot":
+                    case "secondaryBot":
                         activity = MessageFactory.Text("Redirecting to the secondary bot...");
                         activity.Type = ActivityTypes.Event;
 
@@ -95,15 +101,18 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots
                         //AppId
                         ((IEventActivity)activity).Value = SecondaryReceiverAppId;
                         break;
-                    case "Other Bot":
+                    case "other Bot":
                         activity = MessageFactory.Text($"Secondary bot is requesting me the thread control. Passing thread control!");
+                        break;
+                    case "display typing indicator":
+                        activity = FacebookHelper.GenerateTypingActivity(turnContext.Activity.Conversation.Id);
                         break;
                     default:
                         activity = MessageFactory.Text($"Echo: {turnContext.Activity.Text}");
                         break;
                 }
 
-                await FacebookHelper.SendActivityWithTypingIndicatorAsync(activity, turnContext, cancellationToken);
+                await turnContext.SendActivityAsync(activity, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.Bots
                         content: attachment.Content);
 
                     activity.Attachments.Add(image);
-                    await turnContext.SendActivityAsync(activity, cancellationToken);
+                    await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
                 }
             }
             else if (turnContext.Activity.GetChannelData<FacebookMessage>().IsStandby)
@@ -74,7 +74,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.Bots
                         break;
                 }
 
-                await turnContext.SendActivityAsync(activity, cancellationToken);
+                await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
             }
         }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.Bots
                         content: attachment.Content);
 
                     activity.Attachments.Add(image);
-                    await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
+                    await FacebookHelper.SendActivityWithTypingIndicatorAsync(activity, turnContext, cancellationToken);
                 }
             }
             else if (turnContext.Activity.GetChannelData<FacebookMessage>().IsStandby)
@@ -74,7 +74,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.Bots
                         break;
                 }
 
-                await FacebookHelper.SendMessage(activity, turnContext, cancellationToken);
+                await FacebookHelper.SendActivityWithTypingIndicatorAsync(activity, turnContext, cancellationToken);
             }
         }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookHelperTests.cs
@@ -42,6 +42,14 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
+        public void GenerateTypingActivityShouldReturnActivityWithTypingOn()
+        {
+            var activity = FacebookHelper.GenerateTypingActivity(string.Empty);
+            Assert.Equal("typing_on", activity.GetChannelData<FacebookMessage>().SenderAction);
+            Assert.Null(activity.GetChannelData<FacebookMessage>().Message);
+        }
+
+        [Fact]
         public void ProcessSingleMessageShouldThrowNullArgumentExceptionWithMessageNull()
         {
             Assert.Throws<ArgumentNullException>(() => { FacebookHelper.ProcessSingleMessage(null); });


### PR DESCRIPTION
## Description
The changes address the issue raised in bug [#3071](https://github.com/microsoft/botbuilder-dotnet/issues/3071) where the typing indicator is not supported in the .NET version of the adapter yet.

## Proposed changes
To display a `typing_on` [sender_action](https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions/) every time the bot prepares a message, we added the _SendMessage_ method in **FacebookHelper** which creates an extra activity with the required format for the Sender Action (note that `FacebookMessage.Message` needs to be null when Sender Actions are present) and then sends it along with the actual message activity using TurnContext [SendActivitiesAsync](https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder/TurnContext.cs#L218) method.
Sample bots have been modified accordingly, displaying typing indicators for messages, attachments, and templates.