### PR TITLE
[Draft] path resolver failure test case

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MiscTests.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [TestMethod]
+        public async Task PathResolver()
+        {
+            await TestUtils.RunTestScript();
+        }
+
+        [TestMethod]
         public async Task DialogManager_InitDialogsEnsureDependencies()
         {
             Dialog CreateDialog()

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/MiscTests/PathResolver.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/MiscTests/PathResolver.test.dialog
@@ -1,0 +1,33 @@
+﻿{
+    "$schema": "../../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "turn.recognized.entities.objs",
+                        "value": "createArray(json(\"{'name': 'n0'}\"), json(\"{'name': 'n1'}\"))"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "@{@objs.name}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserConversationUpdate"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "n0"
+        }
+    ]
+}


### PR DESCRIPTION
Should `@objs.name` be expanded to `turn.recognized.entities.objs.first().name` instead of `turn.recognized.entities.objs.name.first()`? Thanks~

Typical usage: `@geographyV2.location`