### PR TITLE
[Adaptive] Fix Number Input

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
@@ -56,13 +56,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 // Try to parse value based on type
                 var text = results[0].Resolution["value"].ToString();
 
-                if (float.TryParse(text, out var value))
+                if (int.TryParse(text, out var intValue))
                 {
-                    input = value;
+                    input = intValue;
                 }
                 else
                 {
-                    return Task.FromResult(InputState.Unrecognized);
+                    if (float.TryParse(text, out var value))
+                    {
+                        input = value;
+                    }
+                    else
+                    {
+                        return Task.FromResult(InputState.Unrecognized);
+                    }
                 }
             }
             else


### PR DESCRIPTION
Number input treat any inputs as float, if pass the following validation, the number input will convert the integer number to float, "22" -> "22.0" with length 4 which is nonintuitive.

```
{
                "$kind": "Microsoft.NumberInput",
                "property": "user.age",
                "alwaysPrompt": true,
                "prompt": "What is your age?",
                "invalidPrompt": "Please input a number.",
                "validations": [
                  "length(string(this.value)) == 2"
                ]
},
```