### PR TITLE
Add PR conditionals for publish to Github PR

### DIFF
--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -3,7 +3,7 @@
 #
 
 # "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
-name: $(Build.BuildId)
+name: $(Date:yyMMdd)-$(Build.BuildId)
 variables:
   BuildConfiguration: Release-Windows
   BuildPlatform: any cpu

--- a/build/yaml/ci-post-to-github-steps.yml
+++ b/build/yaml/ci-post-to-github-steps.yml
@@ -20,7 +20,8 @@ steps:
    # 
    # Note: The task immediately before this one may not get checked because its log may not yet be available.
    # Calls the Azure DevOps REST API.
-   
+   # Enable OAuth token access in the pipeline agent job for $(System.Accesstoken) to populate.
+
    $stringToCheckFor = '201 Created';
    
    Start-Sleep -Milliseconds 1000 # Give time for the last log to become available
@@ -35,10 +36,7 @@ steps:
    # Get the log containers for the run.
    $uri = "$collectionUri/$teamProjectId/_apis/build/builds/$buildId/logs";
    
-   $personalToken = "$(PersonalAccessToken)";
-   Write-Host '$personalToken =' $personalToken;
-   
-   $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($personalToken)"));
+   $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$(System.AccessToken)"));
    $header = @{authorization = "Basic $token"};
    
    $runLogContainers = Invoke-RestMethod "$uri" -Method Get -ContentType "application/json" -Headers $header;

--- a/build/yaml/ci-post-to-github-steps.yml
+++ b/build/yaml/ci-post-to-github-steps.yml
@@ -5,6 +5,7 @@ steps:
     downloadType: specific
     itemPattern: '**\*.txt'
     downloadPath: '$(System.ArtifactsDirectory)\ApiCompat'
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
   displayName: 'Publish Compat Results to Github'
@@ -12,14 +13,55 @@ steps:
     userToken: '$(GitHubCommentApiKey)'
     bodyFilePath: '$(System.ArtifactsDirectory)\ApiCompat'
     getSubFolders: true
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
-- task: Southworks-Pipelines-Test.github-pr-comment-multiple-files.custom-publish-comment-task.github-pr-comment-multiple-files@0
-  displayName: 'GitHub Comment Publisher -OLD'
-  inputs:
-    userToken: '$(GitHubCommentApiKey)'
-    bodyFilePath: '$(System.ArtifactsDirectory)\ApiCompat'
-    getSubFolders: true
-  enabled: false
+- powershell: |
+   # Check for string in the logs in the current fuselabs DevOps pipeline run.
+   # 
+   # Calls the Azure DevOps REST API.
+   
+   $stringToCheckFor = '201 Created';
+   
+   # Get the current build ID.
+   $buildId = "$env:BUILD_BUILDID";
+   Write-Host 'Build ID = ' $buildId;
+   
+   $personalToken = "$(PersonalAccessToken)";
+   Write-Host '$personalToken =' $personalToken;
+   
+   $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($personalToken)"));
+   $header = @{authorization = "Basic $token"};
+   
+   # Get the log containers for the run.
+   $uri = "https://fuselabs.visualstudio.com/86659c66-c9df-418a-a371-7de7aed35064/_apis/build/builds/$buildId/logs";
+   
+   $runLogContainers = Invoke-RestMethod "$uri" -Method Get -ContentType "application/json" -Headers $header;
+   
+   # Get the logs from the containers.
+   $found = $false;
+   foreach ($container in $runLogContainers.value) {
+       $container.id;
+       $uri = $container.url;
+       $uri;
+       $log = Invoke-RestMethod "$uri" -Method Get -ContentType "application/json" -Headers $header;
+       if (!$found -and $log.Contains($stringToCheckFor)) {
+           $found = $true;
+           $log;
+           Write-Host 'String [' $stringToCheckFor '] found in log' $container.id;
+       } else {
+           ($log -split '\r?\n')[0];  # Print first line
+       }
+   }
+   
+   if (!$found) {
+       Write-Host 
+       $mess =  'Publish Compat Results failed. Is there a PR associated with this build? String [' + $stringToCheckFor + '] not found in the logs';
+       throw $mess;
+   }
+   
+  displayName: 'Verify Publish Compat Results success'
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
 - script: |
    cd ..

--- a/build/yaml/ci-post-to-github-steps.yml
+++ b/build/yaml/ci-post-to-github-steps.yml
@@ -16,15 +16,24 @@ steps:
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
 - powershell: |
-   # Check for string in the logs in the current fuselabs DevOps pipeline run.
+   # Check for string in the logs in the current DevOps pipeline run.
    # 
+   # Note: The task immediately before this one may not get checked because its log may not yet be available.
    # Calls the Azure DevOps REST API.
    
    $stringToCheckFor = '201 Created';
    
+   Start-Sleep -Milliseconds 1000 # Give time for the last log to become available
+   
+   $collectionUri = "$env:SYSTEM_COLLECTIONURI";  # e.g. 'https://fuselabs.visualstudio.com'
+   $teamProjectId = "$env:SYSTEM_TEAMPROJECTID";  # e.g. '86659c66-c9df-418a-a371-7de7aed35064' = SDK_v4
+   
    # Get the current build ID.
    $buildId = "$env:BUILD_BUILDID";
    Write-Host 'Build ID = ' $buildId;
+   
+   # Get the log containers for the run.
+   $uri = "$collectionUri/$teamProjectId/_apis/build/builds/$buildId/logs";
    
    $personalToken = "$(PersonalAccessToken)";
    Write-Host '$personalToken =' $personalToken;
@@ -32,30 +41,32 @@ steps:
    $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($personalToken)"));
    $header = @{authorization = "Basic $token"};
    
-   # Get the log containers for the run.
-   $uri = "https://fuselabs.visualstudio.com/86659c66-c9df-418a-a371-7de7aed35064/_apis/build/builds/$buildId/logs";
-   
    $runLogContainers = Invoke-RestMethod "$uri" -Method Get -ContentType "application/json" -Headers $header;
    
-   # Get the logs from the containers.
+   # Get the log from each log container.
+   Write-Host 'Checking the logs:';
    $found = $false;
    foreach ($container in $runLogContainers.value) {
        $container.id;
        $uri = $container.url;
        $uri;
        $log = Invoke-RestMethod "$uri" -Method Get -ContentType "application/json" -Headers $header;
+       
+       # Search for our string.
        if (!$found -and $log.Contains($stringToCheckFor)) {
            $found = $true;
            $log;
-           Write-Host 'String [' $stringToCheckFor '] found in log' $container.id;
+           $mess = 'String "' + $stringToCheckFor + '" found in log #' + $container.id;
+           Write-Host $mess;
        } else {
-           ($log -split '\r?\n')[0];  # Print first line
+           ($log -split '\r?\n')[0] + '...';  # Print first line
        }
    }
    
+   # If not found, throw an error.
    if (!$found) {
-       Write-Host 
-       $mess =  'Publish Compat Results failed. Is there a PR associated with this build? String [' + $stringToCheckFor + '] not found in the logs';
+       Write-Host;
+       $mess =  'Publish Compat Results failed. Is there a PR associated with this build? String "' + $stringToCheckFor + '" not found in the logs';
        throw $mess;
    }
    


### PR DESCRIPTION
Also add publish-to-Github verification. 
This PR adds to the yaml CI build the same things that are already in effect in build BotBuilder-DotNet-master-CI-PR running here: https://fuselabs.visualstudio.com/SDK_v4/_build?definitionId=457&_a=summary
Examples: The added conditionals in the PR build #98101 let the publish to GitHub steps execute. In the non-PR build #98147 they skip execution. 
The verification step reads the build log searching for the result status "201 Created".
The verification compensates for the fact that the GitHub publish step always indicates "succeeded" regardless of whether the publish succeeded or failed. (Build #97889 shows that problem.) 
