### PR TITLE
Add argument "--framework netcoreapp3.0" to Create PublishedBot.zip

### DIFF
--- a/build/yaml/functional-test-setup-steps.yml
+++ b/build/yaml/functional-test-setup-steps.yml
@@ -5,7 +5,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --framework netcoreapp3.0'
     modifyOutputPath: false
 
 - task: CopyFiles@2


### PR DESCRIPTION
Fixes "error : The 'Publish' target is not supported without specifying a target framework"

(I picked 3.0 instead of 2.1 or 2.2. It seems to work in my test build, but this ought to tell for sure.)