### PR TITLE
fix include activity and enum camelcase

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionChangeType.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionChangeType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
     /// <summary>
     /// How to modify an action sequence.
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter), /*camelCase*/ true)]
     public enum ActionChangeType
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Microsoft.Bot.Expressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -47,11 +48,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public Dialog Dialog { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to have the new dialog include activity.
+        /// Gets or sets a value indicating whether to have the new dialog should process the activity.
         /// </summary>
-        /// <value>If this flag is true, then the activity is flagged to be processed by the new dialog.</value>
-        [JsonProperty("includeActivity")]
-        public bool IncludeActivity { get; set; }
+        /// <value>The default for this will be true, which means the new dialog should not look the activity.  You can set this to false to dispatch the activity to the new dialog.</value>
+        [DefaultValue(true)]
+        [JsonProperty("activityProcessed")]
+        public bool ActivityProcessed { get; set; } = true;
 
         public virtual IEnumerable<Dialog> GetDependencies()
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// Gets or sets a value indicating whether to have the new dialog include activity.
         /// </summary>
         /// <value>If this flag is true, then the activity is flagged to be processed by the new dialog.</value>
-        [JsonProperty("includeProperty")]
+        [JsonProperty("includeActivity")]
         public bool IncludeActivity { get; set; }
 
         public virtual IEnumerable<Dialog> GetDependencies()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginDialog.cs
@@ -70,11 +70,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             // use bindingOptions to bind to the bound options
             var boundOptions = BindOptions(dc, options);
 
-            if (this.IncludeActivity)
-            {
-                // reset this to false so that new dialog has opportunity to process the activity
-                dc.GetState().SetValue(TurnPath.ACTIVITYPROCESSED, false);
-            }
+            // set the activity processed state (default is true)
+            dc.GetState().SetValue(TurnPath.ACTIVITYPROCESSED, this.ActivityProcessed);
 
             // start dialog with bound options passed in as the options
             return await dc.BeginDialogAsync(dialog.Id, options: boundOptions, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditArray.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditArray.cs
@@ -10,6 +10,7 @@ using Microsoft.Bot.Expressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
@@ -64,7 +65,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             this.RegisterSourceLocation(callerPath, callerLine);
         }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(StringEnumConverter), /*camelCase*/ true)]
         public enum ArrayChangeType
         {
             /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/RepeatDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/RepeatDialog.cs
@@ -70,11 +70,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             repeatedIds.Add(targetDialogId);
             dc.GetState().SetValue(TurnPath.REPEATEDIDS, repeatedIds);
 
-            if (this.IncludeActivity)
-            {
-                // reset this to false so that new dialog has opportunity to process the activity
-                dc.GetState().SetValue(TurnPath.ACTIVITYPROCESSED, false);
-            }
+            // set the activity processed state (default is true)
+            dc.GetState().SetValue(TurnPath.ACTIVITYPROCESSED, this.ActivityProcessed);
 
             var turnResult = await dc.Parent.ReplaceDialogAsync(dc.Parent.ActiveDialog.Id, boundOptions, cancellationToken).ConfigureAwait(false);
             turnResult.ParentEnded = true;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ReplaceDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ReplaceDialog.cs
@@ -61,11 +61,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             // use bindingOptions to bind to the bound options
             var boundOptions = BindOptions(dc, options);
 
-            if (this.IncludeActivity)
-            {
-                // reset this to false so that new dialog has opportunity to process the activity
-                dc.GetState().SetValue(TurnPath.ACTIVITYPROCESSED, false);
-            }
+            // set the activity processed state (default is true)
+            dc.GetState().SetValue(TurnPath.ACTIVITYPROCESSED, this.ActivityProcessed);
 
             // replace dialog with bound options passed in as the options
             return await dc.ReplaceDialogAsync(dialog.Id, options: boundOptions, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/AttachmentInput.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
     /// <summary>
     /// Format specifier for outputs.
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter), /*camelCase*/ true)]
     public enum AttachmentOutputFormat
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/NumberInput.cs
@@ -12,23 +12,6 @@ using static Microsoft.Recognizers.Text.Culture;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 {
-    /// <summary>
-    /// What format to output the number in.
-    /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
-    public enum NumberOutputFormat
-    {
-        /// <summary>
-        /// Floating point.
-        /// </summary>
-        Float,
-
-        /// <summary>
-        /// Long.
-        /// </summary>
-        Integer
-    }
-
     public class NumberInput : InputDialog
     {
         [JsonProperty("$kind")]

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.schema
@@ -35,11 +35,11 @@
                 "title": "Options"
             }
         },
-        "includeActivity": {
+        "activityProcessed": {
             "type": "boolean",
-            "title": "Include Activity",
-            "description": "When set to true, dialog that is called can process the current activity.",
-            "default": false
+            "title": "Activity Processed",
+            "description": "When set to false, the dialog that is called can process the current activity.",
+            "default": true
         },
         "resultProperty": {
             "$role": "expression",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditActions.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditActions.schema
@@ -27,11 +27,11 @@
             "title": "Type of change",
             "description": "Type of change to apply to the current actions.",
             "enum": [
-                "InsertActions",
-                "InsertActionsBeforeTags",
-                "AppendActions",
-                "EndSequence",
-                "ReplaceSequence"
+                "insertActions",
+                "insertActionsBeforeTags",
+                "appendActions",
+                "endSequence",
+                "replaceSequence"
             ]
         },
         "actions": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.schema
@@ -19,11 +19,11 @@
             "title": "Type of change",
             "description": "Type of change to the array in memory.",
             "enum": [
-                "Push",
-                "Pop",
-                "Take",
-                "Remove",
-                "Clear"
+                "push",
+                "pop",
+                "take",
+                "remove",
+                "clear"
             ]
         },
         "disabled": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.RepeatDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.RepeatDialog.schema
@@ -27,11 +27,11 @@
                 "title": "Options"
             }
         },
-        "includeActivity": {
+        "activityProcessed": {
             "type": "boolean",
-            "title": "Include Activity",
-            "description": "When set to true, dialog that is called can process the current activity.",
-            "default": false
+            "title": "Activity Processed",
+            "description": "When set to false, the dialog that is called can process the current activity.",
+            "default": true
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.schema
@@ -35,11 +35,11 @@
                 "title": "Options"
             }
         },
-        "includeActivity": {
+        "activityProcessed": {
             "type": "boolean",
-            "title": "Include Activity",
-            "description": "When set to true, dialog that is called can process the current activity.",
-            "default": false
+            "title": "Activity Processed",
+            "description": "When set to false, the dialog that is called can process the current activity.",
+            "default": true
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                     // proposed turn state changes
                     Turn = new Dictionary<string, object>()
                     {
-                        { "recognized", recognizerResult }
                     },
                     Actions = new List<ActionState>()
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ListStyle.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ListStyle.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
     /// Controls the way that choices for a `ChoicePrompt` or yes/no options for a `ConfirmPrompt` are
     /// presented to a user.
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter), /*camelCase*/ true)]
     public enum ListStyle
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Constants/DialogPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Constants/DialogPath.cs
@@ -38,5 +38,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Last trigger event: defined in FormEvent, ask, clarifyEntity etc..
         /// </summary>
         public const string LastTriggerEvent = "dialog.lastTriggerEvent";
+
+        /// <summary>
+        /// Utility function to get just the property name without the memory scope prefix.
+        /// </summary>
+        /// <param name="property">memory scope property path.</param>
+        /// <returns>name of the property without the prefix.</returns>
+        public static string GetPropertyName(string property)
+        {
+            return property.Replace("dialog.", string.Empty);
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Constants/TurnPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Constants/TurnPath.cs
@@ -61,5 +61,15 @@
         /// This is a bool which if set means that the turncontext.activity has been consumed by some component in the system.
         /// </summary>
         public const string ACTIVITYPROCESSED = "turn.activityProcessed";
+
+        /// <summary>
+        /// Utility function to get just the property name without the memory scope prefix.
+        /// </summary>
+        /// <param name="property">memory scope property path.</param>
+        /// <returns>name of the property without the prefix.</returns>
+        public static string GetPropertyName(string property)
+        {
+            return property.Replace("turn.", string.Empty);
+        }
     }
 }

--- a/schemas/sdk.schema
+++ b/schemas/sdk.schema
@@ -1170,11 +1170,11 @@
                         "title": "Options"
                     }
                 },
-                "includeActivity": {
+                "activityProcessed": {
                     "type": "boolean",
-                    "title": "Include Activity",
-                    "description": "When set to true, dialog that is called can process the current activity.",
-                    "default": false
+                    "title": "Activity Processed",
+                    "description": "When set to false, the dialog that is called can process the current activity.",
+                    "default": true
                 },
                 "resultProperty": {
                     "$role": "expression",
@@ -8696,11 +8696,11 @@
                         "title": "Options"
                     }
                 },
-                "includeActivity": {
+                "activityProcessed": {
                     "type": "boolean",
-                    "title": "Include Activity",
-                    "description": "When set to true, dialog that is called can process the current activity.",
-                    "default": false
+                    "title": "Activity Processed",
+                    "description": "When set to false, the dialog that is called can process the current activity.",
+                    "default": true
                 }
             },
             "additionalProperties": false,
@@ -8786,11 +8786,11 @@
                         "title": "Options"
                     }
                 },
-                "includeActivity": {
+                "activityProcessed": {
                     "type": "boolean",
-                    "title": "Include Activity",
-                    "description": "When set to true, dialog that is called can process the current activity.",
-                    "default": false
+                    "title": "Activity Processed",
+                    "description": "When set to false, the dialog that is called can process the current activity.",
+                    "default": true
                 }
             },
             "additionalProperties": false,

--- a/schemas/sdk.schema
+++ b/schemas/sdk.schema
@@ -878,6 +878,15 @@
                     "title": "Id",
                     "description": "Optional id for the dialog"
                 },
+                "disabled": {
+                    "$role": "expression",
+                    "title": "Disabled",
+                    "description": "Optional condition which if true will disable this action.",
+                    "examples": [
+                        "user.age > 3"
+                    ],
+                    "type": "string"
+                },
                 "activity": {
                     "$kind": "Microsoft.IActivityTemplate",
                     "title": "Activity",
@@ -2847,11 +2856,11 @@
                     "title": "Type of change",
                     "description": "Type of change to apply to the current actions.",
                     "enum": [
-                        "InsertActions",
-                        "InsertActionsBeforeTags",
-                        "AppendActions",
-                        "EndSequence",
-                        "ReplaceSequence"
+                        "insertActions",
+                        "insertActionsBeforeTags",
+                        "appendActions",
+                        "endSequence",
+                        "replaceSequence"
                     ]
                 },
                 "actions": {
@@ -2927,11 +2936,11 @@
                     "title": "Type of change",
                     "description": "Type of change to the array in memory.",
                     "enum": [
-                        "Push",
-                        "Pop",
-                        "Take",
-                        "Remove",
-                        "Clear"
+                        "push",
+                        "pop",
+                        "take",
+                        "remove",
+                        "clear"
                     ]
                 },
                 "disabled": {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -34,6 +34,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [TestMethod]
+        public async Task Action_BeginDialogWithoutActivity()
+        {
+            await TestUtils.RunTestScript();
+        }
+
+        [TestMethod]
         public async Task Action_ChoiceInput()
         {
             await TestUtils.RunTestScript();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionScopeTests/ActionScope_Break.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionScopeTests/ActionScope_Break.test.dialog
@@ -16,37 +16,37 @@
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "1"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "2"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "3"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "4"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "5"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "6"
                     },
                     {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionScopeTests/ActionScope_Continue.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionScopeTests/ActionScope_Continue.test.dialog
@@ -16,37 +16,37 @@
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "1"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "2"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "3"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "4"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "5"
                     },
                     {
                         "$kind": "Microsoft.EditArray",
                         "itemsProperty": "dialog.todo",
-                        "changeType": "Push",
+                        "changeType": "push",
                         "value": "6"
                     },
                     {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginDialogWithoutActivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginDialogWithoutActivity.test.dialog
@@ -29,7 +29,7 @@
                 "actions": [
                     {
                         "$kind": "Microsoft.BeginDialog",
-                        "activityProcessed": false,
+                        "activityProcessed": true,
                         "dialog": {
                             "$kind": "Microsoft.AdaptiveDialog",
                             "autoEndDialog": false,
@@ -38,7 +38,11 @@
                                 "intents": [
                                     {
                                         "intent": "test",
-                                        "pattern": "test"
+                                        "pattern": ".*test.*"
+                                    },
+                                    {
+                                        "intent": "moo",
+                                        "pattern": ".*moo.*"
                                     }
                                 ]
                             },
@@ -48,8 +52,19 @@
                                     "intent": "test",
                                     "actions": [
                                         {
+                                            "$kind": "Microsoft.Test.AssertCondition",
+                                            "condition": "false",
+                                            "description": "Should not trigger"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "$kind": "Microsoft.OnIntent",
+                                    "intent": "moo",
+                                    "actions": [
+                                        {
                                             "$kind": "Microsoft.SendActivity",
-                                            "activity": "test intent"
+                                            "activity": "moo"
                                         }
                                     ]
                                 },
@@ -57,9 +72,8 @@
                                     "$kind": "Microsoft.OnUnknownIntent",
                                     "actions": [
                                         {
-                                            "$kind": "Microsoft.Test.AssertCondition",
-                                            "condition": "false",
-                                            "description": "Should not fire test intent"
+                                            "$kind": "Microsoft.SendActivity",
+                                            "activity": "inner unknown"
                                         }
                                     ]
                                 }
@@ -85,8 +99,20 @@
             "text": "test"
         },
         {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "moo"
+        },
+        {
             "$kind": "Microsoft.Test.AssertReply",
-            "text": "test intent"
+            "text": "moo"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "foo"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "inner unknown"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_EditActionReplaceSequence.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_EditActionReplaceSequence.test.dialog
@@ -52,7 +52,7 @@
                                 "prompt": "What's your name?"
                             }
                         ],
-                        "changeType": "ReplaceSequence"
+                        "changeType": "replaceSequence"
                     }
                 ]
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_EmitEvent.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_EmitEvent.test.dialog
@@ -10,7 +10,7 @@
                 "actions": [
                     {
                         "$kind": "Microsoft.BeginDialog",
-                        "includeActivity": true,
+                        "activityProcessed": false,
                         "options": {},
                         "dialog": {
                             "$kind": "Microsoft.AdaptiveDialog",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_EndDialog.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_EndDialog.test.dialog
@@ -19,7 +19,7 @@
                 "actions": [
                     {
                         "$kind": "Microsoft.BeginDialog",
-                        "includeActivity": true,
+                        "activityProcessed": false,
                         "options": {},
                         "dialog": {
                             "$kind": "Microsoft.AdaptiveDialog",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ForeachPage.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ForeachPage.test.dialog
@@ -16,37 +16,37 @@
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "1"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "2"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "3"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "4"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "5"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "6"
           },
           {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ForeachPage_Partial.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ForeachPage_Partial.test.dialog
@@ -16,31 +16,31 @@
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "1"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "2"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "3"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "4"
           },
           {
             "$kind": "Microsoft.EditArray",
             "itemsProperty": "dialog.todo",
-            "changeType": "Push",
+            "changeType": "push",
             "value": "5"
           },
           {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ReplaceDialog.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_ReplaceDialog.test.dialog
@@ -5,15 +5,6 @@
         "$kind": "Microsoft.AdaptiveDialog",
         "id": "planningTest",
         "autoEndDialog": false,
-        "recognizer": {
-            "$kind": "Microsoft.RegexRecognizer",
-            "intents": [
-                {
-                    "intent": "JokeIntent",
-                    "pattern": "joke"
-                }
-            ]
-        },
         "triggers": [
             {
                 "$kind": "Microsoft.OnBeginDialog",
@@ -28,49 +19,35 @@
                         "dialog": {
                             "$kind": "Microsoft.AdaptiveDialog",
                             "id": "AskNameDialog",
+                            "recognizer": {
+                                "$kind": "Microsoft.RegexRecognizer",
+                                "intents": [
+                                    {
+                                        "intent": "JokeIntent",
+                                        "pattern": ".*joke.*"
+                                    }
+                                ]
+                            },
                             "triggers": [
                                 {
                                     "$kind": "Microsoft.OnBeginDialog",
                                     "actions": [
                                         {
-                                            "$kind": "Microsoft.IfCondition",
-                                            "condition": "(user.name == null)",
-                                            "actions": [
-                                                {
-                                                    "$kind": "Microsoft.TextInput",
-                                                    "property": "user.name",
-                                                    "prompt": "Hello, what is your name?",
-                                                    "unrecognizedPrompt": "How should I call you?",
-                                                    "invalidPrompt": "That does not soud like a name"
-                                                }
-                                            ]
+                                            "$kind": "Microsoft.TextInput",
+                                            "property": "user.name",
+                                            "prompt": "Hello, what is your name?",
+                                            "unrecognizedPrompt": "How should I call you?",
+                                            "invalidPrompt": "That does not soud like a name"
                                         },
                                         {
                                             "$kind": "Microsoft.SendActivity",
                                             "activity": "Hello @{user.name}, nice to meet you!"
                                         }
                                     ]
-                                }
-                            ],
-                            "autoEndDialog": true,
-                            "defaultResultProperty": "dialog.result"
-                        }
-                    }
-                ]
-            },
-            {
-                "$kind": "Microsoft.OnIntent",
-                "intent": "JokeIntent",
-                "actions": [
-                    {
-                        "$kind": "Microsoft.ReplaceDialog",
-                        "options": {},
-                        "dialog": {
-                            "$kind": "Microsoft.AdaptiveDialog",
-                            "id": "TellJokeDialog",
-                            "triggers": [
+                                },
                                 {
-                                    "$kind": "Microsoft.OnUnknownIntent",
+                                    "$kind": "Microsoft.OnIntent",
+                                    "intent": "JokeIntent",
                                     "actions": [
                                         {
                                             "$kind": "Microsoft.SendActivity",
@@ -87,14 +64,21 @@
                                     ]
                                 }
                             ],
-                            "autoEndDialog": true,
-                            "defaultResultProperty": "dialog.result"
+                            "autoEndDialog": false
                         }
                     }
                 ]
+            },
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "uhoh"
+                    }
+                ]
             }
-        ],
-        "defaultResultProperty": "dialog.result"
+        ]
     },
     "script": [
         {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveTests/AdaptiveDialog_AllowInterruptionAlwaysWithFailedValidation.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveTests/AdaptiveDialog_AllowInterruptionAlwaysWithFailedValidation.test.dialog
@@ -60,7 +60,7 @@
                 ]
             }
         ],
-        "autoEndDialog": true,
+        "autoEndDialog": false,
         "defaultResultProperty": "dialog.result"
     },
     "script": [

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/04 - TextInput/TextInput.main.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/04 - TextInput/TextInput.main.dialog
@@ -23,7 +23,6 @@
                             "$kind": "Microsoft.TextInput",
                             "property": "user.name",
                             "prompt": "Hello, I'm Zoidberg. What is your name?",
-                            "outputFormat": "trim(this.value)",
                             "allowInterruptions": "true"
                         }
                     ]
@@ -40,7 +39,6 @@
                             "$kind": "Microsoft.TextInput",
                             "property": "user.name2",
                             "prompt": "Hello, I'm Zoidberg. What is your name?",
-                            "outputFormat": "trim(this.value)",
                             "allowInterruptions": "!#Cancel"
                         }
                     ]

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/04 - TextInput/TextInput.main.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/04 - TextInput/TextInput.main.dialog
@@ -23,6 +23,7 @@
                             "$kind": "Microsoft.TextInput",
                             "property": "user.name",
                             "prompt": "Hello, I'm Zoidberg. What is your name?",
+                            "outputFormat": "trim(this.value)",
                             "allowInterruptions": "true"
                         }
                     ]
@@ -39,6 +40,7 @@
                             "$kind": "Microsoft.TextInput",
                             "property": "user.name2",
                             "prompt": "Hello, I'm Zoidberg. What is your name?",
+                            "outputFormat": "trim(this.value)",
                             "allowInterruptions": "!#Cancel"
                         }
                     ]

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/CalendarBot/Controller/CalendarClearUserData.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/CalendarBot/Controller/CalendarClearUserData.dialog
@@ -28,12 +28,12 @@
         },
         {
           "$kind": "Microsoft.EditArray",
-          "changeType": "Clear",
+          "changeType": "clear",
           "itemsProperty": "user.meetings"
         },
         {
           "$kind": "Microsoft.EditArray",
-          "changeType": "Clear",
+          "changeType": "clear",
           "itemsProperty": "user.attendees"
         },
         {

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/CalendarBot/Controller/GetDisplayMeetings.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/CalendarBot/Controller/GetDisplayMeetings.dialog
@@ -8,7 +8,7 @@
         "GetMeetingsService",
         {
           "$kind": "Microsoft.EditArray",
-          "changeType": "Clear",
+          "changeType": "clear",
           "itemsProperty": "user.meetings"
         },
         // *** Translate from graph model to view model. Map the same entity from graph/google to the same attribute. ***
@@ -19,37 +19,37 @@
             // Need subarray. Hack for now.
             //{
             //  "$kind": "Microsoft.EditArray",
-            //  "changeType": "Push",
+            //  "changeType": "push",
             //  "itemsProperty": "user.meetings",
             //  "itemProperty": "user.getGraphMeetings.value[user.showIndex * user.pageSize + 0]"
             //},
             //{
             //  "$kind": "Microsoft.EditArray",
-            //  "changeType": "Push",
+            //  "changeType": "push",
             //  "itemsProperty": "user.meetings",
             //  "itemProperty": "user.getGraphMeetings.value[user.showIndex * user.pageSize + 1]"
             //},
             //{
             //  "$kind": "Microsoft.EditArray",
-            //  "changeType": "Push",
+            //  "changeType": "push",
             //  "itemsProperty": "user.meetings",
             //  "itemProperty": "user.getGraphMeetings.value[user.showIndex * user.pageSize + 2]"
             //},
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.meetings",
               "itemProperty": "user.getGraphMeetings.value[0]"
             },
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.meetings",
               "itemProperty": "user.getGraphMeetings.value[1]"
             },
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.meetings",
               "itemProperty": "user.getGraphMeetings.value[2]"
             }

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/CalendarBot/Dialog/FindContact/CalendarFindSingleContact.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/CalendarBot/Dialog/FindContact/CalendarFindSingleContact.dialog
@@ -15,7 +15,7 @@
         "GetContactService"
         //{
         //  "$kind": "Microsoft.EditArray",
-        //  "changeType": "Push",
+        //  "changeType": "push",
         //  "itemsProperty": "user.recipients",
         //  "itemProperty": "dialog.getResponse.value[0].emailAddresses[0].address"
         //}

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/EmailBot/Controller/ClearUserData.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/EmailBot/Controller/ClearUserData.dialog
@@ -29,12 +29,12 @@
     },
     {
       "$kind": "Microsoft.EditArray",
-      "changeType": "Clear",
+      "changeType": "clear",
       "itemsProperty": "user.emails"
     },
     {
       "$kind": "Microsoft.EditArray",
-      "changeType": "Clear",
+      "changeType": "clear",
       "itemsProperty": "user.recipients"
     },
     {

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/EmailBot/Controller/GetDisplayEmails.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/EmailBot/Controller/GetDisplayEmails.dialog
@@ -5,7 +5,7 @@
     "GetEmails",
     {
       "$kind": "Microsoft.EditArray",
-      "changeType": "Clear",
+      "changeType": "clear",
       "itemsProperty": "user.emails"
     },
     {
@@ -27,19 +27,19 @@
 
         //{
         //  "$kind": "Microsoft.EditArray",
-        //  "changeType": "Push",
+        //  "changeType": "push",
         //  "itemsProperty": "user.emails",
         //  "itemProperty": "user.getGraphEmails.value[user.showIndex*user.pageSize+0]"
         //},
         //{
         //  "$kind": "Microsoft.EditArray",
-        //  "changeType": "Push",
+        //  "changeType": "push",
         //  "itemsProperty": "user.emails",
         //  "itemProperty": "user.getGraphEmails.value[user.showIndex*user.pageSize+1]"
         //},
         //{
         //  "$kind": "Microsoft.EditArray",
-        //  "changeType": "Push",
+        //  "changeType": "push",
         //  "itemsProperty": "user.emails",
         //  "itemProperty": "user.getGraphEmails.value[user.showIndex*user.pageSize+2]"
         //}
@@ -50,19 +50,19 @@
           "actions": [
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.emails",
               "itemProperty": "user.getGraphEmails.value[0]"
             },
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.emails",
               "itemProperty": "user.getGraphEmails.value[1]"
             },
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.emails",
               "itemProperty": "user.getGraphEmails.value[2]"
             }
@@ -70,19 +70,19 @@
           "elseActions": [
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.emails",
               "itemProperty": "user.getGraphEmails.value[3]"
             },
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.emails",
               "itemProperty": "user.getGraphEmails.value[4]"
             },
             {
               "$kind": "Microsoft.EditArray",
-              "changeType": "Push",
+              "changeType": "push",
               "itemsProperty": "user.emails",
               "itemProperty": "user.getGraphEmails.value[5]"
             }

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoBot/AddToDo.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoBot/AddToDo.dialog
@@ -29,7 +29,7 @@
                 },
                 {
                     "$kind": "Microsoft.EditArray",
-                    "changeType": "Push",
+                    "changeType": "push",
                     "itemsProperty": "user.todos",
                     "value": "dialog.todo"
                 },

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoBot/ClearToDos.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoBot/ClearToDos.dialog
@@ -8,7 +8,7 @@
             "actions": [
                 {
                     "$kind": "Microsoft.EditArray",
-                    "changeType": "Clear",
+                    "changeType": "clear",
                     "itemsProperty": "user.todos",
                     "resultProperty": "dialog.cleared"
                 },

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoBot/DeleteToDo.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoBot/DeleteToDo.dialog
@@ -20,7 +20,7 @@
                 },
                 {
                     "$kind": "Microsoft.EditArray",
-                    "changeType": "Remove",
+                    "changeType": "remove",
                     "itemsProperty": "user.todos",
                     "value": "dialog.todo",
                     "resultProperty": "dialog.removed"

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoLuisBot/ToDoLuisBot.AddItem.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoLuisBot/ToDoLuisBot.AddItem.dialog
@@ -107,7 +107,7 @@
                 },
                 {
                     "$kind": "Microsoft.EditArray",
-                    "changeType": "Push",
+                    "changeType": "push",
                     "itemsProperty": "user.lists[dialog.listName]",
                     "value": "dialog.item"
                 },

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoLuisBot/ToDoLuisBot.DeleteItem.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/ToDoLuisBot/ToDoLuisBot.DeleteItem.dialog
@@ -107,7 +107,7 @@
                 },
                 {
                     "$kind": "Microsoft.EditArray",
-                    "changeType": "Remove",
+                    "changeType": "remove",
                     "itemsProperty": "user.lists[dialog.listName]",
                     "value": "dialog.item"
                 },


### PR DESCRIPTION
fix #3220 
fix #3228 
* rename IncludeActivity => activityProcessed with default value of true, and dialog actions to always set TurnPath.ACTIVITYPROCESSED when passing focus to another dialog
* fixed unit tests around ActivityProcessed behavior
* added appropriate attributes and updated .schema and dialog files for enums
