### PR TITLE
Change to "--framework netcoreapp2.1"

### DIFF
--- a/build/yaml/functional-test-setup-steps.yml
+++ b/build/yaml/functional-test-setup-steps.yml
@@ -5,7 +5,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --framework netcoreapp3.0'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --framework netcoreapp2.1'
     modifyOutputPath: false
 
 - task: CopyFiles@2

--- a/build/yaml/functional-test-setup2-steps.yml
+++ b/build/yaml/functional-test-setup2-steps.yml
@@ -8,7 +8,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --configuration Release --framework netcoreapp3.0'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --configuration Release --framework netcoreapp2.1'
 
 - task: CopyFiles@2
   displayName: 'Copy root Directory.Build.props to staging'


### PR DESCRIPTION
Turns out netcoreapp3.0 creates a test bot that does not work. Specifying 2.1 does work.