### PR TITLE
Make Ask.ExpectedProperties support expressions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -168,6 +168,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new InterfaceConverter<EntityRecognizer>(refResolver, sourceMap, paths);
             yield return new InterfaceConverter<ITriggerSelector>(refResolver, sourceMap, paths);
             yield return new ExpressionPropertyConverter<ChoiceSet>();
+            yield return new ExpressionPropertyConverter<ExpressionProperty<List<string>>>();
             yield return new ActivityTemplateConverter();
             yield return new JObjectConverter(refResolver);
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/Ask.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/Ask.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
@@ -28,7 +29,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonConstructor]
         public Ask(
             string text = null,
-            List<string> expectedProperties = null,
+            ExpressionProperty<List<string>> expectedProperties = null,
             [CallerFilePath] string callerPath = "",
             [CallerLineNumber] int callerLine = 0)
         : base(text, callerPath, callerLine)
@@ -44,7 +45,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// Properties expected to be filled by response.
         /// </value>
         [JsonProperty("expectedProperties")]
-        public List<string> ExpectedProperties { get; set; } = new List<string>();
+        public ExpressionProperty<List<string>> ExpectedProperties { get; set; }
 
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
@@ -56,10 +57,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             dc.GetState().TryGetValue(TurnPath.DIALOGEVENT, out DialogEvent trigger);
 
+            var expected = ExpectedProperties.GetValue(dc.GetState());
             if (ExpectedProperties != null
                 && dc.GetState().TryGetValue(DialogPath.ExpectedProperties, out List<string> lastExpectedProperties)
-                && !ExpectedProperties.Any(prop => !lastExpectedProperties.Contains(prop))
-                && !lastExpectedProperties.Any(prop => !ExpectedProperties.Contains(prop))
+                && !expected.Any(prop => !lastExpectedProperties.Contains(prop))
+                && !lastExpectedProperties.Any(prop => !expected.Contains(prop))
                 && dc.GetState().TryGetValue(DialogPath.LastTriggerEvent, out DialogEvent lastTrigger)
                 && lastTrigger.Name.Equals(trigger.Name))
             {
@@ -72,7 +74,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             dc.GetState().SetValue(DialogPath.Retries, retries);
             dc.GetState().SetValue(DialogPath.LastTriggerEvent, trigger);
-            dc.GetState().SetValue(DialogPath.ExpectedProperties, ExpectedProperties);            
+            dc.GetState().SetValue(DialogPath.ExpectedProperties, expected);            
             var result = await base.BeginDialogAsync(dc, options, cancellationToken).ConfigureAwait(false);
             result.Status = DialogTurnStatus.CompleteAndWait;
             return result;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.schema
@@ -11,12 +11,19 @@
         {
             "properties": {
                 "expectedProperties": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "title": "Expected Properties",
-                    "description": "Properties expected to be filled by entities from the user"
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "title": "Expected Properties",
+                            "description": "Properties expected to be filled by entities from the user"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/ExpressionProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/ExpressionProperty.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative
                 return (T)result;
             }
 
-            return JObject.FromObject(result).ToObject<T>();
+            return JToken.FromObject(result).ToObject<T>();
         }
     }
 }

--- a/schemas/sdk.schema
+++ b/schemas/sdk.schema
@@ -894,12 +894,21 @@
                     "$ref": "#/definitions/Microsoft.IActivityTemplate"
                 },
                 "expectedProperties": {
-                    "type": "array",
-                    "title": "Expected Properties",
-                    "description": "Properties expected to be filled by entities from the user",
-                    "items": {
-                        "type": "string"
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "title": "string"
+                            },
+                            "title": "array",
+                            "description": "Properties expected to be filled by entities from the user"
+                        },
+                        {
+                            "type": "string",
+                            "title": "string"
+                        }
+                    ]
                 }
             },
             "additionalProperties": false,
@@ -4027,9 +4036,9 @@
                 },
                 "headers": {
                     "type": "object",
-                    "additionalProperties": true,
                     "title": "Headers",
-                    "description": "One or more headers to include in the request (supports data binding)."
+                    "description": "One or more headers to include in the request (supports data binding).",
+                    "additionalProperties": true
                 },
                 "responseType": {
                     "type": "string",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/GeneratorTests/sandwich/sandwich-BreadAsk.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/GeneratorTests/sandwich/sandwich-BreadAsk.dialog
@@ -8,9 +8,7 @@
         {
             "$kind": "Microsoft.Ask",
             "activity": "@{AskBread()}",
-            "expectedProperties": [
-                "Bread"
-            ]
+            "expectedProperties": "createArray('Bread')"
         }
     ]
 }


### PR DESCRIPTION
This allows computing expected properties with an expression or using an explicit list of property names.