### PR TITLE
Initialize security context for Skill ContinueConversationAsync calls

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1219,8 +1219,13 @@ namespace Microsoft.Bot.Builder
                 await CreateConnectorClientAsync(serviceUrl, connectorClaimsIdentity, cancellationToken).ConfigureAwait(false);
             }
 
-            // Add the channel service URL to the trusted services list so we can send messages back to the channel.
-            AppCredentials.TrustServiceUrl(serviceUrl);
+            if (SkillValidation.IsSkillClaim(claimsIdentity.Claims))
+            {
+                // Add the channel service URL to the trusted services list so we can send messages back.
+                // the service URL for skills is trusted because it is applied by the SkillHandler based on the original request
+                // received by the root bot
+                AppCredentials.TrustServiceUrl(serviceUrl);
+            }
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1207,8 +1207,9 @@ namespace Microsoft.Bot.Builder
         {
             // Ensure we have a default ConnectorClient and MSAppCredentials instance for the audience.
             var audience = claimsIdentity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim)?.Value;
-            if (string.IsNullOrWhiteSpace(audience) || !AuthenticationConstants.ToBotFromChannelTokenIssuer.Equals(audience, StringComparison.InvariantCulture))
+            if (string.IsNullOrWhiteSpace(audience) || !AuthenticationConstants.ToBotFromChannelTokenIssuer.Equals(audience, StringComparison.InvariantCultureIgnoreCase))
             {
+                // We create a default connector for audiences that are not coming from the default https://api.botframework.com audience.
                 var defaultConnectorClaims = new List<Claim> { new Claim(AuthenticationConstants.AudienceClaim, audience) };
                 var connectorClaimsIdentity = new ClaimsIdentity(defaultConnectorClaims);
                 await CreateConnectorClientAsync(serviceUrl, connectorClaimsIdentity, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1210,12 +1210,16 @@ namespace Microsoft.Bot.Builder
             if (string.IsNullOrWhiteSpace(audience) || !AuthenticationConstants.ToBotFromChannelTokenIssuer.Equals(audience, StringComparison.InvariantCultureIgnoreCase))
             {
                 // We create a default connector for audiences that are not coming from the default https://api.botframework.com audience.
+                // We create a default claim that contains only the desired audience.
                 var defaultConnectorClaims = new List<Claim> { new Claim(AuthenticationConstants.AudienceClaim, audience) };
                 var connectorClaimsIdentity = new ClaimsIdentity(defaultConnectorClaims);
+                
+                // The CreateConnectorClientAsync will create a ConnectorClient with an associated MicrosoftAppId for that claim and will
+                // initialize the dictionaries that contain the cache instances.
                 await CreateConnectorClientAsync(serviceUrl, connectorClaimsIdentity, cancellationToken).ConfigureAwait(false);
             }
 
-            // Add the channel service URL to the trusted services list so we can send messages back
+            // Add the channel service URL to the trusted services list so we can send messages back to the channel.
             AppCredentials.TrustServiceUrl(serviceUrl);
         }
 


### PR DESCRIPTION
Relates to #3245

Adds code to initialize _appCredentialMap and _connectorClients cache with default instances during  ContinueConversationAsync calls.

This PR also adds the serviceUrl of the reference activity to the AppCredentials.TrustServiceUrl list.

This is needed because these in memory objects are not initialized unless the channel invokes the bot first. In some proactive scenarios and skills, the server may not have been initialized and this cases a 401 when the bot tries to respond to the channel. 