### PR TITLE
[Facebook Adapters] Add Facebook functional test

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.FunctionalTests
+{
+    [TestClass]
+    [TestCategory("FunctionalTests")]
+    public class FacebookChatTests
+    {
+        private string _appSecret;
+        private string _accessToken;
+        private string _botEndpoint;
+        private string _senderId;
+
+        [TestMethod]
+        public async Task SendAndReceiveFacebookMessageShouldSucceed()
+        {
+            GetEnvironmentVars();
+            string echoGuid = Guid.NewGuid().ToString();
+            await SendMessageAsync(echoGuid);
+            string response = await ReceiveMessageAsync();
+
+            Assert.AreEqual($"Echo: {echoGuid}", response);
+        }
+
+        private async Task SendMessageAsync(string echoGuid)
+        {
+            string bodyMessage = CreateBodyMessage(echoGuid);
+            string hubSignature = CreateHubSignature(bodyMessage);
+            var client = new HttpClient();
+            var request = new HttpRequestMessage();
+            request.Headers.Add("user-agent", "facebookexternalua");
+            request.Headers.Add("x-hub-signature", hubSignature);
+            request.Content = new StringContent(bodyMessage, Encoding.UTF8, "application/json");
+            request.Method = HttpMethod.Post;
+            request.RequestUri = new Uri(_botEndpoint);
+
+            await client.SendAsync(request);
+        }
+
+        private async Task<string> ReceiveMessageAsync()
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+            string retrieveMessgesUri = $"https://graph.facebook.com/v5.0/me/conversations?fields=messages{{message}}&user_id={_senderId}&access_token={_accessToken}";
+            var client = new HttpClient();
+            var request = new HttpRequestMessage();
+            request.Method = HttpMethod.Get;
+            request.RequestUri = new Uri(retrieveMessgesUri);
+            var httpResponse = await client.GetAsync(retrieveMessgesUri);
+            var response = httpResponse.Content.ReadAsStringAsync().Result;
+            JObject messages = JObject.Parse(response);
+            var result = messages.SelectToken("data[0].messages.data[0].message").ToString();
+
+            return result;
+        }
+
+        private string CreateHubSignature(string bodyMessage)
+        {
+            string hashResult;
+
+            using (var hmac = new System.Security.Cryptography.HMACSHA1(Encoding.UTF8.GetBytes(_appSecret)))
+            {
+                hmac.Initialize();
+                var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(bodyMessage));
+                var hash = $"SHA1={BitConverter.ToString(hashArray).Replace("-", string.Empty)}";
+                hashResult = hash;
+            }
+
+            return hashResult;
+        }
+
+        private string CreateBodyMessage(string echoGuid)
+        {
+            JObject sender = new JObject();
+            sender["id"] = _senderId;
+
+            JObject recipient = new JObject();
+
+            JObject message = new JObject();
+            message["text"] = echoGuid;
+
+            JObject messagingObj = new JObject();
+            messagingObj["sender"] = sender;
+            messagingObj["recipient"] = recipient;
+            messagingObj["message"] = message;
+
+            JArray messaging = new JArray();
+            messaging.Add(messagingObj);
+
+            JObject entryObj = new JObject();
+            entryObj["messaging"] = messaging;
+
+            JArray entry = new JArray();
+            entry.Add(entryObj);
+
+            JObject body = new JObject();
+            body["object"] = "page";
+            body["entry"] = entry;
+
+            return body.ToString();
+        }
+
+        private void GetEnvironmentVars()
+        {
+            if (string.IsNullOrWhiteSpace(_appSecret) || string.IsNullOrWhiteSpace(_accessToken) || string.IsNullOrWhiteSpace(_botEndpoint) || string.IsNullOrWhiteSpace(_senderId))
+            {
+                _appSecret = Environment.GetEnvironmentVariable("FacebookAppSecret");
+                if (string.IsNullOrWhiteSpace(_appSecret))
+                {
+                    throw new Exception("Environment variable 'FacebookAppSecret' not found.");
+                }
+
+                _accessToken = Environment.GetEnvironmentVariable("FacebookAccessToken");
+                if (string.IsNullOrWhiteSpace(_accessToken))
+                {
+                    throw new Exception("Environment variable 'FacebookAccessToken' not found.");
+                }
+
+                _botEndpoint = Environment.GetEnvironmentVariable("BotEndpoint");
+                if (string.IsNullOrWhiteSpace(_botEndpoint))
+                {
+                    throw new Exception("Environment variable 'BotEndpoint' not found.");
+                }
+
+                _senderId = Environment.GetEnvironmentVariable("UserId");
+                if (string.IsNullOrWhiteSpace(_senderId))
+                {
+                    throw new Exception("Environment variable 'UserId' not found.");
+                }
+            }
+        }
+    }
+}

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
@@ -34,19 +34,21 @@ namespace Microsoft.Bot.Builder.FunctionalTests
         }
 
         private async Task SendMessageAsync(string echoGuid)
-        {
-            var bodyMessage = CreateBodyMessage(echoGuid);
-            var hubSignature = CreateHubSignature(bodyMessage);
-            var client = new HttpClient();
-            var request = new HttpRequestMessage();
+        {            
+            using (var client = new HttpClient())
+            using (var request = new HttpRequestMessage())
+            {
+                var bodyMessage = CreateBodyMessage(echoGuid);
+                var hubSignature = CreateHubSignature(bodyMessage);
 
-            request.Headers.Add("user-agent", "facebookexternalua");
-            request.Headers.Add("x-hub-signature", hubSignature);
-            request.Content = new StringContent(bodyMessage, Encoding.UTF8, "application/json");
-            request.Method = HttpMethod.Post;
-            request.RequestUri = new Uri(_botEndpoint);
+                request.Headers.Add("user-agent", "facebookexternalua");
+                request.Headers.Add("x-hub-signature", hubSignature);
+                request.Content = new StringContent(bodyMessage, Encoding.UTF8, "application/json");
+                request.Method = HttpMethod.Post;
+                request.RequestUri = new Uri(_botEndpoint);
 
-            await client.SendAsync(request);
+                await client.SendAsync(request);
+            }            
         }
 
         private async Task<string> ReceiveMessageAsync()

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-new-rg.json
@@ -1,183 +1,216 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "groupLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "Specifies the location of the Resource Group."
-            }
-        },
-        "groupName": {
-            "type": "string",
-            "metadata": {
-                "description": "Specifies the name of the Resource Group."
-            }
-        },
-        "appId": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
-            }
-        },
-        "appSecret": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
-            }
-        },
-        "botId": {
-            "type": "string",
-            "metadata": {
-                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
-            }
-        },
-        "botSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
-            }
-        },
-        "newAppServicePlanName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the App Service Plan."
-            }
-        },
-        "newAppServicePlanSku": {
-            "type": "object",
-            "defaultValue": {
-                "name": "S1",
-                "tier": "Standard",
-                "size": "S1",
-                "family": "S",
-                "capacity": 1
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "groupLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location of the Resource Group."
+      }
+    },
+    "groupName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Resource Group."
+      }
+    },
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
+    },
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+      }
+    },
+    "botId": {
+      "type": "string",
+      "metadata": {
+        "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+      }
+    },
+    "botSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    },
+    "newAppServicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Service Plan."
+      }
+    },
+    "newAppServicePlanSku": {
+      "type": "object",
+      "defaultValue": {
+        "name": "S1",
+        "tier": "Standard",
+        "size": "S1",
+        "family": "S",
+        "capacity": 1
+      },
+      "metadata": {
+        "description": "The SKU of the App Service Plan. Defaults to Standard values."
+      }
+    },
+    "newAppServicePlanLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The location of the App Service Plan. Defaults to \"westus\"."
+      }
+    },
+    "newWebAppName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+      }
+    },
+    "facebookVerifyToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The verify token for the Facebook bot."
+      }
+    },
+    "facebookAppSecret": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The Facebook app secret."
+      }
+    },
+    "facebookAccessToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The Facebook page access token."
+      }
+    }
+  },
+  "variables": {
+    "appServicePlanName": "[parameters('newAppServicePlanName')]",
+    "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+    "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+    "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('groupName')]",
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2018-05-01",
+      "location": "[parameters('groupLocation')]",
+      "properties": {
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2018-05-01",
+      "name": "storageDeployment",
+      "resourceGroup": "[parameters('groupName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {},
+          "variables": {},
+          "resources": [
+            {
+              "comments": "Create a new App Service Plan",
+              "type": "Microsoft.Web/serverfarms",
+              "name": "[variables('appServicePlanName')]",
+              "apiVersion": "2018-02-01",
+              "location": "[variables('resourcesLocation')]",
+              "sku": "[parameters('newAppServicePlanSku')]",
+              "properties": {
+                "name": "[variables('appServicePlanName')]"
+              }
             },
-            "metadata": {
-                "description": "The SKU of the App Service Plan. Defaults to Standard values."
-            }
-        },
-        "newAppServicePlanLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the App Service Plan. Defaults to \"westus\"."
-            }
-        },
-        "newWebAppName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
-            }
-        }
-    },
-    "variables": {
-        "appServicePlanName": "[parameters('newAppServicePlanName')]",
-        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
-        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
-        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
-    },
-    "resources": [
-        {
-            "name": "[parameters('groupName')]",
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2018-05-01",
-            "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
-        },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2018-05-01",
-            "name": "storageDeployment",
-            "resourceGroup": "[parameters('groupName')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "comments": "Create a new App Service Plan",
-                            "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
-                            "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
-                            "properties": {
-                                "name": "[variables('appServicePlanName')]"
-                            }
-                        },
-                        {
-                            "comments": "Create a Web App using the new App Service Plan",
-                            "type": "Microsoft.Web/sites",
-                            "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "kind": "app",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
-                            ],
-                            "name": "[variables('webAppName')]",
-                            "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
-                                "siteConfig": {
-                                    "appSettings": [
-                                        {
-                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
-                                        },
-                                        {
-                                            "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
-                                        },
-                                        {
-                                            "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
-                                        }
-                                    ],
-                                    "cors": {
-                                        "allowedOrigins": [
-                                            "https://botservice.hosting.portal.azure.net",
-                                            "https://hosting.onecloud.azure-test.net/"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "apiVersion": "2017-12-01",
-                            "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
-                            "location": "global",
-                            "kind": "bot",
-                            "sku": {
-                                "name": "[parameters('botSku')]"
-                            },
-                            "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-                            ]
-                        }
-                    ],
-                    "outputs": {}
+            {
+              "comments": "Create a Web App using the new App Service Plan",
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2015-08-01",
+              "location": "[variables('resourcesLocation')]",
+              "kind": "app",
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+              ],
+              "name": "[variables('webAppName')]",
+              "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[variables('appServicePlanName')]",
+                "siteConfig": {
+                  "appSettings": [
+                    {
+                      "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                      "value": "10.14.1"
+                    },
+                    {
+                      "name": "MicrosoftAppId",
+                      "value": "[parameters('appId')]"
+                    },
+                    {
+                      "name": "MicrosoftAppPassword",
+                      "value": "[parameters('appSecret')]"
+                    },
+                    {
+                      "name": "FacebookVerifyToken",
+                      "value": "[parameters('facebookVerifyToken')]"
+                    },
+                    {
+                      "name": "FacebookAppSecret",
+                      "value": "[parameters('facebookAppSecret')]"
+                    },
+                    {
+                      "name": "FacebookAccessToken",
+                      "value": "[parameters('facebookAccessToken')]"
+                    }
+                  ],
+                  "cors": {
+                    "allowedOrigins": [
+                      "https://botservice.hosting.portal.azure.net",
+                      "https://hosting.onecloud.azure-test.net/"
+                    ]
+                  }
                 }
+              }
+            },
+            {
+              "apiVersion": "2017-12-01",
+              "type": "Microsoft.BotService/botServices",
+              "name": "[parameters('botId')]",
+              "location": "global",
+              "kind": "bot",
+              "sku": {
+                "name": "[parameters('botSku')]"
+              },
+              "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "developerAppInsightsApplicationId": null,
+                "developerAppInsightKey": null,
+                "publishingCredentials": null,
+                "storageResourceId": null
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+              ]
             }
+          ],
+          "outputs": {}
         }
-    ]
+      }
+    }
+  ]
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-preexisting-rg.json
@@ -1,154 +1,187 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "appId": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
-            }
-        },
-        "appSecret": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
-            }
-        },
-        "botId": {
-            "type": "string",
-            "metadata": {
-                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
-            }
-        },
-        "botSku": {
-            "defaultValue": "F0",
-            "type": "string",
-            "metadata": {
-                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
-            }
-        },
-        "newAppServicePlanName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The name of the new App Service Plan."
-            }
-        },
-        "newAppServicePlanSku": {
-            "type": "object",
-            "defaultValue": {
-                "name": "S1",
-                "tier": "Standard",
-                "size": "S1",
-                "family": "S",
-                "capacity": 1
-            },
-            "metadata": {
-                "description": "The SKU of the App Service Plan. Defaults to Standard values."
-            }
-        },
-        "appServicePlanLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the App Service Plan."
-            }
-        },
-        "existingAppServicePlan": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Name of the existing App Service Plan used to create the Web App for the bot."
-            }
-        },
-        "newWebAppName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
     },
-    "variables": {
-        "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
-        "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
-        "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
-        "resourcesLocation": "[parameters('appServicePlanLocation')]",
-        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
-        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings. Defaults to \"\"."
+      }
     },
-    "resources": [
-        {
-            "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
-            "type": "Microsoft.Web/serverfarms",
-            "condition": "[not(variables('useExistingAppServicePlan'))]",
-            "name": "[variables('servicePlanName')]",
-            "apiVersion": "2018-02-01",
-            "location": "[variables('resourcesLocation')]",
-            "sku": "[parameters('newAppServicePlanSku')]",
-            "properties": {
-                "name": "[variables('servicePlanName')]"
-            }
-        },
-        {
-            "comments": "Create a Web App using an App Service Plan",
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2015-08-01",
-            "location": "[variables('resourcesLocation')]",
-            "kind": "app",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
-            ],
-            "name": "[variables('webAppName')]",
-            "properties": {
-                "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
-                "siteConfig": {
-                    "appSettings": [
-                        {
-                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "10.14.1"
-                        },
-                        {
-                            "name": "MicrosoftAppId",
-                            "value": "[parameters('appId')]"
-                        },
-                        {
-                            "name": "MicrosoftAppPassword",
-                            "value": "[parameters('appSecret')]"
-                        }
-                    ],
-                    "cors": {
-                        "allowedOrigins": [
-                            "https://botservice.hosting.portal.azure.net",
-                            "https://hosting.onecloud.azure-test.net/"
-                        ]
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2017-12-01",
-            "type": "Microsoft.BotService/botServices",
-            "name": "[parameters('botId')]",
-            "location": "global",
-            "kind": "bot",
-            "sku": {
-                "name": "[parameters('botSku')]"
+    "botId": {
+      "type": "string",
+      "metadata": {
+        "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+      }
+    },
+    "botSku": {
+      "defaultValue": "F0",
+      "type": "string",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    },
+    "newAppServicePlanName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the new App Service Plan."
+      }
+    },
+    "newAppServicePlanSku": {
+      "type": "object",
+      "defaultValue": {
+        "name": "S1",
+        "tier": "Standard",
+        "size": "S1",
+        "family": "S",
+        "capacity": 1
+      },
+      "metadata": {
+        "description": "The SKU of the App Service Plan. Defaults to Standard values."
+      }
+    },
+    "appServicePlanLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The location of the App Service Plan."
+      }
+    },
+    "existingAppServicePlan": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the existing App Service Plan used to create the Web App for the bot."
+      }
+    },
+    "newWebAppName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+      }
+    },
+    "facebookVerifyToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The verify token for the Facebook bot."
+      }
+    },
+    "facebookAppSecret": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The Facebook app secret."
+      }
+    },
+    "facebookAccessToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The Facebook page access token."
+      }
+    }
+  },
+  "variables": {
+    "defaultAppServicePlanName": "[if(empty(parameters('existingAppServicePlan')), 'createNewAppServicePlan', parameters('existingAppServicePlan'))]",
+    "useExistingAppServicePlan": "[not(equals(variables('defaultAppServicePlanName'), 'createNewAppServicePlan'))]",
+    "servicePlanName": "[if(variables('useExistingAppServicePlan'), parameters('existingAppServicePlan'), parameters('newAppServicePlanName'))]",
+    "resourcesLocation": "[parameters('appServicePlanLocation')]",
+    "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+    "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+  },
+  "resources": [
+    {
+      "comments": "Create a new App Service Plan if no existing App Service Plan name was passed in.",
+      "type": "Microsoft.Web/serverfarms",
+      "condition": "[not(variables('useExistingAppServicePlan'))]",
+      "name": "[variables('servicePlanName')]",
+      "apiVersion": "2018-02-01",
+      "location": "[variables('resourcesLocation')]",
+      "sku": "[parameters('newAppServicePlanSku')]",
+      "properties": {
+        "name": "[variables('servicePlanName')]"
+      }
+    },
+    {
+      "comments": "Create a Web App using an App Service Plan",
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2015-08-01",
+      "location": "[variables('resourcesLocation')]",
+      "kind": "app",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]"
+      ],
+      "name": "[variables('webAppName')]",
+      "properties": {
+        "name": "[variables('webAppName')]",
+        "serverFarmId": "[variables('servicePlanName')]",
+        "siteConfig": {
+          "appSettings": [
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "10.14.1"
             },
-            "properties": {
-                "name": "[parameters('botId')]",
-                "displayName": "[parameters('botId')]",
-                "endpoint": "[variables('botEndpoint')]",
-                "msaAppId": "[parameters('appId')]",
-                "developerAppInsightsApplicationId": null,
-                "developerAppInsightKey": null,
-                "publishingCredentials": null,
-                "storageResourceId": null
+            {
+              "name": "MicrosoftAppId",
+              "value": "[parameters('appId')]"
             },
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+            {
+              "name": "MicrosoftAppPassword",
+              "value": "[parameters('appSecret')]"
+            },
+            {
+              "name": "FacebookVerifyToken",
+              "value": "[parameters('facebookVerifyToken')]"
+            },
+            {
+              "name": "FacebookAppSecret",
+              "value": "[parameters('facebookAppSecret')]"
+            },
+            {
+              "name": "FacebookAccessToken",
+              "value": "[parameters('facebookAccessToken')]"
+            }
+          ],
+          "cors": {
+            "allowedOrigins": [
+              "https://botservice.hosting.portal.azure.net",
+              "https://hosting.onecloud.azure-test.net/"
             ]
+          }
         }
-    ]
+      }
+    },
+    {
+      "apiVersion": "2017-12-01",
+      "type": "Microsoft.BotService/botServices",
+      "name": "[parameters('botId')]",
+      "location": "global",
+      "kind": "bot",
+      "sku": {
+        "name": "[parameters('botSku')]"
+      },
+      "properties": {
+        "name": "[parameters('botId')]",
+        "displayName": "[parameters('botId')]",
+        "endpoint": "[variables('botEndpoint')]",
+        "msaAppId": "[parameters('appId')]",
+        "developerAppInsightsApplicationId": null,
+        "developerAppInsightKey": null,
+        "publishingCredentials": null,
+        "storageResourceId": null
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
NOTE: YAML file to set up a pipeline with this functional test in PR #3262

### Description
This pull request adds a functional test for the Facebook Adapter.

### Changes made
We added the class `FacebookChatTests.cs` with the functional test for Facebook.
Also we edited the templates `template-with-new-rg.json` and `template-with-preexisting-rg.json` from the PrimaryTestBot to include the required variables to deploy it to Azure.

### Testing
![image](https://user-images.githubusercontent.com/38112957/72013638-09618000-323d-11ea-8c58-7b54c03aac6a.png)