### PR TITLE
Make Unit Tests run 3-10x faster.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -698,7 +698,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 var evt = selection.First();
                 await sequenceContext.DebuggerStepAsync(evt, dialogEvent, cancellationToken).ConfigureAwait(false);
-                Trace.TraceInformation($"Executing Dialog: {Id} Rule[{selection}]: {evt.GetType().Name}: {evt.GetExpression(new ExpressionEngine())}");
+                Trace.TraceInformation($"Executing Dialog: {Id} Rule[{evt.Id}]: {evt.GetType().Name}: {evt.GetExpression(new ExpressionEngine())}");
                 var changes = await evt.ExecuteAsync(sequenceContext).ConfigureAwait(false);
 
                 if (changes != null && changes.Any())

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/AssertReplyActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/AssertReplyActivity.cs
@@ -74,31 +74,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Actions
 
         public async override Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback)
         {
-            var timeout = Timeout;
+            var timeout = (int)this.Timeout;
 
-            //if (System.Diagnostics.Debugger.IsAttached)
-            //{
-            //    timeout = uint.MaxValue;
-            //}
-
-            var start = DateTime.UtcNow;
-            while (true)
+            if (System.Diagnostics.Debugger.IsAttached)
             {
-                var current = DateTime.UtcNow;
+                timeout = int.MaxValue;
+            }
 
-                if ((current - start).TotalMilliseconds > timeout)
-                {
-                    throw new TimeoutException($"{timeout}ms Timed out waiting for: {GetConditionDescription()}");
-                }
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter((int)timeout);
+            IActivity replyActivity = await adapter.GetNextReplyAsync(cts.Token).ConfigureAwait(false);
 
-                IActivity replyActivity = adapter.GetNextReply();
-                if (replyActivity != null)
-                {
-                    ValidateReply((Activity)replyActivity);
-                    return;
-                }
-
-                await Task.Delay(100).ConfigureAwait(false);
+            if (replyActivity != null)
+            {
+                ValidateReply((Activity)replyActivity);
+                return;
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserActivity.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -63,7 +64,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 activity.From.Name = this.User;
             }
 
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+            
             await adapter.ProcessActivityAsync(this.Activity, callback, default(CancellationToken)).ConfigureAwait(false);
+            
+            sw.Stop();
+            Trace.TraceInformation($"[Turn Ended => {sw.ElapsedMilliseconds} ms processing UserActivity: {this.Activity.Text} ]");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserConversationUpdate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserConversationUpdate.cs
@@ -64,7 +64,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 }
             }
 
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
             await adapter.ProcessActivityAsync(activity, callback, default(CancellationToken)).ConfigureAwait(false);
+
+            sw.Stop();
+            Trace.TraceInformation($"[Turn Ended => {sw.ElapsedMilliseconds} ms processing UserConversationUpdate[]");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserDelay.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserDelay.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Recognizers.Text.DataTypes.TimexExpression;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
@@ -33,6 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         public async override Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback)
         {
             await Task.Delay((int)Timespan).ConfigureAwait(false);
+            Trace.TraceInformation($"[Turn Ended => {Timespan} ms processing UserDelay[{Timespan}]");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserSays.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserSays.cs
@@ -62,7 +62,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 activity.From.Name = this.User;
             }
 
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
             await adapter.ProcessActivityAsync(activity, callback, default(CancellationToken)).ConfigureAwait(false);
+            sw.Stop();
+            Trace.TraceInformation($"[Turn Ended => {sw.ElapsedMilliseconds} ms processing UserSays: {this.Text} ]");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserTyping.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestActions/UserTyping.cs
@@ -44,7 +44,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
                 typing.From.Name = this.User;
             }
 
+            Stopwatch sw = new Stopwatch();
+            sw.Start();
+
             await adapter.ProcessActivityAsync((Activity)typing, callback, default(CancellationToken)).ConfigureAwait(false);
+
+            sw.Stop();
+
+            Trace.TraceInformation($"[Turn Ended => {sw.ElapsedMilliseconds} ms processing UserConversationUpdate[]");
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Testing/TestScript.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -40,6 +41,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
             NullValueHandling = NullValueHandling.Ignore,
             DefaultValueHandling = DefaultValueHandling.Ignore
         };
+
+        private static IConfiguration defaultConfiguration = new ConfigurationBuilder().Build();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestScript"/> class.
@@ -111,7 +114,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 
             if (adapter == null)
             {
-                TypeFactory.Configuration = configuration ?? new ConfigurationBuilder().Build();
+                TypeFactory.Configuration = configuration ?? defaultConfiguration;
                 var storage = new MemoryStorage();
                 var convoState = new ConversationState(storage);
                 var userState = new UserState(storage);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestUtils.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestUtils.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
@@ -19,6 +18,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
     [TestClass]
     public class TestUtils
     {
+        public static IConfiguration DefaultConfiguration { get; set; } = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
         public static string RootFolder { get; set; } = GetProjectPath();
 
         public static ResourceExplorer ResourceExplorer { get; set; }
@@ -44,12 +45,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         public static async Task RunTestScript(string resourceId = null, [CallerMemberName] string testName = null, IConfiguration configuration = null)
         {
             TestScript script;
-            
+
             // TODO: For now, serialize type loading because config is static and is used by LUIS type loader.
             lock (RootFolder)
             {
-                if (configuration == null || configuration != TypeFactory.Configuration)
+                if (configuration == null)
                 {
+                    configuration = DefaultConfiguration;
+                }
+
+                if (configuration != TypeFactory.Configuration)
+                {
+                    TypeFactory.Configuration = configuration;
                     DeclarativeTypeLoader.Reset();
                     TypeFactory.Configuration = configuration ?? new ConfigurationBuilder().AddInMemoryCollection().Build();
                     DeclarativeTypeLoader.AddComponent(new DialogComponentRegistration());


### PR DESCRIPTION
* adding **testAdapter.GetNextReplyAsync()** in **TestAdapter** and used proper Task semantics without polling
* Changed TestFlow and TEstScript to use the **GetNextReplyAsync()**. This gets rid of all polling in the test adapter/test script.
* cached the **LanguageGeneratorManger** per resourceExplorer as we were creating a new one EVERY test, which took 1 sec each test.
* Cleaned up output to show timings and actual rule which is executing
* Added timings for turns so we can see the amount of time it took to execute a turn when running unit tests.
**All of the unit tests compute in <3 minutes now** (where it was 10 minutes without these changes.
Adaptive Dialog tests now complete in < 2 seconds 