### PR TITLE
Update stale link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### [Click here to find out what's new with Bot Framework](https://github.com/Microsoft/botframework/blob/master/whats-new.md#whats-new)
+### [Click here to find out what's new with Bot Framework](https://docs.microsoft.com/en-us/azure/bot-service/what-is-new?view=azure-bot-service-4.0)
 
 # Bot Framework SDK v4 for .NET
 This repository contains code for the .NET version of the [Microsoft Bot Framework SDK](https://github.com/Microsoft/botbuilder). The Bot Framework SDK v4 enable developers to model conversation and build sophisticated bot applications using .NET.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ![Bot Framework for dotnet](./doc/media/BotFrameworkDotnet_header.png)
+
 ### [Click here to find out what's new with Bot Framework](https://docs.microsoft.com/en-us/azure/bot-service/what-is-new?view=azure-bot-service-4.0)
 
 # Bot Framework SDK v4 for .NET

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-# ![Bot Framework for dotnet](./doc/media/BotFrameworkDotnet_header.png)
-
 ### [Click here to find out what's new with Bot Framework](https://github.com/Microsoft/botframework/blob/master/whats-new.md#whats-new)
 
 # Bot Framework SDK v4 for .NET


### PR DESCRIPTION
Fixes #3271 

The main README has:

[# Click here to find out what's new with Bot Framework](https://github.com/Microsoft/botframework/blob/master/whats-new.md#whats-new) which points to an archived Repo. 

It was updated for Ignite in November. If we're still going to use it, feel free to disregard this PR.

I also considered linking to the Releases page of this repo, but felt it was better to just remove the link.