### PR TITLE
Update Functional Tests YAML files

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -1,14 +1,11 @@
-trigger:
-  - master
+#
+# Runs functional tests against the Facebook channel.
+#
 
-pr:
-  - master
-
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
 pool:
-  name: Hosted Windows 2019 with VS2019
-  demands:
-  - msbuild
-  - visualstudio
+  vmImage: 'windows-2019'
 
 variables:
   ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)

--- a/build/yaml/botbuilder-dotnet-ci-slacktest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slacktest.yml
@@ -46,7 +46,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot --framework netcoreapp2.1'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot'
     modifyOutputPath: false
 
 - task: AzureCLI@1

--- a/build/yaml/botbuilder-dotnet-ci-slacktest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slacktest.yml
@@ -8,37 +8,14 @@ pool:
   vmImage: 'windows-2019'
 
 variables:
+  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)
+  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   BuildConfiguration: 'debug'
   BuildPlatform: 'any cpu'
+  Parameters.solution: Microsoft.Bot.Builder.sln
 
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
-  inputs:
-    version: 2.1.x
-
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 3.1.x'
-  inputs:
-    version: 3.1.x
-
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
-
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
-  inputs:
-    restoreSolution: '$(System.DefaultWorkingDirectory)\Microsoft.Bot.Builder.sln'
-
-- task: VSBuild@1
-  displayName: 'Build solution Microsoft.Bot.Builder.sln'
-  inputs:
-    solution: Microsoft.Bot.Builder.sln
-    vsVersion: 16.0
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+- template: ci-build-steps.yml
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -26,7 +26,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\PublishedBot --framework netcoreapp2.1'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\PublishedBot'
     modifyOutputPath: false
 
 - task: AzureCLI@1

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -1,14 +1,11 @@
-trigger:
-  - master
+#
+# Runs functional tests against the Twilio channel.
+#
 
-pr:
-  - master
-
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
 pool:
-  name: Hosted Windows 2019 with VS2019
-  demands:
-  - msbuild
-  - visualstudio
+  vmImage: 'windows-2019'
 
 variables:
   ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -39,10 +39,10 @@ steps:
      call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\PublishedBot\PublishedBot.zip"
 
 - powershell: |
-   echo '##vso[task.setvariable variable=SenderNumber]$(SenderNumber)'
-   echo '##vso[task.setvariable variable=TwilioAccountSid]$(TwilioAccountSid)'
-   echo '##vso[task.setvariable variable=TwilioNumber]$(TwilioNumber)'
-   echo '##vso[task.setvariable variable=TwilioAuthToken]$(TwilioAuthToken)'
+   echo '##vso[task.setvariable variable=SENDER_NUMBER]$(SenderNumber)'
+   echo '##vso[task.setvariable variable=TWILIO_ACCOUNT_SID]$(TwilioAccountSid)'
+   echo '##vso[task.setvariable variable=TWILIO_NUMBER]$(TwilioNumber)'
+   echo '##vso[task.setvariable variable=TWILIO_AUTH_TOKEN]$(TwilioAuthToken)'
    echo '##vso[task.setvariable variable=TwilioValidationUrl]https://$(BotName).azurewebsites.net/api/messages'
   displayName: 'Set environment variables'
 

--- a/build/yaml/botbuilder-dotnet-ci-webextest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webextest.yml
@@ -43,7 +43,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot --framework netcoreapp2.1'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot'
     modifyOutputPath: false
 
 - task: AzureCLI@1

--- a/build/yaml/botbuilder-dotnet-ci-webextest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webextest.yml
@@ -1,41 +1,22 @@
+#
+# Runs functional tests against the Webex channel.
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
 pool:
   vmImage: 'windows-2019'
-  name: Azure Pipelines
-  demands:
-  - msbuild
-  - visualstudio
 
 variables:
+  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)
+  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'debug'
-  ResourceGroupName: 'testwebexbot-group-ci-build'
-  AzureBotName: 'testwebexbot-echo-ci-build'
+  Parameters.solution: Microsoft.Bot.Builder.sln
+  WebexPublicAddress: 'https://$(BotName).azurewebsites.net/api/messages'
 
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
-  inputs:
-    version: 2.1.x
-
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 3.0.x'
-  inputs:
-    version: 3.0.x
-
-- task: NuGetToolInstaller@1
-  displayName: 'Use NuGet 4.9.1'
-
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
-  inputs:
-    restoreSolution: '$(System.DefaultWorkingDirectory)\Microsoft.Bot.Builder.sln'
-
-- task: VSBuild@1
-  displayName: 'Build solution Microsoft.Bot.Builder.sln'
-  inputs:
-    solution: Microsoft.Bot.Builder.sln
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+- template: ci-build-steps.yml
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish'
@@ -49,16 +30,18 @@ steps:
 - task: AzureCLI@1
   displayName: 'Create Azure Resources'
   inputs:
-    azureSubscription: '$(AzureSubscriptionName)'
+    azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
-    inlineScript: 'call az deployment create --name "$(ResourceGroupName)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(AzureBotName)" botSku=F0 newAppServicePlanName="$(AzureBotName)" newWebAppName="$(AzureBotName)" groupName="$(ResourceGroupName)" groupLocation="westus" newAppServicePlanLocation="westus" webexPublicAddress="$(AzureBotPublicAddress)" webexAccessToken="$(WebexBotAccessToken)" webexSecret="$(WebexWebhookSecret)" webexWebhookName="$(WebexWebhookName)"'
+    inlineScript: |
+     'call az deployment create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexBotAccessToken)" webexSecret="$(WebexWebhookSecret)" webexWebhookName="$(WebexWebhookName)"'
+     'call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"'
 
 - task: AzureCLI@1
   displayName: 'Zip Deploy Bot'
   inputs:
-    azureSubscription: '$(AzureSubscriptionName)'
+    azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
-    inlineScript: 'call az webapp deployment source config-zip --resource-group "$(ResourceGroupName)" --name "$(AzureBotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"'
+    inlineScript: 'call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"'
 
 - powershell: |
    echo '##vso[task.setvariable variable=WEBEX_ROOM_ID]$(WebexRoomId)'
@@ -78,7 +61,7 @@ steps:
 - task: AzureCLI@1
   displayName: 'Delete Resources'
   inputs:
-    azureSubscription: '$(AzureSubscriptionName)'
+    azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
     inlineScript: 'call az group delete -n "$(ResourceGroupName)" --yes'
   condition: always()

--- a/build/yaml/botbuilder-dotnet-ci-webextest.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webextest.yml
@@ -33,8 +33,8 @@ steps:
     azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
     inlineScript: |
-     'call az deployment create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexBotAccessToken)" webexSecret="$(WebexWebhookSecret)" webexWebhookName="$(WebexWebhookName)"'
-     'call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"'
+     call az deployment create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexBotAccessToken)" webexSecret="$(WebexWebhookSecret)" webexWebhookName="$(WebexWebhookName)"
+     call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\PublishedBot\PublishedBot.zip"
 
 - task: AzureCLI@1
   displayName: 'Zip Deploy Bot'
@@ -63,6 +63,6 @@ steps:
   inputs:
     azureSubscription: '$(AzureSubscription)'
     scriptLocation: inlineScript
-    inlineScript: 'call az group delete -n "$(ResourceGroupName)" --yes'
+    inlineScript: 'call az group delete -n "$(BotGroup)" --yes'
   condition: always()
 

--- a/build/yaml/nightly-build-functional-test-unix.yml
+++ b/build/yaml/nightly-build-functional-test-unix.yml
@@ -13,37 +13,14 @@ pool:
   vmImage: 'windows-2019'
 
 variables:
+  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)
+  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Release'
+  Parameters.solution: Microsoft.Bot.Builder.sln
 
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
-  inputs:
-    version: 2.1.x
-
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 3.1.x'
-  inputs:
-    version: 3.1.x
-
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
-
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
-  inputs:
-    restoreSolution: '$(System.DefaultWorkingDirectory)\Microsoft.Bot.Builder.sln'
-
-- task: VSBuild@1
-  displayName: 'Build solution Microsoft.Bot.Builder.sln'
-  inputs:
-    solution: Microsoft.Bot.Builder.sln
-    vsVersion: 16.0
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+- template: ci-build-steps.yml
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'

--- a/build/yaml/nightly-build-functional-test-unix.yml
+++ b/build/yaml/nightly-build-functional-test-unix.yml
@@ -51,7 +51,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot --framework netcoreapp2.1'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot'
     zipAfterPublish: false
     modifyOutputPath: false
 

--- a/build/yaml/nightly-build-functional-test-windows.yml
+++ b/build/yaml/nightly-build-functional-test-windows.yml
@@ -51,7 +51,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --framework netcoreapp2.1'
+    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot'
     modifyOutputPath: false
 
 - task: AzureCLI@1

--- a/build/yaml/nightly-build-functional-test-windows.yml
+++ b/build/yaml/nightly-build-functional-test-windows.yml
@@ -13,37 +13,14 @@ pool:
   vmImage: 'windows-2019'
 
 variables:
+  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)
+  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   BuildPlatform: 'any cpu'
   BuildConfiguration: 'Release'
+  Parameters.solution: Microsoft.Bot.Builder.sln
 
 steps:
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
-  inputs:
-    version: 2.1.x
-
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 3.1.x'
-  inputs:
-    version: 3.1.x
-
-- task: NuGetToolInstaller@0
-  displayName: 'Use NuGet 4.9.1'
-  inputs:
-    versionSpec: 4.9.1
-
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
-  inputs:
-    restoreSolution: '$(System.DefaultWorkingDirectory)\Microsoft.Bot.Builder.sln'
-
-- task: VSBuild@1
-  displayName: 'Build solution Microsoft.Bot.Builder.sln'
-  inputs:
-    solution: Microsoft.Bot.Builder.sln
-    vsVersion: 16.0
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
+- template: ci-build-steps.yml
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'


### PR DESCRIPTION
### Description
This PR updates the functional tests YAML files to work with the Net Framework 3.1 version and to keep consistency betweem them.

### Changes made
- Twilio YAML: Change the set environment variables step to use uppercase: The use of lowercase can conflict with the use of pipeline variables set to hidden.

- Twilio, Slack, Webex, Nightly Build YAMLs: 
   - Change the target for the publish bot step: This is required when the project is multi-target and requires to specify which one to use, now we are using only 3.1.
   - Remove the build steps to replace them with the _ci-build-steps_ template.