### PR TITLE
Implement hash for App Insights session ID

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryBotIdInitializer.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -51,19 +53,30 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
                         var channelId = (string)body["channelId"];
 
                         var conversationId = string.Empty;
+                        var sessionId = string.Empty;
                         var conversation = body["conversation"];
                         if (!string.IsNullOrWhiteSpace(conversation?.ToString()))
                         {
                             conversationId = (string)conversation["id"];
+
+                            using (var sha256Hash = SHA256.Create())
+                            {
+                                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(conversationId));
+                                sessionId = Convert.ToBase64String(bytes);
+                            }
                         }
 
                         // Set the user id on the Application Insights telemetry item.
                         telemetry.Context.User.Id = channelId + userId;
 
                         // Set the session id on the Application Insights telemetry item.
-                        telemetry.Context.Session.Id = conversationId;
+                        // Hashed ID is used due to max session ID length for App Insights session Id
+                        telemetry.Context.Session.Id = sessionId;
 
                         var telemetryProperties = ((ISupportProperties)telemetry).Properties;
+
+                        // Set the conversation id
+                        telemetryProperties.Add("conversationId", conversationId);
 
                         // Set the activity id https://github.com/Microsoft/botframework-obi/blob/master/botframework-activity/botframework-activity.md#id
                         if (!telemetryProperties.ContainsKey("activityId"))

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
@@ -44,6 +46,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -63,7 +66,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
             Assert.IsTrue(telem.Properties["hello"] == "value");
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);
@@ -93,6 +97,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
             var activityID = "ACTIVITYID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
             activity.ChannelId = channelID;
@@ -130,7 +135,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var telem = sentItems[0] as EventTelemetry;
             Assert.IsTrue(telem != null);
 
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
 
             // The TelemetryInitializer honors being overridden
@@ -142,6 +147,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsFalse(telem.Properties["channelId"] == "CHANNELID");
             Assert.IsTrue(telem.Properties["activityType"] == activityTypeValue);
             Assert.IsFalse(telem.Properties["activityType"] == "message");
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);
         }
 
@@ -168,6 +174,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -187,7 +194,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
         }
 
@@ -214,6 +222,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -233,7 +242,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
         }
 
@@ -260,6 +270,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -279,7 +290,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
         }
 
@@ -415,6 +427,15 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             Assert.IsNotNull(mockHttpContextAccessor.Object.HttpContext.Items);
             Assert.IsTrue(mockHttpContextAccessor.Object.HttpContext.Items.Count == 1);
             Assert.AreEqual(mockTelemetryClient.Invocations.Count, 0);
+        }
+
+        private string GetHashedConversationId(string conversationID)
+        {
+            using (var sha256Hash = SHA256.Create())
+            {
+                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(conversationID));
+                return Convert.ToBase64String(bytes);
+            }
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.WebApi.Tests/TelemetryInitializerTests.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Web;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
@@ -43,6 +45,7 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -62,7 +65,8 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
             Assert.IsTrue(telem.Properties["hello"] == "value");
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);
@@ -90,6 +94,7 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -109,7 +114,8 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
         }
 
@@ -135,6 +141,7 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -154,7 +161,8 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
         }
 
@@ -180,6 +188,7 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             var fromID = "FROMID";
             var channelID = "CHANNELID";
             var conversationID = "CONVERSATIONID";
+            var sessionId = GetHashedConversationId(conversationID);
             var activityID = "ACTIVITYID";
             var activity = Activity.CreateMessageActivity();
             activity.From = new ChannelAccount(fromID);
@@ -199,7 +208,8 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             Assert.IsTrue(telem.Properties["activityId"] == activityID);
             Assert.IsTrue(telem.Properties["activityType"] == "message");
             Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.Session.Id == conversationID);
+            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
+            Assert.IsTrue(telem.Context.Session.Id == sessionId);
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
         }
 
@@ -246,6 +256,15 @@ namespace Microsoft.Bot.ApplicationInsights.WebApi.Tests
             Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
             Assert.IsTrue(properties.Properties["hello"] == "value");
             Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+        }
+
+        private string GetHashedConversationId(string conversationID)
+        {
+            using (var sha256Hash = SHA256.Create())
+            {
+                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(conversationID));
+                return Convert.ToBase64String(bytes);
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses this issue reported in JS https://github.com/microsoft/botbuilder-js/issues/1512

App Insights has a maximum session ID of 64 characters, but in some instances for some channels (such as reported with Teams) this may be exceeded due to conversation ID currently being used for session ID.  This PR hashes the conversation ID and sets this as the session ID.  It also adds an additional telemetry property to ensure we retain the original conversation ID within the telemetry.

The hashed ID is only used for Application Insights and the original conversation ID and activity are left untouched.