### PR TITLE
Optimize performance of LG evaluation

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemory.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// we want to make sure the global memory (the first memory passed in) can be
     /// accessible at any sub evaluation process. 
     /// </summary>
-    public class CustomizedMemory : IMemory
+    internal class CustomizedMemory : IMemory
     {
         public CustomizedMemory(object scope)
         {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemory.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// we want to make sure the global memory (the first memory passed in) can be
     /// accessible at any sub evaluation process. 
     /// </summary>
-    internal class CustomizedMemory : IMemory
+    public class CustomizedMemory : IMemory
     {
         public CustomizedMemory(object scope)
         {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public object EvaluateTemplate(string inputTemplateName, object scope)
         {
+            if (!(scope is CustomizedMemory))
+            {
+                scope = new CustomizedMemory(SimpleObjectMemory.Wrap(scope));
+            }
+            
             (var reExecute, var templateName) = ParseTemplateName(inputTemplateName);
 
             if (!TemplateMap.ContainsKey(templateName))

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
 using Microsoft.Bot.Expressions;
+using Microsoft.Bot.Expressions.Memory;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -36,6 +37,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public List<string> EvaluateTemplate(string templateName, object scope)
         {
+            if (!(scope is CustomizedMemory))
+            {
+                scope = new CustomizedMemory(SimpleObjectMemory.Wrap(scope));
+            }
+
             if (!TemplateMap.ContainsKey(templateName))
             {
                 throw new Exception(LGErrors.TemplateNotExist(templateName));

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFile.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFile.cs
@@ -128,9 +128,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             CheckErrors();
 
-            var memory = SimpleObjectMemory.Wrap(scope);
             var evaluator = new Evaluator(AllTemplates.ToList(), ExpressionEngine);
-            return evaluator.EvaluateTemplate(templateName, new CustomizedMemory(memory));
+            return evaluator.EvaluateTemplate(templateName, scope);
         }
 
         /// <summary>
@@ -144,7 +143,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             CheckErrors();
             var expander = new Expander(AllTemplates.ToList(), ExpressionEngine);
-            return expander.EvaluateTemplate(templateName, new CustomizedMemory(scope));
+            return expander.EvaluateTemplate(templateName, scope);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Expressions.Properties/Extensions.cs
+++ b/libraries/Microsoft.Bot.Expressions.Properties/Extensions.cs
@@ -40,10 +40,9 @@ namespace Microsoft.Bot.Expressions.Properties
 
             var newLgFile = LGParser.ParseText(newContent, lgFile.Id, lgFile.ImportResolver);
 
-            var memory = SimpleObjectMemory.Wrap(scope);
             var allTemplates = lgFile.AllTemplates.Union(newLgFile.AllTemplates).ToList();
             var evaluator = new Evaluator(allTemplates, lgFile.ExpressionEngine);
-            return evaluator.EvaluateTemplate(fakeTemplateId, new CustomizedMemory(memory));
+            return evaluator.EvaluateTemplate(fakeTemplateId, scope);
         }
 
         private static void CheckErrors(IList<Diagnostic> diagnostics)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/MessageGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/MessageGeneratorTests.cs
@@ -41,6 +41,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual(ActivityTypes.Message, activity.Type);
             Assert.AreEqual("text", activity.Text);
             Assert.AreEqual("text", activity.Speak);
+
+            var data = new JObject();
+            data["title"] = "titleContent";
+            data["text"] = "textContent";
+            var cardActionLgResult = GetLGFile().Evaluate("@{HerocardWithCardAction()}", data);
+            activity = ActivityFactory.CreateActivity(cardActionLgResult);
+            AssertCardActionActivity(activity);
         }
 
         [TestMethod]


### PR DESCRIPTION
close: #3297

Today, every time a free LG text like "@{welcome}" is evaluated by creating a new "anonymous template" to wrap this free text, and create a temporary LG file with the new content = original content + new anonymous template, for evaluation.

This is not performance friendly. In this pr, we just parse the additional part, so that there is no need to reparse the original content. 
