### PR TITLE
Supporting iterate string by split function

### DIFF
--- a/libraries/Microsoft.Bot.Expressions/BuiltInFunctions.cs
+++ b/libraries/Microsoft.Bot.Expressions/BuiltInFunctions.cs
@@ -2706,12 +2706,27 @@ namespace Microsoft.Bot.Expressions
                     Apply(
                         args =>
                         {
-                            string inputStr = ParseStringOrNull(args[0]);
-                            string segStr = ParseStringOrNull(args[1]);
-                            return inputStr.Split(segStr.ToCharArray());
+                            var inputStr = string.Empty;
+                            var seperator = string.Empty;
+                            if (args.Count == 1)
+                            {
+                                inputStr = ParseStringOrNull(args[0]);
+                            } 
+                            else
+                            {
+                                inputStr = ParseStringOrNull(args[0]);
+                                seperator = ParseStringOrNull(args[1]);
+                            }
+
+                            if (seperator == string.Empty)
+                            {
+                                return inputStr.Select(c => c.ToString()).ToArray();
+                            }
+
+                            return inputStr.Split(seperator.ToCharArray());
                         }, VerifyStringOrNull),
                     ReturnType.Object,
-                    (expression) => ValidateArityAndAnyType(expression, 2, 2, ReturnType.String)),
+                    (expression) => ValidateArityAndAnyType(expression, 1, 2, ReturnType.String)),
                 new ExpressionEvaluator(
                     ExpressionType.Substring,
                     Substring,

--- a/tests/Microsoft.Bot.Expressions.Tests/BadExpressionTests.cs
+++ b/tests/Microsoft.Bot.Expressions.Tests/BadExpressionTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Expressions.Tests
             Test("replaceIgnoreCase(one, 'l', 'k')"), // replaceIgnoreCase only accept string parameter
             Test("replaceIgnoreCase('hi', 1, 'k')"), // replaceIgnoreCase only accept string parameter
             Test("replaceIgnoreCase('hi', 'l', 1)"), // replaceIgnoreCase only accept string parameter
-            Test("split(hello)"), // split need two parameters
+            Test("split(hello, 'a', 'b')"), // split need one or two parameters
             Test("split(one, 'l')"), // split only accept string parameter
             Test("split(hello, 1)"), // split only accept string parameter
             Test("substring(hello, 0.5)"), // the second parameter of substring must be integer

--- a/tests/Microsoft.Bot.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Expressions.Tests/ExpressionEngineTests.cs
@@ -366,6 +366,7 @@ namespace Microsoft.Bot.Expressions.Tests
             Test("replaceIgnoreCase(nullObj, 'L', 'k')", string.Empty),
             Test("split('hello','e')", new string[] { "h", "llo" }),
             Test("split('hello','')", new string[] { "h", "e", "l", "l", "o" }),
+            Test("split('','')", new string[] { }),
             Test("split(nullObj,'e')", new string[] { string.Empty }),
             Test("split('hello')", new string[] { "h", "e", "l", "l", "o" }),
             Test("split('hello',nullObj)", new string[] { "h", "e", "l", "l", "o" }),

--- a/tests/Microsoft.Bot.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Expressions.Tests/ExpressionEngineTests.cs
@@ -366,9 +366,8 @@ namespace Microsoft.Bot.Expressions.Tests
             Test("replaceIgnoreCase(nullObj, 'L', 'k')", string.Empty),
             Test("split('hello','e')", new string[] { "h", "llo" }),
             Test("split(nullObj,'e')", new string[] { string.Empty }),
-
-            //Test("split('hello',nullObj)", new string[] { "h", "e", "l", "l", "o" }),
-            Test("split('hello',nullObj)", new string[] { "hello" }),
+            Test("split('hello')", new string[] { "h", "e", "l", "l", "o" }),
+            Test("split('hello',nullObj)", new string[] { "h", "e", "l", "l", "o" }),
             Test("substring('hello', 0, 5)", "hello"),
             Test("substring('hello', 0, 3)", "hel"),
             Test("substring('hello', 3)", "lo"),

--- a/tests/Microsoft.Bot.Expressions.Tests/ExpressionEngineTests.cs
+++ b/tests/Microsoft.Bot.Expressions.Tests/ExpressionEngineTests.cs
@@ -365,6 +365,7 @@ namespace Microsoft.Bot.Expressions.Tests
             Test("replaceIgnoreCase('hello', 'L', 'k')", "hekko"),
             Test("replaceIgnoreCase(nullObj, 'L', 'k')", string.Empty),
             Test("split('hello','e')", new string[] { "h", "llo" }),
+            Test("split('hello','')", new string[] { "h", "e", "l", "l", "o" }),
             Test("split(nullObj,'e')", new string[] { string.Empty }),
             Test("split('hello')", new string[] { "h", "e", "l", "l", "o" }),
             Test("split('hello',nullObj)", new string[] { "h", "e", "l", "l", "o" }),


### PR DESCRIPTION
closes #3279

Now split function can take a single parameter:
       split('hello'), new string[] { "h", "e", "l", "l", "o" }

Also if the seperator is a null, it will return same result as the seperator is string.Empty. If both input string and seperator are string.Empty or null, it will return a empty string array.
        split('hello',''), new string[] { "h", "e", "l", "l", "o" }
        split('',''), new string[] {  }
        split('hello',nullObj), new string[] { "h", "e", "l", "l", "o" }

If the input string is null, it will return string.Empty regardless the content of the non-empty seperator.
       split(nullObj,'e')", new string[] { string.Empty }


