### PR TITLE
Updated MicrosoftGovernmentAppCredentials to support Skills in Azure Gov

### DIFF
--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Authentication/AllowedCallersClaimsValidator.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Authentication/AllowedCallersClaimsValidator.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.BotBuilderSamples.EchoSkillBot31.Authentication
+{
+    /// <summary>
+    /// Sample claims validator that loads an allowed list from configuration if present
+    /// and checks that requests are coming from allowed parent bots.
+    /// </summary>
+    public class AllowedCallersClaimsValidator : ClaimsValidator
+    {
+        private const string ConfigKey = "AllowedCallers";
+        private readonly List<string> _allowedCallers;
+
+        public AllowedCallersClaimsValidator(IConfiguration config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            // AllowedCallers is the setting in appsettings.json file
+            // that consists of the list of parent bot ids that are allowed to access the skill
+            // to add a new parent bot simply go to the AllowedCallers and add
+            // the parent bot's microsoft app id to the list
+            var section = config.GetSection(ConfigKey);
+            var appsList = section.Get<string[]>();
+            _allowedCallers = appsList != null ? new List<string>(appsList) : null;
+        }
+
+        public override Task ValidateClaimsAsync(IList<Claim> claims)
+        {
+            // if _allowedCallers is null we allow all calls
+            if (_allowedCallers != null && SkillValidation.IsSkillClaim(claims))
+            {
+                // Check that the appId claim in the skill request is in the list of skills configured for this bot.
+                var appId = JwtTokenValidation.GetAppIdFromClaims(claims);
+                if (!_allowedCallers.Contains(appId))
+                {
+                    throw new UnauthorizedAccessException($"Received a request from a bot with an app ID of \"{appId}\". To enable requests from this caller, add the app ID to your configuration file.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Bots/EchoBot.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Bots/EchoBot.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.BotBuilderSamples.EchoSkillBot31.Bots
+{
+    public class EchoBot : ActivityHandler
+    {
+        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            if (turnContext.Activity.Text.Contains("end") || turnContext.Activity.Text.Contains("stop"))
+            {
+                // Send End of conversation at the end.
+                await turnContext.SendActivityAsync(MessageFactory.Text($"ending conversation from the skill..."), cancellationToken);
+                var endOfConversation = Activity.CreateEndOfConversationActivity();
+                endOfConversation.Code = EndOfConversationCodes.CompletedSuccessfully;
+                await turnContext.SendActivityAsync(endOfConversation, cancellationToken);
+            }
+            else
+            {
+                await turnContext.SendActivityAsync(MessageFactory.Text($"Echo (dotnet core 3.1) : {turnContext.Activity.Text}"), cancellationToken);
+                await turnContext.SendActivityAsync(MessageFactory.Text("Say \"end\" or \"stop\" and I'll end the conversation and back to the parent."), cancellationToken);
+            }
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Controllers/BotController.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Controllers/BotController.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace Microsoft.BotBuilderSamples.EchoSkillBot31.Controllers
+{
+    // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
+    // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
+    // achieved by specifying a more specific type for the bot constructor argument.
+    [Route("api/messages")]
+    [ApiController]
+    public class BotController : ControllerBase
+    {
+        private readonly IBotFrameworkHttpAdapter _adapter;
+        private readonly IBot _bot;
+
+        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        {
+            _adapter = adapter;
+            _bot = bot;
+        }
+
+        [HttpPost]
+        public async Task PostAsync()
+        {
+            await _adapter.ProcessAsync(Request, Response, _bot);
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/EchoSkillBot.csproj
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/EchoSkillBot.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <AssemblyName>Microsoft.BotBuilderSamples.EchoSkillBot31</AssemblyName>
+    <RootNamespace>Microsoft.BotBuilderSamples.EchoSkillBot31</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Program.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Program.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.BotBuilderSamples.EchoSkillBot31
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Properties/launchSettings.json
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:39783/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "EchoSkillBot31": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/SkillAdapterWithErrorHandler.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/SkillAdapterWithErrorHandler.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples.EchoSkillBot31
+{
+    public class SkillAdapterWithErrorHandler : BotFrameworkHttpAdapter
+    {
+        public SkillAdapterWithErrorHandler(IConfiguration configuration, ICredentialProvider credentialProvider, AuthenticationConfiguration authConfig, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, credentialProvider, authConfig, logger: logger)
+        {
+            OnTurnError = async (turnContext, exception) =>
+            {
+                // Log any leaked exception from the application.
+                logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+                // Send a message to the user
+                var errorMessageText = "The skill encountered an error or bug.";
+                var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
+                await turnContext.SendActivityAsync(errorMessage);
+
+                errorMessageText = "To continue to run this bot, please fix the bot source code.";
+                errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
+                await turnContext.SendActivityAsync(errorMessage);
+
+                if (conversationState != null)
+                {
+                    try
+                    {
+                        // Delete the conversationState for the current conversation to prevent the
+                        // bot from getting stuck in a error-loop caused by being in a bad state.
+                        // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
+                        await conversationState.DeleteAsync(turnContext);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
+                    }
+                }
+
+                // Send and EndOfConversation activity to the skill caller with the error to end the conversation
+                // and let the caller decide what to do.
+                var endOfConversation = Activity.CreateEndOfConversationActivity();
+                endOfConversation.Code = "SkillError";
+                endOfConversation.Text = exception.Message;
+                await turnContext.SendActivityAsync(endOfConversation);
+
+                // Send a trace activity, which will be displayed in the Bot Framework Emulator
+                // Note: we return the entire exception in the value property to help the developer, this should not be done in prod.
+                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+            };
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Startup.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/Startup.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.BotBuilderSamples.EchoSkillBot31.Authentication;
+using Microsoft.BotBuilderSamples.EchoSkillBot31.Bots;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.BotBuilderSamples.EchoSkillBot31
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers()
+                .AddNewtonsoftJson();
+
+            // Configure credentials
+            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+
+            // Register AuthConfiguration to enable custom claim validation.
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(sp.GetService<IConfiguration>()) });
+
+            // Create the Bot Framework Adapter with error handling enabled.
+            services.AddSingleton<IBotFrameworkHttpAdapter, SkillAdapterWithErrorHandler>();
+
+            // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
+            services.AddTransient<IBot, EchoBot>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            //app.UseHttpsRedirection(); Enable this to support https
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/appsettings.json
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "AllowedCallers": []
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/wwwroot/default.htm
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/wwwroot/default.htm
@@ -1,0 +1,420 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>EchoSkillBot</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
+
+        html,
+        body {
+            height: 100%;
+        }
+
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+        .header-inner-container::after {
+            content: "";
+            clear: both;
+            display: table;
+        }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1 {
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+            height: 32px;
+            width: 571px;
+            color: #808080;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+            padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+        .how-to-build-section>h3 {
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 0.35px;
+            line-height: 22px;
+            margin: 0 0 24px 0;
+            text-transform: uppercase;
+        }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+        .step-container dl {
+            border-left: 1px solid #A0A0A0;
+            display: block;
+            padding: 0 24px;
+            margin: 0;
+        }
+
+        .step-container dl>dt::before {
+            background-color: white;
+            border: 1px solid #A0A0A0;
+            border-radius: 100%;
+            content: '';
+            left: 47px;
+            height: 11px;
+            position: absolute;
+            width: 11px;
+        }
+
+        .step-container dl>.test-bullet::before {
+            background-color: blue;
+        }
+
+        .step-container dl>dt {
+            display: block;
+            font-size: inherit;
+            font-weight: bold;
+            line-height: 20px;
+        }
+
+        .step-container dl>dd {
+            font-size: inherit;
+            line-height: 20px;
+            margin-left: 0;
+            padding-bottom: 32px;
+        }
+
+        .step-container:last-child dl {
+            border-left: 1px solid transparent;
+        }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+        .ctaLink:focus {
+            outline: 1px solid #00bcf2;
+        }
+
+        .ctaLink:hover {
+            text-decoration: underline;
+        }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+        .step-icon>div {
+            height: 30px;
+            width: 30px;
+            background-repeat: no-repeat;
+        }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container>div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl>dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">EchoSkillBot Bot</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
+                by connecting to http://localhost:3978/api/messages.</div>
+            <div class="main-text download-the-emulator"><a class="ctaLink"
+                    href="https://aka.ms/bot-framework-F5-download-emulator" target="_blank">Download the Emulator</a>
+            </div>
+            <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home"
+                    target="_blank">Azure
+                    Bot Service</a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:</div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
+</body>
+
+</html>

--- a/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/wwwroot/manifest/echoskillbot-manifest-1.0.json
+++ b/FunctionalTests/Skills/SimpleBotToBot/EchoSkillBot/wwwroot/manifest/echoskillbot-manifest-1.0.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/skills/skill-manifest-2.0.0.json",
+  "$id": "EchoSkillBot",
+  "name": "Echo Skill bot",
+  "version": "1.0",
+  "description": "This is a sample echo skill",
+  "publisherName": "Microsoft",
+  "privacyUrl": "https://echoskillbot.contoso.com/privacy.html",
+  "copyright": "Copyright (c) Microsoft Corporation. All rights reserved.",
+  "license": "",
+  "iconUrl": "https://echoskillbot.contoso.com/icon.png",
+  "tags": [
+    "sample",
+    "echo"
+  ],
+  "endpoints": [
+    {
+      "name": "default",
+      "protocol": "BotFrameworkV3",
+      "description": "Default endpoint for the skill",
+      "endpointUrl": "https://ggechoskillbot.azurewebsites.net/api/messages",
+      "msAppId": "0be01cfa-478e-4ec2-b2cc-9a4ec02f101b"
+    }
+  ]
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/AdapterWithErrorHandler.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/AdapterWithErrorHandler.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31
+{
+    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
+    {
+        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+            : base(configuration, logger)
+        {
+            OnTurnError = async (turnContext, exception) =>
+            {
+                // Log any leaked exception from the application.
+                logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+                // Send a message to the user
+                var errorMessageText = "The bot encountered an error or bug.";
+                var errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.IgnoringInput);
+                await turnContext.SendActivityAsync(errorMessage);
+
+                errorMessageText = "To continue to run this bot, please fix the bot source code.";
+                errorMessage = MessageFactory.Text(errorMessageText, errorMessageText, InputHints.ExpectingInput);
+                await turnContext.SendActivityAsync(errorMessage);
+
+                if (conversationState != null)
+                {
+                    try
+                    {
+                        // Delete the conversationState for the current conversation to prevent the
+                        // bot from getting stuck in a error-loop caused by being in a bad state.
+                        // ConversationState should be thought of as similar to "cookie-state" in a Web pages.
+                        await conversationState.DeleteAsync(turnContext);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, $"Exception caught on attempting to Delete ConversationState : {ex}");
+                    }
+                }
+
+                // Send a trace activity, which will be displayed in the Bot Framework Emulator
+                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.ToString(), "https://www.botframework.com/schemas/error", "TurnError");
+            };
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Authentication/AllowedSkillsClaimsValidator.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Authentication/AllowedSkillsClaimsValidator.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31.Authentication
+{
+    /// <summary>
+    /// Sample claims validator that loads an allowed list from configuration if present
+    /// and checks that responses are coming from configured skills.
+    /// </summary>
+    public class AllowedSkillsClaimsValidator : ClaimsValidator
+    {
+        private readonly List<string> _allowedSkills;
+
+        public AllowedSkillsClaimsValidator(SkillsConfiguration skillsConfig)
+        {
+            if (skillsConfig == null)
+            {
+                throw new ArgumentNullException(nameof(skillsConfig));
+            }
+
+            // Load the appIds for the configured skills (we will only allow responses from skills we have configured).
+            _allowedSkills = (from skill in skillsConfig.Skills.Values select skill.AppId).ToList();
+        }
+
+        public override Task ValidateClaimsAsync(IList<Claim> claims)
+        {
+            if (SkillValidation.IsSkillClaim(claims))
+            {
+                // Check that the appId claim in the skill request is in the list of skills configured for this bot.
+                var appId = JwtTokenValidation.GetAppIdFromClaims(claims);
+                if (!_allowedSkills.Contains(appId))
+                {
+                    throw new UnauthorizedAccessException($"Received a request from an application with an appID of \"{appId}\". To enable requests from this skill, add the skill to your configuration file.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Bots/RootBot.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Bots/RootBot.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31.Bots
+{
+    public class RootBot : ActivityHandler
+    {
+        private readonly IStatePropertyAccessor<BotFrameworkSkill> _activeSkillProperty;
+        private readonly string _botId;
+        private readonly ConversationState _conversationState;
+        private readonly SkillHttpClient _skillClient;
+        private readonly SkillsConfiguration _skillsConfig;
+        private readonly BotFrameworkSkill _targetSkill;
+
+        public RootBot(ConversationState conversationState, SkillsConfiguration skillsConfig, SkillHttpClient skillClient, IConfiguration configuration)
+        {
+            _conversationState = conversationState ?? throw new ArgumentNullException(nameof(conversationState));
+            _skillsConfig = skillsConfig ?? throw new ArgumentNullException(nameof(skillsConfig));
+            _skillClient = skillClient ?? throw new ArgumentNullException(nameof(skillsConfig));
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            _botId = configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
+            if (string.IsNullOrWhiteSpace(_botId))
+            {
+                throw new ArgumentException($"{MicrosoftAppCredentials.MicrosoftAppIdKey} is not set in configuration");
+            }
+
+            // We use a single skill in this example.
+            var targetSkillId = "EchoSkillBot";
+            if (!_skillsConfig.Skills.TryGetValue(targetSkillId, out _targetSkill))
+            {
+                throw new ArgumentException($"Skill with ID \"{targetSkillId}\" not found in configuration");
+            }
+
+            // Create state property to track the active skill
+            _activeSkillProperty = conversationState.CreateProperty<BotFrameworkSkill>("activeSkillProperty");
+        }
+
+        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            // Try to get the active skill
+            var activeSkill = await _activeSkillProperty.GetAsync(turnContext, () => null, cancellationToken);
+
+            if (activeSkill != null)
+            {
+                // Send the activity to the skill
+                await SendToSkill(turnContext, activeSkill, cancellationToken);
+                return;
+            }
+
+            if (turnContext.Activity.Text.Contains("skill"))
+            {
+                await turnContext.SendActivityAsync(MessageFactory.Text("Got it, connecting you to the skill..."), cancellationToken);
+
+                // Save active skill in state
+                await _activeSkillProperty.SetAsync(turnContext, _targetSkill, cancellationToken);
+
+                // Send the activity to the skill
+                await SendToSkill(turnContext, _targetSkill, cancellationToken);
+                return;
+            }
+
+            // just respond
+            await turnContext.SendActivityAsync(MessageFactory.Text("Me no nothin'. Say \"skill\" and I'll patch you through"), cancellationToken);
+
+            // Save conversation state
+            await _conversationState.SaveChangesAsync(turnContext, force: true, cancellationToken: cancellationToken);
+        }
+
+        protected override async Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        {
+            // forget skill invocation
+            await _activeSkillProperty.DeleteAsync(turnContext, cancellationToken);
+
+            // Show status message, text and value returned by the skill
+            var eocActivityMessage = $"Received {ActivityTypes.EndOfConversation}.\n\nCode: {turnContext.Activity.Code}";
+            if (!string.IsNullOrWhiteSpace(turnContext.Activity.Text))
+            {
+                eocActivityMessage += $"\n\nText: {turnContext.Activity.Text}";
+            }
+
+            if ((turnContext.Activity as Activity)?.Value != null)
+            {
+                eocActivityMessage += $"\n\nValue: {JsonConvert.SerializeObject((turnContext.Activity as Activity)?.Value)}";
+            }
+
+            await turnContext.SendActivityAsync(MessageFactory.Text(eocActivityMessage), cancellationToken);
+
+            // We are back at the root
+            await turnContext.SendActivityAsync(MessageFactory.Text("Back in the root bot. Say \"skill\" and I'll patch you through"), cancellationToken);
+
+            // Save conversation state
+            await _conversationState.SaveChangesAsync(turnContext, cancellationToken: cancellationToken);
+        }
+
+        protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            foreach (var member in membersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                {
+                    await turnContext.SendActivityAsync(MessageFactory.Text("Hello and welcome! (dotnet core 3.1)"), cancellationToken);
+                }
+            }
+        }
+
+        private async Task SendToSkill(ITurnContext<IMessageActivity> turnContext, BotFrameworkSkill targetSkill, CancellationToken cancellationToken)
+        {
+            // NOTE: Always SaveChanges() before calling a skill so that any activity generated by the skill
+            // will have access to current accurate state.
+            await _conversationState.SaveChangesAsync(turnContext, force: true, cancellationToken: cancellationToken);
+
+            // route the activity to the skill
+            var response = await _skillClient.PostActivityAsync(_botId, targetSkill, _skillsConfig.SkillHostEndpoint, (Activity)turnContext.Activity, cancellationToken);
+
+            // Check response status
+            if (!(response.Status >= 200 && response.Status <= 299))
+            {
+                throw new HttpRequestException($"Error invoking the skill id: \"{targetSkill.Id}\" at \"{targetSkill.SkillEndpoint}\" (status is {response.Status}). \r\n {response.Body}");
+            }
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Controllers/BotController.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Controllers/BotController.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31.Controllers
+{
+    // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
+    // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
+    // achieved by specifying a more specific type for the bot constructor argument.
+    [Route("api/messages")]
+    [ApiController]
+    public class BotController : ControllerBase
+    {
+        private readonly BotFrameworkHttpAdapter _adapter;
+        private readonly IBot _bot;
+
+        public BotController(BotFrameworkHttpAdapter adapter, IBot bot)
+        {
+            _adapter = adapter;
+            _bot = bot;
+        }
+
+        [HttpPost]
+        public async Task PostAsync()
+        {
+            try
+            {
+                await _adapter.ProcessAsync(Request, Response, _bot);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                throw;
+            }
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Controllers/SkillController.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Controllers/SkillController.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Skills;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31.Controllers
+{
+    /// <summary>
+    /// A controller that handles skill replies to the bot.
+    /// This example uses the <see cref="SkillHandler"/> that is registered as a <see cref="ChannelServiceHandler"/> in startup.cs.
+    /// </summary>
+    [ApiController]
+    [Route("api/skills")]
+    public class SkillController : ChannelServiceController
+    {
+        public SkillController(ChannelServiceHandler handler)
+            : base(handler)
+        {
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Program.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Program.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Properties/launchSettings.json
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:3978",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "default.htm",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "SimpleRootBot31": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/SimpleRootBot.csproj
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/SimpleRootBot.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>Microsoft.BotBuilderSamples.SimpleRootBot31</AssemblyName>
+    <RootNamespace>Microsoft.BotBuilderSamples.SimpleRootBot31</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/SkillConversationIdFactory.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/SkillConversationIdFactory.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31
+{
+    /// <summary>
+    /// A <see cref="SkillConversationIdFactory"/> that uses an in memory <see cref="ConcurrentDictionary{TKey,TValue}"/>
+    /// to store and retrieve <see cref="ConversationReference"/> instances.
+    /// </summary>
+    public class SkillConversationIdFactory : SkillConversationIdFactoryBase
+    {
+        private readonly ConcurrentDictionary<string, string> _conversationRefs = new ConcurrentDictionary<string, string>();
+
+        public override Task<string> CreateSkillConversationIdAsync(ConversationReference conversationReference, CancellationToken cancellationToken)
+        {
+            var crJson = JsonConvert.SerializeObject(conversationReference);
+            var key = $"{conversationReference.Conversation.Id}-{conversationReference.ChannelId}-skillconvo";
+            _conversationRefs.GetOrAdd(key, crJson);
+            return Task.FromResult(key);
+        }
+
+        public override Task<ConversationReference> GetConversationReferenceAsync(string skillConversationId, CancellationToken cancellationToken)
+        {
+            var conversationReference = JsonConvert.DeserializeObject<ConversationReference>(_conversationRefs[skillConversationId]);
+            return Task.FromResult(conversationReference);
+        }
+
+        public override Task DeleteConversationReferenceAsync(string skillConversationId, CancellationToken cancellationToken)
+        {
+            _conversationRefs.TryRemove(skillConversationId, out _);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/SkillsConfiguration.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/SkillsConfiguration.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31
+{
+    /// <summary>
+    /// A helper class that loads Skills information from configuration.
+    /// </summary>
+    public class SkillsConfiguration
+    {
+        public SkillsConfiguration(IConfiguration configuration)
+        {
+            var section = configuration?.GetSection("BotFrameworkSkills");
+            var skills = section?.Get<BotFrameworkSkill[]>();
+            if (skills != null)
+            {
+                foreach (var skill in skills)
+                {
+                    Skills.Add(skill.Id, skill);
+                }
+            }
+
+            var skillHostEndpoint = configuration?.GetValue<string>(nameof(SkillHostEndpoint));
+            if (!string.IsNullOrWhiteSpace(skillHostEndpoint))
+            {
+                SkillHostEndpoint = new Uri(skillHostEndpoint);
+            }
+        }
+
+        public Uri SkillHostEndpoint { get; }
+
+        public Dictionary<string, BotFrameworkSkill> Skills { get; } = new Dictionary<string, BotFrameworkSkill>();
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Startup.cs
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/Startup.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.BotBuilderSamples.SimpleRootBot31.Authentication;
+using Microsoft.BotBuilderSamples.SimpleRootBot31.Bots;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.BotBuilderSamples.SimpleRootBot31
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers()
+                .AddNewtonsoftJson();
+
+            // Configure credentials
+            services.AddSingleton<ICredentialProvider, ConfigurationCredentialProvider>();
+
+            // Register the skills configuration class
+            services.AddSingleton<SkillsConfiguration>();
+
+            // Register AuthConfiguration to enable custom claim validation.
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+
+            // Register the Bot Framework Adapter with error handling enabled.
+            // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.
+            services.AddSingleton<BotFrameworkHttpAdapter, AdapterWithErrorHandler>();
+            services.AddSingleton<BotAdapter>(sp => sp.GetService<BotFrameworkHttpAdapter>());
+
+            // Register the skills client and skills request handler.
+            services.AddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();
+            services.AddHttpClient<SkillHttpClient>();
+            services.AddSingleton<ChannelServiceHandler, SkillHandler>();
+
+            // Register a ConfigurationChannelProvider (this is only required for Azure Gov, it can be removed if the bot is deployed to Public cloud).
+            services.AddSingleton<IChannelProvider, ConfigurationChannelProvider>();
+
+            // Register the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
+            services.AddSingleton<IStorage, MemoryStorage>();
+
+            // Register Conversation state (used by the Dialog system itself).
+            services.AddSingleton<ConversationState>();
+
+            // Register the bot as a transient. In this case the ASP Controller is expecting an IBot.
+            services.AddTransient<IBot, RootBot>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            //app.UseHttpsRedirection(); Enable this to support https
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/appsettings.json
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/appsettings.json
@@ -1,0 +1,20 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "MicrosoftAppId": "",
+  "MicrosoftAppPassword": "",
+  "SkillHostEndpoint": "http://localhost:3978/api/skills/",
+  "BotFrameworkSkills": [
+    {
+      "Id": "EchoSkillBot",
+      "AppId": "TODO: Add here the App ID for the skill",
+      "SkillEndpoint": "http://localhost:39783/api/messages"
+    }
+  ]
+}

--- a/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/wwwroot/default.htm
+++ b/FunctionalTests/Skills/SimpleBotToBot/SimpleRootBot/wwwroot/default.htm
@@ -1,0 +1,420 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>SimpleRootBot</title>
+    <style>
+        body {
+            margin: 0px;
+            padding: 0px;
+            font-family: Segoe UI;
+        }
+
+        html,
+        body {
+            height: 100%;
+        }
+
+        header {
+            background-image: url("data:image/svg+xml,%3Csvg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 4638.9 651.6' style='enable-background:new 0 0 4638.9 651.6;' xml:space='preserve'%3E%3Cstyle type='text/css'%3E .st0%7Bfill:%2355A0E0;%7D .st1%7Bfill:none;%7D .st2%7Bfill:%230058A8;%7D .st3%7Bfill:%23328BD8;%7D .st4%7Bfill:%23B6DCF1;%7D .st5%7Bopacity:0.2;fill:url(%23SVGID_1_);enable-background:new ;%7D%0A%3C/style%3E%3Crect y='1.1' class='st0' width='4640' height='646.3'/%3E%3Cpath class='st1' d='M3987.8,323.6L4310.3,1.1h-65.6l-460.1,460.1c-17.5,17.5-46.1,17.5-63.6,0L3260.9,1.1H0v646.3h3660.3 L3889,418.7c17.5-17.5,46.1-17.5,63.6,0l228.7,228.7h66.6l-260.2-260.2C3970.3,369.8,3970.3,341.1,3987.8,323.6z'/%3E%3Cpath class='st2' d='M3784.6,461.2L4244.7,1.1h-983.9l460.1,460.1C3738.4,478.7,3767.1,478.7,3784.6,461.2z'/%3E%3Cpath class='st3' d='M4640,1.1h-329.8l-322.5,322.5c-17.5,17.5-17.5,46.1,0,63.6l260.2,260.2H4640L4640,1.1L4640,1.1z'/%3E%3Cpath class='st4' d='M3889,418.8l-228.7,228.7h521.1l-228.7-228.7C3935.2,401.3,3906.5,401.3,3889,418.8z'/%3E%3ClinearGradient id='SVGID_1_' gradientUnits='userSpaceOnUse' x1='3713.7576' y1='438.1175' x2='3911.4084' y2='14.2535' gradientTransform='matrix(1 0 0 -1 0 641.3969)'%3E%3Cstop offset='0' style='stop-color:%23FFFFFF;stop-opacity:0.5'/%3E%3Cstop offset='1' style='stop-color:%23FFFFFF'/%3E%3C/linearGradient%3E%3Cpath class='st5' d='M3952.7,124.5c-17.5-17.5-46.1-17.5-63.6,0l-523,523h1109.6L3952.7,124.5z'/%3E%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            background-size: 100%;
+            background-position: right;
+            background-color: #55A0E0;
+            width: 100%;
+            font-size: 44px;
+            height: 120px;
+            color: white;
+            padding: 30px 0 40px 0px;
+            display: inline-block;
+        }
+
+        .header-icon {
+            background-image: url("data:image/svg+xml;utf8,%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20150.2%20125%22%20style%3D%22enable-background%3Anew%200%200%20150.2%20125%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23FFFFFF%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.5%22%20class%3D%22st0%22%20width%3D%22149.7%22%20height%3D%22125%22/%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M59%2C102.9L21.8%2C66c-3.5-3.5-3.5-9.1%2C0-12.5l37-36.5l2.9%2C3l-37%2C36.4c-1.8%2C1.8-1.8%2C4.7%2C0%2C6.6l37.2%2C37L59%2C102.9z%22%0A%09%09/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M92.5%2C102.9l-3-3l37.2-37c0.9-0.9%2C1.4-2%2C1.4-3.3c0-1.2-0.5-2.4-1.4-3.3L89.5%2C20l2.9-3l37.2%2C36.4%0A%09%09c1.7%2C1.7%2C2.6%2C3.9%2C2.6%2C6.3s-0.9%2C4.6-2.6%2C6.3L92.5%2C102.9z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M90.1%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C98.1%2C64.7%2C94.4%2C68.4%2C90.1%2C68.4z%0A%09%09%20M90.1%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S91.9%2C56.5%2C90.1%2C56.5z%22/%3E%0A%3C/g%3E%0A%3Cg%3E%0A%09%3Cpath%20class%3D%22st1%22%20d%3D%22M61.4%2C68.4c-4.5%2C0-8-3.5-8-8.1c0-4.5%2C3.5-8.1%2C8-8.1c4.4%2C0%2C8%2C3.7%2C8%2C8.1C69.5%2C64.7%2C65.8%2C68.4%2C61.4%2C68.4z%0A%09%09%20M61.4%2C56.5c-2.2%2C0-3.8%2C1.7-3.8%2C3.9c0%2C2.2%2C1.7%2C3.9%2C3.8%2C3.9c1.9%2C0%2C3.8-1.6%2C3.8-3.9S63.3%2C56.5%2C61.4%2C56.5z%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+            background-repeat: no-repeat;
+            float: left;
+            height: 140px;
+            width: 140px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-text {
+            padding-left: 1%;
+            color: #FFFFFF;
+            font-family: "Segoe UI";
+            font-size: 72px;
+            font-weight: 300;
+            letter-spacing: 0.35px;
+            line-height: 96px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .header-inner-container {
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+            vertical-align: middle;
+        }
+
+        .header-inner-container::after {
+            content: "";
+            clear: both;
+            display: table;
+        }
+
+        .main-content-area {
+            padding-left: 30px;
+        }
+
+        .content-title {
+            color: #000000;
+            font-family: "Segoe UI";
+            font-size: 46px;
+            font-weight: 300;
+            line-height: 62px;
+        }
+
+        .main-text {
+            color: #808080;
+            font-size: 24px;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+        }
+
+        .main-text-p1 {
+            padding-top: 48px;
+            padding-bottom: 28px;
+        }
+
+        .endpoint {
+            height: 32px;
+            width: 571px;
+            color: #808080;
+            font-family: "Segoe UI";
+            font-size: 24px;
+            font-weight: 200;
+            line-height: 32px;
+            padding-top: 28px;
+        }
+
+        .how-to-build-section {
+            padding-top: 20px;
+            padding-left: 30px;
+        }
+
+        .how-to-build-section>h3 {
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 0.35px;
+            line-height: 22px;
+            margin: 0 0 24px 0;
+            text-transform: uppercase;
+        }
+
+        .step-container {
+            display: flex;
+            align-items: stretch;
+            position: relative;
+        }
+
+        .step-container dl {
+            border-left: 1px solid #A0A0A0;
+            display: block;
+            padding: 0 24px;
+            margin: 0;
+        }
+
+        .step-container dl>dt::before {
+            background-color: white;
+            border: 1px solid #A0A0A0;
+            border-radius: 100%;
+            content: '';
+            left: 47px;
+            height: 11px;
+            position: absolute;
+            width: 11px;
+        }
+
+        .step-container dl>.test-bullet::before {
+            background-color: blue;
+        }
+
+        .step-container dl>dt {
+            display: block;
+            font-size: inherit;
+            font-weight: bold;
+            line-height: 20px;
+        }
+
+        .step-container dl>dd {
+            font-size: inherit;
+            line-height: 20px;
+            margin-left: 0;
+            padding-bottom: 32px;
+        }
+
+        .step-container:last-child dl {
+            border-left: 1px solid transparent;
+        }
+
+        .ctaLink {
+            background-color: transparent;
+            border: 1px solid transparent;
+            color: #006AB1;
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0;
+            white-space: normal;
+        }
+
+        .ctaLink:focus {
+            outline: 1px solid #00bcf2;
+        }
+
+        .ctaLink:hover {
+            text-decoration: underline;
+        }
+
+        .step-icon {
+            display: flex;
+            height: 38px;
+            margin-right: 15px;
+            width: 38px;
+        }
+
+        .step-icon>div {
+            height: 30px;
+            width: 30px;
+            background-repeat: no-repeat;
+        }
+
+        .ms-logo-container {
+            min-width: 580px;
+            max-width: 980px;
+            margin-left: auto;
+            margin-right: auto;
+            left: 0;
+            right: 0;
+            transition: bottom 400ms;
+        }
+
+        .ms-logo {
+            float: right;
+            background-image: url("data:image/svg+xml;utf8,%0A%3Csvg%20version%3D%221.1%22%20id%3D%22MS-symbol%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20x%3D%220px%22%20y%3D%220px%22%0A%09%20viewBox%3D%220%200%20400%20120%22%20style%3D%22enable-background%3Anew%200%200%20400%20120%3B%22%20xml%3Aspace%3D%22preserve%22%3E%0A%3Cstyle%20type%3D%22text/css%22%3E%0A%09.st0%7Bfill%3Anone%3B%7D%0A%09.st1%7Bfill%3A%23737474%3B%7D%0A%09.st2%7Bfill%3A%23D63F26%3B%7D%0A%09.st3%7Bfill%3A%23167D3E%3B%7D%0A%09.st4%7Bfill%3A%232E76BC%3B%7D%0A%09.st5%7Bfill%3A%23FDB813%3B%7D%0A%3C/style%3E%0A%3Crect%20x%3D%220.6%22%20class%3D%22st0%22%20width%3D%22398.7%22%20height%3D%22119%22/%3E%0A%3Cpath%20class%3D%22st1%22%20d%3D%22M171.3%2C38.4v43.2h-7.5V47.7h-0.1l-13.4%2C33.9h-5l-13.7-33.9h-0.1v33.9h-6.9V38.4h10.8l12.4%2C32h0.2l13.1-32H171.3%0A%09z%20M177.6%2C41.7c0-1.2%2C0.4-2.2%2C1.3-3c0.9-0.8%2C1.9-1.2%2C3.1-1.2c1.3%2C0%2C2.4%2C0.4%2C3.2%2C1.3c0.8%2C0.8%2C1.3%2C1.8%2C1.3%2C3c0%2C1.2-0.4%2C2.2-1.3%2C3%0A%09c-0.9%2C0.8-1.9%2C1.2-3.2%2C1.2s-2.3-0.4-3.1-1.2C178%2C43.8%2C177.6%2C42.8%2C177.6%2C41.7z%20M185.7%2C50.6v31h-7.3v-31H185.7z%20M207.8%2C76.3%0A%09c1.1%2C0%2C2.3-0.3%2C3.6-0.8c1.3-0.5%2C2.5-1.2%2C3.6-2v6.8c-1.2%2C0.7-2.5%2C1.2-4%2C1.5c-1.5%2C0.3-3.1%2C0.5-4.9%2C0.5c-4.6%2C0-8.3-1.4-11.1-4.3%0A%09c-2.9-2.9-4.3-6.6-4.3-11c0-5%2C1.5-9.1%2C4.4-12.3c2.9-3.2%2C7-4.8%2C12.4-4.8c1.4%2C0%2C2.7%2C0.2%2C4.1%2C0.5c1.4%2C0.4%2C2.5%2C0.8%2C3.3%2C1.2v7%0A%09c-1.1-0.8-2.3-1.5-3.4-1.9c-1.2-0.5-2.4-0.7-3.6-0.7c-2.9%2C0-5.2%2C0.9-7%2C2.8c-1.8%2C1.9-2.7%2C4.4-2.7%2C7.6c0%2C3.1%2C0.8%2C5.6%2C2.5%2C7.3%0A%09C202.6%2C75.4%2C204.9%2C76.3%2C207.8%2C76.3z%20M235.7%2C50.1c0.6%2C0%2C1.1%2C0%2C1.6%2C0.1s0.9%2C0.2%2C1.2%2C0.3v7.4c-0.4-0.3-0.9-0.5-1.7-0.8%0A%09c-0.7-0.3-1.6-0.4-2.7-0.4c-1.8%2C0-3.3%2C0.8-4.5%2C2.3c-1.2%2C1.5-1.9%2C3.8-1.9%2C7v15.6h-7.3v-31h7.3v4.9h0.1c0.7-1.7%2C1.7-3%2C3-4%0A%09C232.2%2C50.6%2C233.8%2C50.1%2C235.7%2C50.1z%20M238.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3%0A%09c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5c-4.8%2C0-8.6-1.4-11.4-4.2C240.3%2C75.3%2C238.9%2C71.4%2C238.9%2C66.6z%0A%09%20M246.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5%0A%09c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7C247.2%2C60.5%2C246.5%2C63%2C246.5%2C66.3z%20M281.5%2C58.8c0%2C1%2C0.3%2C1.9%2C1%2C2.5%0A%09c0.7%2C0.6%2C2.1%2C1.3%2C4.4%2C2.2c2.9%2C1.2%2C5%2C2.5%2C6.1%2C3.9c1.2%2C1.5%2C1.8%2C3.2%2C1.8%2C5.3c0%2C2.9-1.1%2C5.3-3.4%2C7c-2.2%2C1.8-5.3%2C2.7-9.1%2C2.7%0A%09c-1.3%2C0-2.7-0.2-4.3-0.5c-1.6-0.3-2.9-0.7-4-1.2v-7.2c1.3%2C0.9%2C2.8%2C1.7%2C4.3%2C2.2c1.5%2C0.5%2C2.9%2C0.8%2C4.2%2C0.8c1.6%2C0%2C2.9-0.2%2C3.6-0.7%0A%09c0.8-0.5%2C1.2-1.2%2C1.2-2.3c0-1-0.4-1.9-1.2-2.5c-0.8-0.7-2.4-1.5-4.6-2.4c-2.7-1.1-4.6-2.4-5.7-3.8c-1.1-1.4-1.7-3.2-1.7-5.4%0A%09c0-2.8%2C1.1-5.1%2C3.3-6.9c2.2-1.8%2C5.1-2.7%2C8.6-2.7c1.1%2C0%2C2.3%2C0.1%2C3.6%2C0.4c1.3%2C0.2%2C2.5%2C0.6%2C3.4%2C0.9v6.9c-1-0.6-2.1-1.2-3.4-1.7%0A%09c-1.3-0.5-2.6-0.7-3.8-0.7c-1.4%2C0-2.5%2C0.3-3.2%2C0.8C281.9%2C57.1%2C281.5%2C57.8%2C281.5%2C58.8z%20M297.9%2C66.6c0-5.1%2C1.4-9.2%2C4.3-12.2%0A%09c2.9-3%2C6.9-4.5%2C12.1-4.5c4.8%2C0%2C8.6%2C1.4%2C11.3%2C4.3c2.7%2C2.9%2C4.1%2C6.8%2C4.1%2C11.7c0%2C5-1.4%2C9-4.3%2C12c-2.9%2C3-6.8%2C4.5-11.8%2C4.5%0A%09c-4.8%2C0-8.6-1.4-11.4-4.2C299.4%2C75.3%2C297.9%2C71.4%2C297.9%2C66.6z%20M305.5%2C66.3c0%2C3.2%2C0.7%2C5.7%2C2.2%2C7.4c1.5%2C1.7%2C3.6%2C2.6%2C6.3%2C2.6%0A%09c2.7%2C0%2C4.7-0.9%2C6.1-2.6c1.4-1.7%2C2.1-4.2%2C2.1-7.6c0-3.3-0.7-5.8-2.2-7.5c-1.4-1.7-3.4-2.5-6-2.5c-2.7%2C0-4.7%2C0.9-6.2%2C2.7%0A%09C306.3%2C60.5%2C305.5%2C63%2C305.5%2C66.3z%20M353.9%2C56.6h-10.9v25h-7.4v-25h-5.2v-6h5.2v-4.3c0-3.3%2C1.1-5.9%2C3.2-8c2.1-2.1%2C4.8-3.1%2C8.1-3.1%0A%09c0.9%2C0%2C1.7%2C0%2C2.4%2C0.1c0.7%2C0.1%2C1.3%2C0.2%2C1.8%2C0.4V42c-0.2-0.1-0.7-0.3-1.3-0.5c-0.6-0.2-1.3-0.3-2.1-0.3c-1.5%2C0-2.7%2C0.5-3.5%2C1.4%0A%09s-1.2%2C2.4-1.2%2C4.2v3.7h10.9v-7l7.3-2.2v9.2h7.4v6h-7.4v14.5c0%2C1.9%2C0.3%2C3.3%2C1%2C4c0.7%2C0.8%2C1.8%2C1.2%2C3.3%2C1.2c0.4%2C0%2C0.9-0.1%2C1.5-0.3%0A%09c0.6-0.2%2C1.1-0.4%2C1.6-0.7v6c-0.5%2C0.3-1.2%2C0.5-2.3%2C0.7c-1.1%2C0.2-2.1%2C0.3-3.2%2C0.3c-3.1%2C0-5.4-0.8-6.9-2.5c-1.5-1.6-2.3-4.1-2.3-7.4%0A%09V56.6z%22/%3E%0A%3Cg%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2224%22%20class%3D%22st2%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2224%22%20class%3D%22st3%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2231%22%20y%3D%2261.8%22%20class%3D%22st4%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%09%3Crect%20x%3D%2268.8%22%20y%3D%2261.8%22%20class%3D%22st5%22%20width%3D%2234.2%22%20height%3D%2234.2%22/%3E%0A%3C/g%3E%0A%3C/svg%3E%0A");
+        }
+
+        .ms-logo-container>div {
+            min-height: 60px;
+            width: 150px;
+            background-repeat: no-repeat;
+        }
+
+        .row {
+            padding: 90px 0px 0 20px;
+            min-width: 480px;
+            max-width: 1366px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .column {
+            float: left;
+            width: 45%;
+            padding-right: 20px;
+        }
+
+        .row:after {
+            content: "";
+            display: table;
+            clear: both;
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        .download-the-emulator {
+            height: 20px;
+            color: #0063B1;
+            font-size: 15px;
+            line-height: 20px;
+            padding-bottom: 70px;
+        }
+
+        .how-to-iframe {
+            max-width: 700px !important;
+            min-width: 650px !important;
+            height: 700px !important;
+        }
+
+        .remove-frame-height {
+            height: 10px;
+        }
+
+        @media only screen and (max-width: 1300px) {
+            .ms-logo {
+                padding-top: 30px;
+            }
+
+            .header-text {
+                font-size: 40x;
+            }
+
+            .column {
+                float: none;
+                padding-top: 30px;
+                width: 100%;
+            }
+
+            .ms-logo-container {
+                padding-top: 30px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            .row {
+                padding: 20px 0px 0 20px;
+                min-width: 480px;
+                max-width: 650px;
+                margin-left: auto;
+                margin-right: auto;
+            }
+        }
+
+        @media only screen and (max-width: 1370px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+        }
+
+        @media only screen and (max-width: 1230px) {
+            header {
+                background-color: #55A0E0;
+                background-size: auto 200px;
+            }
+
+            .header-text {
+                font-size: 44px;
+            }
+
+            .header-icon {
+                height: 120px;
+                width: 120px;
+            }
+        }
+
+        @media only screen and (max-width: 1000px) {
+            header {
+                background-color: #55A0E0;
+                background-image: none;
+            }
+        }
+
+        @media only screen and (max-width: 632px) {
+            .header-text {
+                font-size: 32px;
+            }
+
+            .row {
+                padding: 10px 0px 0 10px;
+                max-width: 490px !important;
+                min-width: 410px !important;
+            }
+
+            .endpoint {
+                font-size: 25px;
+            }
+
+            .main-text {
+                font-size: 20px;
+            }
+
+            .step-container dl>dd {
+                font-size: 14px;
+            }
+
+            .column {
+                padding-right: 5px;
+            }
+
+            .header-icon {
+                height: 110px;
+                width: 110px;
+            }
+
+            .how-to-iframe {
+                max-width: 480px !important;
+                min-width: 400px !important;
+                height: 650px !important;
+                overflow: hidden;
+            }
+        }
+
+        .remove-frame-height {
+            max-height: 10px;
+        }
+    </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            loadFrame();
+        });
+        var loadFrame = function () {
+            var iframe = document.createElement('iframe');
+            iframe.setAttribute("id", "iframe");
+            var offLineHTMLContent = "";
+            var frameElement = document.getElementById("how-to-iframe");
+            if (window.navigator.onLine) {
+                iframe.src = 'https://docs.botframework.com/static/abs/pages/f5.htm';
+                iframe.setAttribute("scrolling", "no");
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("width", "100%");
+                iframe.setAttribute("height", "100%");
+                var frameDiv = document.getElementById("how-to-iframe");
+                frameDiv.appendChild(iframe);
+            } else {
+                frameElement.classList.add("remove-frame-height");
+            }
+        };
+    </script>
+</head>
+
+<body>
+    <header class="header">
+        <div class="header-inner-container">
+            <div class="header-icon" style="display: inline-block"></div>
+            <div class="header-text" style="display: inline-block">SimpleRootBot Bot</div>
+        </div>
+    </header>
+    <div class="row">
+        <div class="column" class="main-content-area">
+            <div class="content-title">Your bot is ready!</div>
+            <div class="main-text main-text-p1">You can test your bot in the Bot Framework Emulator<br />
+                by connecting to http://localhost:3978/api/messages.</div>
+            <div class="main-text download-the-emulator"><a class="ctaLink"
+                    href="https://aka.ms/bot-framework-F5-download-emulator" target="_blank">Download the Emulator</a>
+            </div>
+            <div class="main-text">Visit <a class="ctaLink" href="https://aka.ms/bot-framework-F5-abs-home"
+                    target="_blank">Azure
+                    Bot Service</a> to register your bot and add it to<br />
+                various channels. The bot's endpoint URL typically looks
+                like this:</div>
+            <div class="endpoint">https://<i>your_bots_hostname</i>/api/messages</div>
+        </div>
+        <div class="column how-to-iframe" id="how-to-iframe"></div>
+    </div>
+    <div class="ms-logo-container">
+        <div class="ms-logo"></div>
+    </div>
+</body>
+
+</html>

--- a/Microsoft.Bot.Builder.Skills.sln
+++ b/Microsoft.Bot.Builder.Skills.sln
@@ -1,0 +1,833 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29123.88
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{4269F3C3-6B42-419B-B64A-3E6DC0F1574A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{AD743B78-D61F-4FBF-B620-FA83CE599A50}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Adaptive", "libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\Microsoft.Bot.Builder.Dialogs.Adaptive.csproj", "{3CF175CF-1AF4-4109-96CB-221684DCED7D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Adaptive.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj", "{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Azure.Tests", "tests\Microsoft.Bot.Builder.Azure.Tests\Microsoft.Bot.Builder.Azure.Tests.csproj", "{E325A0E2-716A-49E0-9767-5087CF05727C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Azure", "libraries\Microsoft.Bot.Builder.Azure\Microsoft.Bot.Builder.Azure.csproj", "{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.QnA.Tests", "tests\Microsoft.Bot.Builder.AI.QnA.Tests\Microsoft.Bot.Builder.AI.QnA.Tests.csproj", "{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Connector", "libraries\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj", "{6462DA5D-27DC-4CD5-9467-5EFB998FD838}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Schema", "libraries\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj", "{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder", "libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj", "{ADA8AB8B-2066-4193-B8F7-985669B23E00}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Connector.Tests", "tests\Microsoft.Bot.Connector.Tests\Microsoft.Bot.Connector.Tests.csproj", "{BF414C86-DB3B-4022-9B29-DCE8AA954C12}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{276EBE79-A13A-46BD-A566-B01DC0477A9B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.Luis", "libraries\Microsoft.Bot.Builder.AI.LUIS\Microsoft.Bot.Builder.AI.Luis.csproj", "{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.Luis.Tests", "tests\Microsoft.Bot.Builder.AI.LUIS.Tests\Microsoft.Bot.Builder.AI.Luis.Tests.csproj", "{7BCEBDC1-D57F-4717-9B15-4FACD5473489}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.AspNet.Core", "libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj", "{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TemplateManager", "libraries\Microsoft.Bot.Builder.TemplateManager\Microsoft.Bot.Builder.TemplateManager.csproj", "{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TemplateManager.Tests", "tests\Microsoft.Bot.Builder.TemplateManager\Microsoft.Bot.Builder.TemplateManager.Tests.csproj", "{C93F6192-0123-4121-AD92-374A71E4B0F3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Schema.Tests", "tests\Microsoft.Bot.Schema.Tests\Microsoft.Bot.Schema.Tests.csproj", "{A4184239-F13F-4A09-B2D3-0B9532609248}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.QnA", "libraries\Microsoft.Bot.Builder.AI.QnA\Microsoft.Bot.Builder.AI.QnA.csproj", "{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AI", "AI", "{763168FA-A590-482C-84D8-2922F7ADB1A2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs", "libraries\Microsoft.Bot.Builder.Dialogs\Microsoft.Bot.Builder.Dialogs.csproj", "{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Tests\Microsoft.Bot.Builder.Dialogs.Tests.csproj", "{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.AspNet.Core.Tests", "tests\integration\Microsoft.Bot.Builder.Integration.AspNet.Core.Tests\Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj", "{62C4DC83-3B07-45D7-856E-224FFB368E5F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Tests", "tests\Microsoft.Bot.Builder.Tests\Microsoft.Bot.Builder.Tests.csproj", "{35F9B8A8-1974-4795-930B-5E4980EE85E5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Transcripts.Tests", "tests\Microsoft.Bot.Builder.Transcripts.Tests\Microsoft.Bot.Builder.Transcripts.Tests.csproj", "{71698D71-4C6F-40D5-8BDE-2587514CA21C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Configuration", "libraries\Microsoft.Bot.Configuration\Microsoft.Bot.Configuration.csproj", "{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Configuration.Tests", "tests\Microsoft.Bot.Configuration.Tests\Microsoft.Bot.Configuration.Tests.csproj", "{1B7920E6-5262-4054-B72D-3A8DBBA057D2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.ApplicationInsights.Core", "libraries\integration\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj", "{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.ApplicationInsights", "libraries\Microsoft.Bot.Builder.ApplicationInsights\Microsoft.Bot.Builder.ApplicationInsights.csproj", "{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.ApplicationInsights.Core.Tests", "tests\integration\Microsoft.Bot.ApplicationInsights.Core.Tests\Microsoft.Bot.ApplicationInsights.Core.Tests.csproj", "{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.ApplicationInsights.Tests", "tests\Microsoft.Bot.Builder.ApplicationInsights.Tests\Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj", "{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot", "tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj", "{C113E0AE-5564-4389-BA39-183A8D574210}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.FunctionalTests", "FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj", "{B9DDC8CB-8EDF-4D98-913A-22F19E642223}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FunctionalTests", "FunctionalTests", "{8667F820-8ADA-4498-91AE-AE95DEE5227E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing", "libraries\Microsoft.Bot.Builder.Testing\Microsoft.Bot.Builder.Testing.csproj", "{060F070A-BBFA-490E-BE89-3844C857B771}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Testing.Tests", "tests\Microsoft.Bot.Builder.Testing.Tests\Microsoft.Bot.Builder.Testing.Tests.csproj", "{E4E13301-9193-4106-B0E3-41276B478E7C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot.Tests", "tests\Microsoft.Bot.Builder.TestBot.Tests\Microsoft.Bot.Builder.TestBot.Tests.csproj", "{76391566-9F22-4994-8B0F-02EFC0E9E228}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Declarative", "libraries\Microsoft.Bot.Builder.Dialogs.Declarative\Microsoft.Bot.Builder.Dialogs.Declarative.csproj", "{1BC05915-044E-4776-8956-B44BBEFF2F84}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Expressions.Tests", "tests\Microsoft.Bot.Expressions.Tests\Microsoft.Bot.Expressions.Tests.csproj", "{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Expressions", "libraries\Microsoft.Bot.Expressions\Microsoft.Bot.Expressions.csproj", "{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Declarative.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Declarative.Tests\Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj", "{D5E70443-4BA2-42ED-992A-010268440B08}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Debugging", "libraries\Microsoft.Bot.Builder.Dialogs.Debugging\Microsoft.Bot.Builder.Dialogs.Debugging.csproj", "{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.LanguageGeneration", "libraries\Microsoft.Bot.Builder.LanguageGeneration\Microsoft.Bot.Builder.LanguageGeneration.csproj", "{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Debugging.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Debugging.Tests\Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj", "{F59673EA-2D0D-441A-BB85-CD343DE6BE45}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.LanguageGeneration.Tests", "tests\Microsoft.Bot.Builder.LanguageGeneration.Tests\Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj", "{72EE26E2-E8BE-4169-82AD-93E021539C34}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B6AFE9D-6FA5-4699-B0EB-62335FD431C8}"
+	ProjectSection(SolutionItems) = preProject
+		bot.png = bot.png
+		bot_icon.png = bot_icon.png
+		BotBuilder-DotNet.ruleset = BotBuilder-DotNet.ruleset
+		CodeCoverage.runsettings = CodeCoverage.runsettings
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Schemas", "Schemas", "{EE56F2B6-4995-4E8F-ACFF-310AF0A4DA0F}"
+	ProjectSection(SolutionItems) = preProject
+		schemas\baseComponent.schema = schemas\baseComponent.schema
+		schemas\component.schema = schemas\component.schema
+		schemas\readme.md = schemas\readme.md
+		schemas\sdk.schema = schemas\sdk.schema
+		schemas\update.cmd = schemas\update.cmd
+		schemas\updateBranch.cmd = schemas\updateBranch.cmd
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot.Json", "tests\Microsoft.Bot.Builder.TestBot.Json\Microsoft.Bot.Builder.TestBot.Json.csproj", "{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.Luis.TestUtils", "tests\Microsoft.Bot.Builder.AI.Luis.TestUtils\Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj", "{685271A8-6C69-46E4-9B11-89AF9761CE0A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.LuisV3.Tests", "tests\Microsoft.Bot.Builder.Ai.LUISV3.tests\Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj", "{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Adapters", "Adapters", "{6230B915-B238-4E57-AAC4-06B4498F540F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Twilio", "libraries\Adapters\Microsoft.Bot.Builder.Adapters.Twilio\Microsoft.Bot.Builder.Adapters.Twilio.csproj", "{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Adapters", "Adapters", "{E8CD434A-306F-41D9-B67D-BFFF3287354D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Twilio.Tests", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.Tests\Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj", "{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi", "libraries\integration\Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi\Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj", "{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Integration.AspNet.WebApi", "libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.WebApi\Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj", "{EE76BD65-FB01-498F-B053-4E1B2693D85F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.ApplicationInsights.WebApi.Tests", "tests\integration\Microsoft.Bot.ApplicationInsights.WebApi.Tests\Microsoft.Bot.ApplicationInsights.WebApi.Tests.csproj", "{873BCC1F-ED12-424E-93FA-D76F4BA022C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests", "tests\integration\Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests\Microsoft.Bot.Builder.Integration.AspNet.WebApi.Tests.csproj", "{2614D290-1345-4A41-BE90-F85F817CEADE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Webex", "libraries\Adapters\Microsoft.Bot.Builder.Adapters.Webex\Microsoft.Bot.Builder.Adapters.Webex.csproj", "{F3669415-319E-4C4C-A398-89321589B3A9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Webex.Tests", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.Tests\Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj", "{9878B523-BD1E-4285-A875-3CAB4127F7E6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Webex.TestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj", "{6E39C647-902F-4CFF-A4E4-194B295E3AF4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests", "tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj", "{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Streaming", "libraries\Microsoft.Bot.Streaming\Microsoft.Bot.Streaming.csproj", "{4C82FD14-418F-43E4-AC59-3D926B55CEA3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Streaming.Tests", "tests\Microsoft.Bot.Streaming.Tests\Microsoft.Bot.Streaming.Tests.csproj", "{D243AC2D-7823-4177-9D8A-23FDFDA274D2}"
+	ProjectSection(ProjectDependencies) = postProject
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00} = {ADA8AB8B-2066-4193-B8F7-985669B23E00}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Slack", "libraries\Adapters\Microsoft.Bot.Builder.Adapters.Slack\Microsoft.Bot.Builder.Adapters.Slack.csproj", "{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Slack.TestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj", "{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Slack.Tests", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.Tests\Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj", "{195FC24B-C4DA-4055-918D-5ABF50FD805B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Facebook.Tests", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.Tests\Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj", "{9F7B2BDF-973B-4639-B890-357EB967B2ED}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj", "{E372D54C-73AA-41DB-A471-81348AC37F36}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Facebook", "libraries\Adapters\Microsoft.Bot.Builder.Adapters.Facebook\Microsoft.Bot.Builder.Adapters.Facebook.csproj", "{C8E31CD2-89D4-4659-9557-43EC9C99D984}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot\Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj", "{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestProtocol", "tests\Microsoft.Bot.Builder.TestProtocol\Microsoft.Bot.Builder.TestProtocol.csproj", "{24CCB459-B4F6-484F-8BA4-946A4AB816FA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling", "tests\Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling\Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling.csproj", "{D9242899-AB3F-46BB-BAB4-386CB8EC535C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Adapters.Twilio.TestBot", "tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj", "{F98A9787-B175-450F-99FC-EC241EB9D581}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot.NetCore21", "tests\Microsoft.Bot.Builder.TestBot.NetCore21\Microsoft.Bot.Builder.TestBot.NetCore21.csproj", "{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.TestBot.NetCore21.Tests", "tests\Microsoft.Bot.Builder.TestBot.NetCore21.Tests\Microsoft.Bot.Builder.TestBot.NetCore21.Tests.csproj", "{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Expressions.Properties", "libraries\Microsoft.Bot.Expressions.Properties\Microsoft.Bot.Expressions.Properties.csproj", "{4943C197-0742-480E-B1D3-6738D41582A3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Skills", "Skills", "{3C16F609-61D8-49C5-A243-9D32B9491D91}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SimpleBotToBot", "SimpleBotToBot", "{C9B9D0E6-1579-4F5E-B23B-9EFD17F50D34}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleRootBot", "FunctionalTests\Skills\SimpleBotToBot\SimpleRootBot\SimpleRootBot.csproj", "{A0080C33-4628-4259-84D6-2E6DEDBD26B7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EchoSkillBot", "FunctionalTests\Skills\SimpleBotToBot\EchoSkillBot\EchoSkillBot.csproj", "{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug-Windows|Any CPU = Debug-Windows|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Release-Windows|Any CPU = Release-Windows|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{E325A0E2-716A-49E0-9767-5087CF05727C}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{C93F6192-0123-4121-AD92-374A71E4B0F3}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{A4184239-F13F-4A09-B2D3-0B9532609248}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{C113E0AE-5564-4389-BA39-183A8D574210}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Release|Any CPU.Build.0 = Release|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{060F070A-BBFA-490E-BE89-3844C857B771}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{E4E13301-9193-4106-B0E3-41276B478E7C}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Release|Any CPU.Build.0 = Release|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{76391566-9F22-4994-8B0F-02EFC0E9E228}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{1BC05915-044E-4776-8956-B44BBEFF2F84}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{D5E70443-4BA2-42ED-992A-010268440B08}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{72EE26E2-E8BE-4169-82AD-93E021539C34}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{2614D290-1345-4A41-BE90-F85F817CEADE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2614D290-1345-4A41-BE90-F85F817CEADE}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{2614D290-1345-4A41-BE90-F85F817CEADE}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{2614D290-1345-4A41-BE90-F85F817CEADE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2614D290-1345-4A41-BE90-F85F817CEADE}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{2614D290-1345-4A41-BE90-F85F817CEADE}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{F3669415-319E-4C4C-A398-89321589B3A9}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{E372D54C-73AA-41DB-A471-81348AC37F36}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{F98A9787-B175-450F-99FC-EC241EB9D581}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{4943C197-0742-480E-B1D3-6738D41582A3}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Debug-Windows|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Debug-Windows|Any CPU.Build.0 = Debug|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Release-Windows|Any CPU.ActiveCfg = Release|Any CPU
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D}.Release-Windows|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3CF175CF-1AF4-4109-96CB-221684DCED7D} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{CA008713-655E-46DA-BBDF-1EF6B8CE7DCA} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{E325A0E2-716A-49E0-9767-5087CF05727C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{B2C5EED9-21B2-4763-AB92-C1995B76DA3A} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{9BDF7020-A19F-4C6C-B329-E4BFEFF6DE6B} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{6462DA5D-27DC-4CD5-9467-5EFB998FD838} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{C1F54CDC-AD1D-45BB-8F7D-F49E411AFAF1} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{ADA8AB8B-2066-4193-B8F7-985669B23E00} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{BF414C86-DB3B-4022-9B29-DCE8AA954C12} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{276EBE79-A13A-46BD-A566-B01DC0477A9B} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA} = {763168FA-A590-482C-84D8-2922F7ADB1A2}
+		{7BCEBDC1-D57F-4717-9B15-4FACD5473489} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{053BD8B8-B5C1-4C45-81D4-C9BA8D5B3CE2} = {276EBE79-A13A-46BD-A566-B01DC0477A9B}
+		{EED5F0D3-6F00-4ED1-9108-5ADCB10A3734} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{C93F6192-0123-4121-AD92-374A71E4B0F3} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{A4184239-F13F-4A09-B2D3-0B9532609248} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{D9B2EF5D-0515-460F-948A-2BB70C8DCF62} = {763168FA-A590-482C-84D8-2922F7ADB1A2}
+		{763168FA-A590-482C-84D8-2922F7ADB1A2} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{0F639EB4-FB64-4909-8A10-FB93E7BE3AFB} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{2F77CA1D-E6F0-4DEA-96BB-8A039F4D0FF8} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{62C4DC83-3B07-45D7-856E-224FFB368E5F} = {0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}
+		{35F9B8A8-1974-4795-930B-5E4980EE85E5} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{71698D71-4C6F-40D5-8BDE-2587514CA21C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{0B8ABFDB-F9CF-4EC6-988E-9C32D9E01C26} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{1B7920E6-5262-4054-B72D-3A8DBBA057D2} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{8FC920C6-E895-4A17-AB2F-452FAAA36CC8} = {276EBE79-A13A-46BD-A566-B01DC0477A9B}
+		{B609DB2C-5C1F-46D1-A0FA-A0FF9216899A} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{3F4A0DD8-4D47-4B9C-939A-3146E68C84F7} = {0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}
+		{D790A4BB-D8AC-4AAE-B3FE-0CF432CA8031} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{C113E0AE-5564-4389-BA39-183A8D574210} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{B9DDC8CB-8EDF-4D98-913A-22F19E642223} = {8667F820-8ADA-4498-91AE-AE95DEE5227E}
+		{060F070A-BBFA-490E-BE89-3844C857B771} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{E4E13301-9193-4106-B0E3-41276B478E7C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{76391566-9F22-4994-8B0F-02EFC0E9E228} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{1BC05915-044E-4776-8956-B44BBEFF2F84} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{AE3FC7F6-B212-4438-B1D7-C121BB4C15ED} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{8DC1257B-7650-40EB-97A2-C1CBA306DA6A} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{D5E70443-4BA2-42ED-992A-010268440B08} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{84E3B6A2-42D9-498A-9CD2-1C5F5BE0D526} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{52CDBBA9-E5AF-433C-80F0-5EF3C8B14946} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{F59673EA-2D0D-441A-BB85-CD343DE6BE45} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{72EE26E2-E8BE-4169-82AD-93E021539C34} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{2454BBCD-77BC-4E3D-B5A6-3562BED898D6} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{685271A8-6C69-46E4-9B11-89AF9761CE0A} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{474C57B1-C9FC-4B71-A92B-B25BA27FAFA7} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{6230B915-B238-4E57-AAC4-06B4498F540F} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{1D1AD39B-EBCF-4960-930E-84246DEF6AAE} = {6230B915-B238-4E57-AAC4-06B4498F540F}
+		{E8CD434A-306F-41D9-B67D-BFFF3287354D} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{6B51F54F-86E8-4FBC-8FDD-3C386E97D0E1} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{E0223463-97C6-4108-B5A9-AFBA16B9D5CC} = {276EBE79-A13A-46BD-A566-B01DC0477A9B}
+		{EE76BD65-FB01-498F-B053-4E1B2693D85F} = {276EBE79-A13A-46BD-A566-B01DC0477A9B}
+		{873BCC1F-ED12-424E-93FA-D76F4BA022C2} = {0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}
+		{2614D290-1345-4A41-BE90-F85F817CEADE} = {0A0E26B0-7A46-4F1A-8BFE-9A763FDF6CF8}
+		{F3669415-319E-4C4C-A398-89321589B3A9} = {6230B915-B238-4E57-AAC4-06B4498F540F}
+		{9878B523-BD1E-4285-A875-3CAB4127F7E6} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{6E39C647-902F-4CFF-A4E4-194B295E3AF4} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{EFAA1D3D-3102-4307-A5DD-EAB4DB9B0386} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{4C82FD14-418F-43E4-AC59-3D926B55CEA3} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{D243AC2D-7823-4177-9D8A-23FDFDA274D2} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{D2D9931A-EBFC-4923-A7BC-EF8BBD76D079} = {6230B915-B238-4E57-AAC4-06B4498F540F}
+		{170EA6A3-26A6-4A1A-A6F9-44BE5208FA06} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{195FC24B-C4DA-4055-918D-5ABF50FD805B} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{9F7B2BDF-973B-4639-B890-357EB967B2ED} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{E372D54C-73AA-41DB-A471-81348AC37F36} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{C8E31CD2-89D4-4659-9557-43EC9C99D984} = {6230B915-B238-4E57-AAC4-06B4498F540F}
+		{1D05EFE4-7F25-4D5A-BCEE-1109B9EF25A8} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{24CCB459-B4F6-484F-8BA4-946A4AB816FA} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{D9242899-AB3F-46BB-BAB4-386CB8EC535C} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{F98A9787-B175-450F-99FC-EC241EB9D581} = {E8CD434A-306F-41D9-B67D-BFFF3287354D}
+		{99C466C3-1931-4C0E-AA0A-A8D9D140F56E} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{2FBA2BB7-73C8-45CD-99B7-D65F817C9051} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{4943C197-0742-480E-B1D3-6738D41582A3} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
+		{3C16F609-61D8-49C5-A243-9D32B9491D91} = {8667F820-8ADA-4498-91AE-AE95DEE5227E}
+		{C9B9D0E6-1579-4F5E-B23B-9EFD17F50D34} = {3C16F609-61D8-49C5-A243-9D32B9491D91}
+		{A0080C33-4628-4259-84D6-2E6DEDBD26B7} = {C9B9D0E6-1579-4F5E-B23B-9EFD17F50D34}
+		{C8F3C6E5-6A21-4F77-ADF7-30119D836A4D} = {C9B9D0E6-1579-4F5E-B23B-9EFD17F50D34}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7173C9F3-A7F9-496E-9078-9156E35D6E16}
+	EndGlobalSection
+EndGlobal

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1191,7 +1191,7 @@ namespace Microsoft.Bot.Builder
             var appPassword = await CredentialProvider.GetAppPasswordAsync(appId).ConfigureAwait(false);
 
             // Construct an AppCredentials using the app + password combination. If government, we create a government specific credential.
-            return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
+            return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftGovernmentAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftGovernmentAppCredentials.cs
@@ -39,6 +39,14 @@ namespace Microsoft.Bot.Connector.Authentication
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MicrosoftGovernmentAppCredentials"/> class.
+        /// </summary>
+        /// <param name="appId">The Microsoft app ID.</param>
+        /// <param name="password">The Microsoft app password.</param>
+        /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
+        /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
+        /// <param name="oAuthScope">The scope for the token (defaults to <see cref="GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope"/> if null).</param>
         public MicrosoftGovernmentAppCredentials(string appId, string password, HttpClient customHttpClient, ILogger logger, string oAuthScope = null)
             : base(appId, password, customHttpClient, logger, oAuthScope ?? GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope)
         {

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftGovernmentAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftGovernmentAppCredentials.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// An empty set of credentials.
         /// </summary>
-        public static new readonly MicrosoftGovernmentAppCredentials Empty = new MicrosoftGovernmentAppCredentials(null, null);
+        public static new readonly MicrosoftGovernmentAppCredentials Empty = new MicrosoftGovernmentAppCredentials(null, null, null, null, GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MicrosoftGovernmentAppCredentials"/> class.
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="password">The Microsoft app password.</param>
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         public MicrosoftGovernmentAppCredentials(string appId, string password, HttpClient customHttpClient = null)
-            : base(appId, password, customHttpClient)
+            : this(appId, password, customHttpClient, null, GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope)
         {
         }
 
@@ -35,7 +35,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
         public MicrosoftGovernmentAppCredentials(string appId, string password, HttpClient customHttpClient, ILogger logger)
-            : base(appId, password, customHttpClient, logger)
+            : this(appId, password, customHttpClient, logger, GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope)
+        {
+        }
+
+        public MicrosoftGovernmentAppCredentials(string appId, string password, HttpClient customHttpClient, ILogger logger, string oAuthScope = null)
+            : base(appId, password, customHttpClient, logger, oAuthScope ?? GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope)
         {
         }
 
@@ -48,17 +53,6 @@ namespace Microsoft.Bot.Connector.Authentication
         public override string OAuthEndpoint
         {
             get { return GovernmentAuthenticationConstants.ToChannelFromBotLoginUrl; }
-        }
-
-        /// <summary>
-        /// Gets the OAuth scope to use.
-        /// </summary>
-        /// <value>
-        /// The OAuth scope to use.
-        /// </value>
-        public override string OAuthScope
-        {
-            get { return GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope; }
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         protected virtual async Task<AppCredentials> BuildCredentialsAsync(string appId, string oAuthScope = null)
         {
             var appPassword = await CredentialProvider.GetAppPasswordAsync(appId).ConfigureAwait(false);
-            return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
+            return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
         }
 
         private static object GetBodyContent(string content)

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/MicrosoftGovernmentAppCredentialsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/MicrosoftGovernmentAppCredentialsTests.cs
@@ -25,6 +25,14 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
+        public void MicrosoftGovernmentAppCredentials_Uses_Custom_Scope()
+        {
+            var cred = new MicrosoftGovernmentAppCredentials(string.Empty, string.Empty, null, null, "my Custom oAuthScope");
+
+            Assert.Equal("my Custom oAuthScope", cred.OAuthScope);
+        }
+
+        [Fact]
         public void GovernmentAuthenticationConstants_ChannelService_IsRight()
         {
             // This value should not change


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/3233

Added constructor to MicrosoftGovernmentAppCredentials that takes OAuthScope to support skills in gov.
Updated BotFrameworkHttpClient and BotFrameworkAdapter to pass the OAuthScope to MicrosoftGovernmentAppCredentials
Added SimpleBotToBot functional test for testing.
Added Microsoft.Bot.Framework.Skills.sln to load skills test projects.