### PR TITLE
Added cancellation token to ContinueConversationAsync on Facebook adapter

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -96,15 +96,15 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                         if (activity.Name.Equals(HandoverConstants.PassThreadControl, StringComparison.Ordinal))
                         {
                             var recipient = (string)activity.Value == "inbox" ? HandoverConstants.PageInboxId : (string)activity.Value;
-                            await _facebookClient.PassThreadControlAsync(recipient, activity.Conversation.Id, HandoverConstants.MetadataPassThreadControl).ConfigureAwait(false);
+                            await _facebookClient.PassThreadControlAsync(recipient, activity.Conversation.Id, HandoverConstants.MetadataPassThreadControl, cancellationToken).ConfigureAwait(false);
                         }
                         else if (activity.Name.Equals(HandoverConstants.TakeThreadControl, StringComparison.Ordinal))
                         {
-                            await _facebookClient.TakeThreadControlAsync(activity.Conversation.Id, HandoverConstants.MetadataTakeThreadControl).ConfigureAwait(false);
+                            await _facebookClient.TakeThreadControlAsync(activity.Conversation.Id, HandoverConstants.MetadataTakeThreadControl, cancellationToken).ConfigureAwait(false);
                         }
                         else if (activity.Name.Equals(HandoverConstants.RequestThreadControl, StringComparison.Ordinal))
                         {
-                            await _facebookClient.RequestThreadControlAsync(activity.Conversation.Id, HandoverConstants.MetadataRequestThreadControl).ConfigureAwait(false);
+                            await _facebookClient.RequestThreadControlAsync(activity.Conversation.Id, HandoverConstants.MetadataRequestThreadControl, cancellationToken).ConfigureAwait(false);
                         }
                     }
 
@@ -149,8 +149,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// </summary>
         /// <param name="reference">A conversation reference to be applied to future messages.</param>
         /// <param name="logic">A bot logic function that will perform continuing action in the form `async(context) => { ... }`.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task ContinueConversationAsync(ConversationReference reference, BotCallbackHandler logic)
+        public async Task ContinueConversationAsync(ConversationReference reference, BotCallbackHandler logic, CancellationToken cancellationToken)
         {
             if (reference == null)
             {
@@ -166,7 +167,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
             using (var context = new TurnContext(this, request))
             {
-                await RunPipelineAsync(context, logic, default).ConfigureAwait(false);
+                await RunPipelineAsync(context, logic, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
@@ -169,8 +169,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// </summary>
         /// <param name="postType">The REST post type (GET, PUT, POST, etc).</param>
         /// <param name="content">The string content to be posted to Facebook.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A bool indicating the success of the operation.</returns>
-        public virtual async Task<bool> PostToFacebookApiAsync(string postType, string content)
+        public virtual async Task<bool> PostToFacebookApiAsync(string postType, string content, CancellationToken cancellationToken)
         {
             if (postType == null)
             {
@@ -195,7 +196,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
                 using (var client = new HttpClient())
                 {
-                    var res = await client.SendAsync(requestMessage, CancellationToken.None).ConfigureAwait(false);
+                    var res = await client.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
                     return res.IsSuccessStatusCode;
                 }
             }
@@ -206,8 +207,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// </summary>
         /// <param name="userId">The sender user Id.</param>
         /// <param name="message">An optional message for the metadata paremter.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A bool value indicating the success of the operation.</returns>
-        public virtual async Task<bool> RequestThreadControlAsync(string userId, string message)
+        public virtual async Task<bool> RequestThreadControlAsync(string userId, string message, CancellationToken cancellationToken)
         {
             if (userId == null)
             {
@@ -215,7 +217,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             }
 
             var content = new { recipient = new { id = userId }, metadata = message };
-            return await PostToFacebookApiAsync($"/me/{HandoverConstants.RequestThreadControl}", JsonConvert.SerializeObject(content)).ConfigureAwait(false);
+            return await PostToFacebookApiAsync($"/me/{HandoverConstants.RequestThreadControl}", JsonConvert.SerializeObject(content), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -223,8 +225,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// </summary>
         /// <param name="userId">The sender user Id.</param>
         /// <param name="message">An optional message for the metadata paremter.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A bool value indicating the success of the operation.</returns>
-        public virtual async Task<bool> TakeThreadControlAsync(string userId, string message)
+        public virtual async Task<bool> TakeThreadControlAsync(string userId, string message, CancellationToken cancellationToken)
         {
             if (userId == null)
             {
@@ -232,7 +235,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             }
 
             var content = new { recipient = new { id = userId }, metadata = message };
-            return await PostToFacebookApiAsync($"/me/{HandoverConstants.TakeThreadControl}", JsonConvert.SerializeObject(content)).ConfigureAwait(false);
+            return await PostToFacebookApiAsync($"/me/{HandoverConstants.TakeThreadControl}", JsonConvert.SerializeObject(content), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -241,8 +244,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// <param name="targetAppId">The Id of the target app to pass control to.</param>
         /// <param name="userId">The sender user Id.</param>
         /// <param name="message">An optional message for the metadata paremter.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>A bool value indicating the success of the operation.</returns>
-        public virtual async Task<bool> PassThreadControlAsync(string targetAppId, string userId, string message)
+        public virtual async Task<bool> PassThreadControlAsync(string targetAppId, string userId, string message, CancellationToken cancellationToken)
         {
             if (targetAppId == null)
             {
@@ -255,7 +259,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             }
 
             var content = new { recipient = new { id = userId }, target_app_id = targetAppId, metadata = message };
-            return await PostToFacebookApiAsync($"/me/{HandoverConstants.PassThreadControl}", JsonConvert.SerializeObject(content)).ConfigureAwait(false);
+            return await PostToFacebookApiAsync($"/me/{HandoverConstants.PassThreadControl}", JsonConvert.SerializeObject(content), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookEntry.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookEntry.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
 
         public bool ShouldSerializeStandby()
         {
-            return Messaging.Count > 0;
+            return Standby.Count > 0;
         }
 
         public bool ShouldSerializeChanges()
         {
-            return Messaging.Count > 0;
+            return Changes.Count > 0;
         }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 {
                     var messageOptions = TwilioHelper.ActivityToTwilio(activity, _twilioClient.Options.TwilioNumber);
 
-                    var res = await _twilioClient.SendMessage(messageOptions).ConfigureAwait(false);
+                    var res = await _twilioClient.SendMessage(messageOptions, cancellationToken).ConfigureAwait(false);
 
                     var response = new ResourceResponse() { Id = res, };
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Twilio;
@@ -51,8 +52,9 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// Sends a Twilio SMS message.
         /// </summary>
         /// <param name="messageOptions">An object containing the parameters for the message to send.</param>
+        /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The SID of the Twilio message sent.</returns>
-        public virtual async Task<string> SendMessage(CreateMessageOptions messageOptions)
+        public virtual async Task<string> SendMessage(CreateMessageOptions messageOptions, CancellationToken cancellationToken)
         {
             var messageResource = await MessageResource.CreateAsync(messageOptions).ConfigureAwait(false);
             return messageResource.Sid;

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
                 return Task.CompletedTask;
             }
 
-            await facebookAdapter.ContinueConversationAsync(conversationReference, BotsLogic);
+            await facebookAdapter.ContinueConversationAsync(conversationReference, BotsLogic, default);
             Assert.True(callbackInvoked);
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
                 return Task.CompletedTask;
             }
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookAdapter.ContinueConversationAsync(null, BotsLogic); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookAdapter.ContinueConversationAsync(null, BotsLogic, default); });
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             var facebookAdapter = new FacebookAdapter(new Mock<FacebookClientWrapper>(_testOptions).Object);
             var conversationReference = new ConversationReference();
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookAdapter.ContinueConversationAsync(conversationReference, null); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookAdapter.ContinueConversationAsync(conversationReference, null, default); });
         }
 
         [Fact]
@@ -279,7 +279,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             ResourceResponse[] responses = null;
 
             facebookClientWrapper.Setup(api => api.SendMessageAsync(It.IsAny<string>(), It.IsAny<FacebookMessage>(), It.IsAny<HttpMethod>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(testResponse));
-            facebookClientWrapper.Setup(api => api.PassThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            facebookClientWrapper.Setup(api => api.PassThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), default)).Returns(Task.FromResult(true));
 
             using (var turnContext = new TurnContext(facebookAdapter, activity))
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             }
 
             Assert.Equal(testResponse, responses[0].Id);
-            facebookClientWrapper.Verify(api => api.PassThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            facebookClientWrapper.Verify(api => api.PassThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), default), Times.Once);
         }
 
         [Fact]
@@ -311,7 +311,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             ResourceResponse[] responses = null;
 
             facebookClientWrapper.Setup(api => api.SendMessageAsync(It.IsAny<string>(), It.IsAny<FacebookMessage>(), It.IsAny<HttpMethod>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(testResponse));
-            facebookClientWrapper.Setup(api => api.TakeThreadControlAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            facebookClientWrapper.Setup(api => api.TakeThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), default)).Returns(Task.FromResult(true));
 
             using (var turnContext = new TurnContext(facebookAdapter, activity))
             {
@@ -319,7 +319,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             }
 
             Assert.Equal(testResponse, responses[0].Id);
-            facebookClientWrapper.Verify(api => api.TakeThreadControlAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            facebookClientWrapper.Verify(api => api.TakeThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), default), Times.Once);
         }
 
         [Fact]
@@ -343,7 +343,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             ResourceResponse[] responses = null;
 
             facebookClientWrapper.Setup(api => api.SendMessageAsync(It.IsAny<string>(), It.IsAny<FacebookMessage>(), It.IsAny<HttpMethod>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(testResponse));
-            facebookClientWrapper.Setup(api => api.RequestThreadControlAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            facebookClientWrapper.Setup(api => api.RequestThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), default)).Returns(Task.FromResult(true));
 
             using (var turnContext = new TurnContext(facebookAdapter, activity))
             {
@@ -351,7 +351,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
             }
 
             Assert.Equal(testResponse, responses[0].Id);
-            facebookClientWrapper.Verify(api => api.RequestThreadControlAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            facebookClientWrapper.Verify(api => api.RequestThreadControlAsync(It.IsAny<string>(), It.IsAny<string>(), default), Times.Once);
         }
         
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PassThreadControlAsync(null, "fakeUserId", "Test Pass Thread Control"); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PassThreadControlAsync(null, "fakeUserId", "Test Pass Thread Control", default); });
         }
 
         [Fact]
@@ -174,7 +174,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PassThreadControlAsync("fakeAppId", null, "Test Pass Thread Control"); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PassThreadControlAsync("fakeAppId", null, "Test Pass Thread Control", default); });
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.RequestThreadControlAsync(null, "Test Pass Thread Control"); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.RequestThreadControlAsync(null, "Test Pass Thread Control", default); });
         }
 
         [Fact]
@@ -190,7 +190,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.TakeThreadControlAsync(null, "Test Pass Thread Control"); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.TakeThreadControlAsync(null, "Test Pass Thread Control", default); });
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PostToFacebookApiAsync(null, "fakeContent"); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PostToFacebookApiAsync(null, "fakeContent", default); });
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PostToFacebookApiAsync("fakePostType", null); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await facebookClientWrapper.PostToFacebookApiAsync("fakePostType", null, default); });
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             const string resourceIdentifier = "Mocked Resource Identifier";
             var twilioApi = new Mock<TwilioClientWrapper>(_testOptions);
-            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>())).Returns(Task.FromResult(resourceIdentifier));
+            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
 
             var twilioAdapter = new TwilioAdapter(twilioApi.Object);
             var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default).ConfigureAwait(false);
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             const string resourceIdentifier = "Mocked Resource Identifier";
             var twilioApi = new Mock<TwilioClientWrapper>(_testOptions);
-            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>())).Returns(Task.FromResult(resourceIdentifier));
+            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
 
             var twilioAdapter = new TwilioAdapter(twilioApi.Object);
             var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #3370 
Also updates use of cancellation tokens in adapters for consistency.