### PR TITLE
[LG] optimize inline text evaluation

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFile.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFile.cs
@@ -156,11 +156,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             var newContent = $"# {fakeTemplateId} \r\n - {inlineStr}";
 
-            var newLgFile = LGParser.ParseText(newContent, this.Id, this.ImportResolver);
+            var newLgFile = LGParser.ParseTextWithRef(newContent, this);
 
-            var allTemplates = this.AllTemplates.Union(newLgFile.AllTemplates).ToList();
-            var evaluator = new Evaluator(allTemplates, this.ExpressionEngine);
-            return evaluator.EvaluateTemplate(fakeTemplateId, scope);
+            return newLgFile.EvaluateTemplate(fakeTemplateId, scope);
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public TestContext TestContext { get; set; }
 
         [TestMethod]
-        [ExpectedException(typeof(System.Data.SyntaxErrorException))]
+        [ExpectedException(typeof(Exception))]
         public async Task TestNotFoundTemplate()
         {
             var context = GetTurnContext(string.Empty);

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/LGFileTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/LGFileTest.cs
@@ -968,6 +968,22 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual("null", jObjEvaled["key1"]);
         }
 
+        [TestMethod]
+        public void TestInlineEvaluate()
+        {
+            var lgFile = LGParser.ParseFile(GetExampleFilePath("2.lg"));
+            var evaled = lgFile.Evaluate("hello");
+            Assert.AreEqual("hello", evaled);
+
+            // test template reference
+            evaled = lgFile.Evaluate("@{wPhrase()}");
+            var options = new List<string> { "Hi", "Hello", "Hiya" };
+            Assert.IsTrue(options.Contains(evaled), $"The result `{evaled}` is not in those options [{string.Join(",", options)}]");
+
+            var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("@{ErrrorTemplate()}"));
+            Assert.IsTrue(exception.Message.Contains("it's not a built-in function or a customized function"));
+        }
+
         public class LoopClass
         {
             public string Name { get; set; }


### PR DESCRIPTION
Originally, we do parse the additional inline text directly.

In this pr, we will add a new text parser, that accepts the text and original LGFile both.
So, there will be no intermediate error messages appearing in parse directly. 
At the same time, no impact on parse performance.

close: #3352