### PR TITLE
Fix BotStateScope to show full botState and give control for dialogState Property name

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/DialogManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Initializes a new instance of the <see cref="DialogManager"/> class.
         /// </summary>
         /// <param name="rootDialog">rootdialog to use.</param>
-        /// <param name="dialogStateProperty">alternate name for the dialogState property. Default is "_dialogs".</param>
+        /// <param name="dialogStateProperty">alternate name for the dialogState property. (Default is "DialogState").</param>
         public DialogManager(Dialog rootDialog = null, string dialogStateProperty = null)
         {
             if (rootDialog != null)
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 this.RootDialog = rootDialog;
             }
 
-            this.dialogStateProperty = dialogStateProperty ?? "_dialogs";
+            this.dialogStateProperty = dialogStateProperty ?? "DialogState";
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/DialogManager.cs
@@ -2,16 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
-using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Memory;
-using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
@@ -21,16 +15,23 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public class DialogManager
     {
-        private const string DIALOGS = "_dialogs";
         private const string LASTACCESS = "_lastAccess";
         private string rootDialogId;
+        private string dialogStateProperty;
 
-        public DialogManager(Dialog rootDialog = null)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogManager"/> class.
+        /// </summary>
+        /// <param name="rootDialog">rootdialog to use.</param>
+        /// <param name="dialogStateProperty">alternate name for the dialogState property. Default is "_dialogs".</param>
+        public DialogManager(Dialog rootDialog = null, string dialogStateProperty = null)
         {
             if (rootDialog != null)
             {
                 this.RootDialog = rootDialog;
             }
+
+            this.dialogStateProperty = dialogStateProperty ?? "_dialogs";
         }
 
         /// <summary>
@@ -166,7 +167,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             await lastAccessProperty.SetAsync(context, lastAccess, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // get dialog stack 
-            var dialogsProperty = ConversationState.CreateProperty<DialogState>(DIALOGS);
+            var dialogsProperty = ConversationState.CreateProperty<DialogState>(this.dialogStateProperty);
             DialogState dialogState = await dialogsProperty.GetAsync(context, () => new DialogState(), cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // Create DialogContext

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/DialogStateManager.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
                 {
                     // Root is handled by SetMemory rather than SetValue
                     var scope = GetMemoryScope(key) ?? throw new ArgumentOutOfRangeException(GetBadScopeMessage(key));
-                    scope.SetMemory(this.dialogContext, value);
+                    scope.SetMemory(this.dialogContext, JToken.FromObject(value));
                 }
                 else
                 {
@@ -268,6 +268,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             if (value is Task)
             {
                 throw new Exception($"{path} = You can't pass an unresolved Task to SetValue");
+            }
+
+            if (value != null)
+            {
+                value = JToken.FromObject(value);
             }
 
             path = this.TransformPath(path ?? throw new ArgumentNullException(nameof(path)));

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Scopes/ConversationMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Scopes/ConversationMemoryScope.cs
@@ -17,9 +17,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// Initializes a new instance of the <see cref="ConversationMemoryScope"/> class.
         /// Create new ConversationMemoryScope bound to ConversationState.
         /// </summary>
-        /// <param name="propertyName">alterative property for conversation memory scope to be stored under.</param>
-        public ConversationMemoryScope(string propertyName = null)
-            : base(ScopePath.CONVERSATION, propertyName)
+        public ConversationMemoryScope()
+            : base(ScopePath.CONVERSATION)
         {
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Scopes/UserMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Scopes/UserMemoryScope.cs
@@ -16,9 +16,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// <summary>
         /// Initializes a new instance of the <see cref="UserMemoryScope"/> class.
         /// </summary>
-        /// <param name="propertyName">Optional alternate propertyName to store UserMemoryScope in.</param>
-        public UserMemoryScope(string propertyName = null)
-            : base(ScopePath.USER, propertyName)
+        public UserMemoryScope()
+            : base(ScopePath.USER)
         {
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -201,13 +202,14 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var lastSegment = segments.Last();
                 if (lastSegment is string property)
                 {
-                    try
+                    // ConcurrentDictionary doesn't implement Remove, but it does implement IDictionary
+                    if (current is IDictionary<string, object> dict)
+                    {
+                        dict.Remove(property);
+                    }
+                    else
                     {
                         current.Remove(property);
-                    }
-                    catch (Exception)
-                    {
-                        ObjectPath.SetObjectSegment(current, property, null);
                     }
                 }
                 else

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Bot.Builder
             /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
             public async Task DeleteAsync(ITurnContext turnContext, CancellationToken cancellationToken)
             {
-                await _botState.LoadAsync(turnContext, false, cancellationToken).ConfigureAwait(false); 
+                await _botState.LoadAsync(turnContext, false, cancellationToken).ConfigureAwait(false);
                 await _botState.DeletePropertyValueAsync(turnContext, Name, cancellationToken).ConfigureAwait(false);
             }
 
@@ -401,40 +401,23 @@ namespace Microsoft.Bot.Builder
             public async Task<T> GetAsync(ITurnContext turnContext, Func<T> defaultValueFactory, CancellationToken cancellationToken)
             {
                 await _botState.LoadAsync(turnContext, false, cancellationToken).ConfigureAwait(false);
-                try
+                var result = await _botState.GetPropertyValueAsync<T>(turnContext, Name, cancellationToken).ConfigureAwait(false);
+                if (EqualityComparer<T>.Default.Equals(result, default(T)))
                 {
-                    var result = await _botState.GetPropertyValueAsync<T>(turnContext, Name, cancellationToken).ConfigureAwait(false);
-                    if (EqualityComparer<T>.Default.Equals(result, default(T)))
-                    {
-                        // if this returns default value then we call defaultValueFactory
-                        if (defaultValueFactory == null)
-                        {
-                            return default(T);
-                        }
-
-                        result = defaultValueFactory();
-
-                        // save default value for any further calls
-                        await SetAsync(turnContext, result, cancellationToken).ConfigureAwait(false);
-                        return result;
-                    }
-
-                    return result;
-                }
-                catch (KeyNotFoundException)
-                {
-                    // ask for default value from factory
+                    // if this returns default value then we call defaultValueFactory
                     if (defaultValueFactory == null)
                     {
                         return default(T);
                     }
 
-                    var result = defaultValueFactory();
+                    result = defaultValueFactory();
 
                     // save default value for any further calls
                     await SetAsync(turnContext, result, cancellationToken).ConfigureAwait(false);
                     return result;
                 }
+
+                return result;
             }
 
             /// <summary>

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Bot.Builder
         {
             public CachedBotState(IDictionary<string, object> state = null)
             {
-                State = state ?? new ConcurrentDictionary<string, object>();
+                State = state ?? new Dictionary<string, object>();
                 Hash = ComputeHash(State);
             }
 

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -269,6 +269,11 @@ namespace Microsoft.Bot.Builder
                 return Task.FromResult(JToken.FromObject(result).ToObject<T>());
             }
 
+            if (typeof(T).IsValueType)
+            {
+                throw new KeyNotFoundException(propertyName);
+            }
+
             return Task.FromResult(default(T));
         }
 
@@ -400,21 +405,31 @@ namespace Microsoft.Bot.Builder
             /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
             public async Task<T> GetAsync(ITurnContext turnContext, Func<T> defaultValueFactory, CancellationToken cancellationToken)
             {
+                T result = default(T);
+                
                 await _botState.LoadAsync(turnContext, false, cancellationToken).ConfigureAwait(false);
-                var result = await _botState.GetPropertyValueAsync<T>(turnContext, Name, cancellationToken).ConfigureAwait(false);
-                if (EqualityComparer<T>.Default.Equals(result, default(T)))
+
+                try
                 {
-                    // if this returns default value then we call defaultValueFactory
-                    if (defaultValueFactory == null)
+                    // if T is a value type, lookup up will throw key not found if not found, but as perf
+                    // optimization it will return null if not found for types which are not value types (string and object).
+                    result = await _botState.GetPropertyValueAsync<T>(turnContext, Name, cancellationToken).ConfigureAwait(false);
+
+                    if (result == null && defaultValueFactory != null)
                     {
-                        return default(T);
+                        // use default Value Factory and save default value for any further calls
+                        result = defaultValueFactory();
+                        await SetAsync(turnContext, result, cancellationToken).ConfigureAwait(false);
                     }
-
-                    result = defaultValueFactory();
-
-                    // save default value for any further calls
-                    await SetAsync(turnContext, result, cancellationToken).ConfigureAwait(false);
-                    return result;
+                }
+                catch (KeyNotFoundException)
+                {
+                    if (defaultValueFactory != null)
+                    {
+                        // use default Value Factory and save default value for any further calls
+                        result = defaultValueFactory();
+                        await SetAsync(turnContext, result, cancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 return result;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                     var trace = (Activity)activity;
                     Assert.AreEqual(ActivityTypes.Trace, trace.Type, "should be trace activity");
                     Assert.AreEqual("memory", trace.ValueType, "value type should be memory");
-                    Assert.AreEqual("Carlos", ((JObject)trace.Value)["name"].ToString(), "value should be user object with name='Carlos'");
+                    Assert.AreEqual("Carlos", (string)((dynamic)trace.Value)["name"], "value should be user object with name='Carlos'");
                 })
             .StartTestAsync();
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
@@ -42,6 +42,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        public async Task DialogManager_AlternateProperty()
+        {
+            var firstConversationId = Guid.NewGuid().ToString();
+            var storage = new MemoryStorage();
+
+            var adaptiveDialog = CreateTestDialog(property: "conversation.name");
+
+            await CreateFlow(adaptiveDialog, storage, firstConversationId, dialogStateProperty: "dialogState")
+            .Send("hi")
+                .AssertReply("Hello, what is your name?")
+            .Send("Carlos")
+                .AssertReply("Hello Carlos, nice to meet you!")
+            .Send("hi")
+                .AssertReply("Hello Carlos, nice to meet you!")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task DialogManager_ConversationState_ClearedAcrossConversations()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -187,7 +205,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             return new AskForNameDialog(property.Replace(".", string.Empty), property);
         }
 
-        private TestFlow CreateFlow(Dialog dialog, IStorage storage, string conversationId)
+        private TestFlow CreateFlow(Dialog dialog, IStorage storage, string conversationId, string dialogStateProperty = null)
         {
             var convoState = new ConversationState(storage);
             var userState = new UserState(storage);
@@ -198,7 +216,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .UseState(userState, convoState)
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
-            DialogManager dm = new DialogManager(dialog);
+            DialogManager dm = new DialogManager(dialog, dialogStateProperty: dialogStateProperty);
             return new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -334,9 +334,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     dc.GetState().RemoveValue("user");
                     Assert.Fail("Should have thrown with known root memory scope");
                 }
-                catch (ArgumentNullException err)
+                catch (NotSupportedException err)
                 {
-                    Assert.IsTrue(err.Message.Contains("cannot be null"));
                 }
 
                 try
@@ -344,9 +343,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     dc.GetState().RemoveValue("xxx");
                     Assert.Fail("Should have thrown with unknown memory scope");
                 }
-                catch (ArgumentOutOfRangeException err)
+                catch (NotSupportedException err)
                 {
-                    Assert.IsTrue(err.Message.Contains("does not match memory scope"));
                 }
             }).StartTestAsync();
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/MemoryScopeTests.cs
@@ -3,6 +3,7 @@
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning disable SA1201 // Elements should appear in the correct order
 
 using System;
 using System.Collections.Generic;
@@ -67,6 +68,57 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }).StartTestAsync();
         }
 
+        internal class BotStateTestDialog : Dialog
+        {
+            public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                {
+                    var botState = dc.Context.TurnState.Get<ConversationState>();
+                    var property = botState.CreateProperty<string>("test");
+                    await property.SetAsync(dc.Context, "cool").ConfigureAwait(false);
+
+                    var result = dc.GetState().GetValue<string>("conversation.test");
+                    Assert.AreEqual("cool", result);
+                    dc.GetState().SetValue("conversation.test", "cool2");
+                    Assert.AreEqual("cool2", await property.GetAsync(dc.Context));
+                }
+
+                {
+                    var botState = dc.Context.TurnState.Get<UserState>();
+                    var property = botState.CreateProperty<string>("test");
+                    await property.SetAsync(dc.Context, "cool").ConfigureAwait(false);
+
+                    var result = dc.GetState().GetValue<string>("user.test");
+                    Assert.AreEqual("cool", result);
+                    dc.GetState().SetValue("user.test", "cool2");
+                    Assert.AreEqual("cool2", await property.GetAsync(dc.Context));
+                }
+
+                await dc.Context.SendActivityAsync("next");
+                return await dc.EndDialogAsync();
+            }
+        }
+
+        [TestMethod]
+        public async Task BotStateScopes()
+        {
+            var storage = new MemoryStorage();
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+                .UseStorage(storage)
+                .UseState(new UserState(storage), new ConversationState(storage))
+                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            DialogManager dm = new DialogManager(new BotStateTestDialog());
+
+            await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
+               {
+                   await dm.OnTurnAsync(turnContext);
+               })
+                .Send("hello")
+                    .AssertReply("next")
+                .StartTestAsync();
+        }
+
         [TestMethod]
         public async Task DialogMemoryScopeTest()
         {
@@ -94,7 +146,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .AddInMemoryCollection(new List<KeyValuePair<string, string>>() { new KeyValuePair<string, string>("test", "yoyo") })
                 .AddJsonFile(@"test.settings.json")
                 .Build();
-            
+
             HostContext.Current.Set<IConfiguration>(configuration);
 
             var storage = new MemoryStorage();


### PR DESCRIPTION
* ChangeBotStateMemoryScope to return full BotState object instead of property Fix #3392 
* Change DialogManager to allow alternate dialogStateProperty (for backward compat with custom property names) Fix #3393 
* Removed internal throw for property access lookup (perf enhancement.)