### PR TITLE
fallback to .value property if there is no text.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -419,6 +419,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 else
                 {
                     input = dc.Context.Activity.Text;
+
+                    // if there is no visible text AND we have a value object, then fallback to that.
+                    if (string.IsNullOrEmpty(dc.Context.Activity.Text) && dc.Context.Activity.Value != null)
+                    {
+                        input = dc.Context.Activity.Value;
+                    }
                 }
             }
 


### PR DESCRIPTION
as per DCR #3089 
if there is not activity.text, or it's empty, AND there is a activity.Value then activity.Value will be used as the value.
