### PR TITLE
update adaptive inputs to set inputHint = expectingInput 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -347,6 +347,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
         protected virtual async Task<IActivity> OnRenderPrompt(DialogContext dc, InputState state)
         {
+            IMessageActivity msg = null;
             var dcState = dc.GetState();
 
             switch (state)
@@ -354,11 +355,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 case InputState.Unrecognized:
                     if (this.UnrecognizedPrompt != null)
                     {
-                        return await this.UnrecognizedPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
+                        msg = await this.UnrecognizedPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
                     }
                     else if (this.InvalidPrompt != null)
                     {
-                        return await this.InvalidPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
+                        msg = await this.InvalidPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
                     }
 
                     break;
@@ -366,17 +367,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 case InputState.Invalid:
                     if (this.InvalidPrompt != null)
                     {
-                        return await this.InvalidPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
+                        msg = await this.InvalidPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
                     }
                     else if (this.UnrecognizedPrompt != null)
                     {
-                        return await this.UnrecognizedPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
+                        msg = await this.UnrecognizedPrompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
                     }
 
                     break;
             }
 
-            return await this.Prompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
+            if (msg == null)
+            {
+                msg = await this.Prompt.BindToData(dc.Context, dcState).ConfigureAwait(false);
+            }
+
+            msg.InputHint = InputHints.ExpectingInput;
+
+            return msg;
         }
 
         private async Task<InputState> RecognizeInput(DialogContext dc, int turnCount)


### PR DESCRIPTION
ref to this issue: #3344

At first, LG `ActivityFactory` use `MessageFactory.Text()` to generate message activity result from LG output, but `MessageFactory.Text()` would inject `inputhint = expectingInput ` into activity, and the prompt of input relies on this feature.

 Then we found there is no reason to add `inputhint` into pure text activity, so we removed it in this pr: #3382. 

At the same time, we should update adaptive inputs to set `inputHint = expectingInput` whenever we are issuing a prompt or reprompt (unrecognized/ invalid prompt).