### PR TITLE
fix Dynamic properties do not work

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/DialogStateManager.cs
@@ -123,14 +123,30 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         public virtual MemoryScope ResolveMemoryScope(string path, out string remainingPath)
         {
             var scope = path;
+            var sepIndex = -1;
             var dot = path.IndexOf(".");
-            if (dot > 0)
+            var openSquareBracket = path.IndexOf("[");
+
+            if (dot > 0 && openSquareBracket > 0)
             {
-                scope = path.Substring(0, dot);
+                sepIndex = Math.Min(dot, openSquareBracket);
+            }
+            else if (dot > 0)
+            {
+                sepIndex = dot;
+            }
+            else if (openSquareBracket > 0)
+            {
+                sepIndex = openSquareBracket;
+            }
+
+            if (sepIndex > 0)
+            {
+                scope = path.Substring(0, sepIndex);
                 var memoryScope = GetMemoryScope(scope);
                 if (memoryScope != null)
                 {
-                    remainingPath = path.Substring(dot + 1);
+                    remainingPath = path.Substring(sepIndex + 1);
                     return memoryScope;
                 }
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -243,6 +243,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [TestMethod]
+        public async Task AdaptiveDialog_NestedMemoryAccess()
+        {
+            await TestUtils.RunTestScript(ResourceExplorer);
+        }
+
+        [TestMethod]
         [Ignore]
         public async Task TestForeachWithLargeItems()
         {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_NestedMemoryAccess.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_NestedMemoryAccess.test.dialog
@@ -1,0 +1,46 @@
+﻿{
+    "$schema": "../../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "NestedMemoryAccess",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "user.name.firstname",
+                      "value": "dialog.jack"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "turn.nameproperty",
+                      "value": "name"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "=user[turn.nameproperty].firstname",
+                      "value": "daniel"
+                    },
+                    {
+                      "$kind": "Microsoft.SendActivity",
+                      "activity": "new firstname is ${dialog.jack}"
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+  "script": [
+      {
+        "$kind": "Microsoft.Test.UserSays",
+        "text": "hi"
+      },
+      {
+        "$kind": "Microsoft.Test.AssertReply",
+        "text": "new firstname is daniel"
+      }
+  ]
+}


### PR DESCRIPTION
close #3391 

When we evaluate such expression like "dialog[a].b" with the scope implement by `DialogStateManager`,
The steps to get the result:
1. call DialogStateManager.TryGetValue
2.TransformPath path to get the right format path
3.ResolveMemoryScope to get the memory scope and remaining path
...

The issue occurs in step3, when `dialog['a'].b` comes in, `ResolveMemoryScope`  would separate the path into two parts, first part is `dialog['a']`, and the second part is `b`, but `dialog['a']` is not a valid scope, `dialog` is. 


How to reproduce:
build the below dialog structure:
```
"actions": 
[
                    {
                      "$kind": "Microsoft.SetProperty",
                      "property": "user.name.firstname",
                      "value": "dialog.jack"
                    },
                    {
                      "$kind": "Microsoft.SetProperty",
                      "property": "turn.nameproperty",
                      "value": "name"
                    },
                    {
                      "$kind": "Microsoft.SetProperty",
                      "property": "=user[turn.nameproperty].firstname",
                      "value": "daniel"
                    },
                    {
                      "$kind": "Microsoft.SendActivity",
                      "activity": "new firstname is ${dialog.jack}"
                    }
  ]
```

expect set value "daniel" into property "dialog.jack", but failed.


 Expectation:
Separate path with both open square bracket and dot to get the right memoryscope.
