### PR TITLE
Fix errors when From is null in telemetry

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder
         {
             var properties = new Dictionary<string, string>()
                 {
-                    { TelemetryConstants.FromIdProperty, activity.From.Id },
+                    { TelemetryConstants.FromIdProperty, activity.From?.Id },
                     { TelemetryConstants.ConversationNameProperty, activity.Conversation.Name },
                     { TelemetryConstants.LocaleProperty, activity.Locale },
                     { TelemetryConstants.RecipientIdProperty, activity.Recipient.Id },
@@ -203,9 +203,9 @@ namespace Microsoft.Bot.Builder
             // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
             if (LogPersonalInformation)
             {
-                if (!string.IsNullOrWhiteSpace(activity.From.Name))
+                if (!string.IsNullOrWhiteSpace(activity.From?.Name))
                 {
-                    properties.Add(TelemetryConstants.FromNameProperty, activity.From.Name);
+                    properties.Add(TelemetryConstants.FromNameProperty, activity.From?.Name);
                 }
 
                 if (!string.IsNullOrWhiteSpace(activity.Text))

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
                     items.Remove(TelemetryBotIdInitializer.BotActivityKey);
                 }
 
-                items.Add(TelemetryBotIdInitializer.BotActivityKey, activityJson);
+                items?.Add(TelemetryBotIdInitializer.BotActivityKey, activityJson);
             }
 
             if (_logActivityTelemetry)

--- a/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
@@ -40,15 +40,7 @@ namespace Microsoft.Bot.Builder.Tests
         {
             // Arrange
             var mockTelemetryClient = new Mock<IBotTelemetryClient>();
-            var conversationReference = new ConversationReference()
-            {
-                ChannelId = Channels.Test,
-                ServiceUrl = "https://test.com",
-                User = null,
-                Bot = new ChannelAccount("bot", "Bot"),
-                Conversation = new ConversationAccount(false, "convo1", "Conversation1"),
-            };
-            TestAdapter adapter = new TestAdapter(conversationReference)
+            TestAdapter adapter = new TestAdapter()
                 .Use(new TelemetryLoggerMiddleware(mockTelemetryClient.Object, logPersonalInformation: true));
             string conversationId = null;
 


### PR DESCRIPTION
Fixes: #3395 

If `TelemetryLoggerMiddleware` is used and then `CreateConversationAsync()` is called, there are cases where `Activity.From` will be null, which causes things like this to throw:

```csharp
{ TelemetryConstants.FromIdProperty, activity.From.Id },
```

**Changes**:

Adds a few null-conditional operators, where appropriate.

**Testing**:

Added one test which calls `CreateConversationAsync()` while ensuring the `Activity.From` is null.