### PR TITLE
use standard OAuthScopes in CreateOAuthApiClientAsync

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1308,7 +1308,7 @@ namespace Microsoft.Bot.Builder
             var appId = GetBotAppId(turnContext);
 
             var clientKey = $"{appId}:{oAuthAppCredentials?.MicrosoftAppId}";
-            var oAuthScope = turnContext.TurnState.Get<string>(OAuthScopeKey);
+            var oAuthScope = GetBotFrameworkOAuthScope();
 
             var appCredentials = oAuthAppCredentials ?? await GetAppCredentialsAsync(appId, oAuthScope).ConfigureAwait(false);
 


### PR DESCRIPTION
Small change in code, revert behavior for using scope in `CreateOAuthApiClientAsync` per discussions with @lzc850612.

The code this PR is reverting does not exist in the other languages afaik.