### PR TITLE
Add additional null check in Telemetry

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
 
                 var activityJson = JObject.FromObject(activity);
 
-                if (items.ContainsKey(TelemetryBotIdInitializer.BotActivityKey))
+                if (items != null && items.ContainsKey(TelemetryBotIdInitializer.BotActivityKey))
                 {
                     items.Remove(TelemetryBotIdInitializer.BotActivityKey);
                 }


### PR DESCRIPTION
Fixes: #3442 

Similar to [this PR](https://github.com/microsoft/botbuilder-dotnet/pull/3436), but adds a null check I missed (plus an additional test).

From

```csharp
if (items.ContainsKey(TelemetryBotIdInitializer.BotActivityKey))
```

To

```csharp
if (items != null && items.ContainsKey(TelemetryBotIdInitializer.BotActivityKey))
```