### PR TITLE
Fix YAML file for functional-test-unix

### DIFF
--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -49,7 +49,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '--output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot'
+    arguments: '-r linux-x64 --configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot'
     zipAfterPublish: false
     modifyOutputPath: false
 


### PR DESCRIPTION
### Description
This pull requests fix the YAML for the functional test in unix. The pipeline was failing when running the test `SendDirectLineMessage` because the bot deployed was not working on Azure after the change of the test bot using net core 2.1 to net core 3.1.

### Changes made
We added an argument to the publish step of the file `botbuilder-dotnet-functional-test-linux.yml` so the bot used in the functional test can be deployed properly and be used by direct line.

### Testing
Below you can see the test failing in previous runs and the test passing in a new one after the change.
![image](https://user-images.githubusercontent.com/38112957/75453037-09831f80-5952-11ea-8ecb-b28838d47a41.png)