### PR TITLE
Renamed SequenceContext to ActionContext

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionContext.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
-    public class SequenceContext : DialogContext
+    public class ActionContext : DialogContext
     {
         private readonly string changeKey;
 
-        public SequenceContext(DialogSet dialogs, DialogContext dc, DialogState state, List<ActionState> actions, string changeKey)
+        public ActionContext(DialogSet dialogs, DialogContext dc, DialogState state, List<ActionState> actions, string changeKey)
             : base(dialogs, dc, state)
         {
             this.Actions = actions;
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return false;
         }
 
-        public SequenceContext InsertActions(List<ActionState> actions)
+        public ActionContext InsertActions(List<ActionState> actions)
         {
             this.QueueChanges(
                 new ActionChangeList()
@@ -131,7 +131,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return this;
         }
 
-        public SequenceContext AppendActions(List<ActionState> actions)
+        public ActionContext AppendActions(List<ActionState> actions)
         {
             this.QueueChanges(
                 new ActionChangeList()
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return this;
         }
 
-        public SequenceContext EndSequence(List<ActionState> actions)
+        public ActionContext EndSequence(List<ActionState> actions)
         {
             this.QueueChanges(
                 new ActionChangeList()
@@ -153,7 +153,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return this;
         }
 
-        public SequenceContext ReplaceSequence(List<ActionState> actions)
+        public ActionContext ReplaceSequence(List<ActionState> actions)
         {
             this.QueueChanges(
                 new ActionChangeList()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ActionContext.cs
@@ -9,18 +9,28 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
+    /// <summary>
+    /// Extends the <see cref="DialogContext"/> with additional methods for manipulating the 
+    /// executing sequence of actions for an <see cref="AdaptiveDialog"/>.
+    /// </summary>
     public class ActionContext : DialogContext
     {
         private readonly string changeKey;
 
-        public ActionContext(DialogSet dialogs, DialogContext dc, DialogState state, List<ActionState> actions, string changeKey)
-            : base(dialogs, dc, state)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionContext"/> class.
+        /// </summary>
+        /// <param name="dialogs">The dialog set to create the action context for.</param>
+        /// <param name="parentDialogContext">Parent dialog context.</param>
+        /// <param name="state">Current dialog state.</param>
+        /// <param name="actions">Current list of remaining actions to execute.</param>
+        /// <param name="changeKey">TurnState key for were to persist any changes.</param>
+        public ActionContext(DialogSet dialogs, DialogContext parentDialogContext, DialogState state, List<ActionState> actions, string changeKey)
+            : base(dialogs, parentDialogContext, state)
         {
             this.Actions = actions;
             this.changeKey = changeKey;
         }
-
-        public AdaptiveDialogState Plans { get; private set; }
 
         /// <summary>
         /// Gets or sets list of actions being executed.
@@ -118,50 +128,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             }
 
             return false;
-        }
-
-        public ActionContext InsertActions(List<ActionState> actions)
-        {
-            this.QueueChanges(
-                new ActionChangeList()
-                {
-                    ChangeType = ActionChangeType.InsertActions,
-                    Actions = actions
-                });
-            return this;
-        }
-
-        public ActionContext AppendActions(List<ActionState> actions)
-        {
-            this.QueueChanges(
-                new ActionChangeList()
-                {
-                    ChangeType = ActionChangeType.AppendActions,
-                    Actions = actions
-                });
-            return this;
-        }
-
-        public ActionContext EndSequence(List<ActionState> actions)
-        {
-            this.QueueChanges(
-                new ActionChangeList()
-                {
-                    ChangeType = ActionChangeType.EndSequence,
-                    Actions = actions
-                });
-            return this;
-        }
-
-        public ActionContext ReplaceSequence(List<ActionState> actions)
-        {
-            this.QueueChanges(
-                new ActionChangeList()
-                {
-                    ChangeType = ActionChangeType.ReplaceSequence,
-                    Actions = actions
-                });
-            return this;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var parent = dc;
             while (parent != null)
             {
-                var sc = parent as SequenceContext;
-                if (sc != null && sc.Changes != null && sc.Changes.Count > 0)
+                var ac = parent as ActionContext;
+                if (ac != null && ac.Changes != null && ac.Changes.Count > 0)
                 {
                     hasChanges = true;
                 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DebugBreak.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DebugBreak.cs
@@ -77,8 +77,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 }
 
                 // Get list of actions
-                var stepState = dc is SequenceContext sc ? sc.Actions : new List<ActionState>();
-                var actionsIds = stepState.Select(s => s.DialogId);
+                var actions = dc.Parent is ActionContext ac ? ac.Actions : new List<ActionState>();
+                var actionsIds = actions.Select(s => s.DialogId);
 
                 Debug.WriteLine($"{path}: {actionsIds.Count()} actions remaining.");
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperties.cs
@@ -65,23 +65,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            // Ensure planning context
-            if (dc is SequenceContext planning)
+            if (this.Properties?.Any() == true)
             {
-                if (this.Properties?.Any() == true)
+                foreach (var property in this.Properties)
                 {
-                    foreach (var property in this.Properties)
-                    {
-                        dcState.RemoveValue(property.GetValue(dcState));
-                    }
+                    dcState.RemoveValue(property.GetValue(dcState));
                 }
+            }
 
-                return await dc.EndDialogAsync();
-            }
-            else
-            {
-                throw new Exception("`DeleteProperty` should only be used in the context of an adaptive dialog.");
-            }
+            return await dc.EndDialogAsync();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/DeleteProperty.cs
@@ -73,16 +73,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            // Ensure planning context
-            if (dc is SequenceContext planning)
-            {
-                dcState.RemoveValue(Property.GetValue(dcState));
-                return await dc.EndDialogAsync();
-            }
-            else
-            {
-                throw new Exception("`ClearProperty` should only be used in the context of an adaptive dialog.");
-            }
+            dcState.RemoveValue(Property.GetValue(dcState));
+            return await dc.EndDialogAsync();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            if (dc is SequenceContext sc)
+            if (dc.Parent is ActionContext ac)
             {
                 var planActions = Actions.Select(s => new ActionState()
                 {
@@ -91,13 +91,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     Actions = planActions.ToList()
                 };
 
-                sc.QueueChanges(changes);
+                ac.QueueChanges(changes);
 
-                return await sc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                throw new Exception("`EditAction` should only be used in the context of an adaptive dialog.");
+                throw new Exception("`EditActions` should only be used in the context of an adaptive dialog.");
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
@@ -106,27 +106,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            // Ensure planning context
-            if (dc is SequenceContext planning)
+            var (conditionResult, error) = this.Condition.TryGetValue(dcState);
+            if (error == null && conditionResult == true && TrueScope.Actions.Any())
             {
-                var (conditionResult, error) = this.Condition.TryGetValue(dcState);
-                if (error == null && conditionResult == true && TrueScope.Actions.Any())
-                {
-                    // replace dialog with If True Action Scope
-                    return await dc.ReplaceDialogAsync(this.TrueScope.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-                else if (conditionResult == false && FalseScope.Actions.Any())
-                {
-                    return await dc.ReplaceDialogAsync(this.FalseScope.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
+                // replace dialog with If True Action Scope
+                return await dc.ReplaceDialogAsync(this.TrueScope.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            else if (conditionResult == false && FalseScope.Actions.Any())
+            {
+                return await dc.ReplaceDialogAsync(this.FalseScope.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
 
-                // end dialog since no triggered actions
-                return await planning.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                throw new Exception("`IfCondition` should only be used in the context of an adaptive dialog.");
-            }
+            // end dialog since no triggered actions
+            return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         protected override string OnComputeId()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -286,23 +286,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent dialogEvent, CancellationToken cancellationToken = default)
         {
-            var sequenceContext = ToActionContext(dc);
+            var actionContext = ToActionContext(dc);
 
             // Process event and queue up any potential interruptions
-            return await ProcessEventAsync(sequenceContext, dialogEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await ProcessEventAsync(actionContext, dialogEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         protected override async Task<bool> OnPostBubbleEventAsync(DialogContext dc, DialogEvent dialogEvent, CancellationToken cancellationToken = default)
         {
-            var sequenceContext = ToActionContext(dc);
+            var actionContext = ToActionContext(dc);
 
             // Process event and queue up any potential interruptions
-            return await ProcessEventAsync(sequenceContext, dialogEvent, preBubble: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await ProcessEventAsync(actionContext, dialogEvent, preBubble: false, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        protected virtual async Task<bool> ProcessEventAsync(ActionContext sequenceContext, DialogEvent dialogEvent, bool preBubble, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<bool> ProcessEventAsync(ActionContext actionContext, DialogEvent dialogEvent, bool preBubble, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var dcState = sequenceContext.GetState();
+            var dcState = actionContext.GetState();
 
             // Save into turn
             dcState.SetValue(TurnPath.DIALOGEVENT, dialogEvent);
@@ -327,7 +327,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                         dcState.SetValue(DialogPath.LastIntent, name);
 
                         // process entities for ambiguity processing (We do this regardless of who handles the event)
-                        ProcessEntities(sequenceContext, activity);
+                        ProcessEntities(actionContext, activity);
                         break;
                     }
 
@@ -347,7 +347,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             dcState.SetValue(DialogPath.EventCounter, ++count);
 
             // Look for triggered evt
-            var handled = await QueueFirstMatchAsync(sequenceContext, dialogEvent, preBubble, cancellationToken).ConfigureAwait(false);
+            var handled = await QueueFirstMatchAsync(actionContext, dialogEvent, preBubble, cancellationToken).ConfigureAwait(false);
 
             if (handled)
             {
@@ -366,11 +366,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                             var activityReceivedEvent = new DialogEvent()
                             {
                                 Name = AdaptiveEvents.ActivityReceived,
-                                Value = sequenceContext.Context.Activity,
+                                Value = actionContext.Context.Activity,
                                 Bubble = false
                             };
 
-                            handled = await ProcessEventAsync(sequenceContext, dialogEvent: activityReceivedEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                            handled = await ProcessEventAsync(actionContext, dialogEvent: activityReceivedEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
                         }
 
                         break;
@@ -385,7 +385,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                                 Value = activity,
                                 Bubble = false
                             };
-                            await ProcessEventAsync(sequenceContext, dialogEvent: recognizeUtteranceEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                            await ProcessEventAsync(actionContext, dialogEvent: recognizeUtteranceEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                             // Emit leading RecognizedIntent event
                             var recognized = dcState.GetValue<RecognizerResult>(TurnPath.RECOGNIZED);
@@ -395,7 +395,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                                 Value = recognized,
                                 Bubble = false
                             };
-                            handled = await ProcessEventAsync(sequenceContext, dialogEvent: recognizedIntentEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                            handled = await ProcessEventAsync(actionContext, dialogEvent: recognizedIntentEvent, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
                         }
 
                         // Has an interruption occured?
@@ -414,14 +414,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                             if (activity.Type == ActivityTypes.Message)
                             {
                                 // Recognize utterance
-                                var recognized = await OnRecognize(sequenceContext, activity, cancellationToken).ConfigureAwait(false);
+                                var recognized = await OnRecognize(actionContext, activity, cancellationToken).ConfigureAwait(false);
 
                                 // TODO figure out way to not use turn state to pass this value back to caller.
                                 dcState.SetValue(TurnPath.RECOGNIZED, recognized);
 
                                 if (Recognizer != null)
                                 {
-                                    await sequenceContext.DebuggerStepAsync(Recognizer, AdaptiveEvents.RecognizeUtterance, cancellationToken).ConfigureAwait(false);
+                                    await actionContext.DebuggerStepAsync(Recognizer, AdaptiveEvents.RecognizeUtterance, cancellationToken).ConfigureAwait(false);
                                 }
 
                                 handled = true;
@@ -445,7 +445,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                                 Bubble = false
                             };
 
-                            handled = await ProcessEventAsync(sequenceContext, dialogEvent: activityReceivedEvent, preBubble: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                            handled = await ProcessEventAsync(actionContext, dialogEvent: activityReceivedEvent, preBubble: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                         }
 
                         break;
@@ -454,7 +454,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                         if (activity.Type == ActivityTypes.Message)
                         {
                             // Empty sequence?
-                            if (!sequenceContext.Actions.Any())
+                            if (!actionContext.Actions.Any())
                             {
                                 // Emit trailing unknownIntent event
                                 var unknownIntentEvent = new DialogEvent
@@ -462,7 +462,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                                     Name = AdaptiveEvents.UnknownIntent,
                                     Bubble = false
                                 };
-                                handled = await ProcessEventAsync(sequenceContext, dialogEvent: unknownIntentEvent, preBubble: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                                handled = await ProcessEventAsync(actionContext, dialogEvent: unknownIntentEvent, preBubble: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                             }
                             else
                             {
@@ -508,7 +508,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 // Continue current step
                 // DEBUG: To debug step execution set a breakpoint on line below and add a watch 
-                //        statement for sequenceContext.Actions.
+                //        statement for actionContext.Actions.
                 var result = await actionDC.ContinueDialogAsync(cancellationToken).ConfigureAwait(false);
 
                 // Start step if not continued
@@ -566,36 +566,36 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return await OnEndOfActionsAsync(actionContext, cancellationToken).ConfigureAwait(false);
         }
 
-        protected Task<bool> EndCurrentActionAsync(ActionContext sequenceContext, CancellationToken cancellationToken = default)
+        protected Task<bool> EndCurrentActionAsync(ActionContext actionContext, CancellationToken cancellationToken = default)
         {
-            if (sequenceContext.Actions.Any())
+            if (actionContext.Actions.Any())
             {
-                sequenceContext.Actions.RemoveAt(0);
+                actionContext.Actions.RemoveAt(0);
             }
 
             return Task.FromResult(false);
         }
 
-        protected async Task<DialogTurnResult> OnEndOfActionsAsync(ActionContext sequenceContext, CancellationToken cancellationToken = default)
+        protected async Task<DialogTurnResult> OnEndOfActionsAsync(ActionContext actionContext, CancellationToken cancellationToken = default)
         {
             // Is the current dialog still on the stack?
-            if (sequenceContext.ActiveDialog != null)
+            if (actionContext.ActiveDialog != null)
             {
-                var dcState = sequenceContext.GetState();
+                var dcState = actionContext.GetState();
 
                 // Completed actions so continue processing entity queues
-                var handled = await ProcessQueuesAsync(sequenceContext, cancellationToken).ConfigureAwait(false);
+                var handled = await ProcessQueuesAsync(actionContext, cancellationToken).ConfigureAwait(false);
 
                 if (handled)
                 {
                     // Still processing queues
-                    return await ContinueActionsAsync(sequenceContext, null, cancellationToken).ConfigureAwait(false);
+                    return await ContinueActionsAsync(actionContext, null, cancellationToken).ConfigureAwait(false);
                 }
-                else if (ShouldEnd(sequenceContext))
+                else if (ShouldEnd(actionContext))
                 {
-                    RestoreParentGenerator(sequenceContext.Context);
+                    RestoreParentGenerator(actionContext.Context);
                     dcState.TryGetValue<object>(DefaultResultProperty, out var result);
-                    return await sequenceContext.EndDialogAsync(result, cancellationToken).ConfigureAwait(false);
+                    return await actionContext.EndDialogAsync(result, cancellationToken).ConfigureAwait(false);
                 }
 
                 return EndOfTurn;
@@ -604,11 +604,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return new DialogTurnResult(DialogTurnStatus.Cancelled);
         }
 
-        protected async Task<RecognizerResult> OnRecognize(ActionContext sequenceContext, Activity activity, CancellationToken cancellationToken = default)
+        protected async Task<RecognizerResult> OnRecognize(ActionContext actionContext, Activity activity, CancellationToken cancellationToken = default)
         {
             if (Recognizer != null)
             {
-                var result = await Recognizer.RecognizeAsync(sequenceContext, activity, cancellationToken).ConfigureAwait(false);
+                var result = await Recognizer.RecognizeAsync(actionContext, activity, cancellationToken).ConfigureAwait(false);
 
                 if (result.Intents.Any())
                 {
@@ -645,12 +645,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
         // This function goes through the ambiguity queues and emits events if present.
         // In order ClearProperties, AssignEntity, ChooseProperties, ChooseEntity, EndOfActions.
-        private async Task<bool> ProcessQueuesAsync(ActionContext sequenceContext, CancellationToken cancellationToken)
+        private async Task<bool> ProcessQueuesAsync(ActionContext actionContext, CancellationToken cancellationToken)
         {
-            var dcState = sequenceContext.GetState();
+            var dcState = actionContext.GetState();
 
             DialogEvent evt;
-            var queues = EntityEvents.Read(sequenceContext);
+            var queues = EntityEvents.Read(actionContext);
             var changed = false;
             if (queues.ClearProperties.Any())
             {
@@ -689,18 +689,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
             if (changed)
             {
-                queues.Write(sequenceContext);
+                queues.Write(actionContext);
             }
 
             dcState.SetValue(DialogPath.LastEvent, evt.Name);
-            var handled = await this.ProcessEventAsync(sequenceContext, dialogEvent: evt, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var handled = await this.ProcessEventAsync(actionContext, dialogEvent: evt, preBubble: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (!handled)
             {
                 // If event wasn't handled, remove it from queues and keep going if things changed
                 if (queues.DequeueEvent(evt.Name))
                 {
-                    queues.Write(sequenceContext);
-                    handled = await this.ProcessQueuesAsync(sequenceContext, cancellationToken);
+                    queues.Write(actionContext);
+                    handled = await this.ProcessQueuesAsync(actionContext, cancellationToken);
                 }
             }
 
@@ -712,19 +712,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return dc.Stack.Count > 0 ? $"{dc.Stack.Count}:{dc.ActiveDialog.Id}" : string.Empty;
         }
 
-        private async Task<bool> QueueFirstMatchAsync(ActionContext sequenceContext, DialogEvent dialogEvent, bool preBubble, CancellationToken cancellationToken)
+        private async Task<bool> QueueFirstMatchAsync(ActionContext actionContext, DialogEvent dialogEvent, bool preBubble, CancellationToken cancellationToken)
         {
-            var selection = await Selector.Select(sequenceContext, cancellationToken).ConfigureAwait(false);
+            var selection = await Selector.Select(actionContext, cancellationToken).ConfigureAwait(false);
             if (selection.Any())
             {
                 var evt = selection.First();
-                await sequenceContext.DebuggerStepAsync(evt, dialogEvent, cancellationToken).ConfigureAwait(false);
+                await actionContext.DebuggerStepAsync(evt, dialogEvent, cancellationToken).ConfigureAwait(false);
                 Trace.TraceInformation($"Executing Dialog: {Id} Rule[{evt.Id}]: {evt.GetType().Name}: {evt.GetExpression()}");
-                var changes = await evt.ExecuteAsync(sequenceContext).ConfigureAwait(false);
+                var changes = await evt.ExecuteAsync(actionContext).ConfigureAwait(false);
 
                 if (changes != null && changes.Any())
                 {
-                    sequenceContext.QueueChanges(changes[0]);
+                    actionContext.QueueChanges(changes[0]);
                     return true;
                 }
             }
@@ -801,9 +801,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 state.Actions = new List<ActionState>();
             }
 
-            var sequenceContext = new ActionContext(dc.Dialogs, dc, new DialogState { DialogStack = dc.Stack }, state.Actions, changeTurnKey);
-            sequenceContext.Parent = dc.Parent;
-            return sequenceContext;
+            var actionContext = new ActionContext(dc.Dialogs, dc, new DialogState { DialogStack = dc.Stack }, state.Actions, changeTurnKey);
+            actionContext.Parent = dc.Parent;
+            return actionContext;
         }
 
         private void SetLocalGenerator(ITurnContext context)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityEvents.cs
@@ -51,11 +51,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Read event queues from memory.
         /// </summary>
-        /// <param name="context">Context for memory.</param>
+        /// <param name="actionContext">Context for memory.</param>
         /// <returns>Event queues.</returns>
-        public static EntityEvents Read(SequenceContext context)
+        public static EntityEvents Read(ActionContext actionContext)
         {
-            var dcState = context.GetState();
+            var dcState = actionContext.GetState();
 
             if (!dcState.TryGetValue<EntityEvents>(Events, out var queues))
             {
@@ -68,9 +68,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Write state into memory.
         /// </summary>
-        /// <param name="context">Memory context.</param>
-        public void Write(SequenceContext context)
-            => context.GetState().SetValue(Events, this);
+        /// <param name="actionContext">Memory context.</param>
+        public void Write(ActionContext actionContext)
+            => actionContext.GetState().SetValue(Events, this);
 
         /// <summary>
         /// Remove an event result from queues.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ITriggerSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/ITriggerSelector.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <summary>
         /// Select the best rule to execute.
         /// </summary>
-        /// <param name="context">Dialog context for evaluation.</param>
+        /// <param name="actionContext">Dialog context for evaluation.</param>
         /// <param name="cancel">Cancellation token.</param>
         /// <returns>Best rule in original list to execute or -1 if none.</returns>
-        Task<IReadOnlyList<OnCondition>> Select(SequenceContext context, CancellationToken cancel = default);
+        Task<IReadOnlyList<OnCondition>> Select(ActionContext actionContext, CancellationToken cancel = default);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/ConditionalSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/ConditionalSelector.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
             _evaluate = evaluate;
         }
 
-        public async Task<IReadOnlyList<OnCondition>> Select(SequenceContext context, CancellationToken cancel = default)
+        public async Task<IReadOnlyList<OnCondition>> Select(ActionContext context, CancellationToken cancel = default)
         {
             var dcState = context.GetState();
             var (eval, _) = Condition.TryGetValue(dcState);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
             _evaluate = evaluate;
         }
 
-        public Task<IReadOnlyList<OnCondition>> Select(SequenceContext context, CancellationToken cancel)
+        public Task<IReadOnlyList<OnCondition>> Select(ActionContext context, CancellationToken cancel)
         {
             OnCondition selection = null;
             var lowestPriority = int.MaxValue;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/MostSpecificSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/MostSpecificSelector.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
             }
         }
 
-        public virtual async Task<IReadOnlyList<OnCondition>> Select(SequenceContext context, CancellationToken cancel)
+        public virtual async Task<IReadOnlyList<OnCondition>> Select(ActionContext context, CancellationToken cancel)
         {
             var triggers = _tree.Matches(context.GetState());
             var matches = new List<OnCondition>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/RandomSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/RandomSelector.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
             }
         }
 
-        public Task<IReadOnlyList<OnCondition>> Select(SequenceContext context, CancellationToken cancel = default)
+        public Task<IReadOnlyList<OnCondition>> Select(ActionContext context, CancellationToken cancel = default)
         {
             var candidates = _conditionals;
             if (_evaluate)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/TrueSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/TrueSelector.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
             _evaluate = evaluate;
         }
 
-        public Task<IReadOnlyList<OnCondition>> Select(SequenceContext context, CancellationToken cancel = default)
+        public Task<IReadOnlyList<OnCondition>> Select(ActionContext context, CancellationToken cancel = default)
         {
             var candidates = _conditionals;
             if (_evaluate)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -160,11 +160,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Compute the current value of the priority expression and return it.
         /// </summary>
-        /// <param name="context">Context to use for evaluation.</param>
+        /// <param name="actionContext">Context to use for evaluation.</param>
         /// <returns>Computed priority.</returns>
-        public int CurrentPriority(SequenceContext context)
+        public int CurrentPriority(ActionContext actionContext)
         {
-            var (priority, error) = this.Priority.TryGetValue(context.GetState());
+            var (priority, error) = this.Priority.TryGetValue(actionContext.GetState());
             if (error != null)
             {
                 priority = -1;
@@ -199,20 +199,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Method called to execute the rule's actions.
         /// </summary>
-        /// <param name="planningContext">Context.</param>
+        /// <param name="actionContext">Context.</param>
         /// <returns>A <see cref="Task"/> with plan change list.</returns>
-        public virtual async Task<List<ActionChangeList>> ExecuteAsync(SequenceContext planningContext)
+        public virtual async Task<List<ActionChangeList>> ExecuteAsync(ActionContext actionContext)
         {
             if (RunOnce)
             {
-                var dcState = planningContext.GetState();
+                var dcState = actionContext.GetState();
                 var count = dcState.GetValue<uint>(DialogPath.EventCounter);
                 dcState.SetValue($"{AdaptiveDialog.ConditionTracker}.{Id}.lastRun", count);
             }
 
             return await Task.FromResult(new List<ActionChangeList>()
             {
-                this.OnCreateChangeList(planningContext)
+                this.OnCreateChangeList(actionContext)
             });
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             yield return this.ActionScope;
         }
 
-        protected virtual ActionChangeList OnCreateChangeList(SequenceContext planning, object dialogOptions = null)
+        protected virtual ActionChangeList OnCreateChangeList(ActionContext actionContext, object dialogOptions = null)
         {
             var changeList = new ActionChangeList()
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         {
         }
 
-        protected override ActionChangeList OnCreateChangeList(SequenceContext planning, object dialogOptions = null)
+        protected override ActionChangeList OnCreateChangeList(ActionContext actionContext, object dialogOptions = null)
         {
-            var changeList = base.OnCreateChangeList(planning, dialogOptions);
+            var changeList = base.OnCreateChangeList(actionContext, dialogOptions);
 
             // For OnError handling we want to replace the old plan with whatever the error plan is, since the old plan blew up.
             changeList.ChangeType = ActionChangeType.ReplaceSequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return Expression.AndExpression(intentExpression, base.GetExpression());
         }
 
-        protected override ActionChangeList OnCreateChangeList(SequenceContext planning, object dialogOptions = null)
+        protected override ActionChangeList OnCreateChangeList(ActionContext actionContext, object dialogOptions = null)
         {
-            var dcState = planning.GetState();
+            var dcState = actionContext.GetState();
             var recognizerResult = dcState.GetValue<RecognizerResult>($"{TurnPath.DIALOGEVENT}.value");
             if (recognizerResult != null)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 };
             }
 
-            return base.OnCreateChangeList(planning, dialogOptions);
+            return base.OnCreateChangeList(actionContext, dialogOptions);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Initializes a new instance of the <see cref="DialogContext"/> class.
         /// </summary>
         /// <param name="dialogs">Parent dialog set.</param>
-        /// <param name="parentDialogContext">Parent dialog state.</param>
+        /// <param name="parentDialogContext">Parent dialog context.</param>
         /// <param name="state">Current dialog state.</param>
         public DialogContext(
             DialogSet dialogs,


### PR DESCRIPTION
- Renamed class and file.
- Cleaned up various variable names.
- Made the context passed into actions a standard DC.
- Updated actions to work against their parent ActionContext for things like sequence manipulation.