### PR TITLE
Update Constant Expression ToString method

### DIFF
--- a/libraries/AdaptiveExpressions/Constant.cs
+++ b/libraries/AdaptiveExpressions/Constant.cs
@@ -51,9 +51,19 @@ namespace AdaptiveExpressions
             {
                 return "null";
             }
-            else if (Value is string)
+            else if (Value is string value)
             {
-                return $"'{Value}'";
+                var result = value;
+                if (value.Contains(@"\"))
+                {
+                    result = result.Replace(@"\", @"\\");
+                }
+
+                return result.Contains("'") ? $"\"{result}\"" : $"'{result}'";
+            }
+            else if (Value is float || Value is double)
+            {
+               return ((double)Value).ToString("0.00########");
             }
             else
             {

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -824,6 +824,11 @@ namespace AdaptiveExpressions.Tests
                 var actualRefs = parsed.References();
                 Assert.IsTrue(expectedRefs.SetEquals(actualRefs), $"References do not match, expected: {string.Join(',', expectedRefs)} acutal: {string.Join(',', actualRefs)}");
             }
+
+            // ToString re-parse
+            var newExpression = Expression.Parse(parsed.ToString());
+            var newActual = newExpression.TryEvaluate(scope).value;
+            AssertObjectEquals(actual, newActual);
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Close #3498
The Expression ToString result should be re-parsed correct and have the same evaluate result as original expression.

For some reason, the expression ToString result may not be exactly the same as the original one. because:
1. float/double format data.  for example, 1.0 is a float/double, the stringify result is "1" or other formats, not the same with 1.0 maybe
2. for the sequence operator, for example, add(1, 2, 3), the expression ToString result is :
"1 && 2 && 3", if we construct with this string, we could get the new expression: 
"(1 && 2) && 3", because "&&" in the expression is a Binary operator. The two string results are not literally equal, but the meaning is the same.


