### PR TITLE
Update LG template content range

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFile.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFile.cs
@@ -226,8 +226,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var templateNameLine = BuildTemplateNameLine(newTemplateName, parameters);
                 var newTemplateBody = ConvertTemplateBody(templateBody);
                 var content = $"{templateNameLine}\r\n{newTemplateBody}\r\n";
-                var startLine = template.ParseTree.Start.Line - 1;
-                var stopLine = template.ParseTree.Stop.Line - 1;
+                var (startLine, stopLine) = template.GetTemplateRange();
 
                 var newContent = ReplaceRangeContent(Content, startLine, stopLine, content);
                 Initialize(LGParser.ParseText(newContent, Id, ImportResolver));
@@ -269,8 +268,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var template = Templates.FirstOrDefault(u => u.Name == templateName);
             if (template != null)
             {
-                var startLine = template.ParseTree.Start.Line - 1;
-                var stopLine = template.ParseTree.Stop.Line - 1;
+                var (startLine, stopLine) = template.GetTemplateRange();
 
                 var newContent = ReplaceRangeContent(Content, startLine, stopLine, null);
                 Initialize(LGParser.ParseText(newContent, Id, ImportResolver));

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFileLexer.g4
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGFileLexer.g4
@@ -60,7 +60,7 @@ OPTIONS
   ;
 
 COMMENTS
-  : '>' ~('\r'|'\n')+ -> skip
+  : '>' ~('\r'|'\n')* -> skip
   ;
 
 WS

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGTemplate.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             ParseTree = parseTree;
             Source = source;
 
-            Name = ExtractName(parseTree);
-            Parameters = ExtractParameters(parseTree);
-            Body = ExtractBody(parseTree, lgfileContent);
+            Name = ExtractName();
+            Parameters = ExtractParameters();
+            Body = ExtractBody(lgfileContent);
         }
 
         /// <summary>
@@ -71,31 +71,35 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public override string ToString() => $"[{Name}({string.Join(", ", Parameters)})]\"{Body}\"";
 
-        private string ExtractBody(LGFileParser.TemplateDefinitionContext parseTree, string lgfileContent)
+        /// <summary>
+        /// Get the startLine and stopLine of template.
+        /// </summary>
+        /// <returns>template content range.</returns>
+        public (int startLine, int stopLine) GetTemplateRange()
         {
-            var startLine = parseTree.Start.Line - 1;
-            var stopLine = parseTree.Stop.Line - 1;
-            if (parseTree?.Parent?.Parent is LGFileParser.FileContext fileContext)
+            var startLine = ParseTree.Start.Line - 1;
+            var stopLine = ParseTree.Stop.Line - 1;
+            if (ParseTree?.Parent?.Parent is LGFileParser.FileContext fileContext)
             {
-                var temTemplateDefinitions = fileContext
+                var templateDefinitions = fileContext
                         .paragraph()
-                        .Where(u => u.templateDefinition() != null)
                         .Select(u => u.templateDefinition())
+                        .Where(u => u != null)
                         .ToList();
                 var currentIndex = -1;
-                for (var i = 0; i < temTemplateDefinitions.Count; i++)
+                for (var i = 0; i < templateDefinitions.Count; i++)
                 {
-                    if (temTemplateDefinitions[i] == parseTree)
+                    if (templateDefinitions[i] == ParseTree)
                     {
                         currentIndex = i;
                         break;
                     }
                 }
 
-                if (currentIndex >= 0 && currentIndex < temTemplateDefinitions.Count - 1)
+                if (currentIndex >= 0 && currentIndex < templateDefinitions.Count - 1)
                 {
                     // in the middle of templates
-                    stopLine = temTemplateDefinitions[currentIndex + 1].Start.Line - 2;
+                    stopLine = templateDefinitions[currentIndex + 1].Start.Line - 2;
                 }
                 else
                 {
@@ -109,18 +113,24 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 stopLine = startLine;
             }
 
-            return GetRangeContent(lgfileContent, startLine, stopLine);
+            return (startLine, stopLine);
         }
 
-        private string ExtractName(LGFileParser.TemplateDefinitionContext parseTree)
+        private string ExtractBody(string lgfileContent)
         {
-            var name = parseTree.templateNameLine().templateName()?.GetText();
+            var (startLine, stopLine) = GetTemplateRange();
+            return startLine >= stopLine ? string.Empty : GetRangeContent(lgfileContent, startLine + 1, stopLine);
+        }
+
+        private string ExtractName()
+        {
+            var name = ParseTree.templateNameLine().templateName()?.GetText();
             return name ?? string.Empty;
         }
 
-        private List<string> ExtractParameters(LGFileParser.TemplateDefinitionContext parseTree)
+        private List<string> ExtractParameters()
         {
-            var parameters = parseTree.templateNameLine().parameters();
+            var parameters = ParseTree.templateNameLine().parameters();
             if (parameters != null)
             {
                 return parameters.IDENTIFIER().Select(param => param.GetText()).ToList();

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/2.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/2.lg
@@ -1,5 +1,6 @@
 > Welcome Phrase template
 > LG runtime will pick a text value from the one-of collection list at random.
+>
 # wPhrase
 > this is an in-template comment
 - Hi

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/LGFileTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/LGFileTest.cs
@@ -581,7 +581,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(lgFile.Templates.Count, 1);
             Assert.AreEqual(lgFile.Imports.Count, 0);
             Assert.AreEqual(lgFile.Templates[0].Name, "wPhrase");
-            Assert.AreEqual(lgFile.Templates[0].Body.Replace("\r\n", "\n"), "- Hi\n- Hello\n- Hiya\n- Hi");
+            Assert.AreEqual(lgFile.Templates[0].Body.Replace("\r\n", "\n"), "> this is an in-template comment\n- Hi\n- Hello\n- Hiya\n- Hi");
 
             lgFile.AddTemplate("newtemplate", new List<string> { "age", "name" }, "- hi ");
             Assert.AreEqual(lgFile.Templates.Count, 2);
@@ -590,12 +590,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(lgFile.Templates[1].Parameters.Count, 2);
             Assert.AreEqual(lgFile.Templates[1].Parameters[0], "age");
             Assert.AreEqual(lgFile.Templates[1].Parameters[1], "name");
-            Assert.AreEqual(lgFile.Templates[1].Body, "- hi ");
+            Assert.AreEqual(lgFile.Templates[1].Body.Replace("\r\n", "\n"), "- hi \n");
 
             lgFile.AddTemplate("newtemplate2", null, "- hi2 ");
             Assert.AreEqual(lgFile.Templates.Count, 3);
             Assert.AreEqual(lgFile.Templates[2].Name, "newtemplate2");
-            Assert.AreEqual(lgFile.Templates[2].Body, "- hi2 ");
+            Assert.AreEqual(lgFile.Templates[2].Body.Replace("\r\n", "\n"), "- hi2 \n");
 
             lgFile.UpdateTemplate("newtemplate", "newtemplateName", new List<string> { "newage", "newname" }, "- new hi\r\n#hi");
             Assert.AreEqual(lgFile.Templates.Count, 3);
@@ -604,13 +604,13 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(lgFile.Templates[1].Parameters.Count, 2);
             Assert.AreEqual(lgFile.Templates[1].Parameters[0], "newage");
             Assert.AreEqual(lgFile.Templates[1].Parameters[1], "newname");
-            Assert.AreEqual(lgFile.Templates[1].Body, "- new hi\r\n- #hi");
+            Assert.AreEqual(lgFile.Templates[1].Body.Replace("\r\n", "\n"), "- new hi\n- #hi\n");
 
             lgFile.UpdateTemplate("newtemplate2", "newtemplateName2", new List<string> { "newage2", "newname2" }, "- new hi\r\n#hi2");
             Assert.AreEqual(lgFile.Templates.Count, 3);
             Assert.AreEqual(lgFile.Imports.Count, 0);
             Assert.AreEqual(lgFile.Templates[2].Name, "newtemplateName2");
-            Assert.AreEqual(lgFile.Templates[2].Body, "- new hi\r\n- #hi2");
+            Assert.AreEqual(lgFile.Templates[2].Body.Replace("\r\n", "\n"), "- new hi\n- #hi2\n");
 
             lgFile.DeleteTemplate("newtemplateName");
             Assert.AreEqual(lgFile.Templates.Count, 2);


### PR DESCRIPTION
Originally, the Body of LGTemplate presents the first line except for comments, to the last line except for comments. 
for example:
```
> comment1
# t1
> comment2
- hi

> comment3
# t2
- hi
```

originally Body of template  t1 is 
```
- hi
```

After this pr, the body of the template presents from the first of template content to the last line before the next template (or end of file). 

So, the body of tempale t1 is
```
> comment2
- hi

> comment3
```

Additionally, allow empty comments.