### PR TITLE
Skill OAuth only change card action for emulator

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -347,9 +347,10 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var signInResource = await adapter.GetSignInResourceAsync(turnContext, _settings.OAuthAppCredentials, _settings.ConnectionName, turnContext.Activity.From.Id, null, cancellationToken).ConfigureAwait(false);
                 var value = signInResource.SignInLink;
 
-                if (turnContext.TurnState.Get<ClaimsIdentity>("BotIdentity") is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims))
+                if (turnContext.Activity.IsFromStreamingConnection() ||
+                    (turnContext.TurnState.Get<ClaimsIdentity>("BotIdentity") is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims)))
                 {
-                    if (turnContext.Activity.ChannelId == "emulator")
+                    if (turnContext.Activity.ChannelId == Channels.Emulator)
                     {
                         cardActionType = ActionTypes.OpenUrl;
                     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 var value = signInResource.SignInLink;
 
                 if (turnContext.Activity.IsFromStreamingConnection() ||
-                    (turnContext.TurnState.Get<ClaimsIdentity>("BotIdentity") is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims)))
+                    (turnContext.TurnState.Get<ClaimsIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims)))
                 {
                     if (turnContext.Activity.ChannelId == Channels.Emulator)
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -349,7 +349,10 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                 if (turnContext.TurnState.Get<ClaimsIdentity>("BotIdentity") is ClaimsIdentity botIdentity && SkillValidation.IsSkillClaim(botIdentity.Claims))
                 {
-                    cardActionType = ActionTypes.OpenUrl;
+                    if (turnContext.Activity.ChannelId == "emulator")
+                    {
+                        cardActionType = ActionTypes.OpenUrl;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
There is code in the OAuthPrompt to change the sign in action of an OAuthCard to "openUrl" instead of "signin" for skills. This really only should be done for the emulator, as it impacts how WebChat handles the card.