### PR TITLE
Fix path resolver not working when alias in middle

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/PathResolvers/AliasPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/PathResolvers/AliasPathResolver.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
                 }
 
                 // $xxx -> path.xxx
-                return $"{this.prefix}{path.Substring(start + alias.Length)}{this.postfix}".TrimEnd('.');
+                return $"{path.Substring(0, start)}{this.prefix}{path.Substring(start + alias.Length)}{this.postfix}".TrimEnd('.');
             }
 
             return path;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/PathResolvers/AliasPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/PathResolvers/AliasPathResolver.cs
@@ -29,16 +29,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
             }
 
             var start = path.IndexOf(this.alias);
-            if (start >= 0)
+            if (start == 0)
             {
-                if (start > 1 && path[start - 1] == '.')
-                {
-                    // don't match on x.$foo 
-                    return path;
-                }
-
+                // here we only deals with trailing alias, alias in middle be handled in further breakdown
                 // $xxx -> path.xxx
-                return $"{path.Substring(0, start)}{this.prefix}{path.Substring(start + alias.Length)}{this.postfix}".TrimEnd('.');
+                return $"{this.prefix}{path.Substring(start + alias.Length)}{this.postfix}".TrimEnd('.');
             }
 
             return path;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
@@ -8,30 +8,55 @@
             {
                 "$kind": "Microsoft.OnBeginDialog",
                 "actions": [
-                  {
-                    "$kind": "Microsoft.SetProperty",
-                    "property": "user.lists",
-                    "value": "={}"
-                  },
-                  {
-                    "$kind": "Microsoft.SetProperty",
-                    "property": "user.lists.todo",
-                    "value": "todo"
-                  },
-                  {
-                    "$kind": "Microsoft.SetProperty",
-                    "property": "$mylist",
-                    "value": "lists"
-                  },
-                  {
-                    "$kind": "Microsoft.SetProperty",
-                    "property": "user[$mylist].todo",
-                    "value": "newtodo"
-                  },
-                  {
-                    "$kind": "Microsoft.SendActivity",
-                    "activity": "${user[$mylist].todo}"
-                  }
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "user.lists",
+                      "value": "={}"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "user.lists.todo",
+                      "value": "todo"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "$mylist",
+                      "value": "lists"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "$listType",
+                      "value": "todo"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "user[$mylist][$listType]",
+                      "value": "newtodo"
+                    },
+                    {
+                      "$kind": "Microsoft.SendActivity",
+                      "activity": "${user[$mylist][$listType]}"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "user.list2",
+                      "value": "=[]"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "$list2",
+                      "value": "list2"
+                    },
+                    {
+                      "$kind": "Microsoft.EditArray",
+                      "changeType": "Push",
+                      "itemsProperty": "user[$list2]",
+                      "value": "milk"
+                    },
+                    {
+                      "$kind": "Microsoft.SendActivity",
+                      "activity": "${user[$list2][0]}"
+                    }
                 ]
             }
         ]
@@ -41,8 +66,12 @@
             "$kind": "Microsoft.Test.UserConversationUpdate"
         },
         {
-            "$kind": "Microsoft.Test.AssertReply",
-            "text": "newtodo"
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "newtodo"
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "milk"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
@@ -7,35 +7,32 @@
         "triggers": [
             {
                 "$kind": "Microsoft.OnBeginDialog",
-              "actions": [
-                {
-                  "$type": "Microsoft.SetProperties",
-                  "assignments": [
-                    {
-                      "property": "user.lists",
-                      "value": "={}"
-                    },
-                    {
-                      "property": "user.lists.todo",
-                      "value": "todo"
-                    },
-                    {
-                      "property": "$mylist",
-                      "value": "lists"
-                    }
-
-                  ]
-                },
-                {
-                  "$kind": "Microsoft.SetProperty",
-                  "property": "user[$mylist].todo",
-                  "value": "newtodo"
-                },
-                {
-                  "$kind": "Microsoft.SendActivity",
-                  "activity": "${user[$mylist].todo}"
-                }
-              ]
+                "actions": [
+                  {
+                    "$kind": "Microsoft.SetProperty",
+                    "property": "user.lists",
+                    "value": "={}"
+                  },
+                  {
+                    "$kind": "Microsoft.SetProperty",
+                    "property": "user.lists.todo",
+                    "value": "todo"
+                  },
+                  {
+                    "$kind": "Microsoft.SetProperty",
+                    "property": "$mylist",
+                    "value": "lists"
+                  },
+                  {
+                    "$kind": "Microsoft.SetProperty",
+                    "property": "user[$mylist].todo",
+                    "value": "newtodo"
+                  },
+                  {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "${user[$mylist].todo}"
+                  }
+                ]
             }
         ]
     },

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
@@ -1,77 +1,95 @@
 {
-    "$schema": "../../../../schemas/sdk.schema",
-    "$kind": "Microsoft.Test.Script",
-    "dialog": {
-        "$kind": "Microsoft.AdaptiveDialog",
-        "id": "planningTest",
-        "triggers": [
-            {
-                "$kind": "Microsoft.OnBeginDialog",
-                "actions": [
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "user.lists",
-                      "value": "={}"
-                    },
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "user.lists.todo",
-                      "value": "todo"
-                    },
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "$mylist",
-                      "value": "lists"
-                    },
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "$listType",
-                      "value": "todo"
-                    },
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "user[$mylist][$listType]",
-                      "value": "newtodo"
-                    },
-                    {
-                      "$kind": "Microsoft.SendActivity",
-                      "activity": "${user[$mylist][$listType]}"
-                    },
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "user.list2",
-                      "value": "=[]"
-                    },
-                    {
-                      "$kind": "Microsoft.SetProperty",
-                      "property": "$list2",
-                      "value": "list2"
-                    },
-                    {
-                      "$kind": "Microsoft.EditArray",
-                      "changeType": "Push",
-                      "itemsProperty": "user[$list2]",
-                      "value": "milk"
-                    },
-                    {
-                      "$kind": "Microsoft.SendActivity",
-                      "activity": "${user[$list2][0]}"
-                    }
-                ]
-            }
+  "$schema": "../../../../schemas/sdk.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "planningTest",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "user.lists",
+            "value": "={}"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "user.lists.todo",
+            "value": "todo"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "$mylist",
+            "value": "lists"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "$listType",
+            "value": "todo"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "user[$mylist][$listType]",
+            "value": "newtodo"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user[$mylist][$listType]}"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "user.list2",
+            "value": "=[]"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "$list2",
+            "value": "list2"
+          },
+          {
+            "$kind": "Microsoft.EditArray",
+            "changeType": "Push",
+            "itemsProperty": "user[$list2]",
+            "value": "milk"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user[$list2][0]}"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "user.$instance",
+            "value": "={}"
+          },
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "user.$instance.name",
+            "value": "name"
+          },
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${user.$instance.name}"
+          }
         ]
-    },
-    "script": [
-        {
-            "$kind": "Microsoft.Test.UserConversationUpdate"
-        },
-        {
-          "$kind": "Microsoft.Test.AssertReply",
-          "text": "newtodo"
-        },
-        {
-          "$kind": "Microsoft.Test.AssertReply",
-          "text": "milk"
-        }
+      }
     ]
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "newtodo"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "milk"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "name"
+    }
+  ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
@@ -7,17 +7,35 @@
         "triggers": [
             {
                 "$kind": "Microsoft.OnBeginDialog",
-                "actions": [
+              "actions": [
+                {
+                  "$type": "Microsoft.SetProperties",
+                  "assignments": [
                     {
-                        "$kind": "Microsoft.SetProperty",
-                        "property": "$p1",
-                        "value": "='val1'"
+                      "property": "user.lists",
+                      "value": "={}"
                     },
                     {
-                        "$kind": "Microsoft.SendActivity",
-                        "activity": "${$p1}"
+                      "property": "user.lists.todo",
+                      "value": "todo"
+                    },
+                    {
+                      "property": "$mylist",
+                      "value": "lists"
                     }
-                ]
+
+                  ]
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "property": "user[$mylist].todo",
+                  "value": "newtodo"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "activity": "${user[$mylist].todo}"
+                }
+              ]
             }
         ]
     },
@@ -27,7 +45,7 @@
         },
         {
             "$kind": "Microsoft.Test.AssertReply",
-            "text": "val1"
+            "text": "newtodo"
         }
     ]
 }


### PR DESCRIPTION
Fix #3545 . 

Our property assignment action, SetProperty, SetProperties, and EditArray are not working when the property contains dynamic values to evaluate, and the dynamic value is reference using a shortcut, for example

user[$mylist].todo // not working 
user[dialog.mylist].todo // working

The root cause is our path resolver assuming alias (#, $) assume this alias at beginning, and do a full replace at the beginning, which cause broken path if alias is in middle. 

The tranforming behavior is broken

`user[$mylist].todo => dialog.mylist].todo` // user[ is dropped
`turn.recongized["$instance"] => dialog.instance"]` // what's before $ is totally dropped

the fix is to enforce the transform only deals the alias at beginning. 