### PR TITLE
[activityfactory] Improve missing type error

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
@@ -153,6 +153,10 @@ namespace Microsoft.Bot.Builder
             {
                 activity = BuildActivity(lgJObj);
             }
+            else
+            {
+                activity = BuildActivityFromText(lgJObj?.ToString()?.Trim());
+            }
 
             return activity;
         }
@@ -462,6 +466,10 @@ namespace Microsoft.Bot.Builder
             try
             {
                 lgStructuredResult = JObject.Parse(lgStringResult);
+                if (string.IsNullOrWhiteSpace(GetStructureType(lgStructuredResult)))
+                {
+                    return false;
+                }
             }
             catch
             {
@@ -476,6 +484,12 @@ namespace Microsoft.Bot.Builder
             var result = new List<string>();
             var type = GetStructureType(lgJObj);
 
+            //if type is empty, just parse it to text activity
+            if (string.IsNullOrWhiteSpace(type))
+            {
+                return result;
+            }
+
             if (GenericCardTypeMapping.ContainsKey(type)
                 || type == nameof(Attachment).ToLowerInvariant())
             {
@@ -487,10 +501,7 @@ namespace Microsoft.Bot.Builder
             }
             else
             {
-                var diagnosticMessage = string.IsNullOrWhiteSpace(type) ?
-                    $"'{LGType}' does not exist in lg output json object."
-                    : $"Type '{type}' is not supported currently.";
-                result.Add(BuildDiagnostic(diagnosticMessage));
+                result.Add(BuildDiagnostic($"Type '{type}' is not supported currently.", false));
             }
 
             return result;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var lgResult = GetNormalStructureLGFile().Evaluate("notSupport");
             var activity = ActivityFactory.FromObject(lgResult);
             Assert.AreEqual(0, activity.Attachments.Count);
-            Assert.AreEqual("{\"lgType\":\"Acti\",\"key\":\"value\"}", activity.Text.Replace("\r\n", string.Empty).Replace(" ", string.Empty));
+            Assert.AreEqual("{\"lgType\":\"Acti\",\"key\":\"value\"}", activity.Text.Replace("\r\n", string.Empty).Replace("\n", string.Empty).Replace(" ", string.Empty));
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(Exception))]
         public void TestNotSupportStructuredType()
         {
+            // fallback to text activity
             var lgResult = GetNormalStructureLGFile().Evaluate("notSupport");
             var activity = ActivityFactory.FromObject(lgResult);
+            Assert.AreEqual(0, activity.Attachments.Count);
+            Assert.AreEqual("{\"lgType\":\"Acti\",\"key\":\"value\"}", activity.Text.Replace("\r\n", string.Empty).Replace(" ", string.Empty));
         }
 
         [TestMethod]
@@ -303,10 +305,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var diagnostics = ActivityFactory.CheckLGResult("Not a valid json");
             Assert.AreEqual(diagnostics.Count, 1);
             Assert.AreEqual("[WARNING]LG output is not a json object, and will fallback to string format.", diagnostics[0]);
-
-            diagnostics = ActivityFactory.CheckLGResult("{}");
-            Assert.AreEqual(diagnostics.Count, 1);
-            Assert.AreEqual("[ERROR]'lgType' does not exist in lg output json object.", diagnostics[0]);
         }
 
         [TestMethod]
@@ -315,7 +313,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var lgResult = GetDiagnosticStructureLGFile().Evaluate("ErrorStructuredType", null);
             var diagnostics = ActivityFactory.CheckLGResult(lgResult);
             Assert.AreEqual(diagnostics.Count, 1);
-            Assert.AreEqual("[ERROR]Type 'mystruct' is not supported currently.", diagnostics[0]);
+            Assert.AreEqual("[WARNING]Type 'mystruct' is not supported currently.", diagnostics[0]);
 
             lgResult = GetDiagnosticStructureLGFile().Evaluate("ErrorActivityType", null);
             


### PR DESCRIPTION
close: #3383
Remove the type checking and return the actual object if no type was found or type definition does not map to a supported activity type

So, if the LG output is `{"key": "value"}`, and no LG type(`lgType`) in the properties, string Activity would be returned. 

if LG output contains `lgType` property, but it does not map to any supported types (activity, xxxCard, cardaction, adaptivecard, attachment. etc.), a warning would be throw shows that the current type is not supported. And finally, the text activity would be the result.