### PR TITLE
make custom function easier

### DIFF
--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -57,7 +57,7 @@ namespace AdaptiveExpressions
         /// This is all available functions, you can add custom functions to it, but you cannot
         /// replace builtin functions.  If you clear the dictionary, it will be reset to the built in functions.
         /// </remarks>
-        public static readonly IDictionary<string, ExpressionEvaluator> Functions = new FunctionTable();
+        public static readonly FunctionTable Functions = new FunctionTable();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Expression"/> class.
@@ -699,7 +699,7 @@ namespace AdaptiveExpressions
         /// <summary>
         /// FunctionTable is a dictionary which merges BuiltinFunctions.Functions with a CustomDictionary.
         /// </summary>
-        private class FunctionTable : IDictionary<string, ExpressionEvaluator>
+        public class FunctionTable : IDictionary<string, ExpressionEvaluator>
         {
             private readonly ConcurrentDictionary<string, ExpressionEvaluator> customFunctions = new ConcurrentDictionary<string, ExpressionEvaluator>(StringComparer.InvariantCultureIgnoreCase);
 
@@ -740,6 +740,11 @@ namespace AdaptiveExpressions
             }
 
             public void Add(string key, ExpressionEvaluator value) => this[key] = value;
+
+            public void Add(string key, Func<IReadOnlyList<dynamic>, object> func)
+            {
+                Add(key, new ExpressionEvaluator(key, ExpressionFunctions.Apply(func)));
+            }
 
             public void Add(KeyValuePair<string, ExpressionEvaluator> item) => this[item.Key] = item.Value;
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/CustomFunction2.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/CustomFunction2.lg
@@ -1,0 +1,2 @@
+﻿# custom
+- ${contoso.sqrt("16") + contoso.sqrt("4")}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -246,6 +246,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Examples\CustomFunction2.lg">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Examples\Expand.lg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1018,6 +1018,28 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(12, evaled);
         }
 
+        [TestMethod]
+        public void TestCustomFunction2()
+        {
+            Expression.Functions.Add("contoso.sqrt", (args) =>
+            {
+                object retValue = null;
+                if (args[0] != null)
+                {
+                    double dblValue;
+                    if (double.TryParse(args[0], out dblValue))
+                    {
+                        retValue = Math.Sqrt(dblValue);
+                    }
+                }
+
+                return retValue;
+            });
+            var templates = Templates.ParseFile(GetExampleFilePath("CustomFunction2.lg"), null);
+            var evaled = templates.Evaluate("custom");
+            Assert.AreEqual(6.0, evaled);
+        }
+
         public class LoopClass
         {
             public string Name { get; set; }


### PR DESCRIPTION
Make customized function in LG and expression easier by accepting just a lambda. 

At the cost of expose FunctionTable instead of a generic IDictionary.

Now you can do

```C#
            Expression.Functions.Add("contoso.sqrt", (args) =>
            {
                object retValue = null;
                if (args[0] != null)
                {
                    double dblValue;
                    if (double.TryParse(args[0], out dblValue))
                    {
                        retValue = Math.Sqrt(dblValue);
                    }
                }

                return retValue;
            });
```
to add a new function