### PR TITLE
Remove unnecessary restrication on memory path

### DIFF
--- a/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
@@ -37,7 +37,7 @@ namespace AdaptiveExpressions.Memory
         public bool TryGetValue(string path, out object value)
         {
             value = null;
-            if (memory == null || path.Length == 0 || (path[0] != '[' && !char.IsLetter(path[0])))
+            if (memory == null || path.Length == 0)
             {
                 return false;
             }

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -20,6 +20,7 @@ namespace AdaptiveExpressions.Tests
 
         private readonly object scope = new Dictionary<string, object>
         {
+            { "$index", "index" },
             {
                 "alist", new List<A>() { new A("item1"), new A("item2") }
             },
@@ -265,6 +266,7 @@ namespace AdaptiveExpressions.Tests
         {
             #region accessProperty and accessIndex
             Test("alist[0].Name", "item1"),
+            Test("$index", "index"),
             #endregion
 
             #region string interpolation test


### PR DESCRIPTION
Loose a restriction on path introduced in https://github.com/microsoft/botbuilder-dotnet/pull/3226. 

To support variable path like "$index"
