### PR TITLE
add title to choices and confirmChoices schema

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.schema
@@ -25,6 +25,7 @@
                     "$role": "expression",
                     "oneOf": [
                         {
+                            "title": "Array of strings",
                             "type": "array",
                             "items": [
                                 {
@@ -33,6 +34,7 @@
                             ]
                         },
                         {
+                            "title": "Array of choice objects",
                             "type": "array",
                             "items": [
                                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.schema
@@ -76,6 +76,7 @@
                     "type": "array",
                     "items": [
                         {
+                            "title": "Array of confirm choice objects",
                             "type": "object",
                             "properties": {
                                 "value": {


### PR DESCRIPTION
The Composer UI will use the title if present when presenting options to the user. Currently, for choices the options are `array`, `array`, and `expression` which is hard to disambiguate.