### PR TITLE
Make the CRUD of the template consistent

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -156,20 +156,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 string aLine;
                 var lineNumber = -1;
-                while (true)
+                while ((aLine = strReader.ReadLine()) != null)
                 {
-                    aLine = strReader.ReadLine();
                     lineNumber++;
-                    if (aLine != null)
+                    if (lineNumber >= startLine && lineNumber <= stopLine)
                     {
-                        if (lineNumber >= startLine && lineNumber <= stopLine)
-                        {
-                            destList.Add(aLine);
-                        }
-                    }
-                    else
-                    {
-                        break;
+                        destList.Add(aLine);
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
@@ -144,14 +145,36 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private string GetRangeContent(string originString, int startLine, int stopLine)
         {
-            var originList = originString.Split('\n');
-            if (startLine < 0 || startLine > stopLine || originList.Length <= stopLine)
+            if (startLine < 0 || startLine > stopLine)
             {
                 throw new Exception("index out of range.");
             }
 
-            var destList = originList.Skip(startLine).Take(stopLine - startLine + 1);
-            return string.Join("\n", destList).TrimEnd('\r');
+            var destList = new List<string>();
+
+            using (var strReader = new StringReader(originString))
+            {
+                string aLine;
+                var lineNumber = -1;
+                while (true)
+                {
+                    aLine = strReader.ReadLine();
+                    lineNumber++;
+                    if (aLine != null)
+                    {
+                        if (lineNumber >= startLine && lineNumber <= stopLine)
+                        {
+                            destList.Add(aLine);
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return string.Join("\r\n", destList);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -335,31 +335,23 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 string aLine;
                 var lineNumber = -1;
                 var replaced = false;
-                while (true)
+                while ((aLine = strReader.ReadLine()) != null)
                 {
-                    aLine = strReader.ReadLine();
                     lineNumber++;
-                    if (aLine != null)
+                    if (lineNumber < startLine || lineNumber > stopLine)
                     {
-                        if (lineNumber < startLine || lineNumber > stopLine)
-                        {
-                            destList.Add(aLine);
-                        }
-                        else
-                        {
-                            if (!replaced)
-                            {
-                                replaced = true;
-                                if (!string.IsNullOrEmpty(replaceString))
-                                {
-                                    destList.Add(replaceString);
-                                }
-                            }
-                        }
+                        destList.Add(aLine);
                     }
                     else
                     {
-                        break;
+                        if (!replaced)
+                        {
+                            replaced = true;
+                            if (!string.IsNullOrEmpty(replaceString))
+                            {
+                                destList.Add(replaceString);
+                            }
+                        }
                     }
                 }
             }
@@ -374,23 +366,15 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             using (var strReader = new StringReader(templateBody))
             {
                 string aLine;
-                while (true)
+                while ((aLine = strReader.ReadLine()) != null)
                 {
-                    aLine = strReader.ReadLine();
-                    if (aLine != null)
+                    var newTemplateBodyLine = aLine;
+                    if (aLine.TrimStart().StartsWith("#"))
                     {
-                        var newTemplateBodyLine = aLine;
-                        if (aLine.TrimStart().StartsWith("#"))
-                        {
-                            newTemplateBodyLine = $"- {aLine.TrimStart()}";
-                        }
+                        newTemplateBodyLine = $"- {aLine.TrimStart()}";
+                    }
 
-                        destList.Add(newTemplateBodyLine);
-                    }
-                    else
-                    {
-                        break;
-                    }
+                    destList.Add(newTemplateBodyLine);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using AdaptiveExpressions;
@@ -20,6 +21,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </remarks>
     public class Templates : List<Template>
     {
+        private readonly string newLine = "\r\n";
+
         public Templates(
             IList<Template> templates = null,
             IList<TemplateImport> imports = null,
@@ -203,7 +206,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             text = !text.Trim().StartsWith(multiLineMark) && text.Contains('\n')
                    ? $"{multiLineMark}{text}{multiLineMark}" : text;
 
-            var newContent = $"# {fakeTemplateId} \r\n - {text}";
+            var newContent = $"# {fakeTemplateId} {newLine} - {text}";
 
             var newLG = TemplatesParser.ParseTextWithRef(newContent, this);
 
@@ -252,7 +255,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 var templateNameLine = BuildTemplateNameLine(newTemplateName, parameters);
                 var newTemplateBody = ConvertTemplateBody(templateBody);
-                var content = $"{templateNameLine}\r\n{newTemplateBody}\r\n";
+                var content = $"{templateNameLine}{newLine}{newTemplateBody}";
                 var (startLine, stopLine) = template.GetTemplateRange();
 
                 var newContent = ReplaceRangeContent(Content, startLine, stopLine, content);
@@ -279,7 +282,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             var templateNameLine = BuildTemplateNameLine(templateName, parameters);
             var newTemplateBody = ConvertTemplateBody(templateBody);
-            var newContent = $"{Content.TrimEnd()}\r\n\r\n{templateNameLine}\r\n{newTemplateBody}\r\n";
+            var newContent = $"{Content}{newLine}{templateNameLine}{newLine}{newTemplateBody}";
             Initialize(ParseText(newContent, Id, ImportResolver));
 
             return this;
@@ -320,108 +323,79 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private string ReplaceRangeContent(string originString, int startLine, int stopLine, string replaceString)
         {
-            var originList = originString.Split('\n');
-            var destList = new List<string>();
-            if (startLine < 0 || startLine > stopLine || stopLine >= originList.Length)
+            if (startLine < 0 || startLine > stopLine)
             {
                 throw new Exception("index out of range.");
             }
 
-            destList.AddRange(TrimList(originList.Take(startLine).ToList()));
+            var destList = new List<string>();
 
-            if (stopLine < originList.Length - 1)
+            using (var strReader = new StringReader(originString))
             {
-                destList.Add("\r\n");
-                if (!string.IsNullOrEmpty(replaceString))
+                string aLine;
+                var lineNumber = -1;
+                var replaced = false;
+                while (true)
                 {
-                    destList.Add(replaceString);
-                    destList.Add("\r\n");
-                }
-
-                destList.AddRange(TrimList(originList.Skip(stopLine + 1).ToList()));
-            }
-            else
-            {
-                // insert at the tail of the content
-                if (!string.IsNullOrEmpty(replaceString))
-                {
-                    destList.Add("\r\n");
-                    destList.Add(replaceString);
-                }
-            }
-
-            return BuildNewLGContent(TrimList(destList));
-        }
-
-        /// <summary>
-        /// trim the newlines at the beginning or at the tail of the array.
-        /// </summary>
-        /// <param name="input">input array.</param>
-        /// <returns>trimed list.</returns>
-        private IList<string> TrimList(IList<string> input)
-        {
-            if (input == null)
-            {
-                return null;
-            }
-
-            var startIndex = 0;
-            var endIndex = input.Count;
-            for (var i = 0; i < input.Count; i++)
-            {
-                if (!string.IsNullOrWhiteSpace(input[i]?.Trim()))
-                {
-                    startIndex = i;
-                    break;
+                    aLine = strReader.ReadLine();
+                    lineNumber++;
+                    if (aLine != null)
+                    {
+                        if (lineNumber < startLine || lineNumber > stopLine)
+                        {
+                            destList.Add(aLine);
+                        }
+                        else
+                        {
+                            if (!replaced)
+                            {
+                                replaced = true;
+                                if (!string.IsNullOrEmpty(replaceString))
+                                {
+                                    destList.Add(replaceString);
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
 
-            for (var i = input.Count - 1; i >= 0; i--)
-            {
-                if (!string.IsNullOrWhiteSpace(input[i]?.Trim()))
-                {
-                    endIndex = i + 1;
-                    break;
-                }
-            }
-
-            return input.Skip(startIndex).Take(endIndex - startIndex).ToList();
-        }
-
-        private string BuildNewLGContent(IList<string> destList)
-        {
-            var result = new StringBuilder();
-            for (var i = 0; i < destList.Count; i++)
-            {
-                var currentItem = destList[i];
-                result.Append(currentItem);
-                if (currentItem.EndsWith("\r"))
-                {
-                    result.Append("\n");
-                }
-                else if (i < destList.Count - 1 && !currentItem.EndsWith("\r\n"))
-                {
-                    result.Append("\r\n");
-                }
-            }
-
-            return result.ToString();
+            return string.Join(newLine, destList);
         }
 
         private string ConvertTemplateBody(string templateBody)
         {
-            if (string.IsNullOrWhiteSpace(templateBody))
+            var destList = new List<string>();
+
+            using (var strReader = new StringReader(templateBody))
             {
-                return string.Empty;
+                string aLine;
+                while (true)
+                {
+                    aLine = strReader.ReadLine();
+                    if (aLine != null)
+                    {
+                        var newTemplateBodyLine = aLine;
+                        if (aLine.TrimStart().StartsWith("#"))
+                        {
+                            newTemplateBodyLine = $"- {aLine.TrimStart()}";
+                        }
+
+                        destList.Add(newTemplateBodyLine);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
             }
 
-            var replaceList = templateBody.Split('\n');
-
-            return string.Join("\n", replaceList.Select(u => WrapTemplateBodyString(u)));
+            return string.Join(newLine, destList);
         }
-
-        // we will warp '# abc' into '- #abc', to avoid adding additional template.
-        private string WrapTemplateBodyString(string replaceItem) => replaceItem.TrimStart().StartsWith("#") ? $"- {replaceItem.TrimStart()}" : replaceItem;
 
         private string BuildTemplateNameLine(string templateName, List<string> parameters)
         {
@@ -459,7 +433,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var errors = AllDiagnostics.Where(u => u.Severity == DiagnosticSeverity.Error);
                 if (errors.Count() != 0)
                 {
-                    throw new Exception(string.Join("\n", errors));
+                    throw new Exception(string.Join(newLine, errors));
                 }
             }
         }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -617,12 +617,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(templates[1].Parameters.Count, 2);
             Assert.AreEqual(templates[1].Parameters[0], "age");
             Assert.AreEqual(templates[1].Parameters[1], "name");
-            Assert.AreEqual(templates[1].Body.Replace("\r\n", "\n"), "- hi \n");
+            Assert.AreEqual(templates[1].Body.Replace("\r\n", "\n"), "- hi ");
 
             templates.AddTemplate("newtemplate2", null, "- hi2 ");
             Assert.AreEqual(templates.Count, 3);
             Assert.AreEqual(templates[2].Name, "newtemplate2");
-            Assert.AreEqual(templates[2].Body.Replace("\r\n", "\n"), "- hi2 \n");
+            Assert.AreEqual(templates[2].Body.Replace("\r\n", "\n"), "- hi2 ");
 
             templates.UpdateTemplate("newtemplate", "newtemplateName", new List<string> { "newage", "newname" }, "- new hi\r\n#hi");
             Assert.AreEqual(templates.Count, 3);
@@ -631,13 +631,13 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(templates[1].Parameters.Count, 2);
             Assert.AreEqual(templates[1].Parameters[0], "newage");
             Assert.AreEqual(templates[1].Parameters[1], "newname");
-            Assert.AreEqual(templates[1].Body.Replace("\r\n", "\n"), "- new hi\n- #hi\n");
+            Assert.AreEqual(templates[1].Body.Replace("\r\n", "\n"), "- new hi\n- #hi");
 
             templates.UpdateTemplate("newtemplate2", "newtemplateName2", new List<string> { "newage2", "newname2" }, "- new hi\r\n#hi2");
             Assert.AreEqual(templates.Count, 3);
             Assert.AreEqual(templates.Imports.Count, 0);
             Assert.AreEqual(templates[2].Name, "newtemplateName2");
-            Assert.AreEqual(templates[2].Body.Replace("\r\n", "\n"), "- new hi\n- #hi2\n");
+            Assert.AreEqual(templates[2].Body.Replace("\r\n", "\n"), "- new hi\n- #hi2");
 
             templates.DeleteTemplate("newtemplateName");
             Assert.AreEqual(templates.Count, 2);


### PR DESCRIPTION
Originally, we treat LG file as the combination of templates and use empty string as the separator.
From now on separator "\r\n" would be used.

So, if we update a template with the body "- A", we would always get the body "- A" but not "-A\r\n" in any case. This idempotent relationship will greatly increase robustness and consistency