### PR TITLE
Fix local culture info changes the result of parsing number and datetime

### DIFF
--- a/libraries/AdaptiveExpressions/Constant.cs
+++ b/libraries/AdaptiveExpressions/Constant.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace AdaptiveExpressions
@@ -71,7 +72,7 @@ namespace AdaptiveExpressions
             }
             else if (Value is float || Value is double)
             {
-               return ((double)Value).ToString("0.00########");
+               return ((double)Value).ToString("0.00########", CultureInfo.InvariantCulture);
             }
             else
             {

--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using AdaptiveExpressions.Converters;

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -1267,7 +1267,7 @@ namespace AdaptiveExpressions
                 throw new ArgumentNullException();
             }
 
-            if (Convert.ToDouble(a) > Convert.ToDouble(b))
+            if (CultureInvariantDoubleConvert(a) > CultureInvariantDoubleConvert(b))
             {
                 return a;
             }
@@ -1284,7 +1284,7 @@ namespace AdaptiveExpressions
                 throw new ArgumentNullException();
             }
 
-            if (Convert.ToDouble(a) <= Convert.ToDouble(b))
+            if (CultureInvariantDoubleConvert(a) <= CultureInvariantDoubleConvert(b))
             {
                 return a;
             }
@@ -1293,6 +1293,8 @@ namespace AdaptiveExpressions
                 return b;
             }
         }
+
+        private static double CultureInvariantDoubleConvert(object numberObj) => Convert.ToDouble(numberObj, CultureInfo.InvariantCulture);
 
         private static object Add(object a, object b)
         {
@@ -1307,7 +1309,7 @@ namespace AdaptiveExpressions
             }
             else
             {
-                return Convert.ToDouble(a) + Convert.ToDouble(b);
+                return CultureInvariantDoubleConvert(a) + CultureInvariantDoubleConvert(b);
             }
         }
 
@@ -1324,7 +1326,7 @@ namespace AdaptiveExpressions
             }
             else
             {
-                return Convert.ToDouble(a) - Convert.ToDouble(b);
+                return CultureInvariantDoubleConvert(a) - CultureInvariantDoubleConvert(b);
             }
         }
 
@@ -1341,7 +1343,7 @@ namespace AdaptiveExpressions
             }
             else
             {
-                return Convert.ToDouble(a) * Convert.ToDouble(b);
+                return CultureInvariantDoubleConvert(a) * CultureInvariantDoubleConvert(b);
             }
         }
 
@@ -1358,7 +1360,7 @@ namespace AdaptiveExpressions
             }
             else
             {
-                return Convert.ToDouble(a) % Convert.ToDouble(b);
+                return CultureInvariantDoubleConvert(a) % CultureInvariantDoubleConvert(b);
             }
         }
 
@@ -1375,7 +1377,7 @@ namespace AdaptiveExpressions
             }
             else
             {
-                return Convert.ToDouble(a) / Convert.ToDouble(b);
+                return CultureInvariantDoubleConvert(a) / CultureInvariantDoubleConvert(b);
             }
         }
 
@@ -2575,7 +2577,7 @@ namespace AdaptiveExpressions
 
             if (args[0].IsNumber() && args[0].IsNumber())
             {
-                if (Math.Abs(Convert.ToDouble(args[0]) - Convert.ToDouble(args[1])) < 0.00000001)
+                if (Math.Abs(CultureInvariantDoubleConvert(args[0]) - CultureInvariantDoubleConvert(args[1])) < 0.00000001)
                 {
                     return true;
                 }
@@ -2750,7 +2752,7 @@ namespace AdaptiveExpressions
 
                     return result;
                 }),
-                MultivariateNumeric(ExpressionType.Power, args => Math.Pow(Convert.ToDouble(args[0]), Convert.ToDouble(args[1]))),
+                MultivariateNumeric(ExpressionType.Power, args => Math.Pow(CultureInvariantDoubleConvert(args[0]), CultureInvariantDoubleConvert(args[1]))),
                 new ExpressionEvaluator(
                     ExpressionType.Mod,
                     ApplyWithError(
@@ -2949,13 +2951,13 @@ namespace AdaptiveExpressions
                     (expression) => ValidateOrder(expression, null, ReturnType.Object)),
 
                 // Booleans
-                Comparison(ExpressionType.LessThan, args => Convert.ToDouble(args[0]) < Convert.ToDouble(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
-                Comparison(ExpressionType.LessThanOrEqual, args => Convert.ToDouble(args[0]) <= Convert.ToDouble(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
+                Comparison(ExpressionType.LessThan, args => CultureInvariantDoubleConvert(args[0]) < CultureInvariantDoubleConvert(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
+                Comparison(ExpressionType.LessThanOrEqual, args => CultureInvariantDoubleConvert(args[0]) <= CultureInvariantDoubleConvert(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
 
                 Comparison(ExpressionType.Equal, IsEqual, ValidateBinary),
                 Comparison(ExpressionType.NotEqual, args => !IsEqual(args), ValidateBinary),
-                Comparison(ExpressionType.GreaterThan, args => Convert.ToDouble(args[0]) > Convert.ToDouble(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
-                Comparison(ExpressionType.GreaterThanOrEqual, args => Convert.ToDouble(args[0]) >= Convert.ToDouble(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
+                Comparison(ExpressionType.GreaterThan, args => CultureInvariantDoubleConvert(args[0]) > CultureInvariantDoubleConvert(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
+                Comparison(ExpressionType.GreaterThanOrEqual, args => CultureInvariantDoubleConvert(args[0]) >= CultureInvariantDoubleConvert(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
                 Comparison(ExpressionType.Exists, args => args[0] != null, ValidateUnary, VerifyNotNull),
                 new ExpressionEvaluator(
                     ExpressionType.Contains,
@@ -3846,7 +3848,7 @@ namespace AdaptiveExpressions
                     ValidateUnary),
 
                 // Conversions
-                new ExpressionEvaluator(ExpressionType.Float, Apply(args => Convert.ToDouble(args[0], CultureInfo.InvariantCulture)), ReturnType.Number, ValidateUnary),
+                new ExpressionEvaluator(ExpressionType.Float, Apply(args => CultureInvariantDoubleConvert(args[0])), ReturnType.Number, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Int, Apply(args => Convert.ToInt32(args[0])), ReturnType.Number, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Binary, Apply(args => ToBinary(args[0].ToString()), VerifyString), ReturnType.String, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Base64, Apply(args => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(args[0].ToString())), VerifyString), ReturnType.String, ValidateUnary),
@@ -4022,12 +4024,12 @@ namespace AdaptiveExpressions
                     ValidateUnary),
                 new ExpressionEvaluator(
                     ExpressionType.IsInteger,
-                    Apply(args => Extensions.IsNumber(args[0]) && Convert.ToDouble(args[0]) % 1 == 0),
+                    Apply(args => Extensions.IsNumber(args[0]) && CultureInvariantDoubleConvert(args[0]) % 1 == 0),
                     ReturnType.Boolean,
                     ValidateUnary),
                 new ExpressionEvaluator(
                     ExpressionType.IsFloat,
-                    Apply(args => Extensions.IsNumber(args[0]) && Convert.ToDouble(args[0]) % 1 != 0),
+                    Apply(args => Extensions.IsNumber(args[0]) && CultureInvariantDoubleConvert(args[0]) % 1 != 0),
                     ReturnType.Boolean,
                     ValidateUnary),
                 new ExpressionEvaluator(

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -1793,7 +1793,7 @@ namespace AdaptiveExpressions
             string error = null;
             try
             {
-                result = datetime.ToString(format);
+                result = datetime.ToString(format, CultureInfo.InvariantCulture.DateTimeFormat);
             }
             catch
             {
@@ -3325,7 +3325,7 @@ namespace AdaptiveExpressions
                     ValidateUnaryString),
                 new ExpressionEvaluator(
                     ExpressionType.Date,
-                    ApplyWithError(args => ParseISOTimestamp((string)args[0], dt => dt.Date.ToString("M/dd/yyyy")), VerifyString),
+                    ApplyWithError(args => ParseISOTimestamp((string)args[0], dt => dt.Date.ToString("M/dd/yyyy", CultureInfo.InvariantCulture)), VerifyString),
                     ReturnType.String,
                     ValidateUnaryString),
                 new ExpressionEvaluator(
@@ -3347,14 +3347,21 @@ namespace AdaptiveExpressions
                             object timestamp = args[0];
                             if (Extensions.IsNumber(timestamp))
                             {
-                                if (double.TryParse(args[0].ToString(), out double unixTimestamp))
+                                if (double.TryParse(args[0].ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out double unixTimestamp))
                                 {
                                     var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
                                     timestamp = dateTime.AddSeconds(unixTimestamp);
                                 }
                             }
 
-                            (result, error) = ParseTimestamp((string)timestamp.ToString(), dt => dt.ToString(args.Count() == 2 ? args[1].ToString() : DefaultDateTimeFormat));
+                            if (timestamp is string tsString)
+                            {
+                                (result, error) = ParseTimestamp(tsString, dt => dt.ToString(args.Count() == 2 ? args[1].ToString() : DefaultDateTimeFormat, CultureInfo.InvariantCulture));
+                            }
+                            else
+                            {
+                                (result, error) = ParseTimestamp((string)((DateTime)timestamp).ToString(CultureInfo.InvariantCulture), dt => dt.ToString(args.Count() == 2 ? args[1].ToString() : DefaultDateTimeFormat, CultureInfo.InvariantCulture));
+                            }
 
                             return (result, error);
                         }),
@@ -3839,7 +3846,7 @@ namespace AdaptiveExpressions
                     ValidateUnary),
 
                 // Conversions
-                new ExpressionEvaluator(ExpressionType.Float, Apply(args => Convert.ToDouble(args[0])), ReturnType.Number, ValidateUnary),
+                new ExpressionEvaluator(ExpressionType.Float, Apply(args => Convert.ToDouble(args[0], CultureInfo.InvariantCulture)), ReturnType.Number, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Int, Apply(args => Convert.ToInt32(args[0])), ReturnType.Number, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Binary, Apply(args => ToBinary(args[0].ToString()), VerifyString), ReturnType.String, ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Base64, Apply(args => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(args[0].ToString())), VerifyString), ReturnType.String, ValidateUnary),

--- a/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
+++ b/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using AdaptiveExpressions.parser;
@@ -165,7 +166,7 @@ namespace AdaptiveExpressions
                     return Expression.ConstantExpression(intValue);
                 }
 
-                if (double.TryParse(context.GetText(), out var doubleValue))
+                if (double.TryParse(context.GetText(), NumberStyles.Any, CultureInfo.InvariantCulture, out var doubleValue))
                 {
                     return Expression.ConstantExpression(doubleValue);
                 }

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using AdaptiveExpressions.Memory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -677,10 +678,10 @@ namespace AdaptiveExpressions.Tests
             Test("getFutureTime(1,'Month','MM-dd-yy')", DateTime.Now.AddMonths(1).ToString("MM-dd-yy")),
             Test("getFutureTime(1,'Week','MM-dd-yy')", DateTime.Now.AddDays(7).ToString("MM-dd-yy")),
             Test("getFutureTime(1,'Day','MM-dd-yy')", DateTime.Now.AddDays(1).ToString("MM-dd-yy")),
-            Test("convertFromUTC('2018-01-02T02:00:00.000Z', 'Pacific Standard Time', 'D')", "Monday, January 1, 2018"),
-            Test("convertFromUTC('2018-01-02T01:00:00.000Z', 'America/Los_Angeles', 'D')", "Monday, January 1, 2018"),
+            Test("convertFromUTC('2018-01-02T02:00:00.000Z', 'Pacific Standard Time', 'D')", "Monday, 01 January 2018"),
+            Test("convertFromUTC('2018-01-02T01:00:00.000Z', 'America/Los_Angeles', 'D')", "Monday, 01 January 2018"),
             Test("convertToUTC('01/01/2018 00:00:00', 'Pacific Standard Time')", "2018-01-01T08:00:00.000Z"),
-            Test("addToTime('2018-01-01T08:00:00.000Z', 1, 'Day', 'D')", "Tuesday, January 2, 2018"),
+            Test("addToTime('2018-01-01T08:00:00.000Z', 1, 'Day', 'D')", "Tuesday, 02 January 2018"),
             Test("addToTime('2018-01-01T00:00:00.000Z', 1, 'Week')", "2018-01-08T00:00:00.000Z"),
             Test("startOfDay('2018-03-15T13:30:30.000Z')", "2018-03-15T00:00:00.000Z"),
             Test("startOfHour('2018-03-15T13:30:30.000Z')", "2018-03-15T13:00:00.000Z"),
@@ -975,8 +976,8 @@ namespace AdaptiveExpressions.Tests
             AssertResult<ushort>(ushort.MaxValue.ToString(), ushort.MaxValue);
             AssertResult<uint>(uint.MaxValue.ToString(), uint.MaxValue);
             AssertResult<ulong>(uint.MaxValue.ToString(), uint.MaxValue);
-            AssertResult<float>(15.32322F.ToString(), 15.32322F);
-            AssertResult<double>(15.32322.ToString(), 15.32322);
+            AssertResult<float>(15.32322F.ToString(CultureInfo.InvariantCulture), 15.32322F);
+            AssertResult<double>(15.32322.ToString(CultureInfo.InvariantCulture), 15.32322);
         }
 
         private void AssertResult<T>(string text, T expected)

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -902,52 +902,31 @@ namespace AdaptiveExpressions.Tests
 
         [DataTestMethod]
         [DynamicData(nameof(Data))]
-        public void EvaluateInDeCulture(string input, object expected, HashSet<string> expectedRefs)
-        {
-            var originalCuture = Thread.CurrentThread.CurrentCulture;
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
-            var parsed = Expression.Parse(input);
-            Assert.IsNotNull(parsed);
-            var (actual, msg) = parsed.TryEvaluate(scope);
-            Assert.AreEqual(null, msg);
-            AssertObjectEquals(expected, actual);
-            if (expectedRefs != null)
+        public void EvaluateInOtherCultures(string input, object expected, HashSet<string> expectedRefs)
+        { 
+            var cultureList = new List<string>() { "de-DE", "fr-FR", "es-ES" };
+            foreach (var newCultureInfo in cultureList)
             {
-                var actualRefs = parsed.References();
-                Assert.IsTrue(expectedRefs.SetEquals(actualRefs), $"References do not match, expected: {string.Join(',', expectedRefs)} acutal: {string.Join(',', actualRefs)}");
-            }
+                var originalCuture = Thread.CurrentThread.CurrentCulture;
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(newCultureInfo);
+                var parsed = Expression.Parse(input);
+                Assert.IsNotNull(parsed);
+                var (actual, msg) = parsed.TryEvaluate(scope);
+                Assert.AreEqual(null, msg);
+                AssertObjectEquals(expected, actual);
+                if (expectedRefs != null)
+                {
+                    var actualRefs = parsed.References();
+                    Assert.IsTrue(expectedRefs.SetEquals(actualRefs), $"References do not match, expected: {string.Join(',', expectedRefs)} acutal: {string.Join(',', actualRefs)}");
+                }
 
-            // ToString re-parse
-            var newExpression = Expression.Parse(parsed.ToString());
-            var newActual = newExpression.TryEvaluate(scope).value;
-            AssertObjectEquals(actual, newActual);
+                // ToString re-parse
+                var newExpression = Expression.Parse(parsed.ToString());
+                var newActual = newExpression.TryEvaluate(scope).value;
+                AssertObjectEquals(actual, newActual);
 
-            Thread.CurrentThread.CurrentCulture = originalCuture;
-        }
-
-        [DataTestMethod]
-        [DynamicData(nameof(Data))]
-        public void EvaluateInFrCulture(string input, object expected, HashSet<string> expectedRefs)
-        {
-            var originalCuture = Thread.CurrentThread.CurrentCulture;
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
-            var parsed = Expression.Parse(input);
-            Assert.IsNotNull(parsed);
-            var (actual, msg) = parsed.TryEvaluate(scope);
-            Assert.AreEqual(null, msg);
-            AssertObjectEquals(expected, actual);
-            if (expectedRefs != null)
-            {
-                var actualRefs = parsed.References();
-                Assert.IsTrue(expectedRefs.SetEquals(actualRefs), $"References do not match, expected: {string.Join(',', expectedRefs)} acutal: {string.Join(',', actualRefs)}");
-            }
-
-            // ToString re-parse
-            var newExpression = Expression.Parse(parsed.ToString());
-            var newActual = newExpression.TryEvaluate(scope).value;
-            AssertObjectEquals(actual, newActual);
-
-            Thread.CurrentThread.CurrentCulture = originalCuture;
+                Thread.CurrentThread.CurrentCulture = originalCuture;
+            } 
         }
 
         [DataTestMethod]

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading;
 using AdaptiveExpressions.Memory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -882,6 +883,50 @@ namespace AdaptiveExpressions.Tests
         [DynamicData(nameof(Data))]
         public void Evaluate(string input, object expected, HashSet<string> expectedRefs)
         {
+            var parsed = Expression.Parse(input);
+            Assert.IsNotNull(parsed);
+            var (actual, msg) = parsed.TryEvaluate(scope);
+            Assert.AreEqual(null, msg);
+            AssertObjectEquals(expected, actual);
+            if (expectedRefs != null)
+            {
+                var actualRefs = parsed.References();
+                Assert.IsTrue(expectedRefs.SetEquals(actualRefs), $"References do not match, expected: {string.Join(',', expectedRefs)} acutal: {string.Join(',', actualRefs)}");
+            }
+
+            // ToString re-parse
+            var newExpression = Expression.Parse(parsed.ToString());
+            var newActual = newExpression.TryEvaluate(scope).value;
+            AssertObjectEquals(actual, newActual);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Data))]
+        public void EvaluateInDeCulture(string input, object expected, HashSet<string> expectedRefs)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            var parsed = Expression.Parse(input);
+            Assert.IsNotNull(parsed);
+            var (actual, msg) = parsed.TryEvaluate(scope);
+            Assert.AreEqual(null, msg);
+            AssertObjectEquals(expected, actual);
+            if (expectedRefs != null)
+            {
+                var actualRefs = parsed.References();
+                Assert.IsTrue(expectedRefs.SetEquals(actualRefs), $"References do not match, expected: {string.Join(',', expectedRefs)} acutal: {string.Join(',', actualRefs)}");
+            }
+
+            // ToString re-parse
+            var newExpression = Expression.Parse(parsed.ToString());
+            var newActual = newExpression.TryEvaluate(scope).value;
+            AssertObjectEquals(actual, newActual);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(Data))]
+        public void EvaluateInFrCulture(string input, object expected, HashSet<string> expectedRefs)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
             var parsed = Expression.Parse(input);
             Assert.IsNotNull(parsed);
             var (actual, msg) = parsed.TryEvaluate(scope);

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -904,6 +904,7 @@ namespace AdaptiveExpressions.Tests
         [DynamicData(nameof(Data))]
         public void EvaluateInDeCulture(string input, object expected, HashSet<string> expectedRefs)
         {
+            var originalCuture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
             var parsed = Expression.Parse(input);
             Assert.IsNotNull(parsed);
@@ -921,13 +922,14 @@ namespace AdaptiveExpressions.Tests
             var newActual = newExpression.TryEvaluate(scope).value;
             AssertObjectEquals(actual, newActual);
 
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = originalCuture;
         }
 
         [DataTestMethod]
         [DynamicData(nameof(Data))]
         public void EvaluateInFrCulture(string input, object expected, HashSet<string> expectedRefs)
         {
+            var originalCuture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
             var parsed = Expression.Parse(input);
             Assert.IsNotNull(parsed);
@@ -945,7 +947,7 @@ namespace AdaptiveExpressions.Tests
             var newActual = newExpression.TryEvaluate(scope).value;
             AssertObjectEquals(actual, newActual);
 
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = originalCuture;
         }
 
         [DataTestMethod]

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -920,6 +920,8 @@ namespace AdaptiveExpressions.Tests
             var newExpression = Expression.Parse(parsed.ToString());
             var newActual = newExpression.TryEvaluate(scope).value;
             AssertObjectEquals(actual, newActual);
+
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
         }
 
         [DataTestMethod]
@@ -942,6 +944,8 @@ namespace AdaptiveExpressions.Tests
             var newExpression = Expression.Parse(parsed.ToString());
             var newActual = newExpression.TryEvaluate(scope).value;
             AssertObjectEquals(actual, newActual);
+
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
         }
 
         [DataTestMethod]


### PR DESCRIPTION
fixes #3598 
use CultureInfo.InvariantCuture to make sure the cultureInfo of user's local machine won't affect the outcome of expresssion functions.
For example, in de-DE 
1.0 will be parsed to 10. 
03/12/2012 will be parsed to03,12,2012
