### PR TITLE
DCR: Change .dialog file string resource lookup to fallback to non-dialog files.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
@@ -29,6 +29,8 @@
     <Content Include="**/*.lg" />
     <Content Include="**/*.lu" />
     <Content Include="**/*.schema" />
+    <Content Include="**/*.qna"/>
+    <Content Include="**/*.json"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
@@ -28,6 +28,8 @@
     <Content Include="**/*.lg" />
     <Content Include="**/*.lu" />
     <Content Include="**/*.schema" />
+    <Content Include="**/*.qna"/>
+    <Content Include="**/*.json"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -38,13 +38,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**/*.dialog" />
-    <Content Include="**/*.lg" />
-    <Content Include="**/*.lu" />
-    <Content Include="**/*.schema" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.2.0" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
@@ -30,6 +30,8 @@
     <Content Include="**/*.lg" />
     <Content Include="**/*.lu" />
     <Content Include="**/*.schema" />
+    <Content Include="**/*.qna"/>
+    <Content Include="**/*.json"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -28,10 +28,11 @@
 
   <ItemGroup>
     <Content Include="**/*.dialog" />
-    <Content Include="Schemas/**/*.json" />
     <Content Include="**/*.lg" />
     <Content Include="**/*.lu" />
     <Content Include="**/*.schema" />
+    <Content Include="**/*.qna"/>
+    <Content Include="**/*.json"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
@@ -26,14 +26,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <Content Include="**/*.dialog" />
-    <Content Include="schemas/**/*.json" />
-    <Content Include="**/*.lg" />
-    <Content Include="**/*.lu" />
-    <Content Include="**/*.schema" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Json.Pointer" Version="0.61.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FileResource.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FileResource.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
     /// </summary>
     public class FileResource : IResource
     {
-        private string path;
         private Task<byte[]> contentTask;
         private Task<string> textTask;
 
@@ -19,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <param name="path">path to file.</param>
         public FileResource(string path)
         {
-            this.path = path;
+            this.FullName = path;
             this.Id = Path.GetFileName(path);
         }
 
@@ -37,10 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <value>
         /// The full path to the resource on disk.
         /// </value>
-        public string FullName
-        {
-            get { return this.path; }
-        }
+        public string FullName { get; }
 
         /// <summary>
         /// Open a stream to the resource.
@@ -53,11 +49,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                 this.contentTask = Task.Run(async () =>
                 {
                     Trace.TraceInformation($"Loading {this.Id}");
-                    var fileInfo = new FileInfo(this.path);
+                    var fileInfo = new FileInfo(this.FullName);
                     Stream stream = null;
                     try
                     {
-                        stream = File.OpenRead(this.path);
+                        stream = File.OpenRead(this.FullName);
                         var buffer = new byte[fileInfo.Length];
                         await stream.ReadAsync(buffer, 0, (int)fileInfo.Length).ConfigureAwait(false);
                         return buffer;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FolderResourceProviderExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FolderResourceProviderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <returns>The resource explorer.</returns>
         public static ResourceExplorer AddFolder(this ResourceExplorer explorer, string folder, bool includeSubFolders = true, bool monitorChanges = true)
         {
-            explorer.AddResourceProvider(new FolderResourceProvider(folder, includeSubFolders: includeSubFolders, monitorChanges: monitorChanges));
+            explorer.AddResourceProvider(new FolderResourceProvider(explorer, folder, includeSubFolders: includeSubFolders, monitorChanges: monitorChanges));
             return explorer;
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             }
             else
             {
-                resourceExplorer.AddResourceProvider(new FolderResourceProvider(projectFolder, includeSubFolders: true, monitorChanges: monitorChanges));
+                resourceExplorer.AddResourceProvider(new FolderResourceProvider(resourceExplorer, projectFolder, includeSubFolders: true, monitorChanges: monitorChanges));
             }
 
             // add project references
@@ -112,7 +112,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                 path = Path.GetDirectoryName(path);
                 if (Directory.Exists(path))
                 {
-                    resourceExplorer.AddResourceProvider(new FolderResourceProvider(path, includeSubFolders: true, monitorChanges: monitorChanges));
+                    resourceExplorer.AddResourceProvider(new FolderResourceProvider(resourceExplorer, path, includeSubFolders: true, monitorChanges: monitorChanges));
                 }
             }
 
@@ -141,7 +141,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                     var folder = Path.Combine(packages, PathUtils.NormalizePath(pathResolver.GetPackageDirectoryName(package)));
                     if (Directory.Exists(folder))
                     {
-                        resourceExplorer.AddResourceProvider(new FolderResourceProvider(folder, includeSubFolders: true, monitorChanges: monitorChanges));
+                        resourceExplorer.AddResourceProvider(new FolderResourceProvider(resourceExplorer, folder, includeSubFolders: true, monitorChanges: monitorChanges));
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -76,6 +76,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         }
 
         /// <summary>
+        /// Gets the resource type id extensions that you want to manage.
+        /// </summary>
+        /// <value>
+        /// The extensions that you want the to manage.
+        /// </value>
+        public HashSet<string> ResourceTypes { get; private set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "dialog",
+            "lu",
+            "lg",
+            "qna",
+            "schema",
+            "json"
+        };
+
+        /// <summary>
         /// Add a resource provider to the resources managed by the resource explorer.
         /// </summary>
         /// <param name="resourceProvider">resource provider.</param>
@@ -364,10 +380,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                 throw new InvalidOperationException("Failed to resolve reference, $copy property not present");
             }
 
-            var resource = this.GetResource($"{refTarget}.dialog");
-            if (resource == null)
+            // see if there is a dialog file for this resource.id
+            if (!this.TryGetResource($"{refTarget}.dialog", out IResource resource))
             {
-                throw new FileNotFoundException($"Failed to find resource named {refTarget}.dialog");
+                // if not, try loading the resource directly.
+                if (!this.TryGetResource(refTarget, out resource))
+                {
+                    throw new FileNotFoundException($"Failed to find resource named {refTarget}.dialog or {refTarget}.");
+                }
             }
 
             string text = await resource.ReadTextAsync().ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -28,24 +28,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**/*.dialog" />
-    <Content Include="**/*.lg" />
-    <Content Include="**/*.lu" />
-    <Content Include="**/*.schema" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Templating\**" />
-    <Content Remove="Templating\**" />
-    <EmbeddedResource Remove="Templating\**" />
-    <None Remove="Templating\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="Schemas\Microsoft.IRecognizer.schema" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="4.8.0-local" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddResourceProvider(new FolderResourceProvider(path));
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
 
                 await AssertResourceType(path, explorer, "dialog");
                 var resources = explorer.GetResources("foo").ToArray();
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddResourceProvider(new FolderResourceProvider(path));
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
                 try
                 {
                     explorer.GetResource("bogus.dialog");
@@ -130,7 +130,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddResourceProvider(new FolderResourceProvider(path, monitorChanges: true));
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path, monitorChanges: true));
 
                 AssertResourceFound(explorer, testId);
 
@@ -170,7 +170,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
             using (var explorer = new ResourceExplorer())
             {
-                explorer.AddResourceProvider(new FolderResourceProvider(path, monitorChanges: true));
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path, monitorChanges: true));
 
                 AssertResourceFound(explorer, testId);
 


### PR DESCRIPTION
#3641 DCR

* Add fallback for string reference binding "foo.xxx" => looks for "foo.xxx.dialog" and if not found attempts to bind to "foo.xxx",

The point of these changes is that it allows new extensions to be added to the resource explorer, and if there are object bindings for those extensions they will be used.  If a file is valid json but NOT a dialog file (Such as .schema files) then they can be used directly without having to have .dialog extension.

For example, this captures the 2 scenarios:
1. **"recognizer":"foo.lu"** => will bind to attempt to bind to "foo.lu.dialog", and if lubuild has run find it. if there is no .dialog it will attempt to load the foo.lu file and appropriately fail.
2. **"schema":"foo.schema"** => will attempt to bind to foo.schema.dialog, and then fall back to foo.schema, which is a valid JSON object to bind and it will load it. (Thus removing the need to have schema file be **foo.schema.dialog**.

Some additional changes:
* Move folderResource.Extensions to resourceExporer.ResourceTypes and make non-static. This allos resource explorer to be configured to pick up additional resource types.
* removed some unused fields in there.
* cleaned up some nonsense I disovered in .csproj files
* added .qna files to pattern list