### PR TITLE
use inner most dc for sending Bot State

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/DialogManager.cs
@@ -231,7 +231,13 @@ namespace Microsoft.Bot.Builder.Dialogs
             await botStateSet.SaveAllChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
 
             // send trace of memory
-            var snapshot = dc.State.GetMemorySnapshot();
+            var snapshotDc = dc;
+            while (snapshotDc.Child != null)
+            {
+                snapshotDc = snapshotDc.Child;
+            }
+
+            var snapshot = snapshotDc.State.GetMemorySnapshot();
             var traceActivity = (Activity)Activity.CreateTraceActivity("BotState", "https://www.botframework.com/schemas/botState", snapshot, "Bot State");
             await dc.Context.SendActivityAsync(traceActivity).ConfigureAwait(false);
 


### PR DESCRIPTION
Before, Bot State will be the state of the out-most dialog, which will be inconvenient:
For example, in this dialog
![image](https://user-images.githubusercontent.com/2876650/78105084-f0730000-7422-11ea-93ab-931f689d44be.png)
Trace will be
![image](https://user-images.githubusercontent.com/2876650/78105404-afc7b680-7423-11ea-81d8-b44824f91da4.png)
While Bot State will be 
![image](https://user-images.githubusercontent.com/2876650/78105446-c79f3a80-7423-11ea-9155-b751b4ad075d.png)
After this, Bot State will be same as trace
![image](https://user-images.githubusercontent.com/2876650/78105557-0503c800-7424-11ea-8935-1b0296441ec5.png)

