### PR TITLE
[LG] Fix missing trailing line break with String.Readline()

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Antlr4.Runtime.Tree;

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
@@ -161,42 +161,5 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             return errorPrefix;
         }
-
-        /// <summary>
-        /// read string content line by line.
-        /// </summary>
-        /// <param name="input">string content.</param>
-        /// <returns>enumerable result.</returns>
-        public static IEnumerable<string> StringReadLine(string input)
-        {
-            if (input == null)
-            {
-                yield return input;
-            }
-
-            using (var strReader = new StringReader(input))
-            {
-                string aLine;
-                while ((aLine = strReader.ReadLine()) != null)
-                {
-                    yield return aLine;
-                }
-            }
-
-            // append newline to result
-            while (input.EndsWith("\r\n") || input.EndsWith("\n"))
-            {
-                if (input.EndsWith("\r\n"))
-                {
-                    input = input.Substring(0, input.Length - 2);
-                }
-                else
-                {
-                    input = input.Substring(0, input.Length - 1);
-                }
-
-                yield return string.Empty;
-            }
-        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Antlr4.Runtime.Tree;
@@ -159,6 +160,43 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             return errorPrefix;
+        }
+
+        /// <summary>
+        /// read string content line by line.
+        /// </summary>
+        /// <param name="input">string content.</param>
+        /// <returns>enumerable result.</returns>
+        public static IEnumerable<string> StringReadLine(string input)
+        {
+            if (input == null)
+            {
+                yield return input;
+            }
+
+            using (var strReader = new StringReader(input))
+            {
+                string aLine;
+                while ((aLine = strReader.ReadLine()) != null)
+                {
+                    yield return aLine;
+                }
+            }
+
+            // append newline to result
+            while (input.EndsWith("\r\n") || input.EndsWith("\n"))
+            {
+                if (input.EndsWith("\r\n"))
+                {
+                    input = input.Substring(0, input.Length - 2);
+                }
+                else
+                {
+                    input = input.Substring(0, input.Length - 1);
+                }
+
+                yield return string.Empty;
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -150,19 +150,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception("index out of range.");
             }
 
-            var destList = new List<string>();
+            var contentCollection = Extensions.StringReadLine(originString);
 
-            using (var strReader = new StringReader(originString))
+            var destList = new List<string>();
+            var lineNumber = -1;
+            foreach (var line in contentCollection)
             {
-                string aLine;
-                var lineNumber = -1;
-                while ((aLine = strReader.ReadLine()) != null)
+                lineNumber++;
+                if (lineNumber >= startLine && lineNumber <= stopLine)
                 {
-                    lineNumber++;
-                    if (lineNumber >= startLine && lineNumber <= stopLine)
-                    {
-                        destList.Add(aLine);
-                    }
+                    destList.Add(line);
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         private string GetRangeContent(string originString, int startLine, int stopLine)
         {
             var originList = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
-            if (startLine < 0 || startLine > stopLine)
+            if (startLine < 0 || startLine > stopLine || stopLine >= originList.Length)
             {
                 throw new Exception("index out of range.");
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -145,23 +145,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private string GetRangeContent(string originString, int startLine, int stopLine)
         {
+            var originList = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
             if (startLine < 0 || startLine > stopLine)
             {
                 throw new Exception("index out of range.");
             }
 
-            var lines = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
-
-            var destList = new List<string>();
-            var lineNumber = -1;
-            foreach (var line in lines)
-            {
-                lineNumber++;
-                if (lineNumber >= startLine && lineNumber <= stopLine)
-                {
-                    destList.Add(line);
-                }
-            }
+            var destList = originList.Skip(startLine).Take(stopLine - startLine + 1);
 
             return string.Join("\r\n", destList);
         }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -150,11 +150,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception("index out of range.");
             }
 
-            var contentCollection = Extensions.StringReadLine(originString);
+            var lines = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
 
             var destList = new List<string>();
             var lineNumber = -1;
-            foreach (var line in contentCollection)
+            foreach (var line in lines)
             {
                 lineNumber++;
                 if (lineNumber >= startLine && lineNumber <= stopLine)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -323,22 +323,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private string ReplaceRangeContent(string originString, int startLine, int stopLine, string replaceString)
         {
-            if (startLine < 0 || startLine > stopLine)
+            var originList = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
+
+            if (startLine < 0 || startLine > stopLine || stopLine >= originList.Length)
             {
                 throw new Exception("index out of range.");
             }
 
-            var lines = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
-
             var destList = new List<string>();
-            var lineNumber = -1;
             var replaced = false;
-            foreach (var line in lines)
+            for (var line = 0; line < originList.Length; line++)
             {
-                lineNumber++;
-                if (lineNumber < startLine || lineNumber > stopLine)
+                if (line < startLine || line > stopLine)
                 {
-                    destList.Add(line);
+                    destList.Add(originList[line]);
                 }
                 else
                 {
@@ -361,14 +359,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var lines = templateBody.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
             var destList = lines.Select(u =>
             {
-                if (u.TrimStart().StartsWith("#"))
-                {
-                    return $"- {u.TrimStart()}";
-                }
-                else
-                {
-                    return u;
-                }
+                return u.TrimStart().StartsWith("#") ? $"- {u.TrimStart()}" : u;
             });
 
             return string.Join(newLine, destList);

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -328,29 +328,26 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception("index out of range.");
             }
 
-            var destList = new List<string>();
+            var contentCollection = Extensions.StringReadLine(originString);
 
-            using (var strReader = new StringReader(originString))
+            var destList = new List<string>();
+            var lineNumber = -1;
+            var replaced = false;
+            foreach (var line in contentCollection)
             {
-                string aLine;
-                var lineNumber = -1;
-                var replaced = false;
-                while ((aLine = strReader.ReadLine()) != null)
+                lineNumber++;
+                if (lineNumber < startLine || lineNumber > stopLine)
                 {
-                    lineNumber++;
-                    if (lineNumber < startLine || lineNumber > stopLine)
+                    destList.Add(line);
+                }
+                else
+                {
+                    if (!replaced)
                     {
-                        destList.Add(aLine);
-                    }
-                    else
-                    {
-                        if (!replaced)
+                        replaced = true;
+                        if (!string.IsNullOrEmpty(replaceString))
                         {
-                            replaced = true;
-                            if (!string.IsNullOrEmpty(replaceString))
-                            {
-                                destList.Add(replaceString);
-                            }
+                            destList.Add(replaceString);
                         }
                     }
                 }
@@ -361,24 +358,20 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private string ConvertTemplateBody(string templateBody)
         {
-            var destList = new List<string>();
-
-            using (var strReader = new StringReader(templateBody))
+            var contentCollection = Extensions.StringReadLine(templateBody);
+            var newCollection = contentCollection.Select(u =>
             {
-                string aLine;
-                while ((aLine = strReader.ReadLine()) != null)
+                if (u.TrimStart().StartsWith("#"))
                 {
-                    var newTemplateBodyLine = aLine;
-                    if (aLine.TrimStart().StartsWith("#"))
-                    {
-                        newTemplateBodyLine = $"- {aLine.TrimStart()}";
-                    }
-
-                    destList.Add(newTemplateBodyLine);
+                    return $"- {u.TrimStart()}";
                 }
-            }
+                else
+                {
+                    return u;
+                }
+            });
 
-            return string.Join(newLine, destList);
+            return string.Join(newLine, newCollection);
         }
 
         private string BuildTemplateNameLine(string templateName, List<string> parameters)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -328,12 +328,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception("index out of range.");
             }
 
-            var contentCollection = Extensions.StringReadLine(originString);
+            var lines = originString.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
 
             var destList = new List<string>();
             var lineNumber = -1;
             var replaced = false;
-            foreach (var line in contentCollection)
+            foreach (var line in lines)
             {
                 lineNumber++;
                 if (lineNumber < startLine || lineNumber > stopLine)
@@ -358,8 +358,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private string ConvertTemplateBody(string templateBody)
         {
-            var contentCollection = Extensions.StringReadLine(templateBody);
-            var newCollection = contentCollection.Select(u =>
+            var lines = templateBody.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
+            var destList = lines.Select(u =>
             {
                 if (u.TrimStart().StartsWith("#"))
                 {
@@ -371,7 +371,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
             });
 
-            return string.Join(newLine, newCollection);
+            return string.Join(newLine, destList);
         }
 
         private string BuildTemplateNameLine(string templateName, List<string> parameters)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -331,25 +331,10 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             var destList = new List<string>();
-            var replaced = false;
-            for (var line = 0; line < originList.Length; line++)
-            {
-                if (line < startLine || line > stopLine)
-                {
-                    destList.Add(originList[line]);
-                }
-                else
-                {
-                    if (!replaced)
-                    {
-                        replaced = true;
-                        if (!string.IsNullOrEmpty(replaceString))
-                        {
-                            destList.Add(replaceString);
-                        }
-                    }
-                }
-            }
+
+            destList.AddRange(originList.Take(startLine));
+            destList.Add(replaceString);
+            destList.AddRange(originList.Skip(stopLine + 1));
 
             return string.Join(newLine, destList);
         }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -633,11 +633,11 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(templates[1].Parameters[1], "newname");
             Assert.AreEqual(templates[1].Body.Replace("\r\n", "\n"), "- new hi\n- #hi");
 
-            templates.UpdateTemplate("newtemplate2", "newtemplateName2", new List<string> { "newage2", "newname2" }, "- new hi\r\n#hi2");
+            templates.UpdateTemplate("newtemplate2", "newtemplateName2", new List<string> { "newage2", "newname2" }, "- new hi\r\n#hi2\r\n");
             Assert.AreEqual(templates.Count, 3);
             Assert.AreEqual(templates.Imports.Count, 0);
             Assert.AreEqual(templates[2].Name, "newtemplateName2");
-            Assert.AreEqual(templates[2].Body.Replace("\r\n", "\n"), "- new hi\n- #hi2");
+            Assert.AreEqual(templates[2].Body.Replace("\r\n", "\n"), "- new hi\n- #hi2\n");
 
             templates.DeleteTemplate("newtemplateName");
             Assert.AreEqual(templates.Count, 2);


### PR DESCRIPTION
In C#, LG use `StringReader.ReadLine` to read the content line from LG file, but there may exist some points that do not match the LG's requirements.

In C# doc: https://docs.microsoft.com/en-us/dotnet/api/system.io.stringreader.readline?view=netframework-4.8#remarks

> The string that is returned does not contain the terminating carriage return or line feed. The returned value is null if the end-of-stream marker has been reached. That is to say, if there is nothing between the last line read and the end-of-stream marker, the method returns null.

So, the trailing newlines would be dropped when parsing the text with `ReadLine` method.

if the template is:
```
# template
- hi



```

and do some CRUD operation on this template, finally, we would get the template body:
```
- hi
```
the tailing newlines are missing.
