### PR TITLE
[LG] Refine Error message and remove duplicate code

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
         }
 
-        internal static void CheckExpressionResult(string exp, string error, string result, ParserRuleContext context = null, string errorPrefix = "")
+        internal static void CheckExpressionResult(string exp, string error, object result, string templateName, ParserRuleContext context = null, string errorPrefix = "")
         {
             var errorMsg = string.Empty;
 
@@ -336,7 +336,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (context != null)
             {
-                errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
+                errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), templateName, errorPrefix));
             }
 
             throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
@@ -399,29 +399,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (strictMode && (error != null || result == null))
             {
-                var errorMsg = string.Empty;
-
-                var childErrorMsg = string.Empty;
-                if (error != null)
-                {
-                    childErrorMsg = ConcatErrorMsg(childErrorMsg, error);
-                }
-                else if (result == null)
-                {
-                    childErrorMsg = ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
-                }
-
-                if (context != null)
-                {
-                    errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
-                }
-
+                var templateName = CurrentTarget().TemplateName;
                 if (evaluationTargetStack.Count > 0)
                 {
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
+                CheckExpressionResult(exp, error, result, templateName, context, errorPrefix);
             }
             else if (error != null
                 || result == null
@@ -441,29 +425,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (error != null || (result == null && strictMode))
             {
-                var errorMsg = string.Empty;
-
-                var childErrorMsg = string.Empty;
-                if (error != null)
-                {
-                    childErrorMsg = ConcatErrorMsg(childErrorMsg, error);
-                }
-                else if (result == null)
-                {
-                    childErrorMsg = ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
-                }
-
-                if (context != null)
-                {
-                    errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
-                }
-
+                var templateName = CurrentTarget().TemplateName;
                 if (evaluationTargetStack.Count > 0)
                 {
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
+                CheckExpressionResult(exp, error, result, templateName, context, errorPrefix);
             }
             else if (result == null && !strictMode)
             {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -306,18 +306,21 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         internal static string ConcatErrorMsg(string firstError, string secondError)
         {
+            string errorMsg;
             if (string.IsNullOrEmpty(firstError))
             {
-                return secondError;
+                errorMsg = secondError;
             }
             else if (string.IsNullOrEmpty(secondError))
             {
-                return firstError;
+                errorMsg = firstError;
             }
             else
             {
-                return firstError + " " + secondError;
+                errorMsg = firstError + " " + secondError;
             }
+
+            return errorMsg;
         }
 
         internal static void CheckExpressionResult(string exp, string error, object result, string templateName, ParserRuleContext context = null, string errorPrefix = "")

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -304,6 +304,44 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             return new CustomizedMemory(memory.GlobalMemory, new SimpleObjectMemory(newScope));
         }
 
+        internal static string ConcatErrorMsg(string firstError, string secondError)
+        {
+            if (string.IsNullOrEmpty(firstError))
+            {
+                return secondError;
+            }
+            else if (string.IsNullOrEmpty(secondError))
+            {
+                return firstError;
+            }
+            else
+            {
+                return firstError + " " + secondError;
+            }
+        }
+
+        internal static void CheckExpressionResult(string exp, string error, string result, ParserRuleContext context = null, string errorPrefix = "")
+        {
+            var errorMsg = string.Empty;
+
+            var childErrorMsg = string.Empty;
+            if (error != null)
+            {
+                childErrorMsg = ConcatErrorMsg(childErrorMsg, error);
+            }
+            else if (result == null)
+            {
+                childErrorMsg = ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
+            }
+
+            if (context != null)
+            {
+                errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
+            }
+
+            throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
+        }
+
         private object VisitStructureValue(LGFileParser.KeyValueStructureLineContext context)
         {
             var values = context.keyValueStructureValue();
@@ -366,16 +404,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var childErrorMsg = string.Empty;
                 if (error != null)
                 {
-                    childErrorMsg += error;
+                    childErrorMsg = ConcatErrorMsg(childErrorMsg, error);
                 }
                 else if (result == null)
                 {
-                    childErrorMsg += TemplateErrors.NullExpression(exp);
+                    childErrorMsg = ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
                 }
 
                 if (context != null)
                 {
-                    errorMsg += TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix);
+                    errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
                 }
 
                 if (evaluationTargetStack.Count > 0)
@@ -383,7 +421,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(childErrorMsg + errorMsg);
+                throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
             }
             else if (error != null
                 || result == null
@@ -408,16 +446,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var childErrorMsg = string.Empty;
                 if (error != null)
                 {
-                    childErrorMsg += error;
+                    childErrorMsg = ConcatErrorMsg(childErrorMsg, error);
                 }
                 else if (result == null)
                 {
-                    childErrorMsg += TemplateErrors.NullExpression(exp);
+                    childErrorMsg = ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
                 }
 
                 if (context != null)
                 {
-                    errorMsg += TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix);
+                    errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
                 }
 
                 if (evaluationTargetStack.Count > 0)
@@ -425,7 +463,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(childErrorMsg + errorMsg);
+                throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
             }
             else if (result == null && !strictMode)
             {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -359,29 +359,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (strictMode && (error != null || result == null))
             {
-                var errorMsg = string.Empty;
-
-                var childErrorMsg = string.Empty;
-                if (error != null)
-                {
-                    childErrorMsg += error;
-                }
-                else if (result == null)
-                {
-                    childErrorMsg += TemplateErrors.NullExpression(exp);
-                }
-
-                if (context != null)
-                {
-                    errorMsg += TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix);
-                }
-
+                var templateName = CurrentTarget().TemplateName;
                 if (evaluationTargetStack.Count > 0)
                 {
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(childErrorMsg + errorMsg);
+                Evaluator.CheckExpressionResult(exp, error, result, templateName, context, errorPrefix);
             }
             else if (error != null
                 || result == null
@@ -401,29 +385,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (error != null || (result == null && strictMode))
             {
-                var errorMsg = string.Empty;
-
-                var childErrorMsg = string.Empty;
-                if (error != null)
-                {
-                    childErrorMsg = Evaluator.ConcatErrorMsg(childErrorMsg, error);
-                }
-                else if (result == null)
-                {
-                    childErrorMsg = Evaluator.ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
-                }
-
-                if (context != null)
-                {
-                    errorMsg = Evaluator.ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
-                }
-
+                var templateName = CurrentTarget().TemplateName;
                 if (evaluationTargetStack.Count > 0)
                 {
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(Evaluator.ConcatErrorMsg(childErrorMsg, errorMsg));
+                Evaluator.CheckExpressionResult(exp, error, result, templateName, context, errorPrefix);
             }
             else if (result == null && !strictMode)
             {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -406,16 +406,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var childErrorMsg = string.Empty;
                 if (error != null)
                 {
-                    childErrorMsg += error;
+                    childErrorMsg = Evaluator.ConcatErrorMsg(childErrorMsg, error);
                 }
                 else if (result == null)
                 {
-                    childErrorMsg += TemplateErrors.NullExpression(exp);
+                    childErrorMsg = Evaluator.ConcatErrorMsg(childErrorMsg, TemplateErrors.NullExpression(exp));
                 }
 
                 if (context != null)
                 {
-                    errorMsg += TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix);
+                    errorMsg = Evaluator.ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(context.GetText(), CurrentTarget().TemplateName, errorPrefix));
                 }
 
                 if (evaluationTargetStack.Count > 0)
@@ -423,7 +423,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     evaluationTargetStack.Pop();
                 }
 
-                throw new Exception(childErrorMsg + errorMsg);
+                throw new Exception(Evaluator.ConcatErrorMsg(childErrorMsg, errorMsg));
             }
             else if (result == null && !strictMode)
             {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -402,9 +402,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
                 catch (Exception e)
                 {
-                    var suffixErrorMsg = TemplateErrors.ExpressionParseError(exp) + " " + e.Message;
-                    var errorMsg = string.IsNullOrEmpty(prefix) ? suffixErrorMsg
-                         : prefix + " " + suffixErrorMsg;
+                    var suffixErrorMsg = Evaluator.ConcatErrorMsg(TemplateErrors.ExpressionParseError(exp), e.Message);
+                    var errorMsg = Evaluator.ConcatErrorMsg(prefix, suffixErrorMsg);
 
                     result.Add(BuildLGDiagnostic(errorMsg, context: context));
                     return result;

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -402,7 +402,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
                 catch (Exception e)
                 {
-                    var errorMsg = prefix + TemplateErrors.ExpressionParseError(exp) + e.Message;
+                    var suffixErrorMsg = TemplateErrors.ExpressionParseError(exp) + " " + e.Message;
+                    var errorMsg = string.IsNullOrEmpty(prefix) ? suffixErrorMsg
+                         : prefix + " " + suffixErrorMsg;
 
                     result.Add(BuildLGDiagnostic(errorMsg, context: context));
                     return result;

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
@@ -8,84 +8,84 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </summary>
     public class TemplateErrors
     {
-        public const string NoTemplate = "LG file must have at least one template definition. ";
+        public const string NoTemplate = "LG file must have at least one template definition.";
 
-        public const string InvalidTemplateName = "Invalid template name. Template name should start with letter/number/_ and can only contains letter/number/_/./-. ";
+        public const string InvalidTemplateName = "Invalid template name. Template name should start with letter/number/_ and can only contains letter/number/_/./-.";
 
         public const string InvalidTemplateBody = "Invalid template body. Expecting '-' prefix. ";
 
         public const string InvalidStrucName = "Invalid structure name. name should start with letter/number/_ and can only contains letter/number/_/./-.";
 
-        public const string MissingStrucEnd = "Invalid structure body. Expecting ']' at the end of the body. ";
+        public const string MissingStrucEnd = "Invalid structure body. Expecting ']' at the end of the body.";
 
         public const string EmptyStrucContent = "Invalid structure body. Body cannot be empty. ";
 
-        public const string InvalidStrucBody = "Invalid structure body. Body can include <PropertyName> = <Value> pairs or ${reference()} template reference. ";
+        public const string InvalidStrucBody = "Invalid structure body. Body can include <PropertyName> = <Value> pairs or ${reference()} template reference.";
 
-        public const string InvalidWhitespaceInCondition = "Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'. ";
+        public const string InvalidWhitespaceInCondition = "Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.";
 
-        public const string NotStartWithIfInCondition = "Invalid condition: Conditions must start with 'IF/ELSEIF/ELSE' prefix ";
+        public const string NotStartWithIfInCondition = "Invalid condition: Conditions must start with 'IF/ELSEIF/ELSE' prefix.";
 
-        public const string MultipleIfInCondition = "Invalid template body. There cannot be more than one 'IF' condition. Expecting 'IFELSE' or 'ELSE' statement. ";
+        public const string MultipleIfInCondition = "Invalid template body. There cannot be more than one 'IF' condition. Expecting 'IFELSE' or 'ELSE' statement.";
 
-        public const string NotEndWithElseInCondition = "Conditional response template does not end with 'ELSE' condition. ";
+        public const string NotEndWithElseInCondition = "Conditional response template does not end with 'ELSE' condition.";
 
-        public const string InvalidMiddleInCondition = "Invalid template body. Expecting 'ELSEIF'. ";
+        public const string InvalidMiddleInCondition = "Invalid template body. Expecting 'ELSEIF'.";
 
-        public const string InvalidExpressionInCondition = "Invalid condition. 'IF', 'ELSEIF' definitions must include a valid expression. ";
+        public const string InvalidExpressionInCondition = "Invalid condition. 'IF', 'ELSEIF' definitions must include a valid expression.";
 
-        public const string ExtraExpressionInCondition = "Invalid condition. 'ELSE' definition cannot include an expression. ";
+        public const string ExtraExpressionInCondition = "Invalid condition. 'ELSE' definition cannot include an expression.";
 
-        public const string MissingTemplateBodyInCondition = "Invalid condition body. Conditions must include a valid body. ";
+        public const string MissingTemplateBodyInCondition = "Invalid condition body. Conditions must include a valid body.";
 
-        public const string InvalidWhitespaceInSwitchCase = "Invalid condition: At most 1 whitespace allowed between 'SWITCH/CASE/DEFAULT' and ':'. ";
+        public const string InvalidWhitespaceInSwitchCase = "Invalid condition: At most 1 whitespace allowed between 'SWITCH/CASE/DEFAULT' and ':'.";
 
-        public const string NotStartWithSwitchInSwitchCase = "Invalid conditional response template. Expecting a 'SWITCH' statement? ";
+        public const string NotStartWithSwitchInSwitchCase = "Invalid conditional response template. Expecting a 'SWITCH' statement?";
 
-        public const string MultipleSwithStatementInSwitchCase = "Invalid template body. There cannot be more than one 'SWITCH' statement. Expecting 'CASE' or 'DEFAULT' statement. ";
+        public const string MultipleSwithStatementInSwitchCase = "Invalid template body. There cannot be more than one 'SWITCH' statement. Expecting 'CASE' or 'DEFAULT' statement.";
 
-        public const string InvalidStatementInMiddlerOfSwitchCase = "Invalid template body. Expecting a 'CASE' statement. ";
+        public const string InvalidStatementInMiddlerOfSwitchCase = "Invalid template body. Expecting a 'CASE' statement.";
 
-        public const string NotEndWithDefaultInSwitchCase = "Conditional response template does not end with 'DEFAULT' condition. ";
+        public const string NotEndWithDefaultInSwitchCase = "Conditional response template does not end with 'DEFAULT' condition.";
 
-        public const string MissingCaseInSwitchCase = "Invalid template body. Expecting at least one 'CASE' statement. ";
+        public const string MissingCaseInSwitchCase = "Invalid template body. Expecting at least one 'CASE' statement.";
 
-        public const string InvalidExpressionInSwiathCase = "Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression. ";
+        public const string InvalidExpressionInSwiathCase = "Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression.";
 
-        public const string ExtraExpressionInSwitchCase = "Invalid condition. 'DEFAULT' statement cannot include an expression. ";
+        public const string ExtraExpressionInSwitchCase = "Invalid condition. 'DEFAULT' statement cannot include an expression.";
 
-        public const string MissingTemplateBodyInSwitchCase = "Invalid condition body. Expecing valid body inside a 'CASE' or 'DEFAULT' block. ";
+        public const string MissingTemplateBodyInSwitchCase = "Invalid condition body. Expecing valid body inside a 'CASE' or 'DEFAULT' block.";
 
-        public const string NoEndingInMultiline = "Expecting '```' to close the multi-line block. ";
+        public const string NoEndingInMultiline = "Expecting '```' to close the multi-line block.";
 
-        public const string NoCloseBracket = "Close } is missing in Expression";
+        public const string NoCloseBracket = "Close } is missing in Expression.";
 
         public const string LoopDetected = "Loop detected:";
 
-        public const string SyntaxError = "Unexpected content. Expecting either a comment or a template definition or an import statement. ";
+        public const string SyntaxError = "Unexpected content. Expecting either a comment or a template definition or an import statement.";
 
-        public const string InvalidMemory = "Scope is not a LG customized memory. ";
+        public const string InvalidMemory = "Scope is not a LG customized memory.";
 
-        public const string StaticFailure = "Static failure with the following error. ";
+        public const string StaticFailure = "Static failure with the following error.";
 
-        public static string DuplicatedTemplateInSameTemplate(string templateName) => $"Duplicated definitions found for template: '{templateName}'. ";
+        public static string DuplicatedTemplateInSameTemplate(string templateName) => $"Duplicated definitions found for template: '{templateName}'.";
 
-        public static string DuplicatedTemplateInDiffTemplate(string templateName, string source) => $"Duplicated definitions found for template: '{templateName}' in '{source}'. ";
+        public static string DuplicatedTemplateInDiffTemplate(string templateName, string source) => $"Duplicated definitions found for template: '{templateName}' in '{source}'.";
 
-        public static string NoTemplateBody(string templateName) => $"Missing template body in template '{templateName}'. ";
+        public static string NoTemplateBody(string templateName) => $"Missing template body in template '{templateName}'.";
 
-        public static string TemplateNotExist(string templateName) => $"No such template '{templateName}'. ";
+        public static string TemplateNotExist(string templateName) => $"No such template '{templateName}'.";
 
-        public static string ErrorExpression(string refFullText, string templateName, string prefixText) => $"[{templateName}] {prefixText} Error occurred when evaluating '{refFullText}'. ";
+        public static string ErrorExpression(string refFullText, string templateName, string prefixText) => $"[{templateName}] {prefixText} Error occurred when evaluating '{refFullText}'.";
 
-        public static string NullExpression(string expression) => $"'{expression}' evaluated to null. ";
+        public static string NullExpression(string expression) => $"'{expression}' evaluated to null.";
 
-        public static string ArgumentMismatch(string templateName, int expectedCount, int actualCount) => $"arguments mismatch for template '{templateName}'. Expecting '{expectedCount}' arguments, actual '{actualCount}'. ";
+        public static string ArgumentMismatch(string templateName, int expectedCount, int actualCount) => $"arguments mismatch for template '{templateName}'. Expecting '{expectedCount}' arguments, actual '{actualCount}'.";
 
-        public static string ErrorTemplateNameformat(string templateName) => $"'{templateName}' cannot be used as a template name. Template names must be avalid string. ";
+        public static string ErrorTemplateNameformat(string templateName) => $"'{templateName}' cannot be used as a template name. Template names must be avalid string.";
 
-        public static string TemplateExist(string templateName) => $"template '{templateName}' already exists. ";
+        public static string TemplateExist(string templateName) => $"template '{templateName}' already exists.";
 
-        public static string ExpressionParseError(string exp) => $"Error occurred when parsing expression '{exp}'. ";
+        public static string ExpressionParseError(string exp) => $"Error occurred when parsing expression '{exp}'.";
     }
 }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -286,35 +286,35 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var lgFile = GetTemplates("RunTimeErrors.lg");
 
-            var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("template1"));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. ", exception.Message);
+            //var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("template1"));
+            //Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
 
-            exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("prebuilt1"));
-            Assert.AreEqual("'dialog.abc' evaluated to null.[prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'. ", exception.Message);
+            var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("prebuilt1"));
+            Assert.AreEqual("'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("template2"));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("conditionalTemplate1", new { dialog = true }));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("conditionalTemplate2"));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("structured1"));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("structured2"));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("structured3"));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("switchcase1", new { turn = new { testValue = 1 } }));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("switchcase2", new { turn = new { testValue = 0 } }));
-            Assert.AreEqual("'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'. ", exception.Message);
+            Assert.AreEqual("'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -286,10 +286,10 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var lgFile = GetTemplates("RunTimeErrors.lg");
 
-            //var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("template1"));
-            //Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
+            var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("template1"));
+            Assert.AreEqual("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
 
-            var exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("prebuilt1"));
+            exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("prebuilt1"));
             Assert.AreEqual("'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'.", exception.Message);
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.Evaluate("template2"));


### PR DESCRIPTION
1. Originally LG use the end white space of error message to separate the error layer to make it more readable.

But it is strange to have such message. So, we concat the error stack at runtime with white space.

2. There are many duplicate code to build the stack error message,  extract them make the code clean and pure.