### PR TITLE
[Expression] Add array return type

### DIFF
--- a/libraries/AdaptiveExpressions/Constant.cs
+++ b/libraries/AdaptiveExpressions/Constant.cs
@@ -45,6 +45,7 @@ namespace AdaptiveExpressions
                       value is string ? ReturnType.String
                       : value.IsNumber() ? ReturnType.Number
                       : value is bool ? ReturnType.Boolean
+                      : ExpressionFunctions.TryParseList(value, out _) ? ReturnType.Array
                       : ReturnType.Object;
                 _value = value;
             }

--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -23,27 +23,27 @@ namespace AdaptiveExpressions
         /// <summary>
         /// True or false boolean value.
         /// </summary>
-        Boolean,
+        Boolean = 1,
 
         /// <summary>
         /// Numerical value like int, float, double, ...
         /// </summary>
-        Number,
+        Number = 2,
 
         /// <summary>
         /// Any value is possible.
         /// </summary>
-        Object,
+        Object = 4,
 
         /// <summary>
         /// String value.
         /// </summary>
-        String,
+        String = 8,
 
         /// <summary>
         /// Array value.
         /// </summary>
-        Array,
+        Array = 16,
     }
 
     /// <summary>

--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -39,6 +39,11 @@ namespace AdaptiveExpressions
         /// String value.
         /// </summary>
         String,
+
+        /// <summary>
+        /// Array value.
+        /// </summary>
+        Array,
     }
 
     /// <summary>

--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -18,6 +18,7 @@ namespace AdaptiveExpressions
     /// <summary>
     /// Type expected from evaluating an expression.
     /// </summary>
+    [Flags]
     public enum ReturnType
     {
         /// <summary>

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -2894,7 +2894,7 @@ namespace AdaptiveExpressions
 
                         return result.ToList();
                         }, VerifyList),
-                    ReturnType.Object,
+                    ReturnType.Array,
                     ValidateAtLeastOne),
                 new ExpressionEvaluator(
                     ExpressionType.Intersection,
@@ -2910,34 +2910,34 @@ namespace AdaptiveExpressions
 
                         return result.ToList();
                         }, VerifyList),
-                    ReturnType.Object,
+                    ReturnType.Array,
                     ValidateAtLeastOne),
                 new ExpressionEvaluator(
                     ExpressionType.Skip,
                     Skip,
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, null, ReturnType.Object, ReturnType.Number)),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, null, ReturnType.Array, ReturnType.Number)),
                 new ExpressionEvaluator(
                     ExpressionType.Take,
                     Take,
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, null, ReturnType.Object, ReturnType.Number)),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, null, ReturnType.Array, ReturnType.Number)),
                 new ExpressionEvaluator(
                     ExpressionType.SubArray,
                     SubArray,
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, new[] { ReturnType.Number }, ReturnType.Object, ReturnType.Number)),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, new[] { ReturnType.Number }, ReturnType.Array, ReturnType.Number)),
                 new ExpressionEvaluator(
                     ExpressionType.SortBy,
                     SortBy(false),
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Object)),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Array)),
                 new ExpressionEvaluator(
                     ExpressionType.SortByDescending,
                     SortBy(true),
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Object)),
-                new ExpressionEvaluator(ExpressionType.IndicesAndValues, IndicesAndValues, ReturnType.Object, ValidateUnary),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, new[] { ReturnType.String }, ReturnType.Array)),
+                new ExpressionEvaluator(ExpressionType.IndicesAndValues, IndicesAndValues, ReturnType.Array, ValidateUnary),
                 new ExpressionEvaluator(
                     ExpressionType.Flatten,
                     Apply(
@@ -2946,8 +2946,8 @@ namespace AdaptiveExpressions
                             var depth = args.Count > 1 ? Convert.ToInt32(args[1]) : 100;
                             return Flatten((IEnumerable<object>)args[0], depth);
                         }),
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, new[] { ReturnType.Number }, ReturnType.Object)),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, new[] { ReturnType.Number }, ReturnType.Array)),
                 new ExpressionEvaluator(
                     ExpressionType.Unique,
                     Apply(
@@ -2955,8 +2955,8 @@ namespace AdaptiveExpressions
                         {
                             return ((IEnumerable<object>)args[0]).Distinct().ToList();
                         }, VerifyList),
-                    ReturnType.Object,
-                    (expression) => ValidateOrder(expression, null, ReturnType.Object)),
+                    ReturnType.Array,
+                    (expression) => ValidateOrder(expression, null, ReturnType.Array)),
 
                 // Booleans
                 Comparison(ExpressionType.LessThan, args => CultureInvariantDoubleConvert(args[0]) < CultureInvariantDoubleConvert(args[1]), ValidateBinaryNumberOrString, VerifyNumberOrString),
@@ -3110,7 +3110,7 @@ namespace AdaptiveExpressions
 
                             return inputStr.Split(seperator.ToCharArray());
                         }, VerifyStringOrNull),
-                    ReturnType.Object,
+                    ReturnType.Array,
                     (expression) => ValidateArityAndAnyType(expression, 1, 2, ReturnType.String)),
                 new ExpressionEvaluator(
                     ExpressionType.Substring,
@@ -3235,7 +3235,7 @@ namespace AdaptiveExpressions
                         return (result, error);
                     },
                     ReturnType.String,
-                    expr => ValidateOrder(expr, new[] { ReturnType.String }, ReturnType.Object, ReturnType.String)),
+                    expr => ValidateOrder(expr, new[] { ReturnType.String }, ReturnType.Array, ReturnType.String)),
                 new ExpressionEvaluator(
                     ExpressionType.NewGuid,
                     Apply(args => Guid.NewGuid().ToString()),
@@ -3273,7 +3273,7 @@ namespace AdaptiveExpressions
                         return (result, error);
                     },
                     ReturnType.Number,
-                    (expression) => ValidateArityAndAnyType(expression, 2, 2, ReturnType.String, ReturnType.Boolean, ReturnType.Number, ReturnType.Object)),
+                    ValidateBinary),
                 new ExpressionEvaluator(
                     ExpressionType.LastIndexOf,
                     (expression, state, options) =>
@@ -3306,7 +3306,7 @@ namespace AdaptiveExpressions
                         return (result, error);
                     },
                     ReturnType.Number,
-                    (expression) => ValidateArityAndAnyType(expression, 2, 2, ReturnType.String, ReturnType.Boolean, ReturnType.Number, ReturnType.Object)),
+                    ValidateBinary),
 
                 // Date and time
                 TimeTransform(ExpressionType.AddDays, (ts, add) => ts.AddDays(add)),
@@ -3903,7 +3903,7 @@ namespace AdaptiveExpressions
                         VerifyInteger),
                     ReturnType.Number,
                     ValidateBinaryNumber),
-                new ExpressionEvaluator(ExpressionType.CreateArray, Apply(args => new List<object>(args)), ReturnType.Object),
+                new ExpressionEvaluator(ExpressionType.CreateArray, Apply(args => new List<object>(args)), ReturnType.Array),
                 new ExpressionEvaluator(
                     ExpressionType.First,
                     Apply(
@@ -3991,10 +3991,10 @@ namespace AdaptiveExpressions
                     SetPathToValue,
                     ReturnType.Object,
                     ValidateBinary),
-                new ExpressionEvaluator(ExpressionType.Select, Foreach, ReturnType.Object, ValidateForeach),
-                new ExpressionEvaluator(ExpressionType.Foreach, Foreach, ReturnType.Object, ValidateForeach),
-                new ExpressionEvaluator(ExpressionType.Where, Where, ReturnType.Object, ValidateWhere),
-                new ExpressionEvaluator(ExpressionType.Coalesce, Apply(args => Coalesce(args.ToArray<object>())), ReturnType.Object, ValidateAtLeastOne),
+                new ExpressionEvaluator(ExpressionType.Select, Foreach, ReturnType.Array, ValidateForeach),
+                new ExpressionEvaluator(ExpressionType.Foreach, Foreach, ReturnType.Array, ValidateForeach),
+                new ExpressionEvaluator(ExpressionType.Where, Where, ReturnType.Array, ValidateWhere),
+                new ExpressionEvaluator(ExpressionType.Coalesce, Apply(args => Coalesce(args.ToArray())), ReturnType.Object, ValidateAtLeastOne),
                 new ExpressionEvaluator(ExpressionType.XPath, ApplyWithError(args => XPath(args[0], args[1])), ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
                 new ExpressionEvaluator(ExpressionType.JPath, ApplyWithError(args => JPath(args[0], args[1].ToString())), ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
 

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -1030,32 +1030,14 @@ namespace AdaptiveExpressions
         private static string BuildTypeValidatorError(ReturnType returnType, Expression childExpr, Expression expr)
         {
             string result;
-            var names = returnType.Names();
-            if (names.Count == 1)
+            var names = returnType.ToString();
+            if (!names.Contains(","))
             {
-                result = $"{childExpr} is not a {names[0]} expression in {expr}.";
+                result = $"{childExpr} is not a {names} expression in {expr}.";
             }
             else
             {
-                var builder = new StringBuilder();
-                builder.Append($"{childExpr} in {expr} is not any of [");
-                var first = true;
-                foreach (var type in names)
-                {
-                    if (first)
-                    {
-                        first = false;
-                    }
-                    else
-                    {
-                        builder.Append(", ");
-                    }
-
-                    builder.Append(type);
-                }
-
-                builder.Append("].");
-                result = builder.ToString();
+                result = $"{childExpr} in {expr} is not any of [{names}].";
             }
 
             return result;

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -3018,19 +3018,19 @@ namespace AdaptiveExpressions
                     ExpressionType.Length,
                     Apply(
                         args =>
-                            {
-                                var result = 0;
-                                if (args[0] is string str)
-                                    {
-                                        result = str.Length;
-                                    }
-                                else
-                                    {
-                                        result = 0;
-                                    }
+                        {
+                            var result = 0;
+                            if (args[0] is string str)
+                                {
+                                    result = str.Length;
+                                }
+                            else
+                                {
+                                    result = 0;
+                                }
 
-                                return result;
-                            }, VerifyStringOrNull),
+                            return result;
+                        }, VerifyStringOrNull),
                     ReturnType.Number,
                     ValidateUnaryString),
                 new ExpressionEvaluator(

--- a/libraries/AdaptiveExpressions/Extensions.cs
+++ b/libraries/AdaptiveExpressions/Extensions.cs
@@ -44,5 +44,25 @@ namespace AdaptiveExpressions
             || value is uint
             || value is long
             || value is ulong;
+
+        /// <summary>
+        /// Get the type names of current return type contains.
+        /// </summary>
+        /// <param name="returntype">enum of ReturnType.</param>
+        /// <returns>The type names of current return type contains.</returns>
+        public static List<string> Names(this ReturnType returntype)
+        {
+            var result = new List<string>();
+
+            foreach (ReturnType type in Enum.GetValues(typeof(ReturnType)))
+            {
+                if ((returntype & type) != 0)
+                {
+                    result.Add(Enum.GetName(typeof(ReturnType), type));
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/libraries/AdaptiveExpressions/Extensions.cs
+++ b/libraries/AdaptiveExpressions/Extensions.cs
@@ -44,25 +44,5 @@ namespace AdaptiveExpressions
             || value is uint
             || value is long
             || value is ulong;
-
-        /// <summary>
-        /// Get the type names of current return type contains.
-        /// </summary>
-        /// <param name="returntype">enum of ReturnType.</param>
-        /// <returns>The type names of current return type contains.</returns>
-        public static List<string> Names(this ReturnType returntype)
-        {
-            var result = new List<string>();
-
-            foreach (ReturnType type in Enum.GetValues(typeof(ReturnType)))
-            {
-                if ((returntype & type) != 0)
-                {
-                    result.Add(Enum.GetName(typeof(ReturnType), type));
-                }
-            }
-
-            return result;
-        }
     }
 }


### PR DESCRIPTION
close: #3615

Add `Array` return type to make array type errors be discovered during the static check period.

For example, before :
```
var expr = Expression.Parse("skip(1, 1)"); // it's ok
var result = expr.TryEvaluate(null); // throw runtime exception, skip can not applied on int
```

After:
```
var expr = Expression.Parse("skip(1, 1)"); // 1 is not a valid array
```

### remark
 why does `Expression.Parse("skip(1, 1)")` not throw exception before.
If the method accepts `Object` type, e.g. `count` method accepts one parameter, which could be string or array. If the param is a string, return string length, and if the param is an array, return the array size.
So, we can only mark the param `object`, any return type here is ok during the static checker period.
Same logic with `skip(1, 1)`, `skip` accepts an object as the first parameters, and all the input types here are treated as valid types in the static checker. 

The root cause is that we treat `Object` as the base type (or any type). So, extract `Array` type may help us get array related errors in advance.

### Additional feature:
Support mixed return type in the static check.
Before, if the expression needs one param that maybe a string or a number. we can only mark it as `Object` return type, but now, we can use `ReturnType.Number | ReturnType.String` to mark it.
This can make type matching more precise.
