### PR TITLE
refactor expander

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -4,9 +4,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using AdaptiveExpressions;
-using AdaptiveExpressions.Memory;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
@@ -20,8 +21,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </summary>
     public class Expander : LGFileParserBaseVisitor<List<string>>
     {
-        private readonly ExpressionParser expanderExpressionParser;
-        private readonly ExpressionParser evaluatorExpressionParser;
+        public const string LGType = "lgType";
+        public static readonly string RegexString = @"(?<!\\)\${(('(\\('|\\)|[^'])*?')|(""(\\(""|\\)|[^""])*?"")|(`(\\(`|\\)|[^`])*?`)|([^\r\n{}'""`])|({\s*}))+}?";
+        public static readonly Regex ExpressionRecognizeRegex = new Regex(RegexString, RegexOptions.Compiled);
         private readonly Stack<EvaluationTarget> evaluationTargetStack = new Stack<EvaluationTarget>();
         private readonly bool strictMode;
 
@@ -38,8 +40,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             this.strictMode = strictMode;
 
             // generate a new customized expression parser by injecting the template as functions
-            this.expanderExpressionParser = new ExpressionParser(CustomizedEvaluatorLookup(expressionParser.EvaluatorLookup, true));
-            this.evaluatorExpressionParser = new ExpressionParser(CustomizedEvaluatorLookup(expressionParser.EvaluatorLookup, false));
+            ExpanderExpressionParser = new ExpressionParser(CustomizedEvaluatorLookup(expressionParser.EvaluatorLookup, true));
+            EvaluatorExpressionParser = new ExpressionParser(CustomizedEvaluatorLookup(expressionParser.EvaluatorLookup, false));
         }
 
         /// <summary>
@@ -49,6 +51,22 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// Templates.
         /// </value>
         public List<Template> Templates { get; }
+
+        /// <summary>
+        /// Gets expander expression parser.
+        /// </summary>
+        /// <value>
+        /// Expression parser.
+        /// </value>
+        public ExpressionParser ExpanderExpressionParser { get; }
+
+        /// <summary>
+        /// Gets evaluator expression parser.
+        /// </summary>
+        /// <value>
+        /// Expression parser.
+        /// </value>
+        public ExpressionParser EvaluatorExpressionParser { get; }
 
         /// <summary>
         /// Gets templateMap.
@@ -378,7 +396,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             return true;
         }
 
-        private List<string> EvalExpression(string exp, ParserRuleContext context, string errorPrefix = "")
+        private List<string> EvalExpression(string exp, ParserRuleContext context = null, string errorPrefix = "")
         {
             exp = exp.TrimExpression();
             var (result, error) = EvalByAdaptiveExpression(exp, CurrentTarget().Scope);
@@ -413,8 +431,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         private (object value, string error) EvalByAdaptiveExpression(string exp, object scope)
         {
-            var expanderExpression = this.expanderExpressionParser.Parse(exp);
-            var evaluatorExpression = this.evaluatorExpressionParser.Parse(exp);
+            var expanderExpression = this.ExpanderExpressionParser.Parse(exp);
+            var evaluatorExpression = this.EvaluatorExpressionParser.Parse(exp);
             var parse = ReconstructExpression(expanderExpression, evaluatorExpression);
             string error;
             object value;
@@ -441,11 +459,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         private EvaluatorLookup CustomizedEvaluatorLookup(EvaluatorLookup baseLookup, bool isExpander)
         => (string name) =>
         {
-            var prebuiltPrefix = "prebuilt.";
+            var standardFunction = baseLookup(name);
 
-            if (name.StartsWith(prebuiltPrefix))
+            if (standardFunction != null)
             {
-                return baseLookup(name.Substring(prebuiltPrefix.Length));
+                return standardFunction;
+            }
+
+            if (name.StartsWith("lg."))
+            {
+                name = name.Substring(3);
             }
 
             if (this.TemplateMap.ContainsKey(name))
@@ -460,7 +483,39 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
             }
 
-            return baseLookup(name);
+            const string template = "template";
+
+            if (name.Equals(template))
+            {
+                return new ExpressionEvaluator(template, ExpressionFunctions.Apply(this.TemplateFunction()), ReturnType.Object, this.ValidateTemplateFunction);
+            }
+
+            const string fromFile = "fromFile";
+
+            if (name.Equals(fromFile))
+            {
+                return new ExpressionEvaluator(fromFile, ExpressionFunctions.Apply(this.FromFile()), ReturnType.String, ExpressionFunctions.ValidateUnaryString);
+            }
+
+            const string activityAttachment = "ActivityAttachment";
+
+            if (name.Equals(activityAttachment))
+            {
+                return new ExpressionEvaluator(
+                    activityAttachment,
+                    ExpressionFunctions.Apply(this.ActivityAttachment()),
+                    ReturnType.Object,
+                    (expr) => ExpressionFunctions.ValidateOrder(expr, null, ReturnType.Object, ReturnType.String));
+            }
+
+            const string isTemplate = "isTemplate";
+
+            if (name.Equals(isTemplate))
+            {
+                return new ExpressionEvaluator(isTemplate, ExpressionFunctions.Apply(this.IsTemplate()), ReturnType.Boolean, ExpressionFunctions.ValidateUnaryString);
+            }
+
+            return null;
         };
 
         private Func<IReadOnlyList<object>, object> TemplateExpander(string templateName) =>
@@ -479,6 +534,36 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var rd = new Random();
                 return value[rd.Next(value.Count)];
             };
+
+        // Evaluator for template(templateName, ...args) 
+        // normal case we can just use templateName(...args), but template function is particularly useful when the template name is not pre-known
+        private Func<IReadOnlyList<object>, object> TemplateFunction()
+        => (IReadOnlyList<object> args) =>
+        {
+            var templateName = args[0].ToString();
+            var newScope = this.ConstructScope(templateName, args.Skip(1).ToList());
+            return this.ExpandTemplate(templateName, newScope);
+        };
+
+        // Validator for template(...)
+        private void ValidateTemplateFunction(Expression expression)
+        {
+            ExpressionFunctions.ValidateAtLeastOne(expression);
+
+            var children0 = expression.Children[0];
+
+            if (children0.ReturnType != ReturnType.Object && children0.ReturnType != ReturnType.String)
+            {
+                throw new Exception(TemplateErrors.ErrorTemplateNameformat(children0.ToString()));
+            }
+
+            // Validate more if the name is string constant
+            if (children0.Type == ExpressionType.Constant)
+            {
+                var templateName = (children0 as Constant).Value.ToString();
+                CheckTemplateReference(templateName, expression.Children.Skip(1));
+            }
+        }
 
         private void ValidTemplateReference(Expression expression)
         {
@@ -519,5 +604,76 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             return expanderExpression;
         }
+
+        private void CheckTemplateReference(string templateName, IEnumerable<Expression> children)
+        {
+            if (!this.TemplateMap.ContainsKey(templateName))
+            {
+                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+            }
+
+            var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count();
+            var actualArgsCount = children.Count();
+
+            if (actualArgsCount != 0 && expectedArgsCount != actualArgsCount)
+            {
+                throw new Exception(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
+            }
+        }
+
+        private Func<IReadOnlyList<object>, object> ActivityAttachment()
+        => (IReadOnlyList<object> args) =>
+        {
+            return new JObject
+            {
+                [LGType] = "attachment",
+                ["contenttype"] = args[1].ToString(),
+                ["content"] = args[0] as JObject
+            };
+        };
+
+        private Func<IReadOnlyList<object>, object> FromFile()
+       => (IReadOnlyList<object> args) =>
+       {
+           var filePath = args[0].ToString().NormalizePath();
+
+           var resourcePath = GetResourcePath(filePath);
+           var stringContent = File.ReadAllText(resourcePath);
+
+           var evaluator = new MatchEvaluator(m => EvalExpression(m.Value).ToString());
+           var result = ExpressionRecognizeRegex.Replace(stringContent, evaluator);
+           return result.Escape();
+       };
+
+        private string GetResourcePath(string filePath)
+        {
+            string resourcePath;
+
+            if (Path.IsPathRooted(filePath))
+            {
+                resourcePath = filePath;
+            }
+            else
+            {
+                var template = TemplateMap[CurrentTarget().TemplateName];
+                var sourcePath = template.Source.NormalizePath();
+                var baseFolder = Environment.CurrentDirectory;
+                if (Path.IsPathRooted(sourcePath))
+                {
+                    baseFolder = Path.GetDirectoryName(sourcePath);
+                }
+
+                resourcePath = Path.GetFullPath(Path.Combine(baseFolder, filePath));
+            }
+
+            return resourcePath;
+        }
+
+        private Func<IReadOnlyList<object>, object> IsTemplate()
+      => (IReadOnlyList<object> args) =>
+      {
+          var templateName = args[0].ToString();
+          return TemplateMap.ContainsKey(templateName);
+      };
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="templateName">Template name to be evaluated.</param>
         /// <param name="scope">The state visible in the evaluation.</param>
         /// <returns>Expand result.</returns>
-        public IList<string> ExpandTemplate(string templateName, object scope = null)
+        public IList<object> ExpandTemplate(string templateName, object scope = null)
         {
             CheckErrors();
             var expander = new Expander(AllTemplates.ToList(), ExpressionParser, StrictMode);

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/Expand.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/Expand.lg
@@ -76,3 +76,28 @@ They are ${ShowAlarm(alarms[1])}
 
 # T4
 - ${substring(T1(), 1, 2)}
+
+# template2(templateName)
+- IF: ${isTemplate(templateName)}
+    - ${Greeting()}
+- ELSE:
+    - ${TimeOfDay()}
+
+# template3(templateName)
+  - ${template(templateName)}
+
+# GetAge
+- how old are you?
+- what's your age?
+
+# ExpanderT1
+[MyStruct
+    Text = Hi "quotes" allowed
+    ${ExpanderT2()}
+]
+
+# ExpanderT2
+[MyStruct
+    Speak = ${GetAge()}
+    Text = zoo
+]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -574,6 +574,33 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         }
 
         [TestMethod]
+        public void TestExpandTemplateWithIsTemplateFunction()
+        {
+            var templates = Templates.ParseFile(GetExampleFilePath("Expand.lg"));
+
+            var evaled = templates.ExpandTemplate("template2", new { templateName = "Greeting" });
+            Assert.AreEqual(2, evaled.Count);
+            Assert.AreEqual("Hi", evaled[0]);
+            Assert.AreEqual("Hello", evaled[1]);
+
+            evaled = templates.ExpandTemplate("template2", new { templateName = "xxx" });
+            Assert.AreEqual(2, evaled.Count);
+            Assert.AreEqual("Morning", evaled[0]);
+            Assert.AreEqual("Evening", evaled[1]);
+        }
+
+        [TestMethod]
+        public void TestExpandTemplateWithTemplateFunction()
+        {
+            var templates = Templates.ParseFile(GetExampleFilePath("Expand.lg"));
+
+            var evaled = templates.ExpandTemplate("template3", new { templateName = "Greeting" });
+            Assert.AreEqual(2, evaled.Count);
+            Assert.AreEqual("Hi", evaled[0]);
+            Assert.AreEqual("Hello", evaled[1]);
+        }
+
+        [TestMethod]
         public void TestEvalExpression()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("EvalExpression.lg"));

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -562,15 +562,15 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             evaled = templates.ExpandTemplate("T2");
             Assert.AreEqual(1, evaled.Count);
-            Assert.AreEqual(true, evaled[0] == "3" || evaled[0] == "5");
+            Assert.AreEqual(true, evaled[0].ToString() == "3" || evaled[0].ToString() == "5");
 
             evaled = templates.ExpandTemplate("T3");
             Assert.AreEqual(1, evaled.Count);
-            Assert.AreEqual(true, evaled[0] == "3" || evaled[0] == "5");
+            Assert.AreEqual(true, evaled[0].ToString() == "3" || evaled[0].ToString() == "5");
 
             evaled = templates.ExpandTemplate("T4");
             Assert.AreEqual(1, evaled.Count);
-            Assert.AreEqual(true, evaled[0] == "ey" || evaled[0] == "el");
+            Assert.AreEqual(true, evaled[0].ToString() == "ey" || evaled[0].ToString() == "el");
         }
 
         [TestMethod]
@@ -598,6 +598,73 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(2, evaled.Count);
             Assert.AreEqual("Hi", evaled[0]);
             Assert.AreEqual("Hello", evaled[1]);
+        }
+
+        [TestMethod]
+        public void TestExpandTemplateWithDoubleQuotation()
+        {
+            var templates = Templates.ParseFile(GetExampleFilePath("Expand.lg"));
+
+            var evaled = templates.ExpandTemplate("ExpanderT1");
+            Assert.AreEqual(2, evaled.Count);
+            var expectedResults = new List<string>()
+            {
+                "{\"lgType\":\"MyStruct\",\"text\":\"Hi \\\"quotes\\\" allowed\",\"speak\":\"how old are you?\"}",
+                "{\"lgType\":\"MyStruct\",\"text\":\"Hi \\\"quotes\\\" allowed\",\"speak\":\"what's your age?\"}"
+            };
+
+            for (var i = 0; i < expectedResults.Count; i++)
+            {
+                Assert.IsTrue(JToken.DeepEquals(JObject.Parse(expectedResults[i]), JObject.Parse(evaled[i].ToString())));
+            }
+        }
+
+        [TestMethod]
+        public void TestExpandTemplateWithEscapeCharacter()
+        {
+            var templates = Templates.ParseFile(GetExampleFilePath("EscapeCharacter.lg"));
+            var evaled = templates.ExpandTemplate("wPhrase", null);
+            Assert.AreEqual(evaled[0], "Hi \r\n\t\\");
+
+            evaled = templates.ExpandTemplate("AtEscapeChar", null);
+            Assert.AreEqual(evaled[0], "Hi{1+1}[wPhrase]{wPhrase()}${wPhrase()}2${1+1}");
+
+            evaled = templates.ExpandTemplate("otherEscape", null);
+            Assert.AreEqual(evaled[0], @"Hi \y \");
+
+            evaled = templates.ExpandTemplate("escapeInExpression", null);
+            Assert.AreEqual(evaled[0], "Hi hello\\\\");
+
+            evaled = templates.ExpandTemplate("escapeInExpression2", null);
+            Assert.AreEqual(evaled[0], "Hi hello'");
+
+            evaled = templates.ExpandTemplate("escapeInExpression3", null);
+            Assert.AreEqual(evaled[0], "Hi hello\"");
+
+            evaled = templates.ExpandTemplate("escapeInExpression4", null);
+            Assert.AreEqual(evaled[0], "Hi hello\"");
+
+            evaled = templates.ExpandTemplate("escapeInExpression5", null);
+            Assert.AreEqual(evaled[0], "Hi hello\n");
+
+            evaled = templates.ExpandTemplate("escapeInExpression6", null);
+            Assert.AreEqual(evaled[0], "Hi hello\n");
+
+            var todos = new[] { "A", "B", "C" };
+            evaled = templates.ExpandTemplate("showTodo", new { todos });
+            Assert.AreEqual(evaled[0].ToString().Replace("\r\n", "\n"), "\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    ");
+
+            evaled = templates.ExpandTemplate("showTodo", null);
+            Assert.AreEqual(evaled[0].ToString().Replace("\r\n", "\n"), "\n    You don't have any \"t\\\\odo'\".\n    ");
+
+            evaled = templates.ExpandTemplate("getUserName", null);
+            Assert.AreEqual(evaled[0], "super \"x man\"");
+
+            evaled = templates.ExpandTemplate("structure1", null);
+            Assert.AreEqual(evaled[0].ToString().Replace("\r\n", "\n").Replace("\n", string.Empty), "{  \"lgType\": \"struct\",  \"list\": [    \"a\",    \"b|c\"  ]}");
+
+            evaled = templates.ExpandTemplate("dollarsymbol");
+            Assert.AreEqual(evaled[0], "$ $ ${'hi'} hi");
         }
 
         [TestMethod]
@@ -851,19 +918,25 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 "{\"lgType\":\"Activity\",\"text\":\"what's your age?\",\"speak\":\"what's your age?\"}"
             };
 
-            expectedResults.ForEach(x => Assert.AreEqual(true, evaled.Contains(x)));
+            for (var i = 0; i < expectedResults.Count; i++)
+            {
+                Assert.IsTrue(JToken.DeepEquals(JObject.Parse(expectedResults[i]), JObject.Parse(evaled[i].ToString())));
+            }
 
             evaled = templates.ExpandTemplate("ExpanderT1");
             Assert.AreEqual(4, evaled.Count);
             expectedResults = new List<string>()
             {
                 "{\"lgType\":\"MyStruct\",\"text\":\"Hi\",\"speak\":\"how old are you?\"}",
-                "{\"lgType\":\"MyStruct\",\"text\":\"Hi\",\"speak\":\"what's your age?\"}",
                 "{\"lgType\":\"MyStruct\",\"text\":\"Hello\",\"speak\":\"how old are you?\"}",
+                "{\"lgType\":\"MyStruct\",\"text\":\"Hi\",\"speak\":\"what's your age?\"}",
                 "{\"lgType\":\"MyStruct\",\"text\":\"Hello\",\"speak\":\"what's your age?\"}"
             };
 
-            expectedResults.ForEach(x => Assert.AreEqual(true, evaled.Contains(x)));
+            for (var i = 0; i < expectedResults.Count; i++)
+            {
+                Assert.IsTrue(JToken.DeepEquals(JObject.Parse(expectedResults[i]), JObject.Parse(evaled[i].ToString())));
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
fix #3523.

- [x] Support all kinds of LG functions

- [x] Discard the 'builtin.' prefix

- [x] Escape issues, including double quotation, escape character

For issue: Achieve the correct result for foreach expansion. ref: #3238. It is R10 item and will be fixed in another PR.