### PR TITLE
Replace null check with string.IsNullOrWhiteSpace()

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -1504,7 +1504,7 @@ namespace Microsoft.Bot.Builder
         /// <returns>App credentials.</returns>
         private async Task<AppCredentials> GetAppCredentialsAsync(string appId, string oAuthScope, CancellationToken cancellationToken = default)
         {
-            if (appId == null)
+            if (string.IsNullOrWhiteSpace(appId))
             {
                 return MicrosoftAppCredentials.Empty;
             }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// <returns>App credentials.</returns>
         private async Task<AppCredentials> GetAppCredentialsAsync(string appId, string oAuthScope = null)
         {
-            if (appId == null)
+            if (string.IsNullOrWhiteSpace(appId))
             {
                 return MicrosoftAppCredentials.Empty;
             }


### PR DESCRIPTION
This fixes issue #3590, by returning MicrosoftAppCredentials.Empty when AppId is set to null or empty spaces.