### PR TITLE
Update telemetry logger to include attachments

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TelemetryConstants.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryConstants.cs
@@ -21,5 +21,6 @@ namespace Microsoft.Bot.Builder
         public static readonly string TextProperty = "text";
         public static readonly string SpeakProperty = "speak";
         public static readonly string UserIdProperty = "userId";
+        public static readonly string AttachmentsProperty = "attachments";
     }
 }

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder
 {
@@ -264,6 +265,11 @@ namespace Microsoft.Bot.Builder
                 if (!string.IsNullOrWhiteSpace(activity.Speak))
                 {
                     properties.Add(TelemetryConstants.SpeakProperty, activity.Speak);
+                }
+
+                if (activity.Attachments != null && activity.Attachments.Any())
+                {
+                    properties.Add(TelemetryConstants.AttachmentsProperty, JsonConvert.SerializeObject(activity.Attachments));
                 }
             }
 


### PR DESCRIPTION
Addresses #1574 in JS repo (https://github.com/microsoft/botbuilder-js/issues/1574)

Telemetry logger will now include the collection of any attachments sent with the activity, if the LogPersonalInformation flag is set to true.