### PR TITLE
[Certificate Authentication] Expose sendX5c parameter

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         private readonly ClientCredential clientCredential;
         private readonly ClientAssertionCertificate clientCertificate;
+        private readonly bool clientCertSendX5c;
         private readonly OAuthConfiguration authConfig;
         private readonly ILogger logger;
 
@@ -54,10 +55,16 @@ namespace Microsoft.Bot.Connector.Authentication
         }
 
         public AdalAuthenticator(ClientAssertionCertificate clientCertificate, OAuthConfiguration configurationOAuth, HttpClient customHttpClient = null, ILogger logger = null)
+            : this(clientCertificate, false, configurationOAuth, customHttpClient, logger)
+        {
+        }
+
+        public AdalAuthenticator(ClientAssertionCertificate clientCertificate, bool sendX5c, OAuthConfiguration configurationOAuth, HttpClient customHttpClient = null, ILogger logger = null)
         {
             this.authConfig = configurationOAuth ?? throw new ArgumentNullException(nameof(configurationOAuth));
             this.clientCertificate = clientCertificate ?? throw new ArgumentNullException(nameof(clientCertificate));
             this.logger = logger;
+            this.clientCertSendX5c = sendX5c;
 
             Initialize(configurationOAuth, customHttpClient);
         }
@@ -123,7 +130,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     // Certificate based auth
                     else if (clientCertificate != null)
                     {
-                        authResult = await authContext.AcquireTokenAsync(authConfig.Scope, clientCertificate).ConfigureAwait(false);
+                        authResult = await authContext.AcquireTokenAsync(authConfig.Scope, clientCertificate, sendX5c: this.clientCertSendX5c).ConfigureAwait(false);
                     }
 
                     // This means we acquired a valid token successfully. We can make our retry policy null.


### PR DESCRIPTION
This parameter enables application developers to achieve easy certificates roll-over in Azure AD: setting this parameter to true will send the public certificate to Azure AD along with the token request, so that Azure AD can use it to validate the subject name based on a trusted issuer policy. This saves the application admin from the need to explicitly manage the certificate rollover (either via portal or powershell/CLI operation)