### PR TITLE
[LG] re-do multiLingualLg

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -30,16 +30,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new ArgumentNullException(nameof(filePerLocale));
             }
 
-            foreach (var filesPerLocale in filePerLocale)
+            foreach (var item in filePerLocale)
             {
-                lgPerLocale[filesPerLocale.Key] = Templates.ParseFile(filesPerLocale.Value);
+                lgPerLocale[item.Key] = Templates.ParseFile(item.Value);
             }
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiLanguageLG"/> class.
         /// </summary>
-        /// <param name="templatesPerLocale">A dictionary of LG file templates.</param>
+        /// <param name="templatesPerLocale">A dictionary of LG file templates per locale.</param>
         /// <param name="defaultLanguage">Default language.</param>
         public MultiLanguageLG(Dictionary<string, Templates> templatesPerLocale, string defaultLanguage = "")
         {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
@@ -20,19 +18,19 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiLanguageLG"/> class.
         /// </summary>
-        /// <param name="localeLGFiles">A dictionary of locale and LG file.</param>
-        /// <param name="defaultLanguages">Default language.</param>
-        public MultiLanguageLG(Dictionary<string, string> localeLGFiles, params string[] defaultLanguages)
+        /// <param name="filePerLocale">A dictionary of locale and LG file.</param>
+        /// <param name="defaultLanguage">Default language.</param>
+        public MultiLanguageLG(Dictionary<string, string> filePerLocale, string defaultLanguage = "")
         {
             lgPerLocale = new Dictionary<string, Templates>(StringComparer.OrdinalIgnoreCase);
-            languageFallbackPolicy = new LanguagePolicy(defaultLanguages);
+            languageFallbackPolicy = new LanguagePolicy(defaultLanguage);
 
-            if (localeLGFiles == null)
+            if (filePerLocale == null)
             {
-                throw new ArgumentNullException(nameof(localeLGFiles));
+                throw new ArgumentNullException(nameof(filePerLocale));
             }
 
-            foreach (var filesPerLocale in localeLGFiles)
+            foreach (var filesPerLocale in filePerLocale)
             {
                 lgPerLocale[filesPerLocale.Key] = Templates.ParseFile(filesPerLocale.Value);
             }
@@ -41,17 +39,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiLanguageLG"/> class.
         /// </summary>
-        /// <param name="templatesDict">A dictionary of LG file templates.</param>
-        /// <param name="defaultLanguages">Default language.</param>
-        public MultiLanguageLG(Dictionary<string, Templates> templatesDict, params string[] defaultLanguages)
+        /// <param name="templatesPerLocale">A dictionary of LG file templates.</param>
+        /// <param name="defaultLanguage">Default language.</param>
+        public MultiLanguageLG(Dictionary<string, Templates> templatesPerLocale, string defaultLanguage = "")
         {
             lgPerLocale = new Dictionary<string, Templates>(StringComparer.OrdinalIgnoreCase);
-            foreach (var templatesPair in templatesDict)
+            foreach (var templatesPair in templatesPerLocale)
             {
                 lgPerLocale.Add(templatesPair.Key, templatesPair.Value);
             }
 
-            languageFallbackPolicy = new LanguagePolicy(defaultLanguages);
+            languageFallbackPolicy = new LanguagePolicy(defaultLanguage);
         }
 
         public object Generate(string template, object data, string locale)
@@ -120,7 +118,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             // See commented section for full sample of output of this function
             private static IDictionary<string, string[]> DefaultPolicy(string[] defaultLanguages = null)
             {
-                if (defaultLanguages == null || defaultLanguages.Length == 0)
+                if (defaultLanguages == null)
                 {
                     defaultLanguages = new string[] { string.Empty };
                 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -114,13 +114,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             // walk through all of the cultures and create a dictionary map with most specific to least specific
             // Example output "en-us" will generate fallback rule like this:
-            //   "en-us" -> "en" -> "" 
-            //   "en" -> ""
-            // So that when we get a locale such as en-gb, we can try to resolve to "en-gb" then "en" then ""
+            //   "en-us" -> "en"
+            //   "" -> defaultLanguages
+            // So that when we get a locale such as en-gb, we can try to resolve to "en-gb" then "en"
             // See commented section for full sample of output of this function
             private static IDictionary<string, string[]> DefaultPolicy(string[] defaultLanguages = null)
             {
-                if (defaultLanguages == null)
+                if (defaultLanguages == null || defaultLanguages.Length == 0)
                 {
                     defaultLanguages = new string[] { string.Empty };
                 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -52,6 +52,13 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             languageFallbackPolicy = new LanguagePolicy(defaultLanguage);
         }
 
+        /// <summary>
+        /// Generate template evaluate result.
+        /// </summary>
+        /// <param name="template">Template name.</param>
+        /// <param name="data">Scope data.</param>
+        /// <param name="locale">Locale info.</param>
+        /// <returns>Evaluate result.</returns>
         public object Generate(string template, object data, string locale)
         {
             if (template == null)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </summary>
     public class MultiLanguageLG
     {
-        private readonly LanguagePolicy languagePolicy;
+        private readonly LanguagePolicy languageFallbackPolicy;
 
         private readonly Dictionary<string, Templates> lgPerLocale;
 
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         public MultiLanguageLG(Dictionary<string, string> localeLGFiles, params string[] defaultLanguages)
         {
             lgPerLocale = new Dictionary<string, Templates>(StringComparer.OrdinalIgnoreCase);
-            languagePolicy = new LanguagePolicy(defaultLanguages);
+            languageFallbackPolicy = new LanguagePolicy(defaultLanguages);
 
             if (localeLGFiles == null)
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 lgPerLocale.Add(templatesPair.Key, templatesPair.Value);
             }
 
-            languagePolicy = new LanguagePolicy(defaultLanguages);
+            languageFallbackPolicy = new LanguagePolicy(defaultLanguages);
         }
 
         public object Generate(string template, object data, string locale)
@@ -69,15 +69,15 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             var fallbackLocales = new List<string>();
-            if (languagePolicy.ContainsKey(locale))
+            if (languageFallbackPolicy.ContainsKey(locale))
             {
-                fallbackLocales.AddRange(languagePolicy[locale]);
+                fallbackLocales.AddRange(languageFallbackPolicy[locale]);
             }
 
             // append empty as fallback to end
-            if (locale != string.Empty && languagePolicy.ContainsKey(string.Empty))
+            if (locale != string.Empty && languageFallbackPolicy.ContainsKey(string.Empty))
             {
-                fallbackLocales.AddRange(languagePolicy[string.Empty]);
+                fallbackLocales.AddRange(languageFallbackPolicy[string.Empty]);
             }
 
             if (fallbackLocales.Count == 0)

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
@@ -20,19 +20,19 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
 
             var generator = new MultiLanguageLG(localPerFile);
 
-            // fallback to "c.en.lg"
+            // fallback to "a.en.lg"
             var result = generator.Generate("templatec", null, "en-us");
             Assert.AreEqual("from a.en.lg", result);
 
-            // "c.en.lg" is used
+            // "a.en.lg" is used
             result = generator.Generate("templatec", null, "en");
             Assert.AreEqual("from a.en.lg", result);
 
-            // locale "fr" has no entry file, default file "c.lg" is used
+            // locale "fr" has no entry file, default file "a.lg" is used
             result = generator.Generate("templatec", null, "fr");
             Assert.AreEqual("from a.lg", result);
 
-            // "c.lg" is used
+            // "a.lg" is used
             result = generator.Generate("templatec", null, null);
             Assert.AreEqual("from a.lg", result);
         }
@@ -47,19 +47,19 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
 
             var generator = new MultiLanguageLG(localPerFile, "en");
 
-            // fallback to "c.en.lg"
+            // fallback to "a.en.lg"
             var result = generator.Generate("templatec", null, "en-us");
             Assert.AreEqual("from a.en.lg", result);
 
-            // "c.en.lg" is used
+            // "a.en.lg" is used
             result = generator.Generate("templatec", null, "en");
             Assert.AreEqual("from a.en.lg", result);
 
-            // locale "fr" has no entry file, default file "c.en.lg" is used
+            // locale "fr" has no entry file, default file "a.en.lg" is used
             result = generator.Generate("templatec", null, "fr");
             Assert.AreEqual("from a.en.lg", result);
 
-            // "c.en.lg" is used
+            // "a.en.lg" is used
             result = generator.Generate("templatec", null, null);
             Assert.AreEqual("from a.en.lg", result);
         }
@@ -75,19 +75,19 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
 
             var generator = new MultiLanguageLG(templatesDict, "en");
 
-            // fallback to "c.en.lg"
+            // fallback to "a.en.lg"
             var result = generator.Generate("myTemplate", null, "en-us");
             Assert.AreEqual("content with id: 1.lg from source: abc", result);
 
-            // "c.en.lg" is used
+            // "a.en.lg" is used
             result = generator.Generate("myTemplate", null, "en");
             Assert.AreEqual("content with id: 1.lg from source: abc", result);
 
-            // locale "fr" has no entry file, default file "c.en.lg" is used
+            // locale "fr" has no entry file, default file "a.en.lg" is used
             result = generator.Generate("myTemplate", null, "fr");
             Assert.AreEqual("content with id: 1.lg from source: abc", result);
 
-            // "c.en.lg" is used
+            // "a.en.lg" is used
             result = generator.Generate("myTemplate", null, null);
             Assert.AreEqual("content with id: 1.lg from source: abc", result);
         }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
     public class MultilanguageLGTest
     {
         [TestMethod]
-        public void TestMultiLanguageLGWithEmptyDefaultLocale()
+        public void EmptyFallbackLocale()
         {
             var localPerFile = new Dictionary<string, string>
             {
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
         }
 
         [TestMethod]
-        public void TestMultiLanguageLGWithEmptySpecificLocale()
+        public void SpecificFallbackLocale()
         {
             var localPerFile = new Dictionary<string, string>
             {
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
         }
 
         [TestMethod]
-        public void TestMultiLanguageLGWithTemplates()
+        public void TemplatesInputs()
         {
             var enTemplates = Templates.ParseText("[import](1.lg)\r\n # template\r\n - hi", "abc", ConstantResolver);
             var templatesDict = new Dictionary<string, Templates>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
     public class MultilanguageLGTest
     {
         [TestMethod]
-        public void TestMultiLanguageLG()
+        public void TestMultiLanguageLGWithEmptyDefaultLocale()
         {
             var localPerFile = new Dictionary<string, string>
             {
@@ -21,20 +21,80 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
             var generator = new MultiLanguageLG(localPerFile);
 
             // fallback to "c.en.lg"
-            var result = generator.Generate("${templatec()}", null, "en-us");
+            var result = generator.Generate("templatec", null, "en-us");
             Assert.AreEqual("from a.en.lg", result);
 
             // "c.en.lg" is used
-            result = generator.Generate("${templatec()}", null, "en");
+            result = generator.Generate("templatec", null, "en");
             Assert.AreEqual("from a.en.lg", result);
 
             // locale "fr" has no entry file, default file "c.lg" is used
-            result = generator.Generate("${templatec()}", null, "fr");
+            result = generator.Generate("templatec", null, "fr");
             Assert.AreEqual("from a.lg", result);
 
             // "c.lg" is used
-            result = generator.Generate("${templatec()}", null, null);
+            result = generator.Generate("templatec", null, null);
             Assert.AreEqual("from a.lg", result);
+        }
+
+        [TestMethod]
+        public void TestMultiLanguageLGWithEmptySpecificLocale()
+        {
+            var localPerFile = new Dictionary<string, string>
+            {
+                { "en", Path.Combine(AppContext.BaseDirectory, "MultiLanguage", "a.en.lg") },
+            };
+
+            var generator = new MultiLanguageLG(localPerFile, "en");
+
+            // fallback to "c.en.lg"
+            var result = generator.Generate("templatec", null, "en-us");
+            Assert.AreEqual("from a.en.lg", result);
+
+            // "c.en.lg" is used
+            result = generator.Generate("templatec", null, "en");
+            Assert.AreEqual("from a.en.lg", result);
+
+            // locale "fr" has no entry file, default file "c.en.lg" is used
+            result = generator.Generate("templatec", null, "fr");
+            Assert.AreEqual("from a.en.lg", result);
+
+            // "c.en.lg" is used
+            result = generator.Generate("templatec", null, null);
+            Assert.AreEqual("from a.en.lg", result);
+        }
+
+        [TestMethod]
+        public void TestMultiLanguageLGWithTemplates()
+        {
+            var enTemplates = Templates.ParseText("[import](1.lg)\r\n # template\r\n - hi", "abc", ConstantResolver);
+            var templatesDict = new Dictionary<string, Templates>
+            {
+                { "en", enTemplates },
+            };
+
+            var generator = new MultiLanguageLG(templatesDict, "en");
+
+            // fallback to "c.en.lg"
+            var result = generator.Generate("myTemplate", null, "en-us");
+            Assert.AreEqual("content with id: 1.lg from source: abc", result);
+
+            // "c.en.lg" is used
+            result = generator.Generate("myTemplate", null, "en");
+            Assert.AreEqual("content with id: 1.lg from source: abc", result);
+
+            // locale "fr" has no entry file, default file "c.en.lg" is used
+            result = generator.Generate("myTemplate", null, "fr");
+            Assert.AreEqual("content with id: 1.lg from source: abc", result);
+
+            // "c.en.lg" is used
+            result = generator.Generate("myTemplate", null, null);
+            Assert.AreEqual("content with id: 1.lg from source: abc", result);
+        }
+
+        private static (string content, string id) ConstantResolver(string sourceId, string resourceId)
+        {
+            return ($"# myTemplate\r\n - content with id: {resourceId} from source: {sourceId}", sourceId + resourceId);
         }
     }
 }


### PR DESCRIPTION
close: #3551 
- add a `defaultLanguages` param format list which can replace "" as default
 - sync with latest SDK how language policy is updated, "de-de" => "de-de", "de"
 - replace `EvaluateText` with `Evaluate`
 - support passed in parsed Templates instead of just file paths, `Dict<string, Templates>`