### PR TITLE
Updates for CallerId

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -13,7 +13,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Integration;
-using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -433,28 +432,17 @@ namespace Microsoft.Bot.Builder
 
             using (var context = new TurnContext(this, activity))
             {
+                activity.CallerId = await GenerateCallerIdAsync(claimsIdentity).ConfigureAwait(false);
+
                 context.TurnState.Add<IIdentity>(BotIdentityKey, claimsIdentity);
-                context.TurnState.Add<BotCallbackHandler>(callback);
-
-                // To create the correct cache key, provide the OAuthScope when calling CreateConnectorClientAsync.
-                string scope;
-                if (SkillValidation.IsSkillClaim(claimsIdentity.Claims))
-                {
-                    // For activities received from another bot, the appropriate audience is obtained from the claims.
-                    scope = JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims);
-
-                    // For skill calls we set the caller ID property in the activity based on the appId in the claims.
-                    activity.CallerId = $"urn:botframework:aadappid:{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
-                }
-                else
-                {
-                    scope = GetBotFrameworkOAuthScope();
-                }
 
                 // The OAuthScope is also stored on the TurnState to get the correct AppCredentials if fetching a token is required.
+                var scope = SkillValidation.IsSkillClaim(claimsIdentity.Claims) ? JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims) : GetBotFrameworkOAuthScope();
                 context.TurnState.Add(OAuthScopeKey, scope);
                 var connectorClient = await CreateConnectorClientAsync(activity.ServiceUrl, claimsIdentity, scope, cancellationToken).ConfigureAwait(false);
                 context.TurnState.Add(connectorClient);
+
+                context.TurnState.Add(callback);
 
                 await RunPipelineAsync(context, callback, cancellationToken).ConfigureAwait(false);
 
@@ -1415,6 +1403,42 @@ namespace Microsoft.Bot.Builder
 
             // Construct an AppCredentials using the app + password combination. If government, we create a government specific credential.
             return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
+        }
+
+        /// <summary>
+        /// Generates the CallerId property for the activity based on
+        /// https://github.com/microsoft/botframework-obi/blob/master/protocols/botframework-activity/botframework-activity.md#appendix-v---caller-id-values.
+        /// </summary>
+        private async Task<string> GenerateCallerIdAsync(ClaimsIdentity claimsIdentity)
+        {
+            // Is the bot accepting all incoming messages?
+            var isAuthDisabled = await CredentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false);
+            if (isAuthDisabled) 
+            {
+                // Return null so that the callerId is cleared.
+                return null;
+            }
+        
+            // Is the activity from another bot?
+            if (SkillValidation.IsSkillClaim(claimsIdentity.Claims))
+            {
+                return $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
+            }
+
+            // Is the activity from Public Azure?
+            if (ChannelProvider == null || ChannelProvider.IsPublicAzure()) 
+            {
+                return CallerIdConstants.PublicAzureChannel;
+            }
+
+            // Is the activity from Azure Gov?
+            if (ChannelProvider != null && ChannelProvider.IsGovernment()) 
+            {
+                return CallerIdConstants.USGovChannel;
+            }
+
+            // Return null so that the callerId is cleared.
+            return null;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Bot.Builder.Skills
             {
                 turnContext.TurnState.Add(SkillConversationReferenceKey, skillConversationReference);
                 activity.ApplyConversationReference(skillConversationReference.ConversationReference);
-                activity.CallerId = $"urn:botframework:aadappid:{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
+                activity.CallerId = $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
                 turnContext.Activity.Id = replyToActivityId;
                 switch (activity.Type)
                 {

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
@@ -179,8 +179,8 @@ namespace Microsoft.Bot.Builder.Skills
             {
                 turnContext.TurnState.Add(SkillConversationReferenceKey, skillConversationReference);
                 activity.ApplyConversationReference(skillConversationReference.ConversationReference);
-                activity.CallerId = $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
                 turnContext.Activity.Id = replyToActivityId;
+                turnContext.Activity.CallerId = $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
                 switch (activity.Type)
                 {
                     case ActivityTypes.EndOfConversation:

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
@@ -178,9 +178,8 @@ namespace Microsoft.Bot.Builder.Skills
             var callback = new BotCallbackHandler(async (turnContext, ct) =>
             {
                 turnContext.TurnState.Add(SkillConversationReferenceKey, skillConversationReference);
-
                 activity.ApplyConversationReference(skillConversationReference.ConversationReference);
-
+                activity.CallerId = $"urn:botframework:aadappid:{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
                 turnContext.Activity.Id = replyToActivityId;
                 switch (activity.Type)
                 {

--- a/libraries/Microsoft.Bot.Schema/CallerIdConstants.cs
+++ b/libraries/Microsoft.Bot.Schema/CallerIdConstants.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Constants used to populate the <see cref="Activity.CallerId"/> property.
+    /// </summary>
+    public static class CallerIdConstants
+    {
+        /// <summary>
+        ///  The caller ID for any Bot Framework channel.
+        /// </summary>
+        public const string PublicAzureChannel = "urn:botframework:azure";
+
+        /// <summary>
+        ///  The caller ID for any Bot Framework US Government cloud channel.
+        /// </summary>
+        public const string USGovChannel = "urn:botframework:azureusgov";
+
+        /// <summary>
+        /// The caller ID prefix when a bot initiates a request to another bot.
+        /// </summary>
+        /// <remarks>
+        /// This prefix will be followed by the Azure Active Directory App ID of the bot that initiated the call.
+        /// </remarks>
+        public const string BotToBotPrefix = "urn:botframework:aadappid:";
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             // Capture current activity settings before changing them.
             var originalConversationId = activity.Conversation.Id;
             var originalServiceUrl = activity.ServiceUrl;
-            var originalCallerId = activity.CallerId;
             var originalRelatesTo = activity.RelatesTo;
             try
             {
@@ -100,7 +99,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 };
                 activity.Conversation.Id = conversationId;
                 activity.ServiceUrl = serviceUrl.ToString();
-                activity.CallerId = $"urn:botframework:aadappid:{fromBotId}";
 
                 using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
                 {
@@ -131,7 +129,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 // Restore activity properties.
                 activity.Conversation.Id = originalConversationId;
                 activity.ServiceUrl = originalServiceUrl;
-                activity.CallerId = originalCallerId;
                 activity.RelatesTo = originalRelatesTo;
             }
         }

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Bot.Builder.Tests
     [TestClass]
     public class BotFrameworkAdapterTests
     {
-        private const string CredsCacheName = "_appCredentialMap";
-        private const string ClientsCacheName = "_connectorClients";
+        private const string AppCredentialsCacheName = "_appCredentialMap";
+        private const string ConnectorClientsCacheName = "_connectorClients";
 
         [TestMethod]
         public async Task TenantIdShouldBeSetInConversationForTeams()
@@ -164,35 +164,38 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        public async Task ProcessActivityAsyncCreatesCorrectCredsAndClient()
+        [DataRow(null, null, null, AuthenticationConstants.ToChannelFromBotOAuthScope, 0, 1)]
+        [DataRow("00000000-0000-0000-0000-000000000001", CallerIdConstants.PublicAzureChannel, null, AuthenticationConstants.ToChannelFromBotOAuthScope, 1, 1)]
+        [DataRow("00000000-0000-0000-0000-000000000001", CallerIdConstants.USGovChannel, GovernmentAuthenticationConstants.ChannelService, GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope, 1, 1)]
+        public async Task ProcessActivityAsyncCreatesCorrectCredsAndClient(string botAppId, string expectedCallerId, string channelService, string expectedScope, int expectedAppCredentialsCount, int expectedClientCredentialsCount)
         {
-            var botAppId = "00000000-0000-0000-0000-000000000001";
-            var claims = new List<Claim>
+            var claims = new List<Claim>();
+            if (botAppId != null)
             {
-                new Claim(AuthenticationConstants.AudienceClaim, botAppId),
-                new Claim(AuthenticationConstants.AppIdClaim, botAppId),
-                new Claim(AuthenticationConstants.VersionClaim, "1.0")
-            };
+                claims.Add(new Claim(AuthenticationConstants.AudienceClaim, botAppId));
+                claims.Add(new Claim(AuthenticationConstants.AppIdClaim, botAppId));
+                claims.Add(new Claim(AuthenticationConstants.VersionClaim, "1.0"));
+            }
+
             var identity = new ClaimsIdentity(claims);
 
-            var credentialProvider = new SimpleCredentialProvider() { AppId = botAppId };
+            var credentialProvider = new SimpleCredentialProvider { AppId = botAppId };
             var serviceUrl = "https://smba.trafficmanager.net/amer/";
             var callback = new BotCallbackHandler(async (context, ct) =>
             {
-                GetCredsAndAssertValues(context, botAppId, AuthenticationConstants.ToChannelFromBotOAuthScope, 1);
-                GetClientAndAssertValues(
+                GetAppCredentialsAndAssertValues(context, botAppId, expectedScope, expectedAppCredentialsCount);
+                GetConnectorClientsAndAssertValues(
                     context,
                     botAppId,
-                    AuthenticationConstants.ToChannelFromBotOAuthScope,
+                    expectedScope,
                     new Uri(serviceUrl),
-                    1);
+                    expectedClientCredentialsCount);
 
                 var scope = context.TurnState.Get<string>(BotAdapter.OAuthScopeKey);
-                Assert.AreEqual(AuthenticationConstants.ToChannelFromBotOAuthScope, scope);
-                Assert.IsNull(context.Activity.CallerId);
+                Assert.AreEqual(expectedCallerId, context.Activity.CallerId);
             });
 
-            var sut = new BotFrameworkAdapter(credentialProvider);
+            var sut = new BotFrameworkAdapter(credentialProvider, new SimpleChannelProvider(channelService));
             await sut.ProcessActivityAsync(
                 identity,
                 new Activity("test")
@@ -221,8 +224,8 @@ namespace Microsoft.Bot.Builder.Tests
             var serviceUrl = "https://root-bot.test.azurewebsites.net/";
             var callback = new BotCallbackHandler(async (context, ct) =>
             {
-                GetCredsAndAssertValues(context, skill1AppId, botAppId, 1);
-                GetClientAndAssertValues(
+                GetAppCredentialsAndAssertValues(context, skill1AppId, botAppId, 1);
+                GetConnectorClientsAndAssertValues(
                     context,
                     skill1AppId,
                     botAppId,
@@ -231,7 +234,7 @@ namespace Microsoft.Bot.Builder.Tests
 
                 var scope = context.TurnState.Get<string>(BotAdapter.OAuthScopeKey);
                 Assert.AreEqual(botAppId, scope);
-                Assert.AreEqual($"urn:botframework:aadappid:{botAppId}", context.Activity.CallerId);
+                Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{botAppId}", context.Activity.CallerId);
             });
 
             var sut = new BotFrameworkAdapter(credentialProvider);
@@ -271,8 +274,8 @@ namespace Microsoft.Bot.Builder.Tests
             // Skill1 is calling ContinueSkillConversationAsync() to proactively send an Activity to the channel
             var callback = new BotCallbackHandler(async (turnContext, ct) =>
             {
-                GetCredsAndAssertValues(turnContext, skill1AppId, AuthenticationConstants.ToChannelFromBotOAuthScope, 1);
-                GetClientAndAssertValues(
+                GetAppCredentialsAndAssertValues(turnContext, skill1AppId, AuthenticationConstants.ToChannelFromBotOAuthScope, 1);
+                GetConnectorClientsAndAssertValues(
                     turnContext,
                     skill1AppId,
                     AuthenticationConstants.ToChannelFromBotOAuthScope,
@@ -281,7 +284,7 @@ namespace Microsoft.Bot.Builder.Tests
 
                 // Get "skill1-to-channel" ConnectorClient off of TurnState
                 var adapter = turnContext.Adapter as BotFrameworkAdapter;
-                var clientCache = GetCache<ConcurrentDictionary<string, ConnectorClient>>(adapter, ClientsCacheName);
+                var clientCache = GetCache<ConcurrentDictionary<string, ConnectorClient>>(adapter, ConnectorClientsCacheName);
                 clientCache.TryGetValue($"{channelServiceUrl}{skill1AppId}:{AuthenticationConstants.ToChannelFromBotOAuthScope}", out var client);
 
                 var turnStateClient = turnContext.TurnState.Get<IConnectorClient>();
@@ -326,8 +329,8 @@ namespace Microsoft.Bot.Builder.Tests
             // Skill1 is calling ContinueSkillConversationAsync() to proactively send an Activity to Skill 2
             var callback = new BotCallbackHandler(async (turnContext, ct) =>
             {
-                GetCredsAndAssertValues(turnContext, skill1AppId, skill2AppId, 1);
-                GetClientAndAssertValues(
+                GetAppCredentialsAndAssertValues(turnContext, skill1AppId, skill2AppId, 1);
+                GetConnectorClientsAndAssertValues(
                     turnContext,
                     skill1AppId,
                     skill2AppId,
@@ -336,7 +339,7 @@ namespace Microsoft.Bot.Builder.Tests
 
                 // Get "skill1-to-skill2" ConnectorClient off of TurnState
                 var adapter = turnContext.Adapter as BotFrameworkAdapter;
-                var clientCache = GetCache<ConcurrentDictionary<string, ConnectorClient>>(adapter, ClientsCacheName);
+                var clientCache = GetCache<ConcurrentDictionary<string, ConnectorClient>>(adapter, ConnectorClientsCacheName);
                 clientCache.TryGetValue($"{skill2ServiceUrl}{skill1AppId}:{skill2AppId}", out var client);
 
                 var turnStateClient = turnContext.TurnState.Get<IConnectorClient>();
@@ -475,50 +478,37 @@ namespace Microsoft.Bot.Builder.Tests
             return await ProcessActivity(channelId, channelData, conversationTenantId);
         }
 
-        private static void GetCredsAndAssertValues(ITurnContext turnContext, string expectedAppId, string expectedScope, int? credsCount = null)
+        private static void GetAppCredentialsAndAssertValues(ITurnContext turnContext, string expectedAppId, string expectedScope, int credsCount)
         {
-            var credsCache = GetCache<ConcurrentDictionary<string, AppCredentials>>((BotFrameworkAdapter)turnContext.Adapter, CredsCacheName);
-            var cacheKey = $"{expectedAppId}{expectedScope}";
-            credsCache.TryGetValue(cacheKey, out var creds);
-            AssertCredentialsValues(creds, expectedAppId, expectedScope);
-
-            if (credsCount != null)
+            if (credsCount > 0)
             {
+                var credsCache = GetCache<ConcurrentDictionary<string, AppCredentials>>((BotFrameworkAdapter)turnContext.Adapter, AppCredentialsCacheName);
+                var cacheKey = $"{expectedAppId}{expectedScope}";
+                credsCache.TryGetValue(cacheKey, out var creds);
                 Assert.AreEqual(credsCount, credsCache.Count);
+
+                Assert.AreEqual(expectedAppId, creds.MicrosoftAppId);
+                Assert.AreEqual(expectedScope, creds.OAuthScope);
             }
         }
 
-        private static void GetClientAndAssertValues(ITurnContext turnContext, string expectedAppId, string expectedScope, Uri expectedUrl, int? clientCount = null)
+        private static void GetConnectorClientsAndAssertValues(ITurnContext turnContext, string expectedAppId, string expectedScope, Uri expectedUrl, int clientCount)
         {
-            var clientCache = GetCache<ConcurrentDictionary<string, ConnectorClient>>((BotFrameworkAdapter)turnContext.Adapter, ClientsCacheName);
-            var cacheKey = $"{expectedUrl}{expectedAppId}:{expectedScope}";
+            var clientCache = GetCache<ConcurrentDictionary<string, ConnectorClient>>((BotFrameworkAdapter)turnContext.Adapter, ConnectorClientsCacheName);
+            var cacheKey = expectedAppId == null ? $"{expectedUrl}:" : $"{expectedUrl}{expectedAppId}:{expectedScope}";
             clientCache.TryGetValue(cacheKey, out var client);
-            AssertConnectorClientValues(client, expectedAppId, expectedUrl, expectedScope);
 
-            if (clientCount != null)
-            {
-                Assert.AreEqual(clientCount, clientCache.Count);
-            }
+            Assert.AreEqual(clientCount, clientCache.Count);
+            var creds = (AppCredentials)client?.Credentials;
+            Assert.AreEqual(expectedAppId, creds?.MicrosoftAppId);
+            Assert.AreEqual(expectedScope, creds?.OAuthScope);
+            Assert.AreEqual(expectedUrl, client?.BaseUri);
         }
 
         private static T GetCache<T>(BotFrameworkAdapter adapter, string fieldName)
         {
             var cacheField = typeof(BotFrameworkAdapter).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
             return (T)cacheField.GetValue(adapter);
-        }
-
-        private static void AssertCredentialsValues(AppCredentials creds, string expectedAppId, string expectedScope = AuthenticationConstants.ToChannelFromBotOAuthScope)
-        {
-            Assert.AreEqual(expectedAppId, creds.MicrosoftAppId);
-            Assert.AreEqual(expectedScope, creds.OAuthScope);
-        }
-
-        private static void AssertConnectorClientValues(IConnectorClient client, string expectedAppId, Uri expectedServiceUrl, string expectedScope = AuthenticationConstants.ToChannelFromBotOAuthScope)
-        {
-            var creds = (AppCredentials)client.Credentials;
-            Assert.AreEqual(expectedAppId, creds.MicrosoftAppId);
-            Assert.AreEqual(expectedScope, creds.OAuthScope);
-            Assert.AreEqual(expectedServiceUrl, client.BaseUri);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -9,14 +9,11 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Security.Claims;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Protected;
@@ -71,7 +68,7 @@ namespace Microsoft.Bot.Builder.Tests
 
             Func<Task<HttpResponseMessage>> createResponseMessage = () =>
             {
-                var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
                 response.Content = new StringContent(new JObject { { activityIdName, activityIdValue }, { conversationIdName, conversationIdValue } }.ToString());
                 return Task.FromResult(response);
             };
@@ -192,6 +189,7 @@ namespace Microsoft.Bot.Builder.Tests
 
                 var scope = context.TurnState.Get<string>(BotAdapter.OAuthScopeKey);
                 Assert.AreEqual(AuthenticationConstants.ToChannelFromBotOAuthScope, scope);
+                Assert.IsNull(context.Activity.CallerId);
             });
 
             var sut = new BotFrameworkAdapter(credentialProvider);
@@ -233,6 +231,7 @@ namespace Microsoft.Bot.Builder.Tests
 
                 var scope = context.TurnState.Get<string>(BotAdapter.OAuthScopeKey);
                 Assert.AreEqual(botAppId, scope);
+                Assert.AreEqual($"urn:botframework:aadappid:{botAppId}", context.Activity.CallerId);
             });
 
             var sut = new BotFrameworkAdapter(credentialProvider);

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/SkillHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/SkillHandlerTests.cs
@@ -102,7 +102,6 @@ namespace Microsoft.Bot.Builder.Tests.Skills
                 .Callback<ClaimsIdentity, ConversationReference, string, BotCallbackHandler, CancellationToken>((identity, reference, audience, callback, cancellationToken) =>
                 {
                     botCallback = callback;
-                    Console.WriteLine("blah");
                 });
 
             var sut = CreateSkillHandlerForTesting();
@@ -113,8 +112,8 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             Assert.IsNull(activity.CallerId);
             await sut.TestOnSendToConversationAsync(_claimsIdentity, _conversationId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
-            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
-            Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{_skillId}", activity.CallerId);
+            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, _conversationReference.GetContinuationActivity()), CancellationToken.None);
+            Assert.IsNull(activity.CallerId);
         }
 
         [TestMethod]
@@ -125,7 +124,6 @@ namespace Microsoft.Bot.Builder.Tests.Skills
                 .Callback<ClaimsIdentity, ConversationReference, string, BotCallbackHandler, CancellationToken>((identity, reference, audience, callback, cancellationToken) =>
                 {
                     botCallback = callback;
-                    Console.WriteLine("blah");
                 });
 
             var sut = CreateSkillHandlerForTesting();
@@ -136,8 +134,8 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 
             await sut.TestOnReplyToActivityAsync(_claimsIdentity, _conversationId, activityId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
-            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
-            Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{_skillId}", activity.CallerId);
+            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, _conversationReference.GetContinuationActivity()), CancellationToken.None);
+            Assert.IsNull(activity.CallerId);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/SkillHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/SkillHandlerTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             await sut.TestOnSendToConversationAsync(_claimsIdentity, _conversationId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
             await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
-            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
+            Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
@@ -137,7 +137,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             await sut.TestOnReplyToActivityAsync(_claimsIdentity, _conversationId, activityId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
             await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
-            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
+            Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
@@ -145,7 +145,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         {
             var activity = (Activity)Activity.CreateEventActivity();
             await TestActivityCallback(activity);
-            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
+            Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
@@ -153,7 +153,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         {
             var activity = (Activity)Activity.CreateEndOfConversationActivity();
             await TestActivityCallback(activity);
-            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
+            Assert.AreEqual($"{CallerIdConstants.BotToBotPrefix}{_skillId}", activity.CallerId);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/SkillHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/SkillHandlerTests.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         private readonly ConversationReference _conversationReference;
         private readonly Mock<BotAdapter> _mockAdapter = new Mock<BotAdapter>();
         private readonly Mock<IBot> _mockBot = new Mock<IBot>();
-        private string _botId = Guid.NewGuid().ToString("N");
-        private string _skillId = Guid.NewGuid().ToString("N");
+        private readonly string _botId = Guid.NewGuid().ToString("N");
+        private readonly string _skillId = Guid.NewGuid().ToString("N");
         private readonly TestConversationIdFactory _testConversationIdFactory = new TestConversationIdFactory();
 
         public SkillHandlerTests()
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
                 ServiceUrl = "http://testbot.com/api/messages"
             };
 
-            var activity = Activity.CreateMessageActivity() as Activity;
+            var activity = (Activity)Activity.CreateMessageActivity();
             activity.ApplyConversationReference(_conversationReference);
             var skill = new BotFrameworkSkill() 
             { 
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         [TestMethod]
         public async Task LegacyConversationIdFactoryTest()
         {
-            var legacycFatory = new TestLegacyConversationIdFactory();
+            var legacyFactory = new TestLegacyConversationIdFactory();
             var conversationReference = new ConversationReference
             {
                 Conversation = new ConversationAccount(id: Guid.NewGuid().ToString("N")),
@@ -74,7 +74,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 
             // Testing the deprecated method for backward compatibility.
 #pragma warning disable 618
-            var conversationId = await legacycFatory.CreateSkillConversationIdAsync(conversationReference, CancellationToken.None);
+            var conversationId = await legacyFactory.CreateSkillConversationIdAsync(conversationReference, CancellationToken.None);
 #pragma warning restore 618
             BotCallbackHandler botCallback = null;
             _mockAdapter.Setup(x => x.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
@@ -84,7 +84,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
                     Console.WriteLine("blah");
                 });
 
-            var sut = CreateSkillHandlerForTesting(legacycFatory);
+            var sut = CreateSkillHandlerForTesting(legacyFactory);
 
             var activity = Activity.CreateMessageActivity();
             activity.ApplyConversationReference(conversationReference);
@@ -107,12 +107,14 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 
             var sut = CreateSkillHandlerForTesting();
 
-            var activity = Activity.CreateMessageActivity();
+            var activity = (Activity)Activity.CreateMessageActivity();
             activity.ApplyConversationReference(_conversationReference);
 
-            await sut.TestOnSendToConversationAsync(_claimsIdentity, _conversationId, (Activity)activity, CancellationToken.None);
+            Assert.IsNull(activity.CallerId);
+            await sut.TestOnSendToConversationAsync(_claimsIdentity, _conversationId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
-            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, (Activity)activity), CancellationToken.None);
+            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
+            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
@@ -128,27 +130,30 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 
             var sut = CreateSkillHandlerForTesting();
 
-            var activity = Activity.CreateMessageActivity();
+            var activity = (Activity)Activity.CreateMessageActivity();
             var activityId = Guid.NewGuid().ToString("N");
             activity.ApplyConversationReference(_conversationReference);
 
-            await sut.TestOnReplyToActivityAsync(_claimsIdentity, _conversationId, activityId, (Activity)activity, CancellationToken.None);
+            await sut.TestOnReplyToActivityAsync(_claimsIdentity, _conversationId, activityId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
-            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, (Activity)activity), CancellationToken.None);
+            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
+            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
         public async Task EventActivityAsyncTest()
         {
-            var activity = Activity.CreateEventActivity();
-            await TestActivityCallback(activity as Activity);
+            var activity = (Activity)Activity.CreateEventActivity();
+            await TestActivityCallback(activity);
+            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
         public async Task EndOfConversationActivityAsyncTest()
         {
-            var activity = Activity.CreateEndOfConversationActivity();
-            await TestActivityCallback(activity as Activity);
+            var activity = (Activity)Activity.CreateEndOfConversationActivity();
+            await TestActivityCallback(activity);
+            Assert.AreEqual($"urn:botframework:aadappid:{_skillId}", activity.CallerId);
         }
 
         [TestMethod]
@@ -282,9 +287,9 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             var activityId = Guid.NewGuid().ToString("N");
             activity.ApplyConversationReference(_conversationReference);
 
-            await sut.TestOnReplyToActivityAsync(_claimsIdentity, _conversationId, activityId, (Activity)activity, CancellationToken.None);
+            await sut.TestOnReplyToActivityAsync(_claimsIdentity, _conversationId, activityId, activity, CancellationToken.None);
             Assert.IsNotNull(botCallback);
-            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, (Activity)activity), CancellationToken.None);
+            await botCallback.Invoke(new TurnContext(_mockAdapter.Object, activity), CancellationToken.None);
         }
 
         private SkillHandlerInstanceForTests CreateSkillHandlerForTesting(SkillConversationIdFactoryBase overrideFactory = null)


### PR DESCRIPTION
Updated callerId assignment to be taken from claims after auth rather than from the activity.
Updated related tests.
Applied temporary fix for the new callerId log for DialogManager (final fix will be done after refactoring to match DialogExtensions.RunAsync logic).