### PR TITLE
Added Slack View UI component to the payload and support for setting request header content type

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModalBlock.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModalBlock.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    public class ModalBlock
+    {
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
+
+        [JsonProperty(PropertyName = "selected_option")]
+        public StaticSelectedOption SelectedOption { get; set; }
+
+        [JsonProperty(PropertyName = "selected_options")]
+        public List<StaticSelectedOption> SelectedOptions { get; set; }
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModalBlock.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModalBlock.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         public StaticSelectedOption SelectedOption { get; set; }
 
         [JsonProperty(PropertyName = "selected_options")]
-        public List<StaticSelectedOption> SelectedOptions { get; set; }
+        public List<StaticSelectedOption> SelectedOptions { get; } = new List<StaticSelectedOption>();
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModalView.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModalView.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    public class ModalView
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "state")]
+        public ModelViewState State { get; set; }
+        
+        [JsonProperty(PropertyName = "callback_id")]
+        public string ModalIndentifier { get; set; }
+
+        [JsonProperty(PropertyName = "private_metadata")]
+        public string PrivateMetadata { get; set; }
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModelViewState.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ModelViewState.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    public class ModelViewState
+    {
+        [JsonProperty(PropertyName = "values")]
+        public Dictionary<string, Dictionary<string, ModalBlock>> Values { get; } = new Dictionary<string, Dictionary<string, ModalBlock>>();
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAction.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAction.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack
@@ -24,5 +25,17 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
         [JsonProperty(PropertyName = "action_ts")]
         public string ActionTs { get; set; }
+
+        /// <summary>
+        /// Used with multi select menu.
+        /// </summary>
+        [JsonProperty(PropertyName = "selected_options")]
+        public List<SlackMenuOption> SelectedOptions { get; } = new List<SlackMenuOption>();
+
+        /// <summary>
+        /// Used with select menu.
+        /// </summary>
+        [JsonProperty(PropertyName = "selected_option")]
+        public SlackMenuOption SelectedOption { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAction.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAction.cs
@@ -26,15 +26,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         [JsonProperty(PropertyName = "action_ts")]
         public string ActionTs { get; set; }
 
-        /// <summary>
-        /// Used with multi select menu.
-        /// </summary>
         [JsonProperty(PropertyName = "selected_options")]
         public List<SlackMenuOption> SelectedOptions { get; } = new List<SlackMenuOption>();
 
-        /// <summary>
-        /// Used with select menu.
-        /// </summary>
         [JsonProperty(PropertyName = "selected_option")]
         public SlackMenuOption SelectedOption { get; set; }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -329,6 +329,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 var code = Convert.ToInt32(context.TurnState.Get<string>("httpStatus"), System.Globalization.CultureInfo.InvariantCulture);
                 var statusCode = (HttpStatusCode)code;
                 var text = context.TurnState.Get<object>("httpBody") != null ? context.TurnState.Get<object>("httpBody").ToString() : string.Empty;
+                var contentType = context.TurnState.Get<object>("httpContentType") != null ? context.TurnState.Get<object>("httpContentType").ToString() : string.Empty;
+
+                response.ContentType = string.IsNullOrEmpty(contentType) ? string.Empty : contentType;
 
                 await SlackHelper.WriteAsync(response, statusCode, text, Encoding.UTF8, cancellationToken).ConfigureAwait(false);
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -126,7 +126,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 throw new ArgumentNullException(nameof(encoding)); 
             }
 
-            response.ContentType = "text/plain";
+            response.ContentType = string.IsNullOrEmpty(response.ContentType) ? "text/plain" : response.ContentType;
+
             response.StatusCode = (int)code;
 
             var data = encoding.GetBytes(text);
@@ -152,7 +153,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 ChannelId = "slack",
                 Conversation = new ConversationAccount()
                 {
-                    Id = slackPayload.Channel.id,
+                    Id = slackPayload.Channel?.id,
                 },
                 From = new ChannelAccount()
                 {

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackMenuOption.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackMenuOption.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    public class SlackMenuOption
+    {
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackPayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackPayload.cs
@@ -52,5 +52,11 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
         [JsonProperty(PropertyName = "response_url")]
         public Uri ResponseUrl { get; set; }
+
+        [JsonProperty(PropertyName = "view")]
+        public ModalView View { get; set; }
+
+        [JsonProperty(PropertyName = "action_id")]
+        public string ActionId { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/StaticSelectedOption.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/StaticSelectedOption.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Slack
+{
+    public class StaticSelectedOption
+    {
+        [JsonProperty(PropertyName = "value")]
+        public string SelectedValue { get; set; }
+    }
+}


### PR DESCRIPTION
1. Support for Slack Views component in SlackPayload.
2. Support for selected option property in SlackAction class for static and multi_static slack UI elements.
3. Option to set http Content-type in header in client code in case the client wants to send other than "text/plain" as required by Slack Api.