### PR TITLE
Change Comparisons to ReturnType of 'template' function use bit operators

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             var children0 = expression.Children[0];
 
-            if (children0.ReturnType != ReturnType.Object && children0.ReturnType != ReturnType.String)
+            if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
             {
                 throw new Exception(TemplateErrors.ErrorTemplateNameformat(children0.ToString()));
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             var children0 = expression.Children[0];
 
-            if (children0.ReturnType != ReturnType.Object && children0.ReturnType != ReturnType.String)
+            if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
             {
                 throw new Exception(TemplateErrors.ErrorTemplateNameformat(children0.ToString()));
             }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/TemplateAsFunction.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/TemplateAsFunction.lg
@@ -17,3 +17,9 @@
 
 # dupNameWithTemplate
 - ${length('ms')}
+
+# foo(property)
+- ${template(property +'Entity')}
+
+# ShowEntity
+- you made it!

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -380,6 +380,9 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             evaled = templates.Evaluate("dupNameWithTemplate").ToString();
             Assert.AreEqual(evaled, "2");
+
+            evaled = templates.Evaluate("foo", new { property = "Show" }).ToString();
+            Assert.AreEqual(evaled, "you made it!");
         }
 
         [TestMethod]


### PR DESCRIPTION
close: #3755 

Originally, we use exact match of returntype to validate the correctness of function parameters.
But, then Expression achieved then ability to support composite types. So, LG/Expression should change the return type comparison, as long as they have the intersection of the same return type, it is correct in the static checker stage.