### PR TITLE
[Expression] Enable setProperty function creating object handling null correctly

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -903,7 +903,7 @@ namespace AdaptiveExpressions
             {
                 if (value != null)
                 {
-                    result = JToken.FromObject(value);
+                    result = ConvertToJToken(value);
                     jobj[property] = (JToken)result;
                 }
                 else
@@ -1550,7 +1550,7 @@ namespace AdaptiveExpressions
                 {
                     list = Object2KVPairList(jobj);
                 }
-                else if (JToken.FromObject(instance) is JObject jobject)
+                else if (ConvertToJToken(instance) is JObject jobject)
                 {
                     list = Object2KVPairList(jobject);
                 }
@@ -1609,7 +1609,7 @@ namespace AdaptiveExpressions
                 {
                     list = Object2KVPairList(jobj);
                 }
-                else if (JToken.FromObject(instance) is JObject jobject)
+                else if (ConvertToJToken(instance) is JObject jobject)
                 {
                     list = Object2KVPairList(jobject);
                 }
@@ -1650,7 +1650,7 @@ namespace AdaptiveExpressions
                         {
                             TryAccessProperty(item, "key", out var keyVal);
                             TryAccessProperty(item, "value", out var val);
-                            jobjResult.Add(keyVal as string, JToken.FromObject(val));
+                            jobjResult.Add(keyVal as string, ConvertToJToken(val));
                         }
 
                         result = jobjResult;
@@ -2324,6 +2324,11 @@ namespace AdaptiveExpressions
             return (result, error);
         }
 
+        private static JToken ConvertToJToken(object value)
+        {
+            return value == null ? JValue.CreateNull() : JToken.FromObject(value);
+        }
+
         // collection functions
         private static (object value, string error) Skip(Expression expression, object state, Options options)
         {
@@ -2548,7 +2553,7 @@ namespace AdaptiveExpressions
                 {
                     result = Object2List(jobj);
                 }
-                else if (JToken.FromObject(instance) is JObject jobject)
+                else if (ConvertToJToken(instance) is JObject jobject)
                 {
                     result = Object2List(jobject);
                 }
@@ -3986,7 +3991,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                newJobj[prop] = JToken.FromObject(args[2]);
+                                newJobj[prop] = ConvertToJToken(args[2]);
                             }
 
                             return (newJobj, error);
@@ -3998,7 +4003,7 @@ namespace AdaptiveExpressions
                     Apply(args =>
                         {
                             var newJobj = (IDictionary<string, JToken>)args[0];
-                            newJobj[args[1].ToString()] = args[2] == null ? null : JToken.FromObject(args[2]);
+                            newJobj[args[1].ToString()] = ConvertToJToken(args[2]);
                             return newJobj;
                         }),
                     ReturnType.Object,

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -901,15 +901,7 @@ namespace AdaptiveExpressions
             }
             else if (instance is JObject jobj)
             {
-                if (value != null)
-                {
-                    result = ConvertToJToken(value);
-                    jobj[property] = (JToken)result;
-                }
-                else
-                {
-                    jobj[property] = null;
-                }
+                jobj[property] = ConvertToJToken(value);
             }
             else
             {

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -3998,8 +3998,7 @@ namespace AdaptiveExpressions
                     Apply(args =>
                         {
                             var newJobj = (IDictionary<string, JToken>)args[0];
-                            newJobj[args[1].ToString()] = JToken.FromObject(args[2]);
-
+                            newJobj[args[1].ToString()] = args[2] == null ? null : JToken.FromObject(args[2]);
                             return newJobj;
                         }),
                     ReturnType.Object,

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -833,6 +833,11 @@ namespace AdaptiveExpressions.Tests
             Test("string({obj: {'name': 'adams'}})", "{\"obj\":{\"name\":\"adams\"}}"),
             Test("string({obj: {'name': 'adams'}, txt: {utter: 'hello'}})", "{\"obj\":{\"name\":\"adams\"},\"txt\":{\"utter\":\"hello\"}}"),
             Test("{a: 1, b: newExpr}.b", "new land"),
+            Test("{name: user.name}.name", null),
+            Test("{name: user.nickname}.name", "John"),
+            Test("setProperty({}, 'name', user.name).name", null),
+            Test("setProperty({name: 'Paul'}, 'name', user.name).name", null),
+            Test("setProperty({}, 'name', user.nickname).name", "John"),
             #endregion
 
             #region  Memory access

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -838,6 +838,7 @@ namespace AdaptiveExpressions.Tests
             Test("setProperty({}, 'name', user.name).name", null),
             Test("setProperty({name: 'Paul'}, 'name', user.name).name", null),
             Test("setProperty({}, 'name', user.nickname).name", "John"),
+            Test("addProperty({}, 'name', user.name).name", null),
             #endregion
 
             #region  Memory access


### PR DESCRIPTION
closes: #3768 
In this PR,
setProperty({}, 'name', user.name).name will return null when user.name is null. It won't throws exception.
Also, create object with {} syntax,
{name: user.name}.name will have the same behavior as setProperty function.
