### PR TITLE
set recognized properties even if interruption is off

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -334,6 +334,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                         // we have received a RecognizedIntent event
                         // get the value and promote to turn.recognized, topintent,topscore and lastintent
                         var recognizedResult = actionContext.State.GetValue<RecognizerResult>($"{TurnPath.DialogEvent}.value");
+
+                        // #3572 set these here too (Even though the emitter may have set them) because this event can be emitted by declarative code.
                         var (name, score) = recognizedResult.GetTopScoringIntent();
                         actionContext.State.SetValue(TurnPath.Recognized, recognizedResult);
                         actionContext.State.SetValue(TurnPath.TopIntent, name);
@@ -428,10 +430,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                             if (activity.Type == ActivityTypes.Message)
                             {
                                 // Recognize utterance
-                                var recognized = await OnRecognize(actionContext, activity, cancellationToken).ConfigureAwait(false);
+                                var recognizedREsult = await OnRecognize(actionContext, activity, cancellationToken).ConfigureAwait(false);
 
                                 // TODO figure out way to not use turn state to pass this value back to caller.
-                                actionContext.State.SetValue(TurnPath.Recognized, recognized);
+                                actionContext.State.SetValue(TurnPath.Recognized, recognizedREsult);
+                                
+                                // Bug #3572 set these here, because if allowedInterruption is true then event is not emitted, but folks still want the value.
+                                var (name, score) = recognizedREsult.GetTopScoringIntent();
+                                actionContext.State.SetValue(TurnPath.TopIntent, name);
+                                actionContext.State.SetValue(TurnPath.TopScore, score);
+                                actionContext.State.SetValue(DialogPath.LastIntent, name);
 
                                 if (Recognizer != null)
                                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -430,13 +430,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                             if (activity.Type == ActivityTypes.Message)
                             {
                                 // Recognize utterance
-                                var recognizedREsult = await OnRecognize(actionContext, activity, cancellationToken).ConfigureAwait(false);
+                                var recognizedResult = await OnRecognize(actionContext, activity, cancellationToken).ConfigureAwait(false);
 
                                 // TODO figure out way to not use turn state to pass this value back to caller.
-                                actionContext.State.SetValue(TurnPath.Recognized, recognizedREsult);
+                                actionContext.State.SetValue(TurnPath.Recognized, recognizedResult);
                                 
                                 // Bug #3572 set these here, because if allowedInterruption is true then event is not emitted, but folks still want the value.
-                                var (name, score) = recognizedREsult.GetTopScoringIntent();
+                                var (name, score) = recognizedResult.GetTopScoringIntent();
                                 actionContext.State.SetValue(TurnPath.TopIntent, name);
                                 actionContext.State.SetValue(TurnPath.TopScore, score);
                                 actionContext.State.SetValue(DialogPath.LastIntent, name);


### PR DESCRIPTION
Fixes bug:
#3572 