### PR TITLE
add recipient in BotFrameworkHttpClient.PostActivityAsync if value is null

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             var originalConversationId = activity.Conversation.Id;
             var originalServiceUrl = activity.ServiceUrl;
             var originalRelatesTo = activity.RelatesTo;
+            var originalRecipient = activity.Recipient;
             try
             {
                 activity.RelatesTo = new ConversationReference()
@@ -99,6 +100,10 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 };
                 activity.Conversation.Id = conversationId;
                 activity.ServiceUrl = serviceUrl.ToString();
+                if (activity.Recipient == null)
+                {
+                    activity.Recipient = new ChannelAccount();
+                }
 
                 using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
                 {
@@ -130,6 +135,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 activity.Conversation.Id = originalConversationId;
                 activity.ServiceUrl = originalServiceUrl;
                 activity.RelatesTo = originalRelatesTo;
+                activity.Recipient = originalRecipient;
             }
         }
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpClientTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpClientTests.cs
@@ -1,10 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
-using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
@@ -35,6 +40,80 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             Assert.False(httpClient.DefaultRequestHeaders.Any());
             var client = new BotFrameworkHttpClient(httpClient, mockCredentialProvider.Object);
             Assert.True(httpClient.DefaultRequestHeaders.Any());
+        }
+
+        [Fact]
+        public async void AddsRecipientAndSetsItBackToNull()
+        {
+            Func<HttpRequestMessage, Task<HttpResponseMessage>> verifyRequestAndCreateResponse = (HttpRequestMessage request) =>
+            {
+                var content = request.Content.ReadAsStringAsync().Result;
+                var a = JsonConvert.DeserializeObject<Activity>(content);
+                Assert.NotNull(a.Recipient);
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+                response.Content = new StringContent(new JObject { }.ToString());
+                return Task.FromResult(response);
+            };
+
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns((HttpRequestMessage request, CancellationToken cancellationToken) => verifyRequestAndCreateResponse(request))
+                .Verifiable();
+
+            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+            var mockCredentialProvider = new Mock<ICredentialProvider>();
+
+            var client = new BotFrameworkHttpClient(httpClient, mockCredentialProvider.Object);
+            var activity = new Activity
+            {
+                Conversation = new ConversationAccount()
+            };
+
+            await client.PostActivityAsync(string.Empty, string.Empty, new Uri("https://skillbot.com/api/messages"), new Uri("https://parentbot.com/api/messages"), "NewConversationId", activity);
+
+            // Assert
+            Assert.Null(activity.Recipient);
+        }
+
+        [Fact]
+        public async void DoesNotOverwriteNonNullRecipientValues()
+        {
+            const string skillRecipientId = "skillBot";
+            Func<HttpRequestMessage, Task<HttpResponseMessage>> verifyRequestAndCreateResponse = (HttpRequestMessage request) =>
+            {
+                var content = request.Content.ReadAsStringAsync().Result;
+                var a = JsonConvert.DeserializeObject<Activity>(content);
+                Assert.NotNull(a.Recipient);
+                Assert.Equal(skillRecipientId, a.Recipient?.Id);
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+
+                response.Content = new StringContent(new JObject { }.ToString());
+                return Task.FromResult(response);
+            };
+
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns((HttpRequestMessage request, CancellationToken cancellationToken) => verifyRequestAndCreateResponse(request))
+                .Verifiable();
+
+            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+            var mockCredentialProvider = new Mock<ICredentialProvider>();
+
+            var client = new BotFrameworkHttpClient(httpClient, mockCredentialProvider.Object);
+            var activity = new Activity
+            {
+                Conversation = new ConversationAccount(),
+                Recipient = new ChannelAccount("skillBot")
+            };
+
+            await client.PostActivityAsync(string.Empty, string.Empty, new Uri("https://skillbot.com/api/messages"), new Uri("https://parentbot.com/api/messages"), "NewConversationId", activity);
+
+            // Assert
+            Assert.Equal("skillBot", activity?.Recipient?.Id);
         }
     }
 }


### PR DESCRIPTION
Fixes: #3684

### Description
If Activity.Recipient is null, this can cause skills to throw errors as the Recipient field is expected. This PR sets Recipient to an empty ChannelAccount if the value is null.

### Context
https://github.com/microsoft/botframework-sdk/issues/5785

### Testing
Added positive and negative tests for `BotFrameworkHttpClient.PostActivityAsync()` changes