### PR TITLE
Revert the reusing of json converters

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         private readonly ConcurrentDictionary<Type, ICustomDeserializer> kindDeserializers = new ConcurrentDictionary<Type, ICustomDeserializer>();
         private readonly ConcurrentDictionary<string, Type> kindToType = new ConcurrentDictionary<string, Type>();
         private readonly ConcurrentDictionary<Type, List<string>> typeToKinds = new ConcurrentDictionary<Type, List<string>>();
-        private readonly List<JsonConverter> converters = new List<JsonConverter>();
         private List<IResourceProvider> resourceProviders = new List<IResourceProvider>();
         private CancellationTokenSource cancelReloadToken = new CancellationTokenSource();
         private ConcurrentBag<IResource> changedResources = new ConcurrentBag<IResource>();
@@ -462,19 +461,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
 
         private T Load<T>(JToken token, SourceContext sourceContext)
         {
-            lock (this.converters)
+            var converters = new List<JsonConverter>();
+
+            // get converters
+            foreach (var component in ComponentRegistration.Components.Value.OfType<IComponentDeclarativeTypes>())
             {
-                if (this.converters.Count == 0)
+                var result = component.GetConverters(this, sourceContext);
+                if (result.Any())
                 {
-                    // get converters
-                    foreach (var component in ComponentRegistration.Components.Value.OfType<IComponentDeclarativeTypes>())
-                    {
-                        var result = component.GetConverters(this, sourceContext);
-                        if (result.Any())
-                        {
-                            converters.AddRange(result);
-                        }
-                    }
+                    converters.AddRange(result);
                 }
             }
 

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\libraries\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj" />
+    <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.AI.QnA\Microsoft.Bot.Builder.AI.QnA.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs.Adaptive\Microsoft.Bot.Builder.Dialogs.Adaptive.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs.Debugging\Microsoft.Bot.Builder.Dialogs.Debugging.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs.Declarative\Microsoft.Bot.Builder.Dialogs.Declarative.csproj" />

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/TestBot.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/TestBot.cs
@@ -11,6 +11,7 @@ using System.Reflection.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Bot.Builder.AI.QnA.Dialogs;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
@@ -58,6 +59,11 @@ namespace Microsoft.Bot.Builder.TestBot.Json
         private void LoadDialogs()
         {
             System.Diagnostics.Trace.TraceInformation("Loading resources...");
+
+            // Create a non-used dialog just to make sure the target assembly is referred so that
+            // the target assembly's component registration can be used to deserialize declarative components
+            var qnaDialog = new QnAMakerDialog();
+            System.Diagnostics.Trace.TraceInformation($"Touch ${qnaDialog.GetType().ToString()} to make sure assembly is referred.");
 
             var rootDialog = new AdaptiveDialog()
             {


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/botbuilder-dotnet/issues/3769 TestBot.Json broken in master


## Context

https://github.com/microsoft/botbuilder-dotnet/pull/3711 introduced a cache for json converters, in which json converters are created once when converting first json, and reused in later json conversion. 

The issue is, those json converters are stateful, in which SourceContext captured the state (the call stack).  In order to make it work as expected, the call stacked must be initialized with a SourceRange pushed to bottom of the stack, and this initialization only happens when creating those converters. 

So reusing the converters will not re-initializing the state, in this specific case, will not push a SourceRange into stack.  Then all the following source range registering will not get a path value, and fail to load. 

## Fix
The fix in this PR is simply reverting the cache and reusing behavior of converters.

If for performance reason or any other reasons we want to reuse the converters, we need an approach to reset the converters with state. Could simplify be making a sub-class of JsonConverter and add a reset method, or other approach. 

Anyhow, leave the systematic to @tomlm or @willportnoy. 