### PR TITLE
fix parsing datetime in dialogStateManager

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -710,11 +710,6 @@ namespace Microsoft.Bot.Builder.Dialogs
                 if (value is JToken || value is JObject || value is JArray)
                 {
                     val = Clone((JToken)value);
-                    if (val.GetType() == typeof(JValue) && ((JToken)val).Type == JTokenType.Date)
-                    {
-                        var temp = val.ToString();
-                        val = DateTime.Parse(temp).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
-                    }
                 }
                 else if (value == null)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -710,6 +710,10 @@ namespace Microsoft.Bot.Builder.Dialogs
                 if (value is JToken || value is JObject || value is JArray)
                 {
                     val = Clone((JToken)value);
+                    if (val.GetType() == typeof(JValue) && ((JToken)val).Type == JTokenType.Date)
+                    {
+                        val = DateTime.Parse(val.ToString()).ToString("yyyy-MM-ddThh:mm:ss.fffZ");
+                    }
                 }
                 else if (value == null)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -712,7 +712,8 @@ namespace Microsoft.Bot.Builder.Dialogs
                     val = Clone((JToken)value);
                     if (val.GetType() == typeof(JValue) && ((JToken)val).Type == JTokenType.Date)
                     {
-                        val = DateTime.Parse(val.ToString()).ToString("yyyy-MM-ddThh:mm:ss.fffZ");
+                        var temp = val.ToString();
+                        val = DateTime.Parse(temp).ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
                     }
                 }
                 else if (value == null)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
@@ -489,12 +489,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public void SetPathValue()
         {
             Dictionary<string, object> test = new Dictionary<string, object>();
+            ObjectPath.SetPathValue(test, "user.date", new JValue("2008-12-12T23:59:59.000Z"));
             ObjectPath.SetPathValue(test, "x.y.z", 15);
             ObjectPath.SetPathValue(test, "x.p", "hello");
             ObjectPath.SetPathValue(test, "foo", new { Bar = 15, Blat = "yo" });
             ObjectPath.SetPathValue(test, "x.a[1]", "yabba");
             ObjectPath.SetPathValue(test, "x.a[0]", "dabba");
             ObjectPath.SetPathValue(test, "null", null);
+            ObjectPath.SetPathValue(test, "enum", TypeCode.Empty);
             ObjectPath.SetPathValue(test, "enum", TypeCode.Empty);
 
             Assert.AreEqual(15, ObjectPath.GetPathValue<int>(test, "x.y.z"));
@@ -506,6 +508,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual("yabba", value2);
             Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "x.a[0]", out value2));
             Assert.AreEqual("dabba", value2);
+            Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "user.date", out var value3));
+            Assert.AreEqual("2008-12-12T23:59:59.000Z", value3);
             Assert.IsFalse(ObjectPath.TryGetPathValue<object>(test, "null", out var nullValue));
             Assert.AreEqual(TypeCode.Empty, ObjectPath.GetPathValue<TypeCode>(test, "enum"));
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
@@ -489,7 +489,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         public void SetPathValue()
         {
             Dictionary<string, object> test = new Dictionary<string, object>();
-            ObjectPath.SetPathValue(test, "user.date", new JValue("2008-12-12T23:59:59.000Z"));
             ObjectPath.SetPathValue(test, "x.y.z", 15);
             ObjectPath.SetPathValue(test, "x.p", "hello");
             ObjectPath.SetPathValue(test, "foo", new { Bar = 15, Blat = "yo" });
@@ -508,8 +507,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual("yabba", value2);
             Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "x.a[0]", out value2));
             Assert.AreEqual("dabba", value2);
-            Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "user.date", out var value3));
-            Assert.AreEqual("2008-12-12T23:59:59.000Z", value3);
             Assert.IsFalse(ObjectPath.TryGetPathValue<object>(test, "null", out var nullValue));
             Assert.AreEqual(TypeCode.Empty, ObjectPath.GetPathValue<TypeCode>(test, "enum"));
 


### PR DESCRIPTION
Original Issue: https://github.com/microsoft/BotFramework-Composer/issues/2731

When users use setProperty in dialog, timestamp string will be stored as 'JTokenType.Date' in memory. 
It will cause error when evaluating some datetime functions. Such as addSecond, addToTime, etc.

In this PR, the JTokenType.Date value will be converted to a ISO-8061 string. 
 
