### PR TITLE
[PORT] Bot Change Detection

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -58,6 +60,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
 
             return await OnNextActionAsync(dc, result, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override string GetVersion()
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var action in this.Actions)
+            {
+                var v = action.GetVersion();
+                if (v != null)
+                {
+                    sb.Append(v);
+                }
+            }
+
+            return Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(sb.ToString())));
         }
 
         public virtual IEnumerable<Dialog> GetDependencies()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using AdaptiveExpressions;
 using AdaptiveExpressions.Converters;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using AdaptiveExpressions;
 using AdaptiveExpressions.Properties;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             await EnsureInitializedAsync(outerDc).ConfigureAwait(false);
 
+            await this.CheckForVersionChangeAsync(outerDc).ConfigureAwait(false);
+
             var innerDc = this.CreateChildContext(outerDc);
             var turnResult = await OnBeginDialogAsync(innerDc, options, cancellationToken).ConfigureAwait(false);
 
@@ -116,6 +118,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <seealso cref="DialogContext.ContinueDialogAsync(CancellationToken)"/>
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext outerDc, CancellationToken cancellationToken = default(CancellationToken))
         {
+            await EnsureInitializedAsync(outerDc).ConfigureAwait(false);
+
+            await this.CheckForVersionChangeAsync(outerDc).ConfigureAwait(false);
+
             // Continue execution of inner dialog
             var innerDc = this.CreateChildContext(outerDc);
             var turnResult = await this.OnContinueDialogAsync(innerDc, cancellationToken).ConfigureAwait(false);
@@ -164,6 +170,8 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             await EnsureInitializedAsync(outerDc).ConfigureAwait(false);
+
+            await this.CheckForVersionChangeAsync(outerDc).ConfigureAwait(false);
 
             // Containers are typically leaf nodes on the stack but the dev is free to push other dialogs
             // on top of the stack which will result in the container receiving an unexpected call to

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -179,6 +179,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
+        /// Gets a unique string which represents the version of this dialog.  If the version changes between turns the dialog system will emit a DialogChanged event.
+        /// </summary>
+        /// <returns>Unique string which should only change when dialog has changed in a way that should restart the dialog.</returns>
+        public virtual string GetVersion()
+        {
+            return this.Id;
+        }
+
+        /// <summary>
         /// Called when an event has been raised, using `DialogContext.emitEvent()`, by either the current dialog or a dialog that the current dialog started.
         /// </summary>
         /// <param name="dc">The dialog context for the current turn of conversation.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 // Give bot an opportunity to handle the change.
                 // - If bot handles it the changeHash will have been updated as to avoid triggering the 
                 //   change again.
-                var handled = await dc.EmitEventAsync(DialogEvents.DialogChanged, this.Id, true, false).ConfigureAwait(false);
+                var handled = await dc.EmitEventAsync(DialogEvents.VersionChanged, this.Id, true, false).ConfigureAwait(false);
                 if (!handled)
                 {
                     // Throw an error for bot to catch

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -25,9 +26,19 @@ namespace Microsoft.Bot.Builder.Dialogs
             return this.Dialogs.Find(dialogId);
         }
 
-        public override string GetVersion()
+        /// <summary>
+        /// GetInternalVersion - Returns internal version identifier for this container.
+        /// </summary>
+        /// <remarks>
+        /// DialogContainers detect changes of all sub-components in the container and map that to an DialogChanged event.
+        /// Because they do this, DialogContainers "hide" the internal changes and just have the .id. This isolates changes
+        /// to the container level unless a container doesn't handle it.  To support this DialogContainers define a
+        /// protected virtual method GetInternalVersion() which computes if this dialog or child dialogs have changed
+        /// which is then examined via calls to CheckForVersionChangeAsync().
+        /// </remarks>
+        /// <returns>version which represents the change of the internals of this container.</returns>
+        protected virtual string GetInternalVersion()
         {
-            // use dialogset's concept of version.
             return this.Dialogs.GetVersion();
         }
 
@@ -42,13 +53,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// 
         /// This should be called at the start of `beginDialog()`, `continueDialog()`, and `resumeDialog()`.
         /// </remarks>
-        protected async Task CheckForVersionChangeAsync(DialogContext dc)
+        protected virtual async Task CheckForVersionChangeAsync(DialogContext dc)
         {
             var current = dc.ActiveDialog.Version;
-            dc.ActiveDialog.Version = this.GetVersion();
+            dc.ActiveDialog.Version = this.GetInternalVersion();
 
             // Check for change of previously stored hash
-            if (current != dc.ActiveDialog.Version)
+            if (current != null && current != dc.ActiveDialog.Version)
             {
                 // Give bot an opportunity to handle the change.
                 // - If bot handles it the changeHash will have been updated as to avoid triggering the 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
     public abstract class DialogContainer : Dialog
-    {       
+    {
         protected DialogContainer(string dialogId = null)
             : base(dialogId)
         {
@@ -21,6 +23,43 @@ namespace Microsoft.Bot.Builder.Dialogs
         public virtual Dialog FindDialog(string dialogId)
         {
             return this.Dialogs.Find(dialogId);
+        }
+
+        public override string GetVersion()
+        {
+            // use dialogset's concept of version.
+            return this.Dialogs.GetVersion();
+        }
+
+        /// <summary>
+        /// CheckForVersionChangeAsync.
+        /// </summary>
+        /// <param name="dc">dialog context.</param>
+        /// <returns>task.</returns>
+        /// <remarks>
+        /// Checks to see if a containers child dialogs have changed since the current dialog instance
+        /// was started.
+        /// 
+        /// This should be called at the start of `beginDialog()`, `continueDialog()`, and `resumeDialog()`.
+        /// </remarks>
+        protected async Task CheckForVersionChangeAsync(DialogContext dc)
+        {
+            var current = dc.ActiveDialog.Version;
+            dc.ActiveDialog.Version = this.GetVersion();
+
+            // Check for change of previously stored hash
+            if (current != dc.ActiveDialog.Version)
+            {
+                // Give bot an opportunity to handle the change.
+                // - If bot handles it the changeHash will have been updated as to avoid triggering the 
+                //   change again.
+                var handled = await dc.EmitEventAsync(DialogEvents.DialogChanged, this.Id, true, false).ConfigureAwait(false);
+                if (!handled)
+                {
+                    // Throw an error for bot to catch
+                    throw new Exception($"Version change detected for '{this.Id}' dialog.");
+                }
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         public const string RepromptDialog = "repromptDialog";
         public const string CancelDialog = "cancelDialog";
         public const string ActivityReceived = "activityReceived";
+        public const string DialogChanged = "dialogChanged";
         public const string Error = "error";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
@@ -5,11 +5,34 @@ namespace Microsoft.Bot.Builder.Dialogs
 {
     public class DialogEvents
     {
+        /// <summary>
+        /// Event fired when a dialog beginDialog() is called.
+        /// </summary>
         public const string BeginDialog = "beginDialog";
+
+        /// <summary>
+        /// Event fired when a dialog RepromptDialog is Called.
+        /// </summary>
         public const string RepromptDialog = "repromptDialog";
+
+        /// <summary>
+        /// Event fired when a dialog is canceled.
+        /// </summary>
         public const string CancelDialog = "cancelDialog";
+
+        /// <summary>
+        /// Event fired when an activity is received from the adapter (or a request to reprocess an activity).
+        /// </summary>
         public const string ActivityReceived = "activityReceived";
-        public const string DialogChanged = "dialogChanged";
+        
+        /// <summary>
+        /// Event which is fired when the system has detected that deployed code has changed the execution of dialogs between turns.
+        /// </summary>
+        public const string VersionChanged = "versionChanged";
+
+        /// <summary>
+        /// Event fired when there was an exception thrown in the system.
+        /// </summary>
         public const string Error = "error";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
@@ -41,5 +41,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// the parent DC.
         /// </value>
         public int? StackIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets version string.
+        /// </summary>
+        /// <value>Unique string from the dialog this dialoginstance is tracking which is used to identify when a dialog has changed in way that should emit an event for changed content.</value>
+        public string Version { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -43,30 +43,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
-        /// Gets a unique string which represents the version of this dialogset.  
-        /// </summary>
-        /// <returns>Version will change when any of the child dialogs version changes.</returns>
-        public virtual string GetVersion()
-        {
-            if (this._version == null)
-            {
-                StringBuilder sb = new StringBuilder();
-                foreach (var dialog in this._dialogs)
-                {
-                    var v = this._dialogs[dialog.Key].GetVersion();
-                    if (v != null)
-                    {
-                        sb.Append(v);
-                    }
-                }
-
-                this._version = Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(sb.ToString())));
-            }
-
-            return this._version;
-        }
-
-        /// <summary>
         /// Gets or sets the <see cref="IBotTelemetryClient"/> to use for logging.
         /// </summary>
         /// <value>The <see cref="IBotTelemetryClient"/> to use for logging.</value>
@@ -88,6 +64,30 @@ namespace Microsoft.Bot.Builder.Dialogs
                     dialog.TelemetryClient = _telemetryClient;
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets a unique string which represents the combined versions of all dialogs in this this dialogset.  
+        /// </summary>
+        /// <returns>Version will change when any of the child dialogs version changes.</returns>
+        public virtual string GetVersion()
+        {
+            if (this._version == null)
+            {
+                StringBuilder sb = new StringBuilder();
+                foreach (var dialog in this._dialogs)
+                {
+                    var v = this._dialogs[dialog.Key].GetVersion();
+                    if (v != null)
+                    {
+                        sb.Append(v);
+                    }
+                }
+
+                this._version = Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(sb.ToString())));
+            }
+
+            return this._version;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallDialog.cs
@@ -42,6 +42,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
+        /// Gets a unique string which represents the version of this dialog.  If the version changes between turns the dialog system will emit a DialogChanged event.
+        /// </summary>
+        /// <returns>Version will change when steps count changes (because dialog has no way of evaluating the content of the steps.</returns>
+        public override string GetVersion()
+        {
+            return $"{this.Id}:{_steps.Count}";
+        }
+
+        /// <summary>
         /// Adds a new step to the waterfall.
         /// </summary>
         /// <param name="step">Step to add.</param>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1204 // Static elements should appear before instance elements
 #pragma warning disable SA1210 // Using directives should be ordered alphabetically by namespace
 #pragma warning disable SA1202 // Elements should be ordered by access
+#pragma warning disable SA1201 // Elements should appear in the correct order
 
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -15,6 +16,9 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
+using Newtonsoft.Json.Linq;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
@@ -49,7 +53,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             await TestUtils.RunTestScript(ResourceExplorer);
         }
-        
+
         [TestMethod]
         public async Task AdaptiveDialog_AllowInterruption()
         {
@@ -299,6 +303,164 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 }
 
                 return await innerDc.BeginDialogAsync("doItems", new { Items = items }, cancellationToken);
+            }
+        }
+
+        [TestMethod]
+        public void AdaptiveDialog_GetInternalVersion()
+        {
+            var ds = new TestAdaptiveDialog();
+            var version1 = ds.GetInternalVersion_Test();
+            Assert.IsNotNull(version1);
+
+            var ds2 = new TestAdaptiveDialog();
+            var version2 = ds.GetInternalVersion_Test();
+            Assert.IsNotNull(version2);
+            Assert.AreEqual(version1, version2, "Same configuration should give same version");
+
+            ds2 = new TestAdaptiveDialog()
+            {
+                Triggers = new List<OnCondition>()
+                {
+                    new OnIntent("foo")
+                    {
+                    }
+                }
+            };
+
+            var version3 = ds2.GetInternalVersion_Test();
+            Assert.IsNotNull(version3);
+            Assert.AreNotEqual(version2, version3, "version should change if trigger added");
+
+            ds2 = new TestAdaptiveDialog()
+            {
+                Triggers = new List<OnCondition>()
+                {
+                    new OnIntent("foo")
+                    {
+                        Condition = "user.name == 'joe'"
+                    }
+                }
+            };
+
+            var version4 = ds2.GetInternalVersion_Test();
+            Assert.IsNotNull(version4);
+            Assert.AreNotEqual(version3, version4, "version should change if condition modified");
+
+            var ds3 = new TestAdaptiveDialog()
+            {
+                Triggers = new List<OnCondition>()
+                {
+                    new OnIntent("foo")
+                    {
+                        Condition = "user.name == 'joe'",
+                        Actions = new List<Dialog>()
+                        {
+                            new SendActivity() { Activity = new ActivityTemplate("yo") }
+                        }
+                    }
+                }
+            };
+
+            var version5 = ds3.GetInternalVersion_Test();
+            Assert.IsNotNull(version5);
+            Assert.AreNotEqual(version4, version5, "version should change if action added ");
+
+            var version6 = ds3.GetInternalVersion_Test();
+            Assert.AreEqual(version5, version6, "version should be same if no change");
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_ChangeDetect_None()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var storage = new MemoryStorage();
+            var adapter = new TestAdapter()
+                .UseStorage(storage)
+                .UseState(new UserState(storage), new ConversationState(storage));
+
+            var dm1 = new DialogManager(CreateDialog("test"));
+            var dm2 = new DialogManager(CreateDialog("test"));
+            var dialogManager = dm1;
+            await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
+            {
+                await dialogManager.OnTurnAsync(turnContext, cancellationToken);
+                dialogManager = dm2;
+            })
+                .Send("hello")
+                    .AssertReply("test")
+                .Send("hello")
+                    .AssertReply("test")
+                .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task AdaptiveDialog_ChangeDetect()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var storage = new MemoryStorage();
+            var adapter = new TestAdapter()
+                .UseStorage(storage)
+                .UseState(new UserState(storage), new ConversationState(storage));
+
+            var dm1 = new DialogManager(CreateDialog("test"));
+            var dm2 = new DialogManager(CreateDialog("test2"));
+            var dialogManager = dm1;
+            await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
+            {
+                await dialogManager.OnTurnAsync(turnContext, cancellationToken);
+                dialogManager = dm2;
+            })
+                .Send("hello")
+                    .AssertReply("test")
+                .Send("hello")
+                    .AssertReply("changed")
+                .Send("hello")
+                    .AssertReply("test2")
+                .StartTestAsync();
+        }
+
+        private static AdaptiveDialog CreateDialog(string custom)
+        {
+            return new AdaptiveDialog()
+            {
+                AutoEndDialog = false,
+                Recognizer = new RegexRecognizer()
+                {
+                    Intents = new List<IntentPattern>()
+                    {
+                    }
+                },
+                Triggers = new List<OnCondition>()
+                {
+                    new OnDialogEvent(DialogEvents.DialogChanged)
+                    {
+                        Actions = new List<Dialog>()
+                        {
+                            new SendActivity("changed")
+                        }
+                    },
+                    new OnUnknownIntent()
+                    {
+                        Actions = new List<Dialog>()
+                        {
+                            new SendActivity(custom)
+                        }
+                    }
+                }
+            };
+        }
+
+        public class TestAdaptiveDialog : AdaptiveDialog
+        {
+            public string GetInternalVersion_Test()
+            {
+                this.EnsureDependenciesInstalled();
+                return GetInternalVersion();
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 },
                 Triggers = new List<OnCondition>()
                 {
-                    new OnDialogEvent(DialogEvents.DialogChanged)
+                    new OnDialogEvent(DialogEvents.VersionChanged)
                     {
                         Actions = new List<Dialog>()
                         {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogContainerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogContainerTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma warning disable SA1402 // File may only contain a single type
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    [TestClass]
+    public class DialogContainerTests
+    {
+        [TestMethod]
+        public void DialogContainer_GetVersion()
+        {
+            var ds = new TestContainer();
+            var version1 = ds.GetInternalVersion_Test();
+            Assert.IsNotNull(version1);
+
+            var ds2 = new TestContainer();
+            var version2 = ds.GetInternalVersion_Test();
+            Assert.IsNotNull(version2);
+            Assert.AreEqual(version1, version2, "Same configuration should give same version");
+
+            ds2.Dialogs.Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
+            var version3 = ds2.GetInternalVersion_Test();
+            Assert.IsNotNull(version3);
+            Assert.AreNotEqual(version2, version3, "version should change if there is a dialog added");
+
+            var version4 = ds2.GetInternalVersion_Test();
+            Assert.IsNotNull(version3);
+            Assert.AreEqual(version3, version4, "version be same if there is no change");
+
+            var ds3 = new TestContainer();
+            ds3.Dialogs.Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
+
+            var version5 = ds3.GetInternalVersion_Test();
+            Assert.IsNotNull(version5);
+            Assert.AreEqual(version5, version4, "version be same if there is no change");
+
+            ds3.Property = "foobar";
+            var version6 = ds3.GetInternalVersion_Test();
+            Assert.IsNotNull(version6);
+            Assert.AreNotEqual(version6, version5, "version should change if property changes");
+
+            var ds4 = new TestContainer()
+            {
+                Property = "foobar"
+            };
+
+            ds4.Dialogs.Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
+            var version7 = ds4.GetInternalVersion_Test();
+            Assert.IsNotNull(version7);
+            Assert.AreEqual(version7, version6, "version be the same when constructed the same way");
+        }
+    }
+
+    public class TestContainer : DialogContainer
+    {
+        public string Property { get; set; }
+
+        public override Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
+        {
+            return dc.EndDialogAsync();
+        }
+
+        public override DialogContext CreateChildContext(DialogContext dc)
+        {
+            return dc;
+        }
+
+        public string GetInternalVersion_Test()
+        {
+            return GetInternalVersion();
+        }
+
+        protected override string GetInternalVersion()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(base.GetInternalVersion());
+            sb.Append(Property ?? string.Empty);
+
+            return Convert.ToBase64String(SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(sb.ToString())));
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -58,6 +59,35 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.IsNotNull(ds.Find("B"), "B is missing");
             Assert.IsNull(ds.Find("C"), "C should not be found");
             await Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public void DialogSet_VersionConsistent()
+        {
+            var ds = new DialogSet();
+            var version1 = ds.GetVersion();
+            Assert.IsNotNull(version1);
+
+            var ds2 = new DialogSet();
+            var version2 = ds.GetVersion();
+            Assert.IsNotNull(version2);
+            Assert.AreEqual(version1, version2, "Same configuration should give same version");
+
+            ds2.Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
+            var version3 = ds2.GetVersion();
+            Assert.IsNotNull(version3);
+            Assert.AreNotEqual(version2, version3, "version should change if there is a change");
+
+            var version4 = ds2.GetVersion();
+            Assert.IsNotNull(version3);
+            Assert.AreEqual(version3, version4, "version be same if there is no change");
+
+            var ds3 = new DialogSet()
+                .Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
+
+            var version5 = ds3.GetVersion();
+            Assert.IsNotNull(version5);
+            Assert.AreEqual(version5, version4, "version be same if there is no change");
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
-        public void DialogSet_VersionConsistent()
+        public void DialogSet_GetVersion()
         {
             var ds = new DialogSet();
             var version1 = ds.GetVersion();


### PR DESCRIPTION
* Add **dialoginstance.version** property for saving version string between turns.
* Add **dialog.GetVersion()** which allows a dialog to return unique string for a configuration
* Add **DialogSet.GetVersion()** which will be different if collection of dialogs and the GetVersion() have changed.
* Add **DialogContainer.GetInternalVersion()** - which detects at the container level internal changes for children.
Add **DialogContainer.CheckForVersionChange()** - which is called on BeginDialog/ContinueDialog/ResumeDialog() to detect that a dialogContainer has changed
* Add DialogEvents.VersionChanged event which is fired when change is detected
* Implement AdaptiveDialog.GetInternalVersion() to detect triggers changes, schema changes as well as dialog changes
Unit tests, etc.