### PR TITLE
make running storage emulators disabled on build server

### DIFF
--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -7,13 +7,13 @@ steps:
    New-Item CodeCoverage -ItemType Directory -Force
   displayName: 'Create Code Coverage directory'
 
-- task: petergroenewegen.PeterGroenewegen-Xpirit-Vsts-Build-InlinePowershell.Xpirit-Vsts-Build-InlinePowershell.InlinePowershell@1
-  displayName: 'Start CosmosDB Emulator'
-  inputs:
-    Script: |
-        Write-Host "Starting CosmosDB Emulator on Windows"
-        Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
-        Start-CosmosDbEmulator
+# - task: petergroenewegen.PeterGroenewegen-Xpirit-Vsts-Build-InlinePowershell.Xpirit-Vsts-Build-InlinePowershell.InlinePowershell@1
+#   displayName: 'Start CosmosDB Emulator'
+#   inputs:
+#     Script: |
+#         Write-Host "Starting CosmosDB Emulator on Windows"
+#         Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
+#         Start-CosmosDbEmulator
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release)'

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestInitialize]
         public async Task TestInit()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var container = CloudStorageAccount.Parse(ConnectionString)
                     .CreateCloudBlobClient()
@@ -45,28 +45,10 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public bool CheckEmulator()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var (code, output) = StorageEmulatorHelper.Status();
-                if (output.IndexOf("IsRunning: True") > 0)
-                {
-                    return true;
-                }
-
-                (code, output) = StorageEmulatorHelper.StartStorageEmulator();
-                return output.IndexOf("started") > 0;
-            }
-
-            Assert.Inconclusive("This test requires Azure Storage Emulator to run");
-            return false;
-        }
-
         [TestMethod]
         public void BlobStorageParamTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 Assert.ThrowsException<FormatException>(() => new AzureBlobStorage("123", ContainerName));
 
@@ -89,7 +71,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TestBlobStorageWriteRead()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 // Arrange
                 var storage = GetStorage();
@@ -114,7 +96,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TestBlobStorageWriteDeleteRead()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 // Arrange
                 var storage = GetStorage();
@@ -139,7 +121,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TestBlobStorageChanges()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 // Arrange
                 var storage = GetStorage();
@@ -161,7 +143,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TestConversationStateBlobStorage()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 // Arrange
                 var storage = GetStorage();
@@ -214,7 +196,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         private async Task TestConversationStateBlobStorage_Method(AzureBlobStorage storage)
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 // Arrange
                 var conversationState = new ConversationState(storage);

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             if (StorageEmulatorHelper.CheckEmulator())
             {
                 await ContainerInit();
-               
+
                 // Arrange
                 var storage = GetStorage();
                 var conversationState = new ConversationState(storage);
@@ -185,19 +185,28 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TestConversationStateBlobStorage_TypeNameHandlingDefault()
         {
-            await TestConversationStateBlobStorage_Method(GetStorage());
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                await TestConversationStateBlobStorage_Method(GetStorage());
+            }
         }
 
         [TestMethod]
         public async Task TestConversationStateBlobStorage_TypeNameHandlingNone()
         {
-            await TestConversationStateBlobStorage_Method(GetStorage(true));
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                await TestConversationStateBlobStorage_Method(GetStorage(true));
+            }
         }
 
         [TestMethod]
         public async Task StatePersistsThroughMultiTurn_TypeNameHandlingNone()
         {
-            await StatePersistsThroughMultiTurn(GetStorage(true));
+            if (StorageEmulatorHelper.CheckEmulator())
+            {
+                await StatePersistsThroughMultiTurn(GetStorage(true));
+            }
         }
 
         private async Task TestConversationStateBlobStorage_Method(AzureBlobStorage storage)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -33,23 +33,21 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // These tests require Azure Storage Emulator v5.7
-        [TestInitialize]
-        public async Task TestInit()
+        public async Task ContainerInit()
         {
-            if (StorageEmulatorHelper.CheckEmulator())
-            {
-                var container = CloudStorageAccount.Parse(ConnectionString)
-                    .CreateCloudBlobClient()
-                    .GetContainerReference(ContainerName);
-                await container.DeleteIfExistsAsync();
-            }
+            var container = CloudStorageAccount.Parse(ConnectionString)
+                .CreateCloudBlobClient()
+                .GetContainerReference(ContainerName);
+            await container.DeleteIfExistsAsync();
         }
 
         [TestMethod]
-        public void BlobStorageParamTest()
+        public async Task BlobStorageParamTest()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                await ContainerInit();
+
                 Assert.ThrowsException<FormatException>(() => new AzureBlobStorage("123", ContainerName));
 
                 Assert.ThrowsException<ArgumentNullException>(() =>
@@ -73,6 +71,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                await ContainerInit();
+
                 // Arrange
                 var storage = GetStorage();
 
@@ -98,6 +98,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                await ContainerInit();
+
                 // Arrange
                 var storage = GetStorage();
 
@@ -123,6 +125,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                await ContainerInit();
+
                 // Arrange
                 var storage = GetStorage();
 
@@ -145,6 +149,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                await ContainerInit();
+               
                 // Arrange
                 var storage = GetStorage();
                 var conversationState = new ConversationState(storage);
@@ -198,6 +204,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                await ContainerInit();
+
                 // Arrange
                 var conversationState = new ConversationState(storage);
                 var propAccessor = conversationState.CreateProperty<Prop>("prop");

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -72,22 +72,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public bool CheckEmulator()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return StorageEmulatorHelper.EnsureStarted();
-            }
-
-            Assert.Inconclusive("This test requires Azure Storage Emulator to run");
-            return false;
-        }
-
         // These tests require Azure Storage Emulator v5.7
         [TestMethod]
         public async Task TranscriptsEmptyTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var unusedChannelId = Guid.NewGuid().ToString();
                 var transcripts = await TranscriptStore.ListTranscriptsAsync(unusedChannelId);
@@ -99,7 +88,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task ActivityEmptyTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 foreach (var convoId in ConversationSpecialIds)
                 {
@@ -113,7 +102,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task ActivityAddTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var loggedActivities = new IActivity[5];
                 var activities = new List<IActivity>();
@@ -133,7 +122,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TranscriptRemoveTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 for (var i = 0; i < 5; i++)
                 {
@@ -151,7 +140,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task ActivityAddSpecialCharsTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var loggedActivities = new IActivity[ConversationSpecialIds.Length];
                 var activities = new List<IActivity>();
@@ -171,7 +160,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TranscriptRemoveSpecialCharsTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 for (var i = 0; i < ConversationSpecialIds.Length; i++)
                 {
@@ -189,7 +178,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task ActivityAddPagedResultTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var cleanChanel = Guid.NewGuid().ToString();
 
@@ -221,7 +210,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task TranscriptRemovePagedTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var loggedActivities = new PagedResult<IActivity>();
                 int i;
@@ -241,7 +230,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task LongIdAddTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 try
                 {
@@ -263,7 +252,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public void BlobTranscriptParamTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 Assert.ThrowsException<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
 
@@ -284,7 +273,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestMethod]
         public async Task NullBlobTest()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 AzureBlobTranscriptStore store = null;
 
@@ -299,7 +288,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestCategory("Middleware")]
         public async Task LogActivities()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
                 TestAdapter adapter = new TestAdapter(conversation)
@@ -346,7 +335,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestCategory("Middleware")]
         public async Task LogUpdateActivities()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
                 TestAdapter adapter = new TestAdapter(conversation)
@@ -388,7 +377,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestCategory("Middleware")]
         public async Task TestDateLogUpdateActivities()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var dateTimeStartOffset1 = new DateTimeOffset(DateTime.Now);
                 var dateTimeStartOffset2 = new DateTimeOffset(DateTime.UtcNow);
@@ -445,7 +434,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestCategory("Middleware")]
         public async Task LogDeleteActivities()
         {
-            if (CheckEmulator())
+            if (StorageEmulatorHelper.CheckEmulator())
             {
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
                 TestAdapter adapter = new TestAdapter(conversation)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -60,16 +60,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         // These tests require Azure Storage Emulator v5.7
-        [TestInitialize]
-        public void TestInit()
+        public void ContainerInit()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var container = CloudStorageAccount.Parse(ConnectionString)
-                    .CreateCloudBlobClient()
-                    .GetContainerReference(ContainerName);
-                container.DeleteIfExists();
-            }
+            var container = CloudStorageAccount.Parse(ConnectionString)
+                .CreateCloudBlobClient()
+                .GetContainerReference(ContainerName);
+            container.DeleteIfExists();
         }
 
         // These tests require Azure Storage Emulator v5.7
@@ -78,6 +74,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+
                 var unusedChannelId = Guid.NewGuid().ToString();
                 var transcripts = await TranscriptStore.ListTranscriptsAsync(unusedChannelId);
                 Assert.AreEqual(transcripts.Items.Length, 0);
@@ -90,6 +88,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 foreach (var convoId in ConversationSpecialIds)
                 {
                     var activities = await TranscriptStore.GetTranscriptActivitiesAsync(ChannelId, convoId);
@@ -104,6 +104,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var loggedActivities = new IActivity[5];
                 var activities = new List<IActivity>();
                 for (var i = 0; i < 5; i++)
@@ -124,6 +126,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 for (var i = 0; i < 5; i++)
                 {
                     var a = CreateActivity(i, i, ConversationIds);
@@ -142,6 +146,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var loggedActivities = new IActivity[ConversationSpecialIds.Length];
                 var activities = new List<IActivity>();
                 for (var i = 0; i < ConversationSpecialIds.Length; i++)
@@ -162,6 +168,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 for (var i = 0; i < ConversationSpecialIds.Length; i++)
                 {
                     var a = CreateActivity(i, i, ConversationSpecialIds);
@@ -180,6 +188,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var cleanChanel = Guid.NewGuid().ToString();
 
                 var loggedPagedResult = new PagedResult<IActivity>();
@@ -212,6 +222,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var loggedActivities = new PagedResult<IActivity>();
                 int i;
                 for (i = 0; i < ConversationSpecialIds.Length; i++)
@@ -232,6 +244,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
                 try
                 {
                     var a = CreateActivity(0, 0, LongId);
@@ -254,6 +267,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
                 Assert.ThrowsException<FormatException>(() => new AzureBlobTranscriptStore("123", ContainerName));
 
                 Assert.ThrowsException<ArgumentNullException>(() =>
@@ -275,6 +289,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
                 AzureBlobTranscriptStore store = null;
 
                 await Assert.ThrowsExceptionAsync<NullReferenceException>(async () =>
@@ -290,6 +305,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
                 TestAdapter adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));
@@ -337,6 +354,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
                 TestAdapter adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));
@@ -379,6 +398,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var dateTimeStartOffset1 = new DateTimeOffset(DateTime.Now);
                 var dateTimeStartOffset2 = new DateTimeOffset(DateTime.UtcNow);
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
@@ -436,6 +457,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {
+                ContainerInit();
+                
                 var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
                 TestAdapter adapter = new TestAdapter(conversation)
                     .Use(new TranscriptLoggerMiddleware(TranscriptStore));

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
         {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
+            {
+                return false;
+            }
+
             if (File.Exists(_emulatorPath))
             {
                 var p = new Process

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
             {
                 return false;
             }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
             {
                 return false;
             }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         private static readonly string _emulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
         private static readonly Lazy<bool> _hasEmulator = new Lazy<bool>(() =>
         {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
+            {
+                return false;
+            }
+
             if (File.Exists(_emulatorPath))
             {
                 var tries = 5;
@@ -82,7 +87,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         [TestInitialize]
         public void TestInit()
         {
-            if (_hasEmulator.Value)
+            if (CheckEmulator())
             {
                 _storage = new CosmosDbStorage(new CosmosDbStorageOptions
                 {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // These tests require Azure Storage Emulator v5.7
 // The emulator must be installed at this path C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe
@@ -37,6 +39,29 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             /// <summary>Clear command</summary>
             Clear,
+        }
+
+        public static bool CheckEmulator()
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
+            {
+                Assert.Inconclusive("This test requires Azure Storage Emulator to run and is disabled on the build server.");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var (code, output) = StorageEmulatorHelper.Status();
+                if (output.IndexOf("IsRunning: True") > 0)
+                {
+                    return true;
+                }
+
+                (code, output) = StorageEmulatorHelper.StartStorageEmulator();
+                return output.IndexOf("started") > 0;
+            }
+
+            Assert.Inconclusive("This test requires Azure Storage Emulator to run");
+            return false;
         }
 
         public static bool EnsureStarted()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         public static bool CheckEmulator()
         {
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
             {
                 Assert.Inconclusive("This test requires Azure Storage Emulator to run and is disabled on the build server.");
                 return false;

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/StorageEmulatorHelper.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsBuildServer")))
             {
                 Assert.Inconclusive("This test requires Azure Storage Emulator to run and is disabled on the build server.");
+                return false;
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Running storage in cloud is not being reliable.  This consolidates the code in the unit tests so we can disable if running on build server.