### PR TITLE
Check for null on Activity.From when logging telemetry

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMaker.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             properties.Add(QnATelemetryConstants.KnowledgeBaseIdProperty, _endpoint.KnowledgeBaseId);
 
             var text = turnContext.Activity.Text;
-            var userName = turnContext.Activity.From.Name;
+            var userName = turnContext.Activity.From?.Name;
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text and user name are common examples
             if (this.LogPersonalInformation)


### PR DESCRIPTION
Fixes #3814 - null reference exception when logging telemetry and [From] property is null.