### PR TITLE
Adds serialization fix for #3833

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -209,6 +209,12 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else
                     {
+                        if (activityFromSkill.Type == ActivityTypesEx.InvokeResponse && activityFromSkill.Value is JObject jObject)
+                        {
+                            // Ensure the value in the invoke response is of type InvokeResponse (it gets deserialized as JObject by default).
+                            activityFromSkill.Value = jObject.ToObject<InvokeResponse>();
+                        }
+
                         // Send the response back to the channel. 
                         await context.SendActivityAsync(activityFromSkill, cancellationToken).ConfigureAwait(false);
                     }


### PR DESCRIPTION
Added code to ensure that InvokeResponse values are deserialized as InvokeResponse (they come as JObject in C# by default)