### PR TITLE
Fix signature of LanguageGenerator base class

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGeneratorBase.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/MultiLanguageGeneratorBase.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// <param name="template">The template.</param>
         /// <param name="data">data to bind to.</param>
         /// <returns>The generator.</returns>
-        public override async Task<string> Generate(DialogContext dialogContext, string template, object data)
+        public override async Task<object> Generate(DialogContext dialogContext, string template, object data)
         {
             var targetLocale = dialogContext.Context.Activity.Locale?.ToLower() ?? string.Empty;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -85,11 +85,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// <param name="template">template to evaluate.</param>
         /// <param name="data">data to bind to.</param>
         /// <returns>generated text.</returns>
-        public override async Task<string> Generate(DialogContext dialogContext, string template, object data)
+        public override async Task<object> Generate(DialogContext dialogContext, string template, object data)
         {
             try
             {
-                return await Task.FromResult(lg.EvaluateText(template, data).ToString());
+                return await Task.FromResult(lg.EvaluateText(template, data));
             }
             catch (Exception err)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGenerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <param name="dialogContext">dialogContext.</param>
         /// <param name="template">template or [templateId].</param>
         /// <param name="data">data to bind to.</param>
-        /// <returns>text.</returns>
-        public abstract Task<string> Generate(DialogContext dialogContext, string template, object data);
+        /// <returns>object or text.</returns>
+        public abstract Task<object> Generate(DialogContext dialogContext, string template, object data);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
-    public static class LGExtensions
+    public static class LanguageGeneratorExtensions
     {
         private static Dictionary<ResourceExplorer, LanguageGeneratorManager> languageGeneratorManagers = new Dictionary<ResourceExplorer, LanguageGeneratorManager>();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
                     dialogContext,
                     template: Template,
                     data: data ?? dialogContext.State).ConfigureAwait(false);
-                return result;
+                return result.ToString();
             }
 
             return null;

--- a/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
@@ -56,9 +56,7 @@ namespace Microsoft.Bot.Builder
 
             if (lgResult is string lgStringResult)
             {
-                var isStructuredLG = ParseStructuredLGResult(lgStringResult, out var lgStructuredResult);
-                return isStructuredLG ? BuildActivityFromLGStructuredResult(lgStructuredResult)
-                    : BuildActivityFromText(lgStringResult?.Trim());
+                return BuildActivityFromText(lgStringResult?.Trim());
             }
 
             try
@@ -444,39 +442,6 @@ namespace Microsoft.Bot.Builder
             {
                 return false;
             }
-        }
-
-        /// <summary>
-        /// parse the lg string output. If the output is structured result, get the object result and return true.
-        /// </summary>
-        /// <param name="lgStringResult">lg string output.</param>
-        /// <param name="lgStructuredResult">lg json object result.</param>
-        /// <returns>judge if the lg string output is structured result.</returns>
-        private static bool ParseStructuredLGResult(string lgStringResult, out JObject lgStructuredResult)
-        {
-            lgStructuredResult = new JObject();
-            lgStringResult = lgStringResult?.Trim();
-
-            if (string.IsNullOrWhiteSpace(lgStringResult)
-                || !lgStringResult.StartsWith("{") || !lgStringResult.EndsWith("}"))
-            {
-                return false;
-            }
-
-            try
-            {
-                lgStructuredResult = JObject.Parse(lgStringResult);
-                if (string.IsNullOrWhiteSpace(GetStructureType(lgStructuredResult)))
-                {
-                    return false;
-                }
-            }
-            catch
-            {
-                return false;
-            }
-
-            return true;
         }
 
         private static IList<string> CheckStructuredResult(JObject lgJObj)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dynamic data = new JObject();
             data.title = "titleContent";
             data.text = "textContent";
-            var lgResult = GetNormalStructureLGFile().Evaluate("HerocardWithCardAction", data).ToString();
+            var lgResult = GetNormalStructureLGFile().Evaluate("HerocardWithCardAction", data);
             var activity = ActivityFactory.FromObject(lgResult);
             AssertCardActionActivity(activity);
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             dynamic data = new JObject();
             data.adaptiveCardTitle = "test";
-            var lgResult = GetNormalStructureLGFile().Evaluate("adaptivecardActivity", data).ToString();
+            var lgResult = GetNormalStructureLGFile().Evaluate("adaptivecardActivity", data);
             var activity = ActivityFactory.FromObject(lgResult);
             AssertAdaptiveCardActivity(activity);
         }
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         {
             dynamic data = new JObject();
             data.adaptiveCardTitle = "test";
-            var lgResult = GetNormalStructureLGFile().Evaluate("externalAdaptiveCardActivity", data).ToString();
+            var lgResult = GetNormalStructureLGFile().Evaluate("externalAdaptiveCardActivity", data);
             var activity = ActivityFactory.FromObject(lgResult);
             AssertAdaptiveCardActivity(activity);
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                     }
                 });
 
-                await dialogContext.Context.SendActivityAsync(result);
+                await dialogContext.Context.SendActivityAsync(result.ToString());
 
                 return await dialogContext.EndDialogAsync();
             }
@@ -473,9 +473,9 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
     public class MockLanguageGenerator : LanguageGenerator
     {
-        public override Task<string> Generate(DialogContext dialogContext, string template, object data)
+        public override Task<object> Generate(DialogContext dialogContext, string template, object data)
         {
-            return Task.FromResult(template);
+            return Task.FromResult((object)template);
         }
     }
 }


### PR DESCRIPTION
fixes #3558

LG returns an object when binding to herocards/activity.
object was being serialized to JSON, then run through code to detect if it's JSON and convert it to an object.  
This was all because LanguageGenerator.Generate() had signature of string for the return type.
Changes
* Changed Generate() to return an object
* Removed goofy code with double-deserialization
* Updated unit tests to not do goofy double-deserialization
* also made LGExtensions class name match other classes in system.