### PR TITLE
[Expression] Add formatNumber, formatEpoch and  formatTicks as prebuilt functions

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -4077,12 +4077,14 @@ namespace AdaptiveExpressions
                     ApplyWithError(
                         args => 
                         {
-                            double? result = null;
+                            string result = null;
                             string error = null;
                             var originalNum = CultureInvariantDoubleConvert(args[0]);
-                            if (args[1] is int digits)
+                            if (args[1].IsInteger())
                             {
-                                result = Math.Round(originalNum, digits);
+                                var digits = Convert.ToInt32(args[1]);
+                                var fmt = "0." + new string('0', digits);
+                                result = Math.Round(originalNum, digits).ToString(fmt, CultureInfo.InvariantCulture);
                             }
                             else
                             {
@@ -4091,7 +4093,7 @@ namespace AdaptiveExpressions
 
                             return (result, error);
                         }), 
-                    ReturnType.Number, 
+                    ReturnType.String, 
                     ValidateBinaryNumber),
 
                 // Misc

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -4072,6 +4072,27 @@ namespace AdaptiveExpressions
                 new ExpressionEvaluator(ExpressionType.String, Apply(args => JsonConvert.SerializeObject(args[0]).TrimStart('"').TrimEnd('"')), ReturnType.String, ValidateUnary),
                 Comparison(ExpressionType.Bool, args => IsLogicTrue(args[0]), ValidateUnary),
                 new ExpressionEvaluator(ExpressionType.Xml, ApplyWithError(args => ToXml(args[0])), ReturnType.String, ValidateUnary),
+                new ExpressionEvaluator(
+                    ExpressionType.FormatNumber, 
+                    ApplyWithError(
+                        args => 
+                        {
+                            double? result = null;
+                            string error = null;
+                            var originalNum = CultureInvariantDoubleConvert(args[0]);
+                            if (args[1] is int digits)
+                            {
+                                result = Math.Round(originalNum, digits);
+                            }
+                            else
+                            {
+                                error = $"The second parameter {args[1]} should be an integer";
+                            }
+
+                            return (result, error);
+                        }), 
+                    ReturnType.Number, 
+                    ValidateBinaryNumber),
 
                 // Misc
                 new ExpressionEvaluator(ExpressionType.Accessor, Accessor, ReturnType.Object, ValidateAccessor),

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -4122,7 +4122,7 @@ namespace AdaptiveExpressions
                             {
                                 error = $"formatNumber first argument ${args[0]} must be number";
                             }
-                            else if (!args[1].IsNumber())
+                            else if (!args[1].IsInteger())
                             {
                                 error = $"formatNumber second argument ${args[1]} must be number";
                             }
@@ -4137,7 +4137,7 @@ namespace AdaptiveExpressions
                                     var number = Convert.ToDouble(args[0]);
                                     var precision = Convert.ToInt32(args[1]);
                                     var locale = args.Count == 3 ? new CultureInfo(args[2] as string) : CultureInfo.InvariantCulture;
-                                    result = number.ToString("F" + precision.ToString(), locale);
+                                    result = number.ToString("N" + precision.ToString(), locale);
                                 }
                                 catch
                                 {

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -87,6 +87,8 @@ namespace AdaptiveExpressions
         public const string Year = "year";
         public const string UtcNow = "utcNow";
         public const string FormatDateTime = "formatDateTime";
+        public const string FormatEpoch = "formatEpoch";
+        public const string FormatTicks = "formatTicks";
         public const string SubtractFromTime = "subtractFromTime";
         public const string DateReadBack = "dateReadBack";
         public const string GetTimeOfDay = "getTimeOfDay";

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -124,6 +124,7 @@ namespace AdaptiveExpressions
         public const string UriComponent = "uriComponent";
         public const string UriComponentToString = "uriComponentToString";
         public const string Xml = "xml";
+        public const string FormatNumber = "formatNumber";
 
         // URI Parsing Functions
         public const string UriHost = "uriHost";

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -231,7 +231,13 @@ namespace AdaptiveExpressions.Tests
             Test("formatDateTime(notValidTimestamp)"), // error datetime format
             Test("formatDateTime(notValidTimestamp2)"), // error datetime format
             Test("formatDateTime(notValidTimestamp3)"), // error datetime format
-            Test("formatDateTime(timestamp, 'yyyy', 1)"), // should have 2 or 3 params
+            Test("formatDateTime({})"), // error valid datetime
+            Test("formatDateTime(timestamp, 1)"), // invalid format string
+            Test("formatEpoch('time')"), // error string
+            Test("formatEpoch(timestamp, 'yyyy', 1)"), // should have 1 or 2 params
+            Test("formatTicks('string')"), // String is not valid
+            Test("formatTicks(2.3)"), // float is not valid
+            Test("formatTicks({})"), // object is not valid
             Test("subtractFromTime('errortime', 'yyyy', 1)"), // error datetime format
             Test("subtractFromTime(timestamp, 1, 'W')"), // error time unit
             Test("subtractFromTime(timestamp, timestamp, 'W')"), // error parameters format
@@ -341,7 +347,7 @@ namespace AdaptiveExpressions.Tests
             Test("sortBy(createArray('H','e','l','l','o'), 'x', hi)"), // second param should be string
 #endregion
 
-#region Object manipulation and construction functions test
+            #region Object manipulation and construction functions test
             Test("json(1,2)"), // should have 1 parameter
             Test("json(1)"), // should be string parameter
             Test("json('{\"key1\":value1\"}')"), // invalid json format string 
@@ -359,25 +365,25 @@ namespace AdaptiveExpressions.Tests
             Test("jPath(hello,'Manufacturers[0].Products[0].Price')"), // not a valid json
             Test("jPath(hello,'Manufacturers[0]/Products[0]/Price')"), // not a valid path
             Test("jPath(jsonStr,'$..Products[?(@.Price >= 100)].Name')"), // no matched node
-#endregion
+            #endregion
 
-#region Memory access test
+            #region Memory access test
             Test("getProperty(bag, 1)"), // second param should be string
             Test("Accessor(1)"), // first param should be string
             Test("Accessor(bag, 1)"), // second should be object
             Test("one[0]"),  // one is not list
             Test("items[3]"), // index out of range
             Test("items[one+0.5]"), // index is not integer
-#endregion
+            #endregion
             
-#region Regex
+            #region Regex
             Test("isMatch('^[a-z]+$')"), // should have 2 parameter
             Test("isMatch('abC', one)"), // second param should be string
             Test("isMatch(1, '^[a-z]+$')"), // first param should be string
             Test("isMatch('abC', '^[a-z+$')"), // bad regular expression
-#endregion
+            #endregion
 
-#region Type Checking
+            #region Type Checking
             Test("isString(hello, hello)"), // should have 1 parameter
             Test("isInteger(2, 3)"), // should have 1 parameter
             Test("isFloat(1.2, 3.1)"), // should have 1 parameter
@@ -385,18 +391,18 @@ namespace AdaptiveExpressions.Tests
             Test("isObejct(emptyJObject, hello)"), // should have 1 parameter
             Test("isDateTime('2018-03-15T13:00:00.000Z', hello)"), // should have 1 parameter
             Test("isBoolean(false, false)"), // should have 1 parameter
-#endregion
+            #endregion
 
-#region SetPathToValue tests
+            #region SetPathToValue tests
             Test("setPathToValue(2+3, 4)"), // Not a real path
             Test("setPathToValue(a)"), // Missing value
-#endregion
+            #endregion
 
-#region TriggerTree Tests
+            #region TriggerTree Tests
 
             // optional throws because it's a placeholder only interpreted by trigger tree and is removed before evaluation
             Test("optional(true)"), 
-#endregion
+            #endregion
         };
 
         /// <summary>

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -139,6 +139,9 @@ namespace AdaptiveExpressions.Tests
             Test("base64ToBinary(one)"), // should have string param
             Test("base64ToString(hello, world)"), // shoule have 1 param
             Test("base64ToString(false)"), // should have string param
+            Test("formatNumber(1,2,3)"), // should have 2 parameters
+            Test("formatNumber(1,2.0)"), // the second parameter should be an integer
+            Test("formatNumber(hello,2.0)"), // the first parameter should be a number
             #endregion
 
             #region Math functions test

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -139,7 +139,8 @@ namespace AdaptiveExpressions.Tests
             Test("base64ToBinary(one)"), // should have string param
             Test("base64ToString(hello, world)"), // shoule have 1 param
             Test("base64ToString(false)"), // should have string param
-            Test("formatNumber(1,2,3)"), // should have 2 parameters
+            Test("formatNumber(1,2,3)"), // invalid locale type
+            Test("formatNumber(1,2,'dlkj'"), // invalid locale
             Test("formatNumber(1,2.0)"), // the second parameter should be an integer
             Test("formatNumber(hello,2.0)"), // the first parameter should be a number
             #endregion

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -632,6 +632,10 @@ namespace AdaptiveExpressions.Tests
             Test("uriComponentToString('http%3A%2F%2Fcontoso.com')", "http://contoso.com"),
             Test("json(jsonContainsDatetime).date", "/Date(634250351766060665)/"),
             Test("json(jsonContainsDatetime).invalidDate", "/Date(whatever)/"),
+            Test("formatNumber(12.123, 2)", 12.12),
+            Test("formatNumber(20, 2)", 20.00),
+            Test("formatNumber(1.555, 2)", 1.56),
+            Test("formatNumber(12.123, 4)", 12.1230),
 
             #endregion
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -633,7 +633,7 @@ namespace AdaptiveExpressions.Tests
             Test("json(jsonContainsDatetime).invalidDate", "/Date(whatever)/"),
             Test("formatNumber(20.0000, 2)", "20.00"),
             Test("formatNumber(12.123, 2)", "12.12"),
-            Test("formatNumber(1.555, 2)", "1.56"),
+            Test("formatNumber(1.551, 2)", "1.55"),
             Test("formatNumber(12.123, 4)", "12.1230"),
             Test("formatNumber(12000.3, 4, 'fr-fr')", "12\x00a0000,3000"),
             #endregion

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -633,7 +633,7 @@ namespace AdaptiveExpressions.Tests
             Test("json(jsonContainsDatetime).invalidDate", "/Date(whatever)/"),
             Test("formatNumber(20.0000, 2)", "20.00"),
             Test("formatNumber(12.123, 2)", "12.12"),
-            Test("formatNumber(1.555, 2)", "1.55"),
+            Test("formatNumber(1.555, 2)", "1.56"),
             Test("formatNumber(12.123, 4)", "12.1230"),
             Test("formatNumber(12000.3, 4, 'fr-fr')", "12\x00a0000,3000"),
             #endregion

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -635,6 +635,7 @@ namespace AdaptiveExpressions.Tests
             Test("formatNumber(12.123, 2)", "12.12"),
             Test("formatNumber(1.555, 2)", "1.56"),
             Test("formatNumber(12.123, 4)", "12.1230"),
+            Test("formatNumber(12000.3, 4, 'fr-fr')", "12.000,3000"),
             #endregion
 
             #region  Math functions test

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -312,7 +312,6 @@ namespace AdaptiveExpressions.Tests
             Test("json(`{\"foo\":${{text:\"hello\"}},\"item\": \"${world}\"}`).foo.text", "hello"),
             Test("json(`{\"foo\":${{\"text\":\"hello\"}},\"item\": \"${world}\"}`).foo.text", "hello"),
             Test("`{expr: hello all}`", "{expr: hello all}"),
-
             #endregion
 
             #region SetPathToProperty test
@@ -632,6 +631,10 @@ namespace AdaptiveExpressions.Tests
             Test("uriComponentToString('http%3A%2F%2Fcontoso.com')", "http://contoso.com"),
             Test("json(jsonContainsDatetime).date", "/Date(634250351766060665)/"),
             Test("json(jsonContainsDatetime).invalidDate", "/Date(whatever)/"),
+            Test("formatNumber(20.0000, 2)", "20.00"),
+            Test("formatNumber(12.123, 2)", "12.12"),
+            Test("formatNumber(1.555, 2)", "1.56"),
+            Test("formatNumber(12.123, 4)", "12.1230"),
             #endregion
 
             #region  Math functions test

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -633,9 +633,9 @@ namespace AdaptiveExpressions.Tests
             Test("json(jsonContainsDatetime).invalidDate", "/Date(whatever)/"),
             Test("formatNumber(20.0000, 2)", "20.00"),
             Test("formatNumber(12.123, 2)", "12.12"),
-            Test("formatNumber(1.555, 2)", "1.56"),
+            Test("formatNumber(1.555, 2)", "1.55"),
             Test("formatNumber(12.123, 4)", "12.1230"),
-            Test("formatNumber(12000.3, 4, 'fr-fr')", "12.000,3000"),
+            Test("formatNumber(12000.3, 4, 'fr-fr')", "12\x00a0000,3000"),
             #endregion
 
             #region  Math functions test

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -280,6 +280,10 @@ namespace AdaptiveExpressions.Tests
 
         public static IEnumerable<object[]> Data => new[]
         {
+            Test("formatNumber(20.0000, 2)", "20.00"),
+            Test("formatNumber(12.123, 2)", "12.12"),
+            Test("formatNumber(1.555, 2)", "1.56"),
+            Test("formatNumber(12.123, 4)", "12.1230"),
             #region accessor and element
             Test("`hi\\``", "hi`"),  // `hi\`` -> hi`
             Test("`hi\\y`", "hi\\y"), // `hi\y` -> hi\y
@@ -632,10 +636,6 @@ namespace AdaptiveExpressions.Tests
             Test("uriComponentToString('http%3A%2F%2Fcontoso.com')", "http://contoso.com"),
             Test("json(jsonContainsDatetime).date", "/Date(634250351766060665)/"),
             Test("json(jsonContainsDatetime).invalidDate", "/Date(whatever)/"),
-            Test("formatNumber(12.123, 2)", 12.12),
-            Test("formatNumber(20, 2)", 20.00),
-            Test("formatNumber(1.555, 2)", 1.56),
-            Test("formatNumber(12.123, 4)", 12.1230),
 
             #endregion
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -707,10 +707,10 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(evaled, "{\"ctx\":{\"count\":13}}");
 
             evaled = templates.Evaluate("template10");
-            Assert.AreEqual(evaled, 13);
+            Assert.AreEqual(evaled, 13L);
 
             evaled = templates.Evaluate("template11");
-            Assert.AreEqual(evaled, 18);
+            Assert.AreEqual(evaled, 18L);
         }
 
         [TestMethod]


### PR DESCRIPTION
Refers to the first question in https://github.com/microsoft/botbuilder-dotnet/issues/3873

formatNumber(num1, num2), takes two arguments, the first one should be a numeric value, and the second one should be an integer. The returned value is a string
Examples
formatNumber(12.123, 2) =  "12.12"
formatNumber(20, 2) =  "20.00"
formatNumber(1.555, 2) = "1.56"
formatNumber(12.123, 4) = "12.1230"

Added formatEpoch and formatTicks. 
formatEpoch(1521118800) -> 2018-03-15T13:00:00.000Z
formatTicks(637243624200000000) -> 2020-05-06T11:47:00.000Z

Removed ticks functionality from formatDateTime.

Fixed an issue where JSON conversion would truncate 64 bit values and doubles.