### PR TITLE
[Demo Purpose] fix 3913 by checking if dialog exists

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Observers
                 // to conserve references.
                 if (cache.ContainsKey(hashCode))
                 {
-                    result = ObjectPath.Clone<T>(cache[hashCode] as T);
+                    result = cache[hashCode] as T;
                 }
 
                 // If we don't have a cached value for this hash code, we send null as the value.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(dialog));
             }
 
-            if (_dialogs.ContainsKey(dialog.Id))
+            if (_dialogs.ContainsKey(dialog.Id) && _dialogs[dialog.Id] != dialog)
             {
                 var nextSuffix = 2;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(dialog));
             }
 
-            if (_dialogs.ContainsKey(dialog.Id) && _dialogs[dialog.Id] != dialog)
+            if (_dialogs.ContainsKey(dialog.Id))
             {
                 // If we are trying to add the same exact instance, it's not a name collision.
                 // No operation required since the instance is already in the dialog set.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/IssueTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/IssueTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma warning disable SA1118 // Parameter should not span multiple lines
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    [TestClass]
+    public class IssueTests
+    {
+        public static ResourceExplorer ResourceExplorer { get; set; }
+
+        public TestContext TestContext { get; set; }
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            ResourceExplorer = new ResourceExplorer()
+                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(IssueTests)), monitorChanges: false);
+        }
+
+        [TestMethod]
+        public async Task Issue_3913()
+        {
+            await TestUtils.RunTestScript(ResourceExplorer);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913.test.dialog
@@ -5,7 +5,6 @@
         "$kind": "Microsoft.AdaptiveDialog",
         "recognizer": {
             "$kind": "Microsoft.RegexRecognizer",
-            "id": "x",
             "intents": [
                 {
                     "intent": "aIntent",
@@ -58,6 +57,18 @@
         {
             "$kind": "Microsoft.Test.UserSays",
             "text": "b"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "sub0"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "sub0"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "c"
         },
         {
             "$kind": "Microsoft.Test.AssertReply",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913.test.dialog
@@ -1,0 +1,71 @@
+﻿{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "id": "x",
+            "intents": [
+                {
+                    "intent": "aIntent",
+                    "pattern": "a"
+                },
+                {
+                    "intent": "bIntent",
+                    "pattern": "b"
+                },
+                {
+                    "intent": "cIntent",
+                    "pattern": "c"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "aIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "dialog": "Issue_3913_sub0"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "bIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "dialog": "Issue_3913_sub1"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "cIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "dialog": "Issue_3913_sub1"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "b"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "sub0"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "sub0"
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub0.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub0.dialog
@@ -1,6 +1,5 @@
 ﻿{
     "$kind": "Microsoft.AdaptiveDialog",
-    "id": "Issue_3913_sub0",
     "triggers": [
         {
             "$kind": "Microsoft.OnBeginDialog",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub0.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub0.dialog
@@ -1,0 +1,16 @@
+﻿{
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "sub0",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "sub0"
+                }
+            ]
+        }
+    ],
+    "$schema": "../../../tests.schema"
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub0.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub0.dialog
@@ -1,6 +1,6 @@
 ﻿{
     "$kind": "Microsoft.AdaptiveDialog",
-    "id": "sub0",
+    "id": "Issue_3913_sub0",
     "triggers": [
         {
             "$kind": "Microsoft.OnBeginDialog",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub1.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub1.dialog
@@ -1,0 +1,20 @@
+﻿{
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "sub2",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "Issue_3913_sub0"
+                },
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "Issue_3913_sub0"
+                }
+            ]
+        }
+    ],
+    "$schema": "../../../tests.schema"
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub1.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub1.dialog
@@ -1,6 +1,5 @@
 ﻿{
     "$kind": "Microsoft.AdaptiveDialog",
-    "id": "Issue_3913_sub1",
     "triggers": [
         {
             "$kind": "Microsoft.OnBeginDialog",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub1.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/IssueTests/Issue_3913_sub1.dialog
@@ -1,6 +1,6 @@
 ﻿{
     "$kind": "Microsoft.AdaptiveDialog",
-    "id": "sub2",
+    "id": "Issue_3913_sub1",
     "triggers": [
         {
             "$kind": "Microsoft.OnBeginDialog",


### PR DESCRIPTION
Hope to close https://github.com/microsoft/botbuilder-dotnet/issues/3913

I create a new IssueTests in UT to test issues that can't be categorized.
If we put issue dialogs in TestBot.Json, they may be not tested and forgotten.