### PR TITLE
DialogSet.Add: Unique dialog ids for name collisions but not for reference collisions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
@@ -33,15 +33,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Observers
             var hashCode = Hash<T>(token);
 
             // Pass 1: We track the already visited objects' hash in the 'visited' collection
-            // If we've already visited this hash code and we are still in pass 1, 
-            // we found a loop! If we found a loop, we want to return a value and stop deserializing
-            // to avoid infinite loops.
+            // If we've already visited this hash code and we are still in pass 1, no need to revisit.
             if (visitedPassOne.Contains(hashCode) && CycleDetectionPass == CycleDetectionPasses.PassOne) 
             {
-                // If we already have a hydrated object for this hash code, return it
+                // If we already have a hydrated object for this hash code, 
+                // there is no cycle, just repetition of the object in different parts of the object tree. 
+                // We can get it from the cache but we don't necessarily want it to be the same reference.
+                // In pass 2 when we connect cycles, we won't actually clone because at that point we do want 
+                // to conserve references.
                 if (cache.ContainsKey(hashCode))
                 {
-                    result = cache[hashCode] as T;
+                    result = ObjectPath.Clone<T>(cache[hashCode] as T);
                 }
 
                 // If we don't have a cached value for this hash code, we send null as the value.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -113,6 +113,15 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             if (_dialogs.ContainsKey(dialog.Id))
             {
+                // If we are trying to add the same exact instance, it's not a name collision.
+                // No operation required since the instance is already in the dialog set.
+                if (_dialogs[dialog.Id] == dialog)
+                {
+                    return this;
+                }
+
+                // If we are adding a new dialog with a conflicting name, add a suffix to avoid
+                // dialog name collisions.
                 var nextSuffix = 2;
 
                 while (true)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -66,6 +66,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [TestMethod]
+        public async Task Action_CancelAllDialogs_DoubleCancel()
+        {
+            await TestUtils.RunTestScript(ResourceExplorer);
+        }
+
+        [TestMethod]
         public async Task Action_ChoiceInput()
         {
             await TestUtils.RunTestScript(ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_CancelAllDialogs_DoubleCancel.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_CancelAllDialogs_DoubleCancel.test.dialog
@@ -61,7 +61,17 @@
                                         "activity": "Canceled"
                                     },
                                     {
-                                        "$kind": "Microsoft.CancelAllDialogs"
+                                        "$kind": "Microsoft.SetProperty",
+                                        "property": "$disabled",
+                                        "value": "=false"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.CancelAllDialogs",
+                                        "disabled": "=$disabled"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "Not cancelled"
                                     }
                                 ]
                             },
@@ -74,7 +84,17 @@
                                         "activity": "Restarted"
                                     },
                                     {
-                                        "$kind": "Microsoft.CancelAllDialogs"
+                                        "$kind": "Microsoft.SetProperty",
+                                        "property": "$disabled",
+                                        "value": "=true"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.CancelAllDialogs",
+                                        "disabled": "=$disabled"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "Not cancelled"
                                     }
                                 ]
                             }
@@ -122,12 +142,8 @@
             "text": "Restarted"
         },
         {
-            "$kind": "Microsoft.Test.UserSays",
-            "text": "hi"
-        },
-        {
             "$kind": "Microsoft.Test.AssertReply",
-            "text": "Why did the chicken cross the road?"
-        }
+            "text": "Not cancelled"
+        },
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_CancelAllDialogs_DoubleCancel.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_CancelAllDialogs_DoubleCancel.test.dialog
@@ -1,0 +1,133 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "CancelIntent",
+                    "pattern": "(?i)cancel|never mind"
+                },
+                {
+                    "intent": "RestartIntent",
+                    "pattern": "(?i)restart"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.AdaptiveDialog",
+                        "recognizer": {
+                            "$kind": "Microsoft.RegexRecognizer",
+                            "intents": [
+                                {
+                                    "intent": "CancelIntent",
+                                    "pattern": "(?i)cancel|never mind"
+                                },
+                                {
+                                    "intent": "RestartIntent",
+                                    "pattern": "(?i)restart"
+                                }
+                            ]
+                        },
+                        "triggers": [
+                            {
+                                "$kind": "Microsoft.OnBeginDialog",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "Why did the chicken cross the road?"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.EndTurn"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "To get to the other side"
+                                    }
+                                ]
+                            },
+                            {
+                                "$kind": "Microsoft.OnIntent",
+                                "intent": "CancelIntent",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "Canceled"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.CancelAllDialogs"
+                                    }
+                                ]
+                            },
+                            {
+                                "$kind": "Microsoft.OnIntent",
+                                "intent": "RestartIntent",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "Restarted"
+                                    },
+                                    {
+                                        "$kind": "Microsoft.CancelAllDialogs"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "What am I doing here?"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Why did the chicken cross the road?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "cancel"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Canceled"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Why did the chicken cross the road?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "restart"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Restarted"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Why did the chicken cross the road?"
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -37,6 +37,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         }
 
         [TestMethod]
+        public async Task JsonDialogLoad_DoubleReference()
+        {
+            await BuildTestFlow(@"DoubleReference.dialog")
+                .SendConversationUpdate()
+                .AssertReply("what is your name?")
+                .Send("c")
+                .AssertReply("sub0")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task JsonDialogLoad_CycleDetection()
         {
             await BuildTestFlow(@"Root.dialog")

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <Folder Include="CustomDialogs\" />
+    <Folder Include="Samples\DoubleReference\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
@@ -54,6 +55,21 @@
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder.Dialogs\Microsoft.Bot.Builder.Dialogs.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
     <ProjectReference Include="..\..\libraries\Microsoft.Bot.Connector\Microsoft.Bot.Connector.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="Samples\DoubleReference\DoubleReference.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="Samples\DoubleReference\sub0.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="Samples\DoubleReference\sub2.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Update="Samples\DoubleReference\sub3.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/DoubleReference.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/DoubleReference.dialog
@@ -1,0 +1,110 @@
+﻿{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "recognizer": {
+        "$kind": "Microsoft.RegexRecognizer",
+        "id": "x",
+        "intents": [
+            {
+                "intent": "aIntent",
+                "pattern": "a"
+            },
+            {
+                "intent": "bIntent",
+                "pattern": "b"
+            },
+            {
+                "intent": "cIntent",
+                "pattern": "c"
+            },
+            {
+                "intent": "dIntent",
+                "pattern": "d"
+            },
+            {
+                "intent": "eIntent",
+                "pattern": "e"
+            },
+            {
+                "intent": "fIntent",
+                "pattern": "f"
+            }
+        ]
+    },
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "AskForName",
+                    "resultProperty": "$name"
+                },
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Hello ${dialog.name}, nice to meet you!"
+                }
+            ]
+        },
+        {
+            "$kind": "Microsoft.OnIntent",
+            "intent": "aIntent",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub3"
+                }
+            ]
+        },
+        {
+            "$kind": "Microsoft.OnIntent",
+            "intent": "bIntent",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub2"
+                }
+            ]
+        },
+        {
+            "$kind": "Microsoft.OnIntent",
+            "intent": "cIntent",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub0"
+                }
+            ]
+        },
+        {
+            "$kind": "Microsoft.OnIntent",
+            "intent": "dIntent",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub0"
+                }
+            ]
+        },
+        {
+            "$kind": "Microsoft.OnIntent",
+            "intent": "eIntent",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub3"
+                }
+            ]
+        },
+        {
+            "$kind": "Microsoft.OnIntent",
+            "intent": "fIntent",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub2"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub0.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub0.dialog
@@ -1,0 +1,16 @@
+﻿{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "sub0",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "sub0"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub2.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub2.dialog
@@ -1,0 +1,56 @@
+﻿{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "sub2",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.IfCondition",
+                    "$designer": {
+                        "id": "713992",
+                        "name": "Branch: If/Else"
+                    },
+                    "condition": "dialog.count > 0",
+                    "actions": [
+                        {
+                            "$kind": "Microsoft.IfCondition",
+                            "$designer": {
+                                "id": "5SKPJu"
+                            },
+                            "condition": "=dialog.containsAll == null",
+                            "elseActions": [
+                                {
+                                    "$kind": "Microsoft.IfCondition",
+                                    "$designer": {
+                                        "id": "KTnZSa"
+                                    },
+                                    "condition": "=dialog.result",
+                                    "elseActions": [
+                                        {
+                                            "$kind": "Microsoft.ReplaceDialog",
+                                            "$designer": {
+                                                "id": "epKzn4"
+                                            },
+                                            "dialog": "sub0",
+                                            "options": "=dialog.result"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "$kind": "Microsoft.ReplaceDialog",
+                            "$designer": {
+                                "id": "mFf8Hl"
+                            },
+                            "dialog": "sub0",
+                            "options": "=dialog.result"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub3.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub3.dialog
@@ -1,0 +1,16 @@
+﻿{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "sub3",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.BeginDialog",
+                    "dialog": "sub0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/3913

The `Add()` method of `DialogSet` has a mechanism for supporting multiple dialogs with the same id, which is adding a unique suffix for internal book keeping. 

There is a bug however, if the same exact dialog is added multiple times because it is referenced by multiple dialogs. In this scenario, this is not a name collision, we are just adding the same dialog. But still we are assigning a different Id and treating it as different which brings downstream incorrect behaviors.

The fix here is to more precisely detect whether this is a name collision, by checking whether the dialog that is being added, was already added. If that is the case, we don't assign a new id and just leave things as they are.

Note that this is not a declarative only bug or even an adaptive only bug. But in adaptive code, without declarative, something like the below would also fail without this fix:

```csharp
var d1 = new AdaptiveDialog();
var d2 = new AdaptiveDialog();

Triggers = new List<OnCondition>()
{
    new OnIntent() 
    {
    	Intent = "i1",
      Actions = new Dialog[] {d1};
    },
    new OnIntent() 
    {
    	Intent = "i2",
      Actions = new Dialog[] {d2};
    },
    new OnIntent() 
    {
    	Intent = "i3",
      // eventually this will re-add d1 to the dialog set, and alter the id to 'd12'
      // Then when i1 triggers, it will look for d1 and not find it in the dialog set
      Actions = new Dialog[] {d1}; 
    }
}
```

In addition to the repro test, added another cancellation test to verify other scenraios where instances look the same but are expected to behave differently.

Did a quick performance analysis over 500 medium sized json files (500 lines) and saw no measurable difference in performance. The clone is as efficient as the previous deserialization so its a no change in net time spent loading resources. 