### PR TITLE
Fix QnAMakerDialog to handle interuption scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,4 @@ appsettings.Development.json
 **/*/.luisrc
 /.vscode/launch.json
 /outputpackages
+/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ComposerBugs

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -333,6 +333,12 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             return await base.BeginDialogAsync(dc, dialogOptions, cancellationToken).ConfigureAwait(false);
         }
 
+        protected override Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
+        {
+            // disable interruption
+            return Task.FromResult(true);
+        }
+
         /// <summary>
         /// Gets an <see cref="IQnAMakerClient"/> to use to access the QnA Maker knowledge base.
         /// </summary>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -333,10 +333,57 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             return await base.BeginDialogAsync(dc, dialogOptions, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
+        public override Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
-            // disable interruption
-            return Task.FromResult(true);
+            var interrupted = dc.State.GetValue<bool>(TurnPath.Interrupted, () => false);
+            if (interrupted)
+            {
+                // if qnamaker was interrupted then end the qnamaker dialog
+                return dc.EndDialogAsync(cancellationToken: cancellationToken);
+            }
+
+            return base.ContinueDialogAsync(dc, cancellationToken);
+        }
+
+        protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
+        {
+            if (dc.Context.Activity.Type == ActivityTypes.Message)
+            {
+                // decide whether we want to allow interruption or not.
+                // if we don't get a response from QnA which signifies we expected it,
+                // then we allow interruption.
+
+                var reply = dc.Context.Activity.Text;
+                var dialogOptions = ObjectPath.GetPathValue<QnAMakerDialogOptions>(dc.ActiveDialog.State, Options);
+
+                if (reply.Equals(dialogOptions.ResponseOptions.CardNoMatchText, StringComparison.OrdinalIgnoreCase))
+                {
+                    // it matches nomatch text, we like that.
+                    return true;
+                }
+
+                var suggestedQuestions = dc.State.GetValue<List<string>>($"this.suggestedQuestions");
+                if (suggestedQuestions != null && suggestedQuestions.Any(question => string.Compare(question, reply.Trim(), ignoreCase: true) == 0))
+                {
+                    // it matches one of the suggested actions, we like that.
+                    return true;
+                }
+
+                // Calling QnAMaker to get response.
+                var qnaClient = await GetQnAMakerClientAsync(dc).ConfigureAwait(false);
+                ResetOptions(dc, dialogOptions);
+
+                var response = await qnaClient.GetAnswersRawAsync(dc.Context, dialogOptions.QnAMakerOptions).ConfigureAwait(false);
+
+                // cache result so step doesn't have to do it again, this is a turn cache and we use hashcode so we don't conflict with any other qnamakerdialogs out there.
+                dc.State.SetValue($"turn.qnaresult{this.GetHashCode()}", response);
+
+                // disable interruption if we have answers.
+                return response.Answers.Any();
+            }
+
+            // call base for default behavior.
+            return await OnPostBubbleEventAsync(dc, e, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -403,39 +450,25 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
         private async Task<DialogTurnResult> CallGenerateAnswerAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
-            var dialogOptions = ObjectPath.GetPathValue<QnAMakerDialogOptions>(stepContext.ActiveDialog.State, Options);
+            // clear suggestedQuestions between turns.
+            stepContext.State.RemoveValue($"this.suggestedQuestions");
 
-            // Resetting context and QnAId
-            dialogOptions.QnAMakerOptions.QnAId = 0;
-            dialogOptions.QnAMakerOptions.Context = new QnARequestContext();
+            var dialogOptions = ObjectPath.GetPathValue<QnAMakerDialogOptions>(stepContext.ActiveDialog.State, Options);
+            ResetOptions(stepContext, dialogOptions);
 
             // Storing the context info
             stepContext.Values[ValueProperty.CurrentQuery] = stepContext.Context.Activity.Text;
 
-            // -Check if previous context is present, if yes then put it with the query
-            // -Check for id if query is present in reverse index.
-            var previousContextData = ObjectPath.GetPathValue<Dictionary<string, int>>(stepContext.ActiveDialog.State, QnAContextData, new Dictionary<string, int>());
-            var previousQnAId = ObjectPath.GetPathValue<int>(stepContext.ActiveDialog.State, PreviousQnAId, 0);
-
-            if (previousQnAId > 0)
-            {
-                dialogOptions.QnAMakerOptions.Context = new QnARequestContext
-                {
-                    PreviousQnAId = previousQnAId
-                };
-
-                if (previousContextData.TryGetValue(stepContext.Context.Activity.Text, out var currentQnAId))
-                {
-                    dialogOptions.QnAMakerOptions.QnAId = currentQnAId;
-                }
-            }
-
             // Calling QnAMaker to get response.
             var qnaClient = await GetQnAMakerClientAsync(stepContext).ConfigureAwait(false);
-            var response = await qnaClient.GetAnswersRawAsync(stepContext.Context, dialogOptions.QnAMakerOptions).ConfigureAwait(false);
+            var response = stepContext.State.GetValue<QueryResults>($"turn.qnaresult{this.GetHashCode()}");
+            if (response == null)
+            {
+                response = await qnaClient.GetAnswersRawAsync(stepContext.Context, dialogOptions.QnAMakerOptions).ConfigureAwait(false);
+            }
 
             // Resetting previous query.
-            previousQnAId = -1;
+            var previousQnAId = -1;
             ObjectPath.SetPathValue(stepContext.ActiveDialog.State, PreviousQnAId, previousQnAId);
 
             // Take this value from GetAnswerResponse 
@@ -463,6 +496,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                     await stepContext.Context.SendActivityAsync(message).ConfigureAwait(false);
 
                     ObjectPath.SetPathValue(stepContext.ActiveDialog.State, Options, dialogOptions);
+                    stepContext.State.SetValue($"this.suggestedQuestions", suggestedQuestions);
                     return new DialogTurnResult(DialogTurnStatus.Waiting);
                 }
             }
@@ -478,6 +512,31 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
             // If card is not shown, move to next step with top QnA response.
             return await stepContext.NextAsync(result, cancellationToken).ConfigureAwait(false);
+        }
+
+        private void ResetOptions(DialogContext dc, QnAMakerDialogOptions dialogOptions)
+        {
+            // Resetting context and QnAId
+            dialogOptions.QnAMakerOptions.QnAId = 0;
+            dialogOptions.QnAMakerOptions.Context = new QnARequestContext();
+
+            // -Check if previous context is present, if yes then put it with the query
+            // -Check for id if query is present in reverse index.
+            var previousContextData = ObjectPath.GetPathValue<Dictionary<string, int>>(dc.ActiveDialog.State, QnAContextData, new Dictionary<string, int>());
+            var previousQnAId = ObjectPath.GetPathValue<int>(dc.ActiveDialog.State, PreviousQnAId, 0);
+
+            if (previousQnAId > 0)
+            {
+                dialogOptions.QnAMakerOptions.Context = new QnARequestContext
+                {
+                    PreviousQnAId = previousQnAId
+                };
+
+                if (previousContextData.TryGetValue(dc.Context.Activity.Text, out var currentQnAId))
+                {
+                    dialogOptions.QnAMakerOptions.QnAId = currentQnAId;
+                }
+            }
         }
 
         private async Task<DialogTurnResult> CallTrainAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
             Stopwatch sw = new Stopwatch();
             sw.Start();
             
-            await adapter.ProcessActivityAsync(this.Activity, callback, default(CancellationToken)).ConfigureAwait(false);
+            await adapter.ProcessActivityAsync(activity, callback, default(CancellationToken)).ConfigureAwait(false);
             
             sw.Stop();
             Trace.TraceInformation($"[Turn Ended => {sw.ElapsedMilliseconds} ms processing UserActivity: {this.Activity.Text} ]");

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 User = new ChannelAccount("user1", "User1"),
                 Bot = new ChannelAccount("bot", "Bot"),
                 Conversation = new ConversationAccount(false, "convo1", "Conversation1"),
+                Locale = this.Locale,
             };
         }
 
@@ -73,6 +74,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     User = new ChannelAccount("user1", "User1"),
                     Bot = new ChannelAccount("bot", "Bot"),
                     Conversation = new ConversationAccount(false, "convo1", "Conversation1"),
+                    Locale = this.Locale,
                 };
             }
         }
@@ -125,6 +127,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 Conversation = new ConversationAccount(false, name, name),
                 User = new ChannelAccount(id: user.ToLower(), name: user),
                 Bot = new ChannelAccount(id: bot.ToLower(), name: bot),
+                Locale = "en-us"
             };
         }
 
@@ -427,7 +430,7 @@ namespace Microsoft.Bot.Builder.Adapters
             Activity activity = new Activity
             {
                 Type = ActivityTypes.Message,
-                Locale = this.Locale,
+                Locale = this.Locale ?? "en-us",
                 From = Conversation.User,
                 Recipient = Conversation.Bot,
                 Conversation = Conversation.Conversation,

--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -487,7 +487,7 @@ namespace Microsoft.Bot.Schema
             this.ChannelId = reference.ChannelId;
             this.ServiceUrl = reference.ServiceUrl;
             this.Conversation = reference.Conversation;
-            this.Locale = reference.Locale;
+            this.Locale = reference.Locale ?? this.Locale;
 
             if (isIncoming)
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
@@ -30,11 +30,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         [TestMethod]
         public async Task DebugComposerBot()
         {
+            // luis.settings.{environment}.{region}.json
+            var environment = Environment.UserName;
+            var region = "westus";
             var botPath = Path.Combine(TestUtils.GetProjectPath(), "Tests");
             var testScript = "debug.test.dialog";
             var locale = "en-US";
-            var environment = Environment.UserName; // luis.settings.{environment}.{region}.json
-            var region = "westus"; // luis.settings.{environment}.{region}.json
 
             var resourceExplorer = new ResourceExplorer()
                 .AddFolder(botPath, monitorChanges: false);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#pragma warning disable SA1118 // Parameter should not span multiple lines
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    [TestClass]
+    public class DebugComposer
+    {
+        public TestContext TestContext { get; set; }
+
+        // This test can be used to debug a composer bot, simple point botPath => composer bot
+        // and add debug.test.dialog script to that folder
+        // {
+        //  "$schema": "../../../tests.schema",
+        //  "$kind": "Microsoft.Test.Script",
+        //  "dialog": "bot.root.dialog",
+        //  "script": [...] 
+        // }
+        [Ignore]
+        [TestMethod]
+        public async Task DebugComposerBot()
+        {
+            var botPath = Path.Combine(TestUtils.GetProjectPath(), "Tests");
+            var testScript = "debug.test.dialog";
+            var locale = "en-US";
+            var environment = Environment.UserName; // luis.settings.{environment}.{region}.json
+            var region = "westus"; // luis.settings.{environment}.{region}.json
+
+            var resourceExplorer = new ResourceExplorer()
+                .AddFolder(botPath, monitorChanges: false);
+
+            // add luis settings if there are luis assets
+            var resource = resourceExplorer.GetResource($"luis.settings.{environment}.{region}.json") as FileResource;
+            var builder = new ConfigurationBuilder().AddInMemoryCollection();
+            if (resource != null)
+            {
+                builder.AddJsonFile(resource.FullName);
+            }
+
+            var script = resourceExplorer.LoadType<TestScript>(testScript);
+            script.Locale = locale;
+            script.Configuration = builder.Build();
+            await script.ExecuteAsync(resourceExplorer: resourceExplorer).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Builder.AI.QnA;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
@@ -33,6 +34,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
             ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());
             ComponentRegistration.Add(new LuisComponentRegistration());
+            ComponentRegistration.Add(new QnAMakerComponentRegistration());
         }
 
         public void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
fixes #3908 

* Add PreBubbleEvent handler to decide whether to allow interruptions or not
* added ContinueDialog override to detect we have been interrupted and end the dialog if we have
* refactored some code to cache results computed in PreBubbleEvent and capture suggested questions.
* Added general purpose unit test for debugging a composer bot with all of the QnA/LUIS assets in place.