### PR TITLE
Do NOT call TeamsInfo.getMember for the bot cherry-pick from 4.9 (#3923)

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -253,9 +253,9 @@ namespace Microsoft.Bot.Builder.Teams
             var teamsMembersAdded = new List<TeamsChannelAccount>();
             foreach (var memberAdded in membersAdded)
             {
-                if (memberAdded.Properties.HasValues)
+                if (memberAdded.Properties.HasValues || memberAdded.Id == turnContext.Activity?.Recipient?.Id)
                 {
-                    // when the ChannelAccount object is fully a TeamsChannelAccount (when Teams changes the service to return the full details)
+                    // when the ChannelAccount object is fully a TeamsChannelAccount, or the bot (when Teams changes the service to return the full details)
                     teamsMembersAdded.Add(JObject.FromObject(memberAdded).ToObject<TeamsChannelAccount>());
                 }
                 else

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -26,6 +26,44 @@ namespace Microsoft.Bot.Builder.Teams.Tests
     public class TeamsActivityHandlerTests
     {
         [TestMethod]
+        public async Task TestConversationUpdateBotTeamsMemberAdded()
+        {
+            // Arrange
+            var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty));
+
+            var activity = new Activity
+            {
+                Type = ActivityTypes.ConversationUpdate,
+                MembersAdded = new List<ChannelAccount>
+                {
+                    new ChannelAccount { Id = "bot" },
+                },
+                Recipient = new ChannelAccount { Id = "bot" },
+                ChannelData = new TeamsChannelData
+                {
+                    EventType = "teamMemberAdded",
+                    Team = new TeamInfo
+                    {
+                        Id = "team-id",
+                    },
+                },
+                ChannelId = Channels.Msteams,
+            };
+
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(connectorClient);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.AreEqual(2, bot.Record.Count);
+            Assert.AreEqual("OnConversationUpdateActivityAsync", bot.Record[0]);
+            Assert.AreEqual("OnTeamsMembersAddedAsync", bot.Record[1]);
+        }
+
+        [TestMethod]
         public async Task TestConversationUpdateTeamsMemberAdded()
         {
             // Arrange


### PR DESCRIPTION
* Do NOT call TeamsInfo.getMember for the bot

* Add TestConversationUpdateBotTeamsMemberAdded