### PR TITLE
nuget.client package reference is obselete, replaced with nuget.packaging

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NuGet.Client" Version="4.2.0" />
+    <PackageReference Include="NuGet.Packaging" Version="5.5.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub2.dialog
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Samples/DoubleReference/sub2.dialog
@@ -20,6 +20,7 @@
                                 "id": "5SKPJu"
                             },
                             "condition": "=dialog.containsAll == null",
+                            "actions": [],
                             "elseActions": [
                                 {
                                     "$kind": "Microsoft.IfCondition",
@@ -27,6 +28,7 @@
                                         "id": "KTnZSa"
                                     },
                                     "condition": "=dialog.result",
+                                    "actions": [],
                                     "elseActions": [
                                         {
                                             "$kind": "Microsoft.ReplaceDialog",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -1087,8 +1087,8 @@
 		},
 		"Microsoft.BeginSkill": {
 			"$role": "implements(Microsoft.IDialog)",
-			"title": "Begin a skill dialog",
-			"description": "Begin a remote skill dialog.",
+			"title": "Begin a skill",
+			"description": "Begin a remote skill.",
 			"type": "object",
 			"required": [
 				"$kind"

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -1197,8 +1197,8 @@
 		},
 		"Microsoft.BeginSkill": {
 			"$role": "implements(Microsoft.IDialog)",
-			"title": "Begin a skill dialog",
-			"description": "Begin a remote skill dialog.",
+			"title": "Begin a skill",
+			"description": "Begin a remote skill.",
 			"type": "object",
 			"required": [
 				"$kind"
@@ -4164,6 +4164,30 @@
 					"$ref": "#/definitions/Microsoft.Test.AssertCondition"
 				},
 				{
+					"$ref": "#/definitions/Microsoft.Ask"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.AttachmentInput"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.ChoiceInput"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.ConfirmInput"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.DateTimeInput"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.NumberInput"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.OAuthInput"
+				},
+				{
+					"$ref": "#/definitions/Microsoft.TextInput"
+				},
+				{
 					"$ref": "#/definitions/Microsoft.BeginDialog"
 				},
 				{
@@ -4258,30 +4282,6 @@
 				},
 				{
 					"$ref": "#/definitions/Microsoft.UpdateActivity"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.Ask"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.AttachmentInput"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.ChoiceInput"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.ConfirmInput"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.DateTimeInput"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.NumberInput"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.OAuthInput"
-				},
-				{
-					"$ref": "#/definitions/Microsoft.TextInput"
 				},
 				{
 					"$ref": "#/definitions/Testbot.JavascriptAction"


### PR DESCRIPTION
They stopped updating nuget.client in 2017...it was replaced with **nuget.packaging** which is many versions past the one we were using.

Worse, **nuget.client** had a bad prerelease package pushed in 2017 that breaks installation of adaptive into linqpad because it has a circular dependency chain.

* also fixed .dialog files which were not compliant to schema (missing actions node)