### PR TITLE
Slack sets timestamp as unix time in seconds

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 
         private async Task SendMessageAsync(string echoGuid)
         {
-            var timestamp = DateTime.Now.ToString();
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
 
             using (var client = new HttpClient())
             using (var request = new HttpRequestMessage())


### PR DESCRIPTION
If the server validates that the timestamp is recent to prevent replay attacks, then it would fail.

This PR changes the integration test to simulate what Slack would do.