### PR TITLE
Remove functional test setup from the signed build.

### DIFF
--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -43,4 +43,4 @@ jobs:
   steps:
   - template: ci-build-steps.yml
   - template: sign-steps.yml
-  - template: functional-test-setup-steps.yml
+#  - template: functional-test-setup-steps.yml


### PR DESCRIPTION
The signed build is no longer used for running functional tests.