### PR TITLE
Hardened prompts

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -168,6 +168,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 var activity = turnContext.Activity;
                 var utterance = activity.Text;
+                if (string.IsNullOrEmpty(utterance))
+                {
+                    return Task.FromResult(result);
+                }
+
                 var opt = RecognizerOptions ?? new FindChoicesOptions();
                 opt.Locale = DetermineCulture(activity, opt);
                 var results = ChoiceRecognizers.RecognizeChoices(utterance, choices, opt);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -169,15 +169,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = new PromptRecognizerResult<bool>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
-                if (string.IsNullOrEmpty(turnContext.Activity.Text))
+                // Recognize utterance
+                var utterance = turnContext.Activity.AsMessageActivity().Text;
+                if (string.IsNullOrEmpty(utterance))
                 {
                     return Task.FromResult(result);
                 }
 
-                // Recognize utterance
-                var message = turnContext.Activity.AsMessageActivity();
                 var culture = DetermineCulture(turnContext.Activity);
-                var results = ChoiceRecognizer.RecognizeBoolean(message.Text, culture);
+                var results = ChoiceRecognizer.RecognizeBoolean(utterance, culture);
                 if (results.Count > 0)
                 {
                     var first = results[0];
@@ -199,7 +199,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                         // The text may be a number in which case we will interpret that as a choice.
                         var confirmChoices = ConfirmChoices ?? Tuple.Create(defaults.Item1, defaults.Item2);
                         var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
-                        var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(message.Text, choices);
+                        var secondAttemptResults = ChoiceRecognizers.RecognizeChoices(utterance, choices);
                         if (secondAttemptResults.Count > 0)
                         {
                             result.Succeeded = true;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -169,6 +169,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = new PromptRecognizerResult<bool>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
+                if (string.IsNullOrEmpty(turnContext.Activity.Text))
+                {
+                    return Task.FromResult(result);
+                }
+
                 // Recognize utterance
                 var message = turnContext.Activity.AsMessageActivity();
                 var culture = DetermineCulture(turnContext.Activity);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
@@ -98,6 +98,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = new PromptRecognizerResult<IList<DateTimeResolution>>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
+                if (string.IsNullOrEmpty(turnContext.Activity.Text))
+                {
+                    return Task.FromResult(result);
+                }
+
                 var message = turnContext.Activity.AsMessageActivity();
                 var culture = turnContext.Activity.Locale ?? DefaultLocale ?? English;
                 var refTime = turnContext.Activity.LocalTimestamp?.LocalDateTime;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
@@ -98,15 +98,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = new PromptRecognizerResult<IList<DateTimeResolution>>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
-                if (string.IsNullOrEmpty(turnContext.Activity.Text))
+                var utterance = turnContext.Activity.AsMessageActivity().Text;
+                if (string.IsNullOrEmpty(utterance))
                 {
                     return Task.FromResult(result);
                 }
 
-                var message = turnContext.Activity.AsMessageActivity();
                 var culture = turnContext.Activity.Locale ?? DefaultLocale ?? English;
                 var refTime = turnContext.Activity.LocalTimestamp?.LocalDateTime;
-                var results = DateTimeRecognizer.RecognizeDateTime(message.Text, culture, refTime: refTime);
+                var results = DateTimeRecognizer.RecognizeDateTime(utterance, culture, refTime: refTime);
                 if (results.Count > 0)
                 {
                     // Return list of resolutions from first match

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -103,14 +103,14 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = new PromptRecognizerResult<T>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
-                if (string.IsNullOrEmpty(turnContext.Activity.Text))
+                var utterance = turnContext.Activity.AsMessageActivity().Text;
+                if (string.IsNullOrEmpty(utterance))
                 {
                     return Task.FromResult(result);
                 }
 
-                var message = turnContext.Activity.AsMessageActivity();
                 var culture = turnContext.Activity.Locale ?? DefaultLocale ?? English;
-                var results = RecognizeNumberWithUnit(message.Text, culture);
+                var results = RecognizeNumberWithUnit(utterance, culture);
                 if (results.Count > 0)
                 {
                     // Try to parse value based on type

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -103,6 +103,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = new PromptRecognizerResult<T>();
             if (turnContext.Activity.Type == ActivityTypes.Message)
             {
+                if (string.IsNullOrEmpty(turnContext.Activity.Text))
+                {
+                    return Task.FromResult(result);
+                }
+
                 var message = turnContext.Activity.AsMessageActivity();
                 var culture = turnContext.Activity.Locale ?? DefaultLocale ?? English;
                 var results = RecognizeNumberWithUnit(message.Text, culture);


### PR DESCRIPTION
See parent PR: https://github.com/microsoft/botbuilder-js/pull/2246

## Description

Some of the prompts break if user uploads an attachment instead of responding with text because of some of the `string` methods that get called on `activity.text` (which doesn't exist if an attachment is sent).

## Specific Changes

Add some variation of

```csharp
if (string.isNullOrEmpty(turnContext.Activity.Text)) {
  return Task.FromResult(result);
}
```

to:

1. ChoicePrompt
2. DatetimePrompt
3. NumberPrompt
4. ConfirmPrompt

I also renamed `message` to `utterance` to be more in line with other prompts.

The original issue was only for DatetimePrompt, but I added the other two. Other prompts didn't seem relevant for this.
