### PR TITLE
Remove path excludes from triggers

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -12,31 +12,11 @@ trigger: # ci trigger
   branches:
     include:
      - master
-  paths:
-    include:
-      - '*'
-    exclude:
-      - doc/
-      - specs/
-      - Changes.md
-      - LICENSE
-      - README.md
-      - UsingMyGet.md
 
 pr: # pr trigger
   branches:
     include:
      - master
-  paths:
-    include:
-      - '*'
-    exclude:
-      - doc/
-      - specs/
-      - Changes.md
-      - LICENSE
-      - README.md
-      - UsingMyGet.md
 
 variables:
   BuildConfiguration: debug

--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -8,6 +8,7 @@ name: $(Build.BuildId)
 pool:
     vmImage: 'macOS-10.14'
 
+# No "paths exclude" here: not supported by github required status checks.
 trigger: # ci trigger
   branches:
     include:

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -15,31 +15,11 @@ trigger: # ci trigger
   branches:
     include:
      - master
-  paths:
-    include:
-      - '*'
-    exclude:
-      - doc/
-      - specs/
-      - Changes.md
-      - LICENSE
-      - README.md
-      - UsingMyGet.md
 
 pr: # pr trigger
   branches:
     include:
      - master
-  paths:
-    include:
-      - '*'
-    exclude:
-      - doc/
-      - specs/
-      - Changes.md
-      - LICENSE
-      - README.md
-      - UsingMyGet.md
 
 variables:
   ApiCompatVersion: 4.6.3

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -11,6 +11,7 @@ pool:
   - msbuild
   - visualstudio
 
+# No "paths exclude" here: not supported by github required status checks.
 trigger: # ci trigger
   branches:
     include:


### PR DESCRIPTION
These builds are specified in our github required status checks. Github status checks do not support path-based includes or excludes, so we cannot use them in the yaml.  