### PR TITLE
[DRAFT] Make SkillDialog more robust by adding side car routing

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -124,10 +124,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
 
             // Update the dialog options with the runtime settings.
+            var storage = dc.Context.TurnState.Get<IStorage>();
             DialogOptions.BotId = BotId.GetValue(dc.State);
             DialogOptions.SkillHostEndpoint = new Uri(SkillHostEndpoint.GetValue(dc.State));
-            DialogOptions.ConversationIdFactory = dc.Context.TurnState.Get<SkillConversationIdFactoryBase>() ?? throw new NullReferenceException("Unable to locate SkillConversationIdFactoryBase in HostContext");
-            DialogOptions.SkillClient = dc.Context.TurnState.Get<BotFrameworkClient>() ?? throw new NullReferenceException("Unable to locate BotFrameworkClient in HostContext");
+            DialogOptions.ConversationIdFactory = dc.Context.TurnState.Get<SkillConversationIdFactoryBase>() ?? new SkillConversationReferenceStorage(storage ?? throw new NullReferenceException("Unable to locate SkillConversationIdFactoryBase in turnstate"));
+            DialogOptions.SkillClient = dc.Context.TurnState.Get<BotFrameworkClient>() ?? throw new NullReferenceException("Unable to locate BotFrameworkClient in turnstate");
             DialogOptions.ConversationState = dc.Context.TurnState.Get<ConversationState>() ?? throw new NullReferenceException($"Unable to get an instance of {nameof(ConversationState)} from TurnState.");
             DialogOptions.ConnectionName = ConnectionName.GetValue(dc.State);
 

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillConversationIdFactoryBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillConversationIdFactoryBase.cs
@@ -66,6 +66,17 @@ namespace Microsoft.Bot.Builder.Skills
         }
 
         /// <summary>
+        /// Saves the <see cref="SkillConversationReference"/> used during <see cref="CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions,System.Threading.CancellationToken)"/> for a skillConversationId.
+        /// </summary>
+        /// <param name="skillConversationReference">A skill conversation reference.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>task.</returns>
+        public virtual Task SaveSkillConversationReferenceAsync(SkillConversationReference skillConversationReference, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Deletes a <see cref="ConversationReference"/>.
         /// </summary>
         /// <param name="skillConversationId">A skill conversationId created using <see cref="CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions,System.Threading.CancellationToken)"/>.</param>

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillConversationReference.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillConversationReference.cs
@@ -32,18 +32,18 @@ namespace Microsoft.Bot.Builder.Skills
         public string OAuthScope { get; set; }
 
         /// <summary>
-        /// Gets or sets the contextual activities.
+        /// Gets the contextual activities.
         /// </summary>
         /// <value>
-        /// For async post back we collect Event and EndOfConversation activites to be processed on skillhost calling context.
+        /// For async post back we collect Event and EndOfConversation activities to be processed on SkillHost calling context.
         /// </value>
         [JsonProperty("activities")]
-        public List<Activity> Activities { get; set; } = null;
+        public List<Activity> Activities { get; } = new List<Activity>();
 
         /// <summary>
         /// Gets or sets a value indicating whether a skill host is waiting on the skill to complete it's turn.
         /// </summary>
-        /// <value>If this is true there is a skillHost waiting on the skill to complete the turn, activites should.</value>
+        /// <value>If this is true there is a skillHost waiting on the skill to complete the turn, activities should.</value>
         [JsonProperty("skillHostWaiting")]
         public bool SkillHostWaiting { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillConversationReference.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillConversationReference.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
@@ -31,12 +32,19 @@ namespace Microsoft.Bot.Builder.Skills
         public string OAuthScope { get; set; }
 
         /// <summary>
-        /// Gets or sets the EndOfConversationActivity.
+        /// Gets or sets the contextual activities.
         /// </summary>
         /// <value>
-        /// The EndOfConversation activity which the skill sent back to the skill host to indicate the end of the conversation result.
+        /// For async post back we collect Event and EndOfConversation activites to be processed on skillhost calling context.
         /// </value>
-        [JsonProperty("endOfConversationActivity")]
-        public Activity Activity { get; set; } = null;
+        [JsonProperty("activities")]
+        public List<Activity> Activities { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a skill host is waiting on the skill to complete it's turn.
+        /// </summary>
+        /// <value>If this is true there is a skillHost waiting on the skill to complete the turn, activites should.</value>
+        [JsonProperty("skillHostWaiting")]
+        public bool SkillHostWaiting { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillConversationReference.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillConversationReference.cs
@@ -2,13 +2,41 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Skills
 {
+    /// <summary>
+    /// The SkillConversationReference is a record which is used to track a conversation with a skill.
+    /// </summary>
     public class SkillConversationReference
     {
+        /// <summary>
+        /// Gets or sets the skill conversation id.
+        /// </summary>
+        /// <value>This id is used to lookup, save and delete the SkillConversationReference.</value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the conversation reference of the conversation that invoked the skill.
+        /// </summary>
+        /// <value>
+        /// The original conversation reference.
+        /// </value>
+        [JsonProperty("conversationReference")]
         public ConversationReference ConversationReference { get; set; }
 
+        [JsonProperty("oAuthScope")]
         public string OAuthScope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the EndOfConversationActivity.
+        /// </summary>
+        /// <value>
+        /// The EndOfConversation activity which the skill sent back to the skill host to indicate the end of the conversation result.
+        /// </value>
+        [JsonProperty("endOfConversationActivity")]
+        public Activity Activity { get; set; } = null;
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillConversationreferenceStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillConversationreferenceStorage.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Skills
+{
+    /// <summary>
+    /// Defines a implementation of SkillConversationIdFactoryBase which uses IStorage to persist SkillConversationReference.
+    /// </summary>
+    public class SkillConversationReferenceStorage : SkillConversationIdFactoryBase
+    {
+        private IStorage storage;
+
+        public SkillConversationReferenceStorage(IStorage storage)
+        {
+            this.storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        }
+
+        /// <summary>
+        /// Creates a conversation id for a skill conversation.
+        /// </summary>
+        /// <param name="options">A <see cref="SkillConversationIdFactoryOptions"/> instance containing parameters for creating the conversation ID.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A unique conversation ID used to communicate with the skill.</returns>
+        /// <remarks>
+        /// It should be possible to use the returned string on a request URL and it should not contain special characters. 
+        /// </remarks>
+        public async override Task<string> CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions options, CancellationToken cancellationToken)
+        {
+            var skillState = new SkillConversationReference()
+            {
+                Id = Guid.NewGuid().ToString("n"),
+                ConversationReference = options.Activity.GetConversationReference(),
+                OAuthScope = options.FromBotOAuthScope
+            };
+
+            var changes = new Dictionary<string, object>();
+            changes[skillState.Id] = skillState;
+            await this.storage.WriteAsync(changes, cancellationToken).ConfigureAwait(false);
+
+            return skillState.Id;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ConversationReference"/> created using <see cref="CreateSkillConversationIdAsync(Microsoft.Bot.Schema.ConversationReference,System.Threading.CancellationToken)"/> for a skillConversationId.
+        /// </summary>
+        /// <param name="skillConversationId">A skill conversationId created using <see cref="CreateSkillConversationIdAsync(Microsoft.Bot.Schema.ConversationReference,System.Threading.CancellationToken)"/>.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The caller's <see cref="ConversationReference"/> for a skillConversationId. null if not found.</returns>
+        [Obsolete("Method is deprecated, please use GetSkillConversationReferenceAsync() instead.", false)]
+        public async override Task<ConversationReference> GetConversationReferenceAsync(string skillConversationId, CancellationToken cancellationToken)
+        {
+            var result = await GetSkillConversationReferenceAsync(skillConversationId, cancellationToken).ConfigureAwait(false);
+            if (result != null)
+            {
+                return result.ConversationReference;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SkillConversationReference"/> used during <see cref="CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions,System.Threading.CancellationToken)"/> for a skillConversationId.
+        /// </summary>
+        /// <param name="skillConversationId">A skill conversationId created using <see cref="CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions,System.Threading.CancellationToken)"/>.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The caller's <see cref="ConversationReference"/> for a skillConversationId, with originatingAudience. Null if not found.</returns>
+        public async override Task<SkillConversationReference> GetSkillConversationReferenceAsync(string skillConversationId, CancellationToken cancellationToken)
+        {
+            var results = await this.storage.ReadAsync(new string[] { skillConversationId }, cancellationToken).ConfigureAwait(false);
+            if (results.TryGetValue(skillConversationId, out var reference))
+            {
+                if (reference is SkillConversationReference scr)
+                {
+                    return scr;
+                }
+
+                return JObject.FromObject(reference).ToObject<SkillConversationReference>();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SkillConversationReference"/> used during <see cref="CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions,System.Threading.CancellationToken)"/> for a skillConversationId.
+        /// </summary>
+        /// <param name="skillConversationReference">A skill conversation reference.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>task.</returns>
+        public override Task SaveSkillConversationReferenceAsync(SkillConversationReference skillConversationReference, CancellationToken cancellationToken)
+        {
+            var changes = new Dictionary<string, object>();
+            changes[skillConversationReference.Id] = skillConversationReference;
+            return this.storage.WriteAsync(changes, cancellationToken);
+        }
+
+        /// <summary>
+        /// Deletes a <see cref="SkillConversationReference"/>.
+        /// </summary>
+        /// <param name="skillConversationId">A skill conversationId created using <see cref="CreateSkillConversationIdAsync(SkillConversationIdFactoryOptions,System.Threading.CancellationToken)"/>.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public override Task DeleteConversationReferenceAsync(string skillConversationId, CancellationToken cancellationToken)
+        {
+            return this.storage.DeleteAsync(new string[] { skillConversationId }, cancellationToken);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillConversationReferenceStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillConversationReferenceStorageTests.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual(cr.Bot.Id, record.ConversationReference.Bot.Id);
             Assert.AreEqual(cr.ChannelId, record.ConversationReference.ChannelId);
             Assert.AreEqual(cr.Conversation.Id, record.ConversationReference.Conversation.Id);
-            Assert.IsNull(record.Activity);
+            Assert.IsNull(record.Activities);
 
-            record.Activity = new Activity() { Type = ActivityTypes.EndOfConversation };
+            record.Activities = new List<Activity> { new Activity() { Type = ActivityTypes.EndOfConversation } };
             await scr.SaveSkillConversationReferenceAsync(record, CancellationToken.None);
 
             record = await scr.GetSkillConversationReferenceAsync(id, CancellationToken.None);
@@ -78,8 +78,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual(cr.Bot.Id, record.ConversationReference.Bot.Id);
             Assert.AreEqual(cr.ChannelId, record.ConversationReference.ChannelId);
             Assert.AreEqual(cr.Conversation.Id, record.ConversationReference.Conversation.Id);
-            Assert.IsNotNull(record.Activity);
-            Assert.AreEqual(ActivityTypes.EndOfConversation, record.Activity.Type);
+            Assert.IsNotNull(record.Activities);
+            Assert.AreEqual(ActivityTypes.EndOfConversation, record.Activities[0].Type);
 
             await scr.DeleteConversationReferenceAsync(id, CancellationToken.None);
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillConversationReferenceStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillConversationReferenceStorageTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,9 +66,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.AreEqual(cr.Bot.Id, record.ConversationReference.Bot.Id);
             Assert.AreEqual(cr.ChannelId, record.ConversationReference.ChannelId);
             Assert.AreEqual(cr.Conversation.Id, record.ConversationReference.Conversation.Id);
-            Assert.IsNull(record.Activities);
+            Assert.IsFalse(record.Activities.Any());
 
-            record.Activities = new List<Activity> { new Activity() { Type = ActivityTypes.EndOfConversation } };
+            record.Activities.AddRange(new List<Activity> { new Activity() { Type = ActivityTypes.EndOfConversation } });
             await scr.SaveSkillConversationReferenceAsync(record, CancellationToken.None);
 
             record = await scr.GetSkillConversationReferenceAsync(id, CancellationToken.None);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillConversationReferenceStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillConversationReferenceStorageTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Builder.Testing;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs.Tests
+{
+    [TestClass]
+    public class SkillConversationReferenceStorageTests
+    {
+        [TestMethod]
+        public void CtorThrowsNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new SkillConversationReferenceStorage(null));
+        }
+
+        [TestMethod]
+        public async Task StorageIdIsUnique()
+        {
+            SkillConversationReferenceStorage scr;
+            ConversationReference cr;
+            SkillConversationIdFactoryOptions options;
+            CreateOptions(out scr, out cr, out options);
+
+            var id = await scr.CreateSkillConversationIdAsync(options, default(CancellationToken));
+            Assert.IsTrue(!string.IsNullOrEmpty(id));
+
+            var id2 = await scr.CreateSkillConversationIdAsync(options, default(CancellationToken));
+            Assert.IsTrue(!string.IsNullOrEmpty(id2));
+
+            Assert.AreNotEqual(id, id2);
+        }
+
+        [TestMethod]
+        public async Task VerifyCRUD()
+        {
+            SkillConversationReferenceStorage scr;
+            ConversationReference cr;
+            SkillConversationIdFactoryOptions options;
+            CreateOptions(out scr, out cr, out options);
+
+            var id = await scr.CreateSkillConversationIdAsync(options, CancellationToken.None);
+            Assert.IsTrue(!string.IsNullOrEmpty(id));
+
+            var record = await scr.GetSkillConversationReferenceAsync(id, CancellationToken.None);
+            Assert.AreEqual(id, record.Id);
+            Assert.AreEqual(cr.ServiceUrl, record.ConversationReference.ServiceUrl);
+            Assert.AreEqual(cr.Locale, record.ConversationReference.Locale);
+            Assert.AreEqual(cr.User.Id, record.ConversationReference.User.Id);
+            Assert.AreEqual(cr.Bot.Id, record.ConversationReference.Bot.Id);
+            Assert.AreEqual(cr.ChannelId, record.ConversationReference.ChannelId);
+            Assert.AreEqual(cr.Conversation.Id, record.ConversationReference.Conversation.Id);
+            Assert.IsNull(record.Activity);
+
+            record.Activity = new Activity() { Type = ActivityTypes.EndOfConversation };
+            await scr.SaveSkillConversationReferenceAsync(record, CancellationToken.None);
+
+            record = await scr.GetSkillConversationReferenceAsync(id, CancellationToken.None);
+            Assert.AreEqual(id, record.Id);
+            Assert.AreEqual(cr.ServiceUrl, record.ConversationReference.ServiceUrl);
+            Assert.AreEqual(cr.Locale, record.ConversationReference.Locale);
+            Assert.AreEqual(cr.User.Id, record.ConversationReference.User.Id);
+            Assert.AreEqual(cr.Bot.Id, record.ConversationReference.Bot.Id);
+            Assert.AreEqual(cr.ChannelId, record.ConversationReference.ChannelId);
+            Assert.AreEqual(cr.Conversation.Id, record.ConversationReference.Conversation.Id);
+            Assert.IsNotNull(record.Activity);
+            Assert.AreEqual(ActivityTypes.EndOfConversation, record.Activity.Type);
+
+            await scr.DeleteConversationReferenceAsync(id, CancellationToken.None);
+
+            record = await scr.GetSkillConversationReferenceAsync(id, CancellationToken.None);
+            Assert.IsNull(record);
+        }
+
+        private static void CreateOptions(out SkillConversationReferenceStorage scr, out ConversationReference cr, out SkillConversationIdFactoryOptions options)
+        {
+            scr = new SkillConversationReferenceStorage(new MemoryStorage());
+            var activity = (Activity)Activity.CreateMessageActivity();
+            activity.Id = Guid.NewGuid().ToString("n");
+            activity.Locale = "en-US";
+            activity.ChannelId = "test";
+            activity.From = new ChannelAccount(id: "user");
+            activity.Recipient = new ChannelAccount(id: "bot");
+            activity.Conversation = new ConversationAccount(id: "123123");
+            activity.ServiceUrl = "http//mybot.com";
+            cr = activity.GetConversationReference();
+            var skill = new BotFrameworkSkill()
+            {
+                AppId = Guid.NewGuid().ToString("n"),
+                Id = "skill",
+                SkillEndpoint = new Uri("http://testbot.com/api/messages")
+            };
+
+            options = new SkillConversationIdFactoryOptions
+            {
+                FromBotOAuthScope = "mybot",
+                FromBotId = "mybot",
+                Activity = activity,
+                BotFrameworkSkill = skill
+            };
+        }
+    }
+}


### PR DESCRIPTION
# DO NOT MERGE

* Added SkillConversationReferenceStorage(storage) which persists SkillConversationReference objects
* Added SkillHostWaiting and Activities to SkillConversationReference.
* Made SendToSkill(dc) based
* Changed SkillHost to look to see if SkillHostIsWaiting. If true, then it puts into SCR.Activiteis, if false it's proactive so it runs activity pipeline in the callback.
* Changed SendToSkill() to get activites from HttpResponse (in ExpectedMessages) or SCR.Activities (in async mode).  Logic is the same for both.
* Added proper modeling of Event (We need to emit event and rootDc.continueDialog()
* Unit tests for storage.
