### PR TITLE
support expression in debug evaluate

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using AdaptiveExpressions;
 using Microsoft.Bot.Builder.Dialogs;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
@@ -44,6 +45,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
         public override string ToString() => Name;
 
-        object ICodePoint.Evaluate(string expression) => DialogContext.State.GetValue<object>(expression);
+        object ICodePoint.Evaluate(string expression)
+        {
+            var exp = Expression.Parse(expression);
+            var result = exp.TryEvaluate(DialogContext.State);
+            if (!string.IsNullOrEmpty(result.error))
+            {
+                throw new Exception(result.error);
+            }
+
+            return result.value;
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DialogDebugAdapter.cs
@@ -575,9 +575,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                 var arguments = evaluate.Arguments;
                 DecodeFrame(arguments.FrameId, out var thread, out var frame);
                 var expression = arguments.Expression.Trim('"');
-                var result = frame.Evaluate(expression);
-                if (result != null)
+
+                try
                 {
+                    var result = frame.Evaluate(expression);
                     var body = new
                     {
                         result = dataModel.ToString(result),
@@ -586,9 +587,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
                     return Protocol.Response.From(NextSeq, evaluate, body);
                 }
-                else
+                catch (Exception ex)
                 {
-                    return Protocol.Response.Fail(NextSeq, evaluate, string.Empty);
+                    return Protocol.Response.Fail(NextSeq, evaluate, ex.Message);
                 }
             }
             else if (message is Protocol.Request<Protocol.Continue> cont)


### PR DESCRIPTION
Following changes:
* support expression in debug evaluate
* output error for expression grammar
* output error for evaluation process
* treat null as normal output instead of error (since value could be null)
![image](https://user-images.githubusercontent.com/2876650/82629269-b9022200-9c21-11ea-94e0-7ac17c1312f0.png)

Blockers:
* https://github.com/microsoft/botbuilder-dotnet/issues/3970 fixes debugging
* https://github.com/microsoft/botbuilder-dotnet/issues/3969 then we could tell if it is a null value or non-exist value
