### PR TITLE
make some error messages in prebuilt functions more accurate

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -772,7 +772,7 @@ namespace AdaptiveExpressions
                         }
                         else
                         {
-                            error = $"{expr} could not be evaluated";
+                            error = $"{expr} should contain a ISO format timestamp and an integer of time interval.";
                         }
                     }
 
@@ -3455,7 +3455,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, an integer of time interval, a string represents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3552,7 +3552,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an integer of time interval, a string represents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3582,7 +3582,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an integer of time interval, a string represents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3607,7 +3607,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of destination timezone and an optional string of output format.";
                             }
                         }
 
@@ -3632,7 +3632,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of origin timezone and an optional string of output format.";
                             }
                         }
 
@@ -3657,7 +3657,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, an integer of time interval, a string repesents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3682,7 +3682,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp and an optional string of output format.";
                             }
                         }
 
@@ -3707,7 +3707,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp and an optional string of output format.";
                             }
                         }
 
@@ -3732,7 +3732,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp and an optional string of output format.";
                             }
                         }
 
@@ -3756,7 +3756,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp.";
                             }
                         }
 
@@ -3947,7 +3947,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -3971,7 +3971,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -3995,7 +3995,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -4019,7 +4019,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -4043,7 +4043,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -4067,7 +4067,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 


### PR DESCRIPTION
fixes: #3955 
replace $"{expr} can't evaluate." with more detailed messages based on the context of some prebuilt functions