### PR TITLE
Change error messages in pre-built functions to make the descriptions more accurate

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -772,7 +772,7 @@ namespace AdaptiveExpressions
                         }
                         else
                         {
-                            error = $"{expr} could not be evaluated";
+                            error = $"{expr} should contain a ISO format timestamp and an integer of time interval.";
                         }
                     }
 
@@ -3483,7 +3483,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, an integer of time interval, a string represents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3578,7 +3578,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an integer of time interval, a string represents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3608,7 +3608,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an integer of time interval, a string represents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3633,7 +3633,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of destination timezone and an optional string of output format.";
                             }
                         }
 
@@ -3658,7 +3658,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of origin timezone and an optional string of output format.";
                             }
                         }
 
@@ -3683,7 +3683,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain an ISO format timestamp, an integer of time interval, a string repesents unit of time and an optional string of output format.";
                             }
                         }
 
@@ -3945,7 +3945,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -3969,7 +3969,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -3993,7 +3993,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -4017,7 +4017,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -4041,7 +4041,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 
@@ -4065,7 +4065,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} can't evaluate.";
+                                error = $"{expr} should contain a string of URI.";
                             }
                         }
 

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -3633,7 +3633,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a string of destination timezone and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of destination time zone and an optional string of output format.";
                             }
                         }
 
@@ -3658,7 +3658,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a string of origin timezone and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of origin time zone and an optional string of output format.";
                             }
                         }
 

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -771,7 +771,7 @@ namespace AdaptiveExpressions
                         }
                         else
                         {
-                            error = $"{expr} should contain an ISO format timestamp and and a time interval integer.";
+                            error = $"{expr} should contain an ISO format timestamp and a time interval integer.";
                         }
                     }
 
@@ -3577,7 +3577,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a time interval integer, a string unit of time and an optional output format string.";
+                                error = $"{expr} should contain a time interval integer, a string unit of time and an optional output format string.";
                             }
                         }
 
@@ -3632,7 +3632,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a string of destination time zone and an optional output format string.";
+                                error = $"{expr} should contain an ISO format timestamp, a destination time zone string and an optional output format string.";
                             }
                         }
 
@@ -3657,7 +3657,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a string of origin time zone and an optional output format string.";
+                                error = $"{expr} should contain an ISO format timestamp, a origin time zone string and an optional output format string.";
                             }
                         }
 

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -772,7 +772,7 @@ namespace AdaptiveExpressions
                         }
                         else
                         {
-                            error = $"{expr} should contain a ISO format timestamp and an integer of time interval.";
+                            error = $"{expr} should contain an ISO format timestamp and an integer of time interval.";
                         }
                     }
 

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -771,7 +771,7 @@ namespace AdaptiveExpressions
                         }
                         else
                         {
-                            error = $"{expr} should contain an ISO format timestamp and an integer of time interval.";
+                            error = $"{expr} should contain an ISO format timestamp and and a time interval integer.";
                         }
                     }
 
@@ -3482,7 +3482,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, an integer of time interval, a string represents unit of time and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a time interval integer, a string unit of time and an optional output format string.";
                             }
                         }
 
@@ -3577,7 +3577,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an integer of time interval, a string represents unit of time and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a time interval integer, a string unit of time and an optional output format string.";
                             }
                         }
 
@@ -3607,7 +3607,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an integer of time interval, a string represents unit of time and an optional string of output format.";
+                                error = $"{expr} should a time interval integer, a string unit of time and an optional output format string.";
                             }
                         }
 
@@ -3632,7 +3632,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a string of destination time zone and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of destination time zone and an optional output format string.";
                             }
                         }
 
@@ -3657,7 +3657,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, a string of origin time zone and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a string of origin time zone and an optional output format string.";
                             }
                         }
 
@@ -3682,7 +3682,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain an ISO format timestamp, an integer of time interval, a string repesents unit of time and an optional string of output format.";
+                                error = $"{expr} should contain an ISO format timestamp, a time interval integer, a string unit of time and an optional output format string.";
                             }
                         }
 
@@ -3976,7 +3976,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain a string of URI.";
+                                error = $"{expr} should contain a URI string.";
                             }
                         }
 
@@ -4000,7 +4000,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain a string of URI.";
+                                error = $"{expr} should contain a URI string.";
                             }
                         }
 
@@ -4024,7 +4024,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain a string of URI.";
+                                error = $"{expr} should contain a URI string.";
                             }
                         }
 
@@ -4048,7 +4048,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain a string of URI.";
+                                error = $"{expr} should contain a URI string.";
                             }
                         }
 
@@ -4072,7 +4072,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain a string of URI.";
+                                error = $"{expr} should contain a URI string .";
                             }
                         }
 
@@ -4096,7 +4096,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should contain a string of URI.";
+                                error = $"{expr} should contain a URI string.";
                             }
                         }
 

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -3607,7 +3607,7 @@ namespace AdaptiveExpressions
                             }
                             else
                             {
-                                error = $"{expr} should a time interval integer, a string unit of time and an optional output format string.";
+                                error = $"{expr} should contain a time interval integer, a string unit of time and an optional output format string.";
                             }
                         }
 


### PR DESCRIPTION
fixes: #3955 
replace $"{expr} can't evaluate." with more detailed messages based on the context of some pre-built functions