### PR TITLE
Change xUnit test attribute to fit "TestCategory" filtering 

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -56,7 +56,7 @@ steps:
     projects: |
      Tests/**/*Tests.csproj
      
-    arguments: '-v n  --configuration $(BuildConfiguration) --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests&Platform!=WindowsOnly" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+    arguments: '-v n  --configuration $(BuildConfiguration) --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests&TestCategory!=WindowsOnly" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: build folder'

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        [Trait("Platform", "WindowsOnly")]
+        [Trait("TestCategory", "WindowsOnly")]
         public async Task JwtTokenExtractor_WithExpiredCert_ShouldNotAllowCertSigningKey()
         {
             var now = DateTimeOffset.UtcNow;
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        [Trait("Platform", "WindowsOnly")]
+        [Trait("TestCategory", "WindowsOnly")]
         public async Task JwtTokenExtractor_WithValidCert_ShouldNotAllowCertSigningKey()
         {
             var now = DateTimeOffset.UtcNow;


### PR DESCRIPTION
This merges to master. The previous PR of the same name was for merging to 4.9.
This means test runs can uniformly use "TestCategory" for filtering both xUnit and MSTest tests.