### PR TITLE
Add EOL builtin function

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -3285,6 +3285,11 @@ namespace AdaptiveExpressions
                     ReturnType.String,
                     (exprssion) => ValidateArityAndAnyType(exprssion, 0, 0)),
                 new ExpressionEvaluator(
+                    ExpressionType.EOL,
+                    Apply(args => Environment.NewLine),
+                    ReturnType.String,
+                    (exprssion) => ValidateArityAndAnyType(exprssion, 0, 0)),
+                new ExpressionEvaluator(
                     ExpressionType.IndexOf,
                     (expression, state, options) =>
                     {

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -52,6 +52,7 @@ namespace AdaptiveExpressions
         public const string NewGuid = "newGuid";
         public const string IndexOf = "indexOf";
         public const string LastIndexOf = "lastIndexOf";
+        public const string EOL = "EOL";
 
         // Collection
         public const string Count = "count";

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -87,6 +87,7 @@ namespace AdaptiveExpressions.Tests
             Test("addOrdinal(one)"), // should have Integer param
             Test("addOrdinal(one, two)"), // should have one param
             Test("newGuid(one)"), // should have no parameters
+            Test("EOL(one)"), // should have no parameters
             Test("indexOf(hello)"), // should have two parameters
             Test("indexOf(hello, world, one)"), // should have two parameters
             Test("indexOf(hello, one)"), // second parameter should be string

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading;
 using AdaptiveExpressions.Memory;
 using Microsoft.Recognizers.Text.DataTypes.TimexExpression;
@@ -841,6 +842,7 @@ namespace AdaptiveExpressions.Tests
             Test("subArray(createArray('H','e','l','l','o'),2,5)", new List<object> { "l", "l", "o" }),
             Test("count(newGuid())", 36),
             Test("indexOf(newGuid(), '-')", 8),
+            Test("EOL()", RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "\r\n" : "\n"),
             Test("indexOf(nullObj, '-')", -1),
             Test("indexOf(hello, nullObj)", 0),
             Test("indexOf(hello, '-')", -1),


### PR DESCRIPTION
close: #3787 
Add `EOL()` builtin function which supplies the line ending for the current OS.