### PR TITLE
Refine template loop detection to enable recursive functions

### DIFF
--- a/libraries/AdaptiveExpressions/Memory/ReflectionMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/ReflectionMemory.cs
@@ -47,7 +47,7 @@ namespace AdaptiveExpressions.Memory
 
         public string Version()
         {
-            return (string)this.methods.Version.Invoke(obj, Array.Empty<object>());
+            return (string)this.methods?.Version?.Invoke(obj, Array.Empty<object>());
         }
 
         internal static ReflectionMemory Create(object obj)

--- a/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
@@ -16,7 +16,6 @@ namespace AdaptiveExpressions.Memory
     public class SimpleObjectMemory : IMemory
     {
         private object memory = null;
-        private int version = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleObjectMemory"/> class.
@@ -173,14 +172,11 @@ namespace AdaptiveExpressions.Memory
                     return;
                 }
             }
-
-            // Update the version once memory has been updated
-            version++;
         }
 
         public string Version()
         {
-            return version.ToString();
+            return ToString();
         }
 
         public override string ToString()

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemory.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/CustomizedMemory.cs
@@ -86,7 +86,10 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public string Version()
         {
-            return "0";
+            var globalMemoryId = this.GlobalMemory?.Version() ?? string.Empty;
+            var localMemoryId = this.LocalMemory?.Version() ?? string.Empty;
+
+            return globalMemoryId + localMemoryId;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationTarget.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationTarget.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <returns>Id.</returns>
         public string GetId()
         {
-            return TemplateName + Scope.Version();
+            return TemplateName + Scope?.Version();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationTarget.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationTarget.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using AdaptiveExpressions.Memory;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
@@ -15,7 +16,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// </summary>
         /// <param name="templateName">Template name.</param>
         /// <param name="scope">Template scope.</param>
-        public EvaluationTarget(string templateName, object scope)
+        public EvaluationTarget(string templateName, IMemory scope)
         {
             TemplateName = templateName;
             Scope = scope;
@@ -43,7 +44,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Scope.
         /// </value>
-        public object Scope { get; set; }
+        public IMemory Scope { get; set; }
 
         /// <summary>
         /// Get current instance id. If two target has the same Id,
@@ -52,10 +53,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <returns>Id.</returns>
         public string GetId()
         {
-            var memory = (CustomizedMemory)Scope;
-            var globalMemoryId = memory.GlobalMemory?.Version() ?? string.Empty;
-            var localMemoryId = memory.LocalMemory?.ToString() ?? string.Empty;
-            return TemplateName + globalMemoryId + localMemoryId;
+            return TemplateName.GetHashCode().ToString() + Scope.Version().GetHashCode().ToString();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationTarget.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationTarget.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <returns>Id.</returns>
         public string GetId()
         {
-            return TemplateName.GetHashCode().ToString() + Scope.Version().GetHashCode().ToString();
+            return TemplateName + Scope.Version();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -90,14 +90,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception(TemplateErrors.TemplateNotExist(templateName));
             }
 
-            if (evaluationTargetStack.Any(e => e.TemplateName == templateName))
-            {
-                throw new Exception($"{TemplateErrors.LoopDetected} {string.Join(" => ", evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
-            }
-
             var templateTarget = new EvaluationTarget(templateName, scope);
 
             var currentEvaluateId = templateTarget.GetId();
+
+            if (evaluationTargetStack.Any(e => e.GetId() == currentEvaluateId))
+            {
+                throw new Exception($"{TemplateErrors.LoopDetected} {string.Join(" => ", evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
+            }
 
             EvaluationTarget previousEvaluateTarget = null;
             if (evaluationTargetStack.Count != 0)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -78,10 +78,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <returns>Evaluate result.</returns>
         public object EvaluateTemplate(string inputTemplateName, object scope)
         {
-            if (!(scope is CustomizedMemory))
-            {
-                scope = new CustomizedMemory(scope);
-            }
+            var memory = scope is CustomizedMemory scopeMemory ? scopeMemory : new CustomizedMemory(scope);
 
             (var reExecute, var templateName) = ParseTemplateName(inputTemplateName);
 
@@ -90,7 +87,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception(TemplateErrors.TemplateNotExist(templateName));
             }
 
-            var templateTarget = new EvaluationTarget(templateName, scope);
+            var templateTarget = new EvaluationTarget(templateName, memory);
 
             var currentEvaluateId = templateTarget.GetId();
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -84,10 +84,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <returns>All possiable results.</returns>
         public List<object> ExpandTemplate(string templateName, object scope)
         {
-            if (!(scope is CustomizedMemory))
-            {
-                scope = new CustomizedMemory(scope);
-            }
+            var memory = scope is CustomizedMemory scopeMemory ? scopeMemory : new CustomizedMemory(scope);
 
             if (!TemplateMap.ContainsKey(templateName))
             {
@@ -100,7 +97,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             // Using a stack to track the evaluation trace
-            evaluationTargetStack.Push(new EvaluationTarget(templateName, scope));
+            evaluationTargetStack.Push(new EvaluationTarget(templateName, memory));
             var expanderResult = Visit(TemplateMap[templateName].TemplateBodyParseTree);
             evaluationTargetStack.Pop();
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -91,13 +91,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception(TemplateErrors.TemplateNotExist(templateName));
             }
 
-            if (evaluationTargetStack.Any(e => e.TemplateName == templateName))
+            var templateTarget = new EvaluationTarget(templateName, memory);
+
+            var currentEvaluateId = templateTarget.GetId();
+
+            if (evaluationTargetStack.Any(e => e.GetId() == currentEvaluateId))
             {
                 throw new Exception($"{TemplateErrors.LoopDetected} {string.Join(" => ", evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
             }
 
             // Using a stack to track the evaluation trace
-            evaluationTargetStack.Push(new EvaluationTarget(templateName, memory));
+            evaluationTargetStack.Push(templateTarget);
             var expanderResult = Visit(TemplateMap[templateName].TemplateBodyParseTree);
             evaluationTargetStack.Pop();
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/RecursiveTemplate.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/RecursiveTemplate.lg
@@ -1,0 +1,20 @@
+﻿> 1 + 2 + 3 +...+ number
+# RecursiveAccumulate(number)
+- IF:${number <= 1}
+ - ${1}
+- ELSE:
+ - ${RecursiveAccumulate(number - 1) + number}
+
+> 1 * 2 * 3 * 4 * 5 * ... * number
+# RecursiveFactorial(number)
+- IF: ${number <= 1}
+ - ${1}
+- ELSE:
+ - ${RecursiveFactorial(number - 1) * number}
+
+> 1, 1, 2, 3, 5, 8, 13 ... number th
+# RecursiveFibonacciSequence(number)
+- IF: ${number <= 2}
+ - ${1}
+- ELSE:
+ - ${RecursiveFibonacciSequence(number - 1) + RecursiveFibonacciSequence(number - 2)}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/ExceptionExamples/LoopDetected.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/ExceptionExamples/LoopDetected.lg
@@ -8,3 +8,6 @@
 # welcome_user
 - ${wPhrase()}
 
+> self loop
+# shouldFail(x)
+- ${shouldFail(x)}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -62,6 +62,7 @@
     <None Remove="Examples\CustomFunction.lg" />
     <None Remove="Examples\CustomFunctionSub.lg" />
     <None Remove="Examples\Multiline.lg" />
+    <None Remove="Examples\RecursiveTemplate.lg" />
     <None Remove="ExceptionExamples\ConditionFormatError.lg" />
     <None Remove="ExceptionExamples\DuplicatedTemplates.lg" />
     <None Remove="ExceptionExamples\EmptyLGFile.lg" />
@@ -238,6 +239,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Examples\Multiline.lg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Examples\RecursiveTemplate.lg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="ExceptionExamples\ConditionFormatError.lg">

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -258,6 +258,9 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             exception = Assert.ThrowsException<Exception>(() => lgFile.AnalyzeTemplate("wPhrase"));
             Assert.IsTrue(exception.Message.Contains(TemplateErrors.LoopDetected));
+
+            exception = Assert.ThrowsException<Exception>(() => lgFile.AnalyzeTemplate("shouldFail"));
+            Assert.IsTrue(exception.Message.Contains(TemplateErrors.LoopDetected));
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -732,14 +732,14 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestRecursiveTemplate()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("RecursiveTemplate.lg"));
-            var evaled = templates.Evaluate("RecursiveAccumulate", new { number = 100 });
-            Assert.AreEqual(evaled, 5050L);
+            var evaled = templates.Evaluate("RecursiveAccumulate", new { number = 10 });
+            Assert.AreEqual(evaled, 55L);
 
             evaled = templates.Evaluate("RecursiveFactorial", new { number = 5 });
             Assert.AreEqual(evaled, 1 * 2 * 3 * 4 * 5L);
 
-            evaled = templates.Evaluate("RecursiveFibonacciSequence", new { number = 10 });
-            Assert.AreEqual(evaled, 55L);
+            evaled = templates.Evaluate("RecursiveFibonacciSequence", new { number = 5 });
+            Assert.AreEqual(evaled, 5L);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -729,6 +729,20 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         }
 
         [TestMethod]
+        public void TestRecursiveTemplate()
+        {
+            var templates = Templates.ParseFile(GetExampleFilePath("RecursiveTemplate.lg"));
+            var evaled = templates.Evaluate("RecursiveAccumulate", new { number = 100 });
+            Assert.AreEqual(evaled, 5050L);
+
+            evaled = templates.Evaluate("RecursiveFactorial", new { number = 5 });
+            Assert.AreEqual(evaled, 1 * 2 * 3 * 4 * 5L);
+
+            evaled = templates.Evaluate("RecursiveFibonacciSequence", new { number = 10 });
+            Assert.AreEqual(evaled, 55L);
+        }
+
+        [TestMethod]
         public void TestLGResource()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("2.lg"));


### PR DESCRIPTION
close: #4004

Modify the template loop detection to enable the recursive functions.

The loop exception will only be triggered if both the template name and the parameters are same.