### PR TITLE
Don't throw exception on unhandled VersionChangeDetected event (#4000)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -66,12 +66,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 // Give bot an opportunity to handle the change.
                 // - If bot handles it the changeHash will have been updated as to avoid triggering the 
                 //   change again.
-                var handled = await dc.EmitEventAsync(DialogEvents.VersionChanged, this.Id, true, false, cancellationToken).ConfigureAwait(false);
-                if (!handled)
-                {
-                    // Throw an error for bot to catch
-                    throw new Exception($"Version change detected for '{this.Id}' dialog.");
-                }
+                await dc.EmitEventAsync(DialogEvents.VersionChanged, this.Id, true, false, cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
* disable throwing exception if dialog change not handled

* remove trace from versionChanged

Fix #4013 