### PR TITLE
Enrich LG error message

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
@@ -91,7 +91,15 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public override string ToString()
         {
-            return $"[{Severity}] {Source} {Range}: {Message}";
+            // ignore error range if source is inline content
+            if (Source == TemplatesParser.InlineContentId)
+            {
+                return $"[{Severity}] {Source}: {Message}";
+            }
+            else
+            {
+                return $"[{Severity}] {Source} {Range}: {Message}";
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Diagnostic.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public override string ToString()
         {
-            return $"[{Severity}] {Range}: {Message}";
+            return $"[{Severity}] {Source} {Range}: {Message}";
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/ErrorListener.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var startPosition = new Position(lineOffset + line, charPositionInLine);
             var stopPosition = new Position(lineOffset + line, charPositionInLine + offendingSymbol.StopIndex - offendingSymbol.StartIndex + 1);
             var range = new Range(startPosition, stopPosition);
-            var diagnostic = new Diagnostic(range, TemplateErrors.SyntaxError, DiagnosticSeverity.Error, source);
+            var diagnostic = new Diagnostic(range, TemplateErrors.SyntaxError(msg), DiagnosticSeverity.Error, source);
             throw new TemplateException(diagnostic.ToString(), new List<Diagnostic>() { diagnostic });
         }
     }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -574,7 +574,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
             {
-                throw new Exception(TemplateErrors.InvalidTemplateName);
+                throw new Exception(TemplateErrors.InvalidTemplateNameType);
             }
 
             // Validate more if the name is string constant

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
             {
-                throw new Exception(TemplateErrors.InvalidTemplateName);
+                throw new Exception(TemplateErrors.InvalidTemplateNameType);
             }
 
             // Validate more if the name is string constant

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -115,9 +115,10 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var result = new List<Diagnostic>();
 
-            if (context.structuredBodyNameLine().errorStructuredName() != null)
+            var errorName = context.structuredBodyNameLine().errorStructuredName();
+            if (errorName != null)
             {
-                result.Add(BuildLGDiagnostic(TemplateErrors.InvalidStrucName, context: context.structuredBodyNameLine()));
+                result.Add(BuildLGDiagnostic(TemplateErrors.InvalidStrucName(errorName.GetText()), context: context.structuredBodyNameLine()));
             }
 
             if (context.structuredBodyEndLine() == null)
@@ -130,7 +131,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 foreach (var error in errors)
                 {
-                    result.Add(BuildLGDiagnostic(TemplateErrors.InvalidStrucBody, context: error));
+                    result.Add(BuildLGDiagnostic(TemplateErrors.InvalidStrucBody(error.GetText()), context: error));
                 }
             }
             else
@@ -386,9 +387,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             ParserRuleContext context = null)
         {
             var lineOffset = this.currentTemplate != null ? this.currentTemplate.SourceRange.Range.Start.Line : 0;
-            message = this.currentTemplate != null ? $"[{this.currentTemplate.Name}]" + message : message;
+            var templateNameInfo = string.Empty;
+            if (this.currentTemplate != null && this.currentTemplate.Name != "__temp__")
+            {
+                templateNameInfo = $"[{this.currentTemplate.Name}]";
+            }
+
             var range = context == null ? new Range(1 + lineOffset, 0, 1 + lineOffset, 0) : context.ConvertToRange(lineOffset);
-            return new Diagnostic(range, message, severity, templates.Id);
+            return new Diagnostic(range, templateNameInfo + message, severity, templates.Id);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var lineOffset = this.currentTemplate != null ? this.currentTemplate.SourceRange.Range.Start.Line : 0;
             var templateNameInfo = string.Empty;
-            if (this.currentTemplate != null && this.currentTemplate.Name != "__temp__")
+            if (this.currentTemplate != null && this.currentTemplate.Name != Templates.FakeTemplateId)
             {
                 templateNameInfo = $"[{this.currentTemplate.Name}]";
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -388,7 +388,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var lineOffset = this.currentTemplate != null ? this.currentTemplate.SourceRange.Range.Start.Line : 0;
             var templateNameInfo = string.Empty;
-            if (this.currentTemplate != null && this.currentTemplate.Name != Templates.FakeTemplateId)
+            if (this.currentTemplate != null && this.currentTemplate.Name != Templates.InlineTemplateId)
             {
                 templateNameInfo = $"[{this.currentTemplate.Name}]";
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
@@ -10,17 +10,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     {
         public const string NoTemplate = "LG file must have at least one template definition.";
 
-        public const string InvalidTemplateName = "Invalid template name. Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.";
-
         public const string InvalidTemplateBody = "Invalid template body. Expecting '-' prefix. ";
-
-        public const string InvalidStrucName = "Invalid structure name. name should start with letter/number/_ and can only contains letter/number/./_.";
 
         public const string MissingStrucEnd = "Invalid structure body. Expecting ']' at the end of the body.";
 
         public const string EmptyStrucContent = "Invalid structure body. Body cannot be empty. ";
-
-        public const string InvalidStrucBody = "Invalid structure body. Body can include <PropertyName> = <Value> pairs or ${reference()} template reference.";
 
         public const string InvalidWhitespaceInCondition = "Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.";
 
@@ -62,11 +56,21 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public const string LoopDetected = "Loop detected:";
 
-        public const string SyntaxError = "Unexpected content. Expecting a comment, template definition, import statement or option definition.";
-
         public const string InvalidMemory = "Scope is not a LG customized memory.";
 
         public const string StaticFailure = "Static failure with the following error.";
+
+        public const string InvalidTemplateNameType = "Expected string type for the parameter of template function.";
+
+        public static string InvalidStrucBody(string invalidBody) => $"Invalid structure body: '{invalidBody}'. Body can include <PropertyName> = <Value> pairs or ${{reference()}} template reference.";
+
+        public static string InvalidStrucName(string invalidName) => $"Invalid structure name: '{invalidName}'. name should start with letter/number/_ and can only contains letter/number/./_.";
+
+        public static string SyntaxError(string unexpectedContent) => $"{unexpectedContent}. Expecting a comment, template definition, import statement or option definition.";
+
+        public static string InvalidTemplateName(string invalidTemplateName) => $"Invalid template name: '{invalidTemplateName}'. Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.";
+
+        public static string InvalidParameter(string invalidParameter) => $"Invalid parameter name: '{invalidParameter}'. Parameter names can only contain letter, underscore '_' or number.";
 
         public static string DuplicatedTemplateInSameTemplate(string templateName) => $"Duplicated definitions found for template: '{templateName}'.";
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </remarks>
     public class Templates : List<Template>
     {
-        public const string FakeTemplateId = "__temp__";
+        /// <summary>
+        /// Temp Template ID for inline content.
+        /// </summary>
+        public const string InlineTemplateId = "__temp__";
         private readonly string newLine = Environment.NewLine;
         private readonly Regex newLineRegex = new Regex("(\r?\n)");
         private readonly string namespaceKey = "@namespace";
@@ -228,11 +231,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             text = !text.Trim().StartsWith(multiLineMark) && text.Contains('\n')
                    ? $"{multiLineMark}{text}{multiLineMark}" : text;
 
-            var newContent = $"# {FakeTemplateId} {newLine} - {text}";
+            var newContent = $"# {InlineTemplateId} {newLine} - {text}";
 
             var newLG = TemplatesParser.ParseTextWithRef(newContent, this);
 
-            return newLG.Evaluate(FakeTemplateId, scope, evalOpt);
+            return newLG.Evaluate(InlineTemplateId, scope, evalOpt);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </remarks>
     public class Templates : List<Template>
     {
+        public const string FakeTemplateId = "__temp__";
         private readonly string newLine = Environment.NewLine;
         private readonly Regex newLineRegex = new Regex("(\r?\n)");
         private readonly string namespaceKey = "@namespace";
@@ -222,17 +223,16 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             CheckErrors();
 
             // wrap inline string with "# name and -" to align the evaluation process
-            var fakeTemplateId = "__temp__";
             var multiLineMark = "```";
 
             text = !text.Trim().StartsWith(multiLineMark) && text.Contains('\n')
                    ? $"{multiLineMark}{text}{multiLineMark}" : text;
 
-            var newContent = $"# {fakeTemplateId} {newLine} - {text}";
+            var newContent = $"# {FakeTemplateId} {newLine} - {text}";
 
             var newLG = TemplatesParser.ParseTextWithRef(newContent, this);
 
-            return newLG.Evaluate(fakeTemplateId, scope, evalOpt);
+            return newLG.Evaluate(FakeTemplateId, scope, evalOpt);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var lineContent = context.INVALID_LINE().GetText();
                 if (!string.IsNullOrWhiteSpace(lineContent))
                 {
-                    this.templates.Diagnostics.Add(BuildTemplatesDiagnostic(TemplateErrors.SyntaxError, context));
+                    this.templates.Diagnostics.Add(BuildTemplatesDiagnostic(TemplateErrors.SyntaxError($"Unexpected content: '{lineContent}'"), context));
                 }
 
                 return null;
@@ -366,7 +366,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     if (!IdentifierRegex.IsMatch(parameter))
                     {
-                        var diagnostic = BuildTemplatesDiagnostic(TemplateErrors.InvalidTemplateName, context);
+                        var diagnostic = BuildTemplatesDiagnostic(TemplateErrors.InvalidParameter(parameter), context);
                         this.templates.Diagnostics.Add(diagnostic);
                     }
                 }
@@ -379,8 +379,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     if (!TemplateNamePartRegex.IsMatch(id))
                     {
-                        var diagnostic = BuildTemplatesDiagnostic(TemplateErrors.InvalidTemplateName, context);
+                        var diagnostic = BuildTemplatesDiagnostic(TemplateErrors.InvalidTemplateName(templateName), context);
                         this.templates.Diagnostics.Add(diagnostic);
+                        break;
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     public static class TemplatesParser
     {
         /// <summary>
+        /// Inline text id.
+        /// </summary>
+        public const string InlineContentId = "inline content";
+
+        /// <summary>
         /// option regex.
         /// </summary>
         public static readonly Regex OptionRegex = new Regex(@">\s*!#(.*)");
@@ -84,11 +89,10 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new ArgumentNullException(nameof(lg));
             }
 
-            var id = "inline content";
-            var newLG = new Templates(content: content, id: id, importResolver: lg.ImportResolver, options: lg.Options);
+            var newLG = new Templates(content: content, id: InlineContentId, importResolver: lg.ImportResolver, options: lg.Options);
             try
             {
-                newLG = new TemplatesTransformer(newLG).Transform(AntlrParseTemplates(content, id));
+                newLG = new TemplatesTransformer(newLG).Transform(AntlrParseTemplates(content, InlineContentId));
                 newLG.References = GetReferences(newLG)
                         .Union(lg.References)
                         .Union(new List<Templates> { lg })

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             Assert.AreEqual(8, diagnostics.Count);
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[0].Severity);
-            Assert.IsTrue(diagnostics[0].Message.Contains(TemplateErrors.InvalidStrucBody));
+            Assert.IsTrue(diagnostics[0].Message.Contains(TemplateErrors.InvalidStrucBody("abc")));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[1].Severity);
             Assert.IsTrue(diagnostics[1].Message.Contains(TemplateErrors.EmptyStrucContent));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[2].Severity);
@@ -110,13 +110,13 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[3].Severity);
             Assert.IsTrue(diagnostics[3].Message.Contains("Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator"));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[4].Severity);
-            Assert.IsTrue(diagnostics[4].Message.Contains(TemplateErrors.InvalidStrucName));
+            Assert.IsTrue(diagnostics[4].Message.Contains(TemplateErrors.InvalidStrucName("Activity%")));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[5].Severity);
-            Assert.IsTrue(diagnostics[5].Message.Contains(TemplateErrors.InvalidStrucName));
+            Assert.IsTrue(diagnostics[5].Message.Contains(TemplateErrors.InvalidStrucName("Activity]")));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[6].Severity); 
             Assert.IsTrue(diagnostics[6].Message.Contains(TemplateErrors.MissingStrucEnd));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[7].Severity);
-            Assert.IsTrue(diagnostics[7].Message.Contains(TemplateErrors.InvalidStrucBody));
+            Assert.IsTrue(diagnostics[7].Message.Contains(TemplateErrors.InvalidStrucBody("- hi")));
         }
 
         [TestMethod]
@@ -145,11 +145,26 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var diagnostics = GetDiagnostics("ErrorTemplateName.lg");
 
             Assert.AreEqual(7, diagnostics.Count);
-            foreach (var diagnostic in diagnostics)
-            {
-                Assert.AreEqual(DiagnosticSeverity.Error, diagnostic.Severity);
-                Assert.IsTrue(diagnostic.Message.Contains(TemplateErrors.InvalidTemplateName));
-            }
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[0].Severity);
+            Assert.IsTrue(diagnostics[0].Message.Contains(TemplateErrors.InvalidParameter("param1; param2")));
+
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[1].Severity);
+            Assert.IsTrue(diagnostics[1].Message.Contains(TemplateErrors.InvalidParameter("param1 param2")));
+
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[2].Severity);
+            Assert.IsTrue(diagnostics[2].Message.Contains(TemplateErrors.InvalidTemplateName("template3(errorparams")));
+
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[3].Severity);
+            Assert.IsTrue(diagnostics[3].Message.Contains(TemplateErrors.InvalidParameter("a)test(param1")));
+
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[4].Severity);
+            Assert.IsTrue(diagnostics[4].Message.Contains(TemplateErrors.InvalidParameter("$%^")));
+
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[5].Severity);
+            Assert.IsTrue(diagnostics[5].Message.Contains(TemplateErrors.InvalidTemplateName("the-name-of-template")));
+
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[6].Severity);
+            Assert.IsTrue(diagnostics[6].Message.Contains(TemplateErrors.InvalidTemplateName("t1.1")));
         }
 
         [TestMethod]
@@ -323,13 +338,13 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.AreEqual(4, diagnostics.Count);
 
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[0].Severity);
-            Assert.IsTrue(diagnostics[0].Message.Contains(TemplateErrors.SyntaxError));
+            Assert.IsTrue(diagnostics[0].Message.Contains(TemplateErrors.SyntaxError("mismatched input '-' expecting <EOF>")));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[1].Severity);
-            Assert.IsTrue(diagnostics[1].Message.Contains(TemplateErrors.InvalidStrucName));
+            Assert.IsTrue(diagnostics[1].Message.Contains(TemplateErrors.InvalidStrucName("]")));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[2].Severity);
             Assert.IsTrue(diagnostics[2].Message.Contains(TemplateErrors.MissingStrucEnd));
             Assert.AreEqual(DiagnosticSeverity.Error, diagnostics[3].Severity);
-            Assert.IsTrue(diagnostics[3].Message.Contains(TemplateErrors.InvalidStrucBody));
+            Assert.IsTrue(diagnostics[3].Message.Contains(TemplateErrors.InvalidStrucBody("- hi")));
         }
 
         [TestMethod]


### PR DESCRIPTION
close: #3906
- Add more context info into some diagnostic errors.
- Add file path info into diagnostic errors.


|Item | Before | After|
|-- | -- | --|
|Invalid template name | Invalid template name. Template names can only contain letter... | Invalid template name: '{invalidName}'. Template names can only contain letter...|
|Invalid structure body | Invalid structure body. Body can include... | Invalid structure body: '{invalidBody}'. Body can include...|
|Syntax Error | Unexpected Content. Expecting a comment, template def... | {unexpectedContent}. Expecting a comment, template def...|
|Invalid Parameter | Invalid parameter name. Parameter names can ... | Invalid parameter name: '{invalidParameter}'. Parameter names can|
|Diagnostics | [Error] line 3:0 - line 3:8: [template]Invalid condition....[Error] line 10:0 - line 10:14: [template2]Invalid template body... | [Error] C:\\xx\\yy.lg line 3:0 - line 3:8: [template]Invalid condition...[Error] C:\\xx\\zz.lg line 10:0 - line 10:14: [template2]Invalid template body...|

