### PR TITLE
Allow the activity only with channelData property in sendActivity action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendActivity.cs
@@ -81,7 +81,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 || !string.IsNullOrEmpty(activity.Text)
                 || activity.Attachments?.Any() == true
                 || !string.IsNullOrEmpty(activity.Speak)
-                || activity.SuggestedActions != null)
+                || activity.SuggestedActions != null
+                || activity.ChannelData != null)
             {
                 response = await dc.Context.SendActivityAsync(activity, cancellationToken).ConfigureAwait(false);
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SendActivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SendActivity.test.dialog
@@ -38,6 +38,31 @@
                                 "text": "static activity works"
                             }
                         }
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": {
+                        "$kind": "Microsoft.StaticActivityTemplate",
+                        "activity": {
+                            "type": "message",
+                            "channelData": {
+                                "attachment": {
+                                    "type": "template",
+                                    "payload": {
+                                        "template_type": "button",
+                                        "text": "What do you want to do next?",
+                                        "buttons": [
+                                            {
+                                                "type": "web_url",
+                                                "url": "https://www.messenger.com",
+                                                "title": "Visit Messenger"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                        }
                     }
                 ]
             }
@@ -58,6 +83,14 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "static activity works"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'message'",
+                "text == null",
+                "channelData != null"
+            ]
         }
     ]
 }


### PR DESCRIPTION
close: #4001

```
{
     "$kind": "Microsoft.SendActivity",
     "activity": {
       "$kind": "Microsoft.StaticActivityTemplate",
       "activity": {
           "type": "message",
           // only channel data property, no text and speak.
           // This one should be valid and be sent to the channel.
          "channelData": {xxxx}
   }
}
}
```