### PR TITLE
[Expression] Add merge prebuilt function for merging JSON object

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -4495,6 +4495,53 @@ namespace AdaptiveExpressions
                 new ExpressionEvaluator(ExpressionType.Coalesce, Apply(args => Coalesce(args.ToArray())), ReturnType.Object, ValidateAtLeastOne),
                 new ExpressionEvaluator(ExpressionType.XPath, ApplyWithError(args => XPath(args[0], args[1])), ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
                 new ExpressionEvaluator(ExpressionType.JPath, ApplyWithError(args => JPath(args[0], args[1].ToString())), ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
+                new ExpressionEvaluator(
+                    ExpressionType.Merge,
+                    ApplySequenceWithError(args =>
+                                {
+                                    object result = null;
+                                    string error = null;
+                                    if (args[0] is JObject)
+                                    {
+                                        if (!(args[1] is JObject))
+                                        {
+                                            error = $"The parameter {args[1]} must also be a JObject.";
+                                        }
+                                        else
+                                        {
+                                            (args[0] as JObject).Merge(args[1] as JObject, new JsonMergeSettings
+                                            {
+                                                MergeArrayHandling = MergeArrayHandling.Union
+                                            });
+
+                                            result = args[0];
+                                        }
+                                    }
+                                    else if (args[0] is JArray)
+                                    {
+                                        if (!(args[1] is JArray))
+                                        {
+                                            error = $"The parameter {args[1]} must also be a JArray.";
+                                        }
+                                        else
+                                        {
+                                            (args[0] as JArray).Merge(args[1] as JArray, new JsonMergeSettings
+                                            {
+                                                MergeArrayHandling = MergeArrayHandling.Union
+                                            });
+
+                                            result = args[0];
+                                        }
+                                    }
+                                    else
+                                    {
+                                        error = $"The parameter {args[0]} must be a JObject or a JArray.";
+                                    }
+
+                                    return (result, error);
+                                }), 
+                    ReturnType.Object,
+                    (expression) => ValidateArityAndAnyType(expression, 2, int.MaxValue)),
 
                 // Regex expression
                 new ExpressionEvaluator(

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -4501,25 +4501,18 @@ namespace AdaptiveExpressions
                                 {
                                     object result = null;
                                     string error = null;
-                                    if (args[0] is JObject)
+                                    if (args[0] is JObject && args[1] is JObject)
                                     {
-                                        if (!(args[1] is JObject))
+                                        (args[0] as JObject).Merge(args[1] as JObject, new JsonMergeSettings
                                         {
-                                            error = $"The parameter {args[1]} must also be a JSON object.";
-                                        }
-                                        else
-                                        {
-                                            (args[0] as JObject).Merge(args[1] as JObject, new JsonMergeSettings
-                                            {
-                                                MergeArrayHandling = MergeArrayHandling.Replace
-                                            });
+                                            MergeArrayHandling = MergeArrayHandling.Replace
+                                        });
 
-                                            result = args[0];
-                                        }
+                                        result = args[0];
                                     }
                                     else
                                     {
-                                        error = $"The parameter {args[0]} must be a JSON object.";
+                                        error = $"The arguments {args[0]} and {args[1]} must be a JSON objects.";
                                     }
 
                                     return (result, error);

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -2927,7 +2927,7 @@ namespace AdaptiveExpressions
                             var count = Convert.ToInt32(args[1]);
                             if (count <= 0)
                             {
-                                error = $"The second parameter should be more than zero";
+                                error = $"The second parameter ${args[1]} should be more than zero";
                             }
                             else
                             {
@@ -2954,7 +2954,7 @@ namespace AdaptiveExpressions
                         object result = null;
                         if (args.Count == 2 && !args[1].IsInteger())
                         {
-                            error = $"The second {args[1]} parameter must be an integer.";
+                            error = $"The second parameter ${args[1]} must be an integer.";
                         }
 
                         if (error == null)
@@ -2962,7 +2962,7 @@ namespace AdaptiveExpressions
                             var digits = args.Count == 2 ? Convert.ToInt32(args[1]) : 0;
                             if (digits < 0 || digits > 15)
                             {
-                                error = $"The second parameter {args[1]} must be an integer between 0 and 15;";
+                                error = $"The second parameter {args[1]} must be an integer between 0 and 15.";
                             }
                             else
                             {

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -4505,29 +4505,13 @@ namespace AdaptiveExpressions
                                     {
                                         if (!(args[1] is JObject))
                                         {
-                                            error = $"The parameter {args[1]} must also be a JObject.";
+                                            error = $"The parameter {args[1]} must also be a JSON object.";
                                         }
                                         else
                                         {
                                             (args[0] as JObject).Merge(args[1] as JObject, new JsonMergeSettings
                                             {
-                                                MergeArrayHandling = MergeArrayHandling.Union
-                                            });
-
-                                            result = args[0];
-                                        }
-                                    }
-                                    else if (args[0] is JArray)
-                                    {
-                                        if (!(args[1] is JArray))
-                                        {
-                                            error = $"The parameter {args[1]} must also be a JArray.";
-                                        }
-                                        else
-                                        {
-                                            (args[0] as JArray).Merge(args[1] as JArray, new JsonMergeSettings
-                                            {
-                                                MergeArrayHandling = MergeArrayHandling.Union
+                                                MergeArrayHandling = MergeArrayHandling.Replace
                                             });
 
                                             result = args[0];
@@ -4535,7 +4519,7 @@ namespace AdaptiveExpressions
                                     }
                                     else
                                     {
-                                        error = $"The parameter {args[0]} must be a JObject or a JArray.";
+                                        error = $"The parameter {args[0]} must be a JSON object.";
                                     }
 
                                     return (result, error);

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -2358,7 +2358,7 @@ namespace AdaptiveExpressions
                     }
                     else
                     {
-                        error = $"there is no matching node for path: ${jpath} in the given JSON";
+                        error = $"there is no matching node for path: {jpath} in the given JSON";
                     }
                 }
             }
@@ -2927,7 +2927,7 @@ namespace AdaptiveExpressions
                             var count = Convert.ToInt32(args[1]);
                             if (count <= 0)
                             {
-                                error = $"The second parameter ${args[1]} should be more than zero";
+                                error = $"The second parameter {args[1]} should be more than zero";
                             }
                             else
                             {
@@ -2954,7 +2954,7 @@ namespace AdaptiveExpressions
                         object result = null;
                         if (args.Count == 2 && !args[1].IsInteger())
                         {
-                            error = $"The second parameter ${args[1]} must be an integer.";
+                            error = $"The second parameter {args[1]} must be an integer.";
                         }
 
                         if (error == null)
@@ -4328,15 +4328,15 @@ namespace AdaptiveExpressions
                             string error = null;
                             if (!args[0].IsNumber())
                             {
-                                error = $"formatNumber first argument ${args[0]} must be number";
+                                error = $"formatNumber first argument {args[0]} must be number";
                             }
                             else if (!args[1].IsInteger())
                             {
-                                error = $"formatNumber second argument ${args[1]} must be number";
+                                error = $"formatNumber second argument {args[1]} must be number";
                             }
                             else if (args.Count == 3 && !(args[2] is string))
                             {
-                                error = $"formatNumber third agument ${args[2]} must be a locale";
+                                error = $"formatNumber third agument {args[2]} must be a locale";
                             }
                             else
                             {

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -167,6 +167,7 @@ namespace AdaptiveExpressions
         public const string XPath = "xPath";
         public const string SetPathToValue = "setPathToValue";
         public const string JPath = "jPath";
+        public const string Merge = "merge";
 
         // Regular expression
         public const string IsMatch = "isMatch";

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -387,9 +387,9 @@ namespace AdaptiveExpressions.Tests
             Test("jPath(hello,'Manufacturers[0].Products[0].Price')"), // not a valid json
             Test("jPath(hello,'Manufacturers[0]/Products[0]/Price')"), // not a valid path
             Test("jPath(jsonStr,'$..Products[?(@.Price >= 100)].Name')"), // no matched node
-            Test("merger(json(json1))"), // should have at least two arguments
-            Test("merger(json(json1), json(jarray1))"), // arguments should all be JSON objects
-            Test("merger(json(jarray1), json(json1))"), // arguments should all be JSON objects
+            Test("merge(json(json1))"), // should have at least two arguments
+            Test("merge(json(json1), json(jarray1))"), // arguments should all be JSON objects
+            Test("merge(json(jarray1), json(json1))"), // arguments should all be JSON objects
             #endregion
 
             #region Memory access test

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -388,8 +388,8 @@ namespace AdaptiveExpressions.Tests
             Test("jPath(hello,'Manufacturers[0]/Products[0]/Price')"), // not a valid path
             Test("jPath(jsonStr,'$..Products[?(@.Price >= 100)].Name')"), // no matched node
             Test("merger(json(json1))"), // should have at least two arguments
-            Test("merger(json(json1), json(jarray1))"), // arguments should all be JSON object
-            Test("merger(json(jarray1), json(json1))"), // arguments should all be JSON object
+            Test("merger(json(json1), json(jarray1))"), // arguments should all be JSON objects
+            Test("merger(json(jarray1), json(json1))"), // arguments should all be JSON objects
             #endregion
 
             #region Memory access test

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -387,6 +387,9 @@ namespace AdaptiveExpressions.Tests
             Test("jPath(hello,'Manufacturers[0].Products[0].Price')"), // not a valid json
             Test("jPath(hello,'Manufacturers[0]/Products[0]/Price')"), // not a valid path
             Test("jPath(jsonStr,'$..Products[?(@.Price >= 100)].Name')"), // no matched node
+            Test("merger(json(json1))"), // should have at least two arguments
+            Test("merger(json(json1), json(jarray1))"), // arguments should have same type
+            Test("merger(json(jarray1), json(json1))"), // arguments should have same type
             #endregion
 
             #region Memory access test
@@ -498,6 +501,11 @@ namespace AdaptiveExpressions.Tests
                 notValidTimestamp2 = "1521118800",
                 notValidTimestamp3 = "20181115",
                 relativeUri = "../catalog/shownew.htm?date=today",
+                json1 = @"{
+                          'Enabled': true,
+                          'Roles': [ 'User', 'Admin' ]
+                        }",
+                jarray1 = @"['a', 'b']",
                 turn = new
                 {
                     recognized = new

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -388,8 +388,8 @@ namespace AdaptiveExpressions.Tests
             Test("jPath(hello,'Manufacturers[0]/Products[0]/Price')"), // not a valid path
             Test("jPath(jsonStr,'$..Products[?(@.Price >= 100)].Name')"), // no matched node
             Test("merger(json(json1))"), // should have at least two arguments
-            Test("merger(json(json1), json(jarray1))"), // arguments should have same type
-            Test("merger(json(jarray1), json(json1))"), // arguments should have same type
+            Test("merger(json(json1), json(jarray1))"), // arguments should all be JSON object
+            Test("merger(json(jarray1), json(json1))"), // arguments should all be JSON object
             #endregion
 
             #region Memory access test

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -945,8 +945,6 @@ namespace AdaptiveExpressions.Tests
             Test("setProperty({name: 'Paul'}, 'name', user.name).name", null),
             Test("setProperty({}, 'name', user.nickname).name", "John"),
             Test("addProperty({}, 'name', user.name).name", null),
-            Test("string(merge(json(jarray1), json(jarray2)))", "[\"a\",\"b\",\"c\",\"d\"]"),
-            Test("string(merge(json(jarray1), json(jarray2), json(jarray3)))", "[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\"]"),
             Test("string(merge(json(json1), json(json2)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"User\",\"Admin\"]}"),
             Test("string(merge(json(json1), json(json2), json(json3)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"User\",\"Admin\"],\"Age\":36}"),
             #endregion

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -114,6 +114,34 @@ namespace AdaptiveExpressions.Tests
             { "unixTimestamp", 1521118800 },
             { "unixTimestampFraction", 1521118800.5 },
             { "ticks", 637243624200000000 },
+            { 
+                "json1", @"{
+                          'FirstName': 'John',
+                          'LastName': 'Smith',
+                          'Enabled': false,
+                          'Roles': [ 'User' ]
+                        }"
+            },
+            { 
+                "json2", @"{
+                          'Enabled': true,
+                          'Roles': [ 'User', 'Admin' ]
+                        }"
+            },
+            {
+                "json3", @"{
+                          'Age': 36,
+                        }"
+            },
+            {
+                "jarray1", @"['a', 'b']"
+            },
+            {
+                "jarray2", @"['c', 'd']"
+            },
+            {
+                "jarray3", @"['e', 'f']"
+            },
             { "xmlStr", "<?xml version='1.0'?> <produce> <item> <name>Gala</name> <type>apple</type> <count>20</count> </item> <item> <name>Honeycrisp</name> <type>apple</type> <count>10</count> </item> </produce>" },
             {
                 "jsonStr", @"{
@@ -917,6 +945,10 @@ namespace AdaptiveExpressions.Tests
             Test("setProperty({name: 'Paul'}, 'name', user.name).name", null),
             Test("setProperty({}, 'name', user.nickname).name", "John"),
             Test("addProperty({}, 'name', user.name).name", null),
+            Test("string(merge(json(jarray1), json(jarray2)))", "[\"a\",\"b\",\"c\",\"d\"]"),
+            Test("string(merge(json(jarray1), json(jarray2), json(jarray3)))", "[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\"]"),
+            Test("string(merge(json(json1), json(json2)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"User\",\"Admin\"]}"),
+            Test("string(merge(json(json1), json(json2), json(json3)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"User\",\"Admin\"],\"Age\":36}"),
             #endregion
 
             #region  Memory access

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -125,22 +125,13 @@ namespace AdaptiveExpressions.Tests
             { 
                 "json2", @"{
                           'Enabled': true,
-                          'Roles': [ 'User', 'Admin' ]
+                          'Roles': [ 'Customer', 'Admin' ]
                         }"
             },
             {
                 "json3", @"{
                           'Age': 36,
                         }"
-            },
-            {
-                "jarray1", @"['a', 'b']"
-            },
-            {
-                "jarray2", @"['c', 'd']"
-            },
-            {
-                "jarray3", @"['e', 'f']"
             },
             { "xmlStr", "<?xml version='1.0'?> <produce> <item> <name>Gala</name> <type>apple</type> <count>20</count> </item> <item> <name>Honeycrisp</name> <type>apple</type> <count>10</count> </item> </produce>" },
             {
@@ -945,8 +936,8 @@ namespace AdaptiveExpressions.Tests
             Test("setProperty({name: 'Paul'}, 'name', user.name).name", null),
             Test("setProperty({}, 'name', user.nickname).name", "John"),
             Test("addProperty({}, 'name', user.name).name", null),
-            Test("string(merge(json(json1), json(json2)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"User\",\"Admin\"]}"),
-            Test("string(merge(json(json1), json(json2), json(json3)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"User\",\"Admin\"],\"Age\":36}"),
+            Test("string(merge(json(json1), json(json2)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"Customer\",\"Admin\"]}"),
+            Test("string(merge(json(json1), json(json2), json(json3)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"Customer\",\"Admin\"],\"Age\":36}"),
             #endregion
 
             #region  Memory access


### PR DESCRIPTION
issue link: #4014

merge function can take JSON object as input.
merge(jobject1, jobject2, ...)

for example:
```
json1 = @"{
                   'FirstName': 'John',
                   'LastName': 'Smith',
                   'Enabled': false,
                    'Roles': [ 'User' ]
                   }"
```
```
json2 =@"{
                  'Enabled': true,
                  'Roles': [ 'User', 'Admin' ]
                 }"
```
`string(merge(json(json1), json(json2)))` will return
```
{"FirstName":"John","LastName":"Smith","Enabled":true,"Roles":["User","Admin"]}
```
