### PR TITLE
Enables FxCop Analyzer for the Connector library

### DIFF
--- a/libraries/Microsoft.Bot.Connector/AttachmentsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/AttachmentsEx.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Bot.Connector
         /// <param name="attachmentId">id of the attachment.</param>
         /// <param name="viewId">default is "original".</param>
         /// <returns>uri.</returns>
+#pragma warning disable CA1055 // Uri return values should not be strings (we can't change this without breaking binary compat)
         public string GetAttachmentUri(string attachmentId, string viewId = "original")
+#pragma warning restore CA1055 // Uri return values should not be strings
         {
             if (attachmentId == null)
             {
@@ -41,7 +43,7 @@ namespace Microsoft.Bot.Connector
 
             // Construct URL
             var baseUrl = this.Client.BaseUri.AbsoluteUri;
-            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? string.Empty : "/")), "v3/attachments/{attachmentId}/views/{viewId}").ToString();
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/", StringComparison.OrdinalIgnoreCase)), "v3/attachments/{attachmentId}/views/{viewId}").ToString();
             url = url.Replace("{attachmentId}", Uri.EscapeDataString(attachmentId));
             url = url.Replace("{viewId}", Uri.EscapeDataString(viewId));
             return url;

--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -90,12 +90,131 @@ namespace Microsoft.Bot.Connector.Authentication
 
         async Task<AuthenticatorResult> IAuthenticator.GetTokenAsync(bool forceRefresh)
         {
-            var result = await GetTokenAsync(forceRefresh);
+            var result = await GetTokenAsync(forceRefresh).ConfigureAwait(false);
             return new AuthenticatorResult() 
             {
                 AccessToken = result.AccessToken,
                 ExpiresOn = result.ExpiresOn
             };
+        }
+
+        private static RetryParams HandleAdalException(Exception ex, int currentRetryCount)
+        {
+            if (IsAdalServiceUnavailable(ex))
+            {
+                return ComputeAdalRetry(ex);
+            }
+            else if (ex is ThrottleException)
+            {
+                // This is an exception that we threw, with knowledge that
+                // one of our threads is trying to acquire a token from the server
+                // Use the retry parameters recommended in the exception
+                ThrottleException throttlException = (ThrottleException)ex;
+                return throttlException.RetryParams ?? RetryParams.DefaultBackOff(currentRetryCount);
+            }
+            else if (IsAdalServiceInvalidRequest(ex))
+            {
+                return RetryParams.StopRetrying;
+            }
+            else
+            {
+                // We end up here is the exception is not an ADAL exception. An example, is under high traffic
+                // where we could have a timeout waiting to acquire a token, waiting on the semaphore.
+                // If we hit a timeout, we want to retry a reasonable number of times.
+                return RetryParams.DefaultBackOff(currentRetryCount);
+            }
+        }
+
+        private static bool IsAdalServiceUnavailable(Exception ex)
+        {
+            AdalServiceException adalServiceException = ex as AdalServiceException;
+            if (adalServiceException == null)
+            {
+                return false;
+            }
+
+            // When the Service Token Server (STS) is too busy because of “too many requests”,
+            // it returns an HTTP error 429
+            return adalServiceException.ErrorCode == MsalTemporarilyUnavailable || adalServiceException.StatusCode == HttpTooManyRequests;
+        }
+
+        /// <summary>
+        /// Determine whether exception represents an invalid request from AAD.
+        /// </summary>
+        /// <param name="ex">Exception.</param>
+        /// <returns>True if the exception represents an invalid request.</returns>
+        private static bool IsAdalServiceInvalidRequest(Exception ex)
+        {
+            if (ex is AdalServiceException adal)
+            {
+                // ErrorCode is "invalid_request"
+                // but HTTP StatusCode covers more non-retryable conditions
+                if (adal.StatusCode == (int)HttpStatusCode.BadRequest)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static RetryParams ComputeAdalRetry(Exception ex)
+        {
+            if (ex is AdalServiceException)
+            {
+                AdalServiceException adalServiceException = (AdalServiceException)ex;
+
+                // When the Service Token Server (STS) is too busy because of “too many requests”,
+                // it returns an HTTP error 429 with a hint about when you can try again (Retry-After response field) as a delay in seconds
+                if (adalServiceException.ErrorCode == MsalTemporarilyUnavailable || adalServiceException.StatusCode == HttpTooManyRequests)
+                {
+                    RetryConditionHeaderValue retryAfter = adalServiceException.Headers.RetryAfter;
+
+                    // Depending on the service, the recommended retry time may be in retryAfter.Delta or retryAfter.Date. Check both.
+                    if (retryAfter != null && retryAfter.Delta.HasValue)
+                    {
+                        return new RetryParams(retryAfter.Delta.Value);
+                    }
+                    else if (retryAfter != null && retryAfter.Date.HasValue)
+                    {
+                        return new RetryParams(retryAfter.Date.Value.Offset);
+                    }
+
+                    // We got a 429 but didn't get a specific back-off time. Use the default
+                    return RetryParams.DefaultBackOff(0);
+                }
+            }
+
+            return RetryParams.DefaultBackOff(0);
+        }
+        
+        private void ReleaseSemaphore()
+        {
+            try
+            {
+                tokenRefreshSemaphore.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                // We should not be hitting this after switching to SemaphoreSlim, but if we do hit it everything will keep working.
+                // Logging to have clear knowledge of whether this is happening.
+                logger?.LogWarning("Attempted to release a full semaphore.");
+            }
+
+            // Any exception other than SemaphoreFullException should be thrown right away
+        }
+
+        private void Initialize(OAuthConfiguration configurationOAuth, HttpClient customHttpClient)
+        {
+            if (customHttpClient != null)
+            {
+                var httpClientFactory = new ConstantHttpClientFactory(customHttpClient);
+                this.authContext = new AuthenticationContext(configurationOAuth.Authority, true, new TokenCache(), httpClientFactory);
+            }
+            else
+            {
+                this.authContext = new AuthenticationContext(configurationOAuth.Authority);
+            }
         }
 
         private async Task<AuthenticationResult> AcquireTokenAsync(bool forceRefresh = false)
@@ -175,130 +294,6 @@ namespace Microsoft.Bot.Connector.Authentication
                     ReleaseSemaphore();
                 }
             }
-        }
-
-        private void ReleaseSemaphore()
-        {
-            try
-            {
-                tokenRefreshSemaphore.Release();
-            }
-            catch (SemaphoreFullException)
-            {
-                // We should not be hitting this after switching to SemaphoreSlim, but if we do hit it everything will keep working.
-                // Logging to have clear knowledge of whether this is happening.
-                logger?.LogWarning("Attempted to release a full semaphore.");
-            }
-
-            // Any exception other than SemaphoreFullException should be thrown right away
-        }
-
-        private RetryParams HandleAdalException(Exception ex, int currentRetryCount)
-        {
-            if (IsAdalServiceUnavailable(ex))
-            {
-                return ComputeAdalRetry(ex);
-            }
-            else if (ex is ThrottleException)
-            {
-                // This is an exception that we threw, with knowledge that
-                // one of our threads is trying to acquire a token from the server
-                // Use the retry parameters recommended in the exception
-                ThrottleException throttlException = (ThrottleException)ex;
-                return throttlException.RetryParams ?? RetryParams.DefaultBackOff(currentRetryCount);
-            }
-            else if (IsAdalServiceInvalidRequest(ex))
-            {
-                return RetryParams.StopRetrying;
-            }
-            else
-            {
-                // We end up here is the exception is not an ADAL exception. An example, is under high traffic
-                // where we could have a timeout waiting to acquire a token, waiting on the semaphore.
-                // If we hit a timeout, we want to retry a reasonable number of times.
-                return RetryParams.DefaultBackOff(currentRetryCount);
-            }
-        }
-
-        private bool IsAdalServiceUnavailable(Exception ex)
-        {
-            AdalServiceException adalServiceException = ex as AdalServiceException;
-            if (adalServiceException == null)
-            {
-                return false;
-            }
-
-            // When the Service Token Server (STS) is too busy because of “too many requests”,
-            // it returns an HTTP error 429
-            return adalServiceException.ErrorCode == MsalTemporarilyUnavailable || adalServiceException.StatusCode == HttpTooManyRequests;
-        }
-
-        /// <summary>
-        /// Determine whether exception represents an invalid request from AAD.
-        /// </summary>
-        /// <param name="ex">Exception.</param>
-        /// <returns>True if the exception represents an invalid request.</returns>
-        private bool IsAdalServiceInvalidRequest(Exception ex)
-        {
-            if (ex is AdalServiceException adal)
-            {
-                // ErrorCode is "invalid_request"
-                // but HTTP StatusCode covers more non-retryable conditions
-                if (adal.StatusCode == (int)HttpStatusCode.BadRequest)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private RetryParams ComputeAdalRetry(Exception ex)
-        {
-            if (ex is AdalServiceException)
-            {
-                AdalServiceException adalServiceException = (AdalServiceException)ex;
-
-                // When the Service Token Server (STS) is too busy because of “too many requests”,
-                // it returns an HTTP error 429 with a hint about when you can try again (Retry-After response field) as a delay in seconds
-                if (adalServiceException.ErrorCode == MsalTemporarilyUnavailable || adalServiceException.StatusCode == HttpTooManyRequests)
-                {
-                    RetryConditionHeaderValue retryAfter = adalServiceException.Headers.RetryAfter;
-
-                    // Depending on the service, the recommended retry time may be in retryAfter.Delta or retryAfter.Date. Check both.
-                    if (retryAfter != null && retryAfter.Delta.HasValue)
-                    {
-                        return new RetryParams(retryAfter.Delta.Value);
-                    }
-                    else if (retryAfter != null && retryAfter.Date.HasValue)
-                    {
-                        return new RetryParams(retryAfter.Date.Value.Offset);
-                    }
-
-                    // We got a 429 but didn't get a specific back-off time. Use the default
-                    return RetryParams.DefaultBackOff(0);
-                }
-            }
-
-            return RetryParams.DefaultBackOff(0);
-        }
-
-        private void Initialize(OAuthConfiguration configurationOAuth, HttpClient customHttpClient)
-        {
-            if (customHttpClient != null)
-            {
-                var httpClientFactory = new ConstantHttpClientFactory(customHttpClient);
-                this.authContext = new AuthenticationContext(configurationOAuth.Authority, true, new TokenCache(), httpClientFactory);
-            }
-            else
-            {
-                this.authContext = new AuthenticationContext(configurationOAuth.Authority);
-            }
-        }
-
-        private bool UseCertificate()
-        {
-            return this.clientCertificate != null;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticationConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Connector.Authentication
 {
     /// <summary>
@@ -12,7 +14,9 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </remarks>
     public class AuthenticationConfiguration
     {
-        public string[] RequiredEndorsements { get; set; } = { };
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
+        public string[] RequiredEndorsements { get; set; } = Array.Empty<string>();
+#pragma warning restore CA1819 // Properties should not return arrays
 
         /// <summary>
         /// Gets or sets an <see cref="ClaimsValidator"/> instance used to validate the identity claims.

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <value>
         /// The default endpoint that is used for Open ID Metadata requests.
         /// </value>
+#pragma warning disable CA1056 // Uri properties should not be strings (we can't change this without breaking binary compat)
         public static string OpenIdMetadataUrl { get; set; } = AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl;
+#pragma warning restore CA1056 // Uri properties should not be strings
 
         /// <summary>
         /// Validate the incoming Auth Header as a token sent from the Bot Framework Service.
@@ -86,7 +88,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 OpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.
@@ -123,7 +125,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await credentials.IsValidAppIdAsync(appIdFromClaim))
+            if (!await credentials.IsValidAppIdAsync(appIdFromClaim).ConfigureAwait(false))
             {
                 // The AppId is not valid. Not Authorized.
                 throw new UnauthorizedAccessException($"Invalid AppId passed on token: {appIdFromClaim}");
@@ -167,7 +169,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(authConfig));
             }
 
-            var identity = await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig);
+            var identity = await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, authConfig).ConfigureAwait(false);
 
             var serviceUrlClaim = identity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.ServiceUrlClaim)?.Value;
             if (string.IsNullOrWhiteSpace(serviceUrlClaim))
@@ -176,7 +178,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException();
             }
 
-            if (!string.Equals(serviceUrlClaim, serviceUrl))
+            if (!string.Equals(serviceUrlClaim, serviceUrl, StringComparison.OrdinalIgnoreCase))
             {
                 // Claim must match. Not Authorized.
                 throw new UnauthorizedAccessException();

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(retriever));
             }
 
-            var jsonDocument = await retriever.GetDocumentAsync(address, cancellationToken);
+            var jsonDocument = await retriever.GetDocumentAsync(address, cancellationToken).ConfigureAwait(false);
             var configurationRoot = JObject.Parse(jsonDocument);
 
             var keys = configurationRoot["keys"]?.Value<JArray>();
@@ -121,14 +121,14 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(address));
             }
 
-            using (var documentResponse = await _httpClient.GetAsync(address, cancellationToken))
+            using (var documentResponse = await _httpClient.GetAsync(address, cancellationToken).ConfigureAwait(false))
             {
                 if (!documentResponse.IsSuccessStatusCode)
                 {
                     throw new Exception($"An non-success status code of {documentResponse.StatusCode} was received while fetching the endorsements document.");
                 }
 
-                var json = await documentResponse.Content.ReadAsStringAsync();
+                var json = await documentResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (string.IsNullOrWhiteSpace(json))
                 {
@@ -143,14 +143,14 @@ namespace Microsoft.Bot.Connector.Authentication
                     return string.Empty;
                 }
 
-                using (var keysResponse = await _httpClient.GetAsync(keysUrl, cancellationToken))
+                using (var keysResponse = await _httpClient.GetAsync(keysUrl, cancellationToken).ConfigureAwait(false))
                 {
                     if (!keysResponse.IsSuccessStatusCode)
                     {
                         throw new Exception($"An non-success status code of {keysResponse.StatusCode} was received while fetching the web key set document.");
                     }
 
-                    return await keysResponse.Content.ReadAsStringAsync();
+                    return await keysResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
@@ -71,7 +72,7 @@ namespace Microsoft.Bot.Connector.Authentication
             var tokenExtractor = new JwtTokenExtractor(
                 httpClient,
                 ToBotFromEnterpriseChannelTokenValidationParameters,
-                string.Format(AuthenticationConstants.ToBotFromEnterpriseChannelOpenIdMetadataUrlFormat, channelService),
+                string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ToBotFromEnterpriseChannelOpenIdMetadataUrlFormat, channelService),
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
             var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
@@ -119,7 +120,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await credentials.IsValidAppIdAsync(appIdFromClaim))
+            if (!await credentials.IsValidAppIdAsync(appIdFromClaim).ConfigureAwait(false))
             {
                 // The AppId is not valid. Not Authorized.
                 throw new UnauthorizedAccessException($"Invalid AppId passed on token: {appIdFromClaim}");
@@ -134,7 +135,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     throw new UnauthorizedAccessException();
                 }
 
-                if (!string.Equals(serviceUrlClaim, serviceUrl))
+                if (!string.Equals(serviceUrlClaim, serviceUrl, StringComparison.OrdinalIgnoreCase))
                 {
                     // Claim must match. Not Authorized.
                     throw new UnauthorizedAccessException();

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Bot.Connector.Authentication
                 ValidateIssuerSigningKey = true,
             };
 
+#pragma warning disable CA1056 // Uri properties should not be strings (we can't change this without breaking binary compat)
         public static string OpenIdMetadataUrl { get; set; } = GovernmentAuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl;
+#pragma warning restore CA1056 // Uri properties should not be strings
 
         /// <summary>
         /// Validate the incoming Auth Header as a token sent from a Bot Framework Government Channel Service.
@@ -124,7 +126,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await credentials.IsValidAppIdAsync(appIdFromClaim))
+            if (!await credentials.IsValidAppIdAsync(appIdFromClaim).ConfigureAwait(false))
             {
                 // The AppId is not valid. Not Authorized.
                 throw new UnauthorizedAccessException($"Invalid AppId passed on token: {appIdFromClaim}");
@@ -139,7 +141,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     throw new UnauthorizedAccessException();
                 }
 
-                if (!string.Equals(serviceUrlClaim, serviceUrl))
+                if (!string.Equals(serviceUrlClaim, serviceUrl, StringComparison.OrdinalIgnoreCase))
                 {
                     // Claim must match. Not Authorized.
                     throw new UnauthorizedAccessException();

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenExtractor.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public async Task<ClaimsIdentity> GetIdentityAsync(string authorizationHeader, string channelId)
         {
-            return await GetIdentityAsync(authorizationHeader, channelId, new string[] { }).ConfigureAwait(false);
+            return await GetIdentityAsync(authorizationHeader, channelId, Array.Empty<string>()).ConfigureAwait(false);
         }
 
         public async Task<ClaimsIdentity> GetIdentityAsync(string authorizationHeader, string channelId, string[] requiredEndorsements)
@@ -139,7 +139,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public async Task<ClaimsIdentity> GetIdentityAsync(string scheme, string parameter, string channelId)
         {
-            return await GetIdentityAsync(scheme, parameter, channelId, new string[] { }).ConfigureAwait(false);
+            return await GetIdentityAsync(scheme, parameter, channelId, Array.Empty<string>()).ConfigureAwait(false);
         }
 
         public async Task<ClaimsIdentity> GetIdentityAsync(string scheme, string parameter, string channelId, string[] requiredEndorsements)
@@ -231,7 +231,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 // Validate Channel / Token Endorsements. For this, the channelID present on the Activity
                 // needs to be matched by an endorsement.
                 var keyId = (string)parsedJwtToken?.Header?[AuthenticationConstants.KeyIdHeader];
-                var endorsements = await _endorsementsData.GetConfigurationAsync();
+                var endorsements = await _endorsementsData.GetConfigurationAsync().ConfigureAwait(false);
 
                 // Note: On the Emulator Code Path, the endorsements collection is empty so the validation code
                 // below won't run. This is normal.

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             httpClient = httpClient ?? _httpClient;
 
-            var identity = await AuthenticateToken(authHeader, credentials, channelProvider, channelId, authConfig, serviceUrl, httpClient);
+            var identity = await AuthenticateToken(authHeader, credentials, channelProvider, channelId, authConfig, serviceUrl, httpClient).ConfigureAwait(false);
 
             await ValidateClaimsAsync(authConfig, identity.Claims).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -21,10 +21,11 @@ namespace Microsoft.Bot.Connector.Authentication
                 {
                     return await task().ConfigureAwait(false);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (this is a generic catch all to handle retries)
                 catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     exceptions.Add(ex);
-
                     retry = retryExceptionHandler(ex, currentRetryCount);
                 }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Validates JWT tokens sent to and from a Skill.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class SkillValidation
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// TO SKILL FROM BOT and TO BOT FROM SKILL: Token validation parameters when connecting a bot to a skill.

--- a/libraries/Microsoft.Bot.Connector/Authentication/ThrottleException.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ThrottleException.cs
@@ -7,6 +7,20 @@ namespace Microsoft.Bot.Connector.Authentication
 {
     public class ThrottleException : Exception
     {
+        public ThrottleException()
+        {
+        }
+
+        public ThrottleException(string message)
+            : base(message)
+        {
+        }
+
+        public ThrottleException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
         public RetryParams RetryParams { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Bot.Connector.Authentication
     {
         private static readonly Random _random = new Random();
 
+#pragma warning disable CA1801 // Review unused parameters (we can't change this without breaking binary compat)
         public static TimeSpan WithJitter(this TimeSpan delay, double multiplier = 0.1)
+#pragma warning restore CA1801 // Review unused parameters
         {
             // Generate an uniform distribution between zero and 10% of the proposed delay and add it as
             // random noise. The reason for this is that if there are multiple threads about to retry

--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -6,7 +6,11 @@ namespace Microsoft.Bot.Connector
     /// <summary>
     /// Ids of channels supported by the Bot Builder.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
+#pragma warning disable CA1724 // Type names should not match namespaces (we can't change this without breaking binary compat)
     public class Channels
+#pragma warning restore CA1724 // Type names should not match namespaces
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Console channel.

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -70,7 +70,9 @@ namespace Microsoft.Bot.Connector
         /// <param name="customHttpClient">The HTTP client to use for this connector client.</param>
         /// <param name="handlers">Optional, an array of <see cref="DelegatingHandler"/> objects to
         /// add to the HTTP client pipeline.</param>
+#pragma warning disable CA1801 // Review unused parameters (we can't change this without breaking binary compat)
         public ConnectorClient(Uri baseUri, ServiceClientCredentials credentials, HttpClient customHttpClient, bool addJwtTokenRefresher = true, params DelegatingHandler[] handlers)
+#pragma warning restore CA1801 // Review unused parameters
             : this(baseUri, handlers)
         {
             this.Credentials = credentials;
@@ -94,7 +96,9 @@ namespace Microsoft.Bot.Connector
         /// <param name="customHttpClient">The HTTP client to use for this connector client.</param>
         /// <param name="handlers">Optional, an array of <see cref="DelegatingHandler"/> objects to
         /// add to the HTTP client pipeline.</param>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the addJwtTokenRefresher parameter without breaking binary compat)
         public ConnectorClient(Uri baseUri, MicrosoftAppCredentials credentials, HttpClientHandler httpClientHandler, bool addJwtTokenRefresher = true, HttpClient customHttpClient = null, params DelegatingHandler[] handlers)
+#pragma warning restore CA1801 // Review unused parameters
             : this(baseUri, httpClientHandler, handlers)
         {
             this.Credentials = credentials;

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -42,6 +42,10 @@
 		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
 		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
 		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
 		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<Version Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</Version>
-		<Version Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</Version>
-		<PackageVersion Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</PackageVersion>
-		<PackageVersion Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</PackageVersion>
-		<Configurations>Debug;Release</Configurations>
+  <PropertyGroup>
+    <Version Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</Version>
+    <Version Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</Version>
+    <PackageVersion Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</PackageVersion>
+    <PackageVersion Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</PackageVersion>
+    <Configurations>Debug;Release</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\Microsoft.Bot.Connector.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -28,28 +28,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-		<Compile Remove="node_modules\**" />
-		<EmbeddedResource Remove="node_modules\**" />
-		<None Remove="node_modules\**" />
-	</ItemGroup>
+    <Compile Remove="node_modules\**" />
+    <EmbeddedResource Remove="node_modules\**" />
+    <None Remove="node_modules\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Remove="generateClient.cmd" />
   </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
-		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
-		<PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
-		<PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
+    <PackageReference Include="Microsoft.Bot.Schema" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -57,4 +57,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/libraries/Microsoft.Bot.Connector/OAuthClientConfig.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -10,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest;
+using Microsoft.Rest.Serialization;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Connector
@@ -45,7 +47,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("emulateOAuthCards", emulateOAuthCards);
                 ServiceClientTracing.Enter(invocationId, client, "GetToken", tracingParameters);
@@ -53,84 +55,80 @@ namespace Microsoft.Bot.Connector
 
             // Construct URL
             var baseUrl = client.BaseUri.AbsoluteUri;
-            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/") ? string.Empty : "/")), "api/usertoken/emulateOAuthCards?emulate={emulate}").ToString();
+            var url = new Uri(new Uri(baseUrl + (baseUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/usertoken/emulateOAuthCards?emulate={emulate}").ToString();
             url = url.Replace("{emulate}", emulateOAuthCards.ToString());
 
             // Create HTTP transport objects
-            var httpRequest = new HttpRequestMessage();
-            HttpResponseMessage httpResponse = null;
-            httpRequest.Method = new HttpMethod("POST");
-            httpRequest.RequestUri = new System.Uri(url);
-
-            var cancellationToken = CancellationToken.None;
-
-            // Serialize Request
-            string requestContent = null;
-
-            // Set Credentials
-            if (client.Credentials != null)
+            using (var httpRequest = new HttpRequestMessage())
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                await client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            }
+                httpRequest.Method = new HttpMethod("POST");
+                httpRequest.RequestUri = new Uri(url);
 
-            // Send Request
-            if (shouldTrace)
-            {
-                ServiceClientTracing.SendRequest(invocationId, httpRequest);
-            }
+                var cancellationToken = CancellationToken.None;
 
-            cancellationToken.ThrowIfCancellationRequested();
-            httpResponse = await client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-            if (shouldTrace)
-            {
-                ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
-            }
+                // Serialize Request
+                string requestContent = null;
 
-            HttpStatusCode statusCode = httpResponse.StatusCode;
-            cancellationToken.ThrowIfCancellationRequested();
-            string responseContent = null;
-            if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.NotFound)
-            {
-                var ex = new ErrorResponseException(string.Format("Operation returned an invalid status code '{0}'", statusCode));
-                try
+                // Set Credentials
+                if (client.Credentials != null)
                 {
-                    responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    ErrorResponse errorBody = Rest.Serialization.SafeJsonConvert.DeserializeObject<ErrorResponse>(responseContent, client.DeserializationSettings);
-                    if (errorBody != null)
-                    {
-                        ex.Body = errorBody;
-                    }
-                }
-                catch (JsonException)
-                {
-                    // Ignore the exception
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
                 }
 
-                ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
-                ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                // Send Request
                 if (shouldTrace)
                 {
-                    ServiceClientTracing.Error(invocationId, ex);
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
                 }
 
-                httpRequest.Dispose();
-                if (httpResponse != null)
+                cancellationToken.ThrowIfCancellationRequested();
+                var httpResponse = await client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
                 {
-                    httpResponse.Dispose();
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
                 }
 
-                throw ex;
-            }
+                var statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+                if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.NotFound)
+                {
+                    var ex = new ErrorResponseException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", statusCode));
+                    try
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        var errorBody = SafeJsonConvert.DeserializeObject<ErrorResponse>(responseContent, client.DeserializationSettings);
+                        if (errorBody != null)
+                        {
+                            ex.Body = errorBody;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Ignore the exception
+                    }
 
-            // Create Result
-            var result = new HttpOperationResponse<int>();
-            result.Request = httpRequest;
-            result.Response = httpResponse;
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
 
-            if (shouldTrace)
-            {
-                ServiceClientTracing.Exit(invocationId, result);
+                    throw ex;
+                }
+
+                if (shouldTrace)
+                {
+                    // Create  and log result
+                    using (var result = new HttpOperationResponse<int>())
+                    {
+                        result.Request = httpRequest;
+                        result.Response = httpResponse;
+                        ServiceClientTracing.Exit(invocationId, result);
+                    }
+                }
             }
         }
     }

--- a/libraries/Microsoft.Bot.Connector/OAuthClientConfig.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientConfig.cs
@@ -83,50 +83,52 @@ namespace Microsoft.Bot.Connector
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
-                var httpResponse = await client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
-                if (shouldTrace)
+                using (var httpResponse = await client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false))
                 {
-                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
-                }
-
-                var statusCode = httpResponse.StatusCode;
-                cancellationToken.ThrowIfCancellationRequested();
-                string responseContent = null;
-                if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.NotFound)
-                {
-                    var ex = new ErrorResponseException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", statusCode));
-                    try
-                    {
-                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        var errorBody = SafeJsonConvert.DeserializeObject<ErrorResponse>(responseContent, client.DeserializationSettings);
-                        if (errorBody != null)
-                        {
-                            ex.Body = errorBody;
-                        }
-                    }
-                    catch (JsonException)
-                    {
-                        // Ignore the exception
-                    }
-
-                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
-                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
                     if (shouldTrace)
                     {
-                        ServiceClientTracing.Error(invocationId, ex);
+                        ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
                     }
 
-                    throw ex;
-                }
-
-                if (shouldTrace)
-                {
-                    // Create  and log result
-                    using (var result = new HttpOperationResponse<int>())
+                    var statusCode = httpResponse.StatusCode;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    string responseContent = null;
+                    if (statusCode != HttpStatusCode.OK && statusCode != HttpStatusCode.NotFound)
                     {
-                        result.Request = httpRequest;
-                        result.Response = httpResponse;
-                        ServiceClientTracing.Exit(invocationId, result);
+                        var ex = new ErrorResponseException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", statusCode));
+                        try
+                        {
+                            responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var errorBody = SafeJsonConvert.DeserializeObject<ErrorResponse>(responseContent, client.DeserializationSettings);
+                            if (errorBody != null)
+                            {
+                                ex.Body = errorBody;
+                            }
+                        }
+                        catch (JsonException)
+                        {
+                            // Ignore the exception
+                        }
+
+                        ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                        ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw ex;
+                    }
+
+                    if (shouldTrace)
+                    {
+                        // Create  and log result
+                        using (var result = new HttpOperationResponse<int>())
+                        {
+                            result.Request = httpRequest;
+                            result.Response = httpResponse;
+                            ServiceClientTracing.Exit(invocationId, result);
+                        }
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -18,8 +19,11 @@ namespace Microsoft.Bot.Connector
     /// <summary>
     /// Service client to handle requests to the Bot Framework API service.
     /// </summary>
+    [Obsolete("This class is deprecated, us OAuthClientConfig instead", error: true)]
     public class OAuthClientOld : ServiceClient<OAuthClientOld>
     {
+#pragma warning disable CA2000 // Dispose objects before losing scope (this class is deprecated, we won't fix FxCop issues)
+#pragma warning disable CA1801 // Review unused parameters (this class is deprecated, we won't fix FxCop issues)
         private readonly ConnectorClient _client;
         private readonly string _uri;
 
@@ -83,7 +87,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("userId", userId);
                 tracingParameters.Add("connectionName", connectionName);
@@ -93,7 +97,7 @@ namespace Microsoft.Bot.Connector
             }
 
             // Construct URL
-            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/") ? string.Empty : "/")), "api/usertoken/GetToken?userId={userId}&connectionName={connectionName}{magicCodeParam}").ToString();
+            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/usertoken/GetToken?userId={userId}&connectionName={connectionName}{magicCodeParam}").ToString();
             tokenUrl = tokenUrl.Replace("{connectionName}", Uri.EscapeDataString(connectionName));
             tokenUrl = tokenUrl.Replace("{userId}", Uri.EscapeDataString(userId));
             if (!string.IsNullOrEmpty(magicCode))
@@ -107,6 +111,7 @@ namespace Microsoft.Bot.Connector
 
             // Create HTTP transport objects
             var httpRequest = new HttpRequestMessage();
+
             HttpResponseMessage httpResponse = null;
             httpRequest.Method = new HttpMethod("GET");
             httpRequest.RequestUri = new Uri(tokenUrl);
@@ -184,7 +189,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("userId", userId);
                 tracingParameters.Add("connectionName", connectionName);
@@ -193,7 +198,7 @@ namespace Microsoft.Bot.Connector
             }
 
             // Construct URL
-            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/") ? string.Empty : "/")), "api/usertoken/SignOut?&userId={userId}{connectionNameParam}").ToString();
+            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/usertoken/SignOut?&userId={userId}{connectionNameParam}").ToString();
             var connectionNameUri = $"&connectionName={Uri.EscapeDataString(connectionName)}";
             tokenUrl = tokenUrl.Replace(
                 "{connectionNameParam}",
@@ -259,7 +264,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("state", state);
                 tracingParameters.Add("finalRedirect", finalRedirect);
@@ -268,7 +273,7 @@ namespace Microsoft.Bot.Connector
             }
 
             // Construct URL
-            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/") ? string.Empty : "/")), "api/botsignin/getsigninurl?&state={state}{finalRedirectParam}").ToString();
+            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/botsignin/getsigninurl?&state={state}{finalRedirectParam}").ToString();
             tokenUrl = tokenUrl.Replace("{state}", state);
             tokenUrl = tokenUrl.Replace(
                 "{finalRedirectParam}",
@@ -330,7 +335,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("userId", userId);
                 tracingParameters.Add("includeFilter", includeFilter);
@@ -339,7 +344,7 @@ namespace Microsoft.Bot.Connector
             }
 
             // Construct URL
-            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/") ? string.Empty : "/")), "api/usertoken/gettokenstatus?userId={userId}{includeFilterParam}").ToString();
+            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/usertoken/gettokenstatus?userId={userId}{includeFilterParam}").ToString();
             tokenUrl = tokenUrl.Replace("{userId}", Uri.EscapeDataString(userId));
             if (!string.IsNullOrEmpty(includeFilter))
             {
@@ -451,7 +456,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("userId", userId);
                 tracingParameters.Add("connectionName", connectionName);
@@ -461,7 +466,7 @@ namespace Microsoft.Bot.Connector
             }
 
             // Construct URL
-            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/") ? string.Empty : "/")), "api/usertoken/GetAadTokens?userId={userId}&connectionName={connectionName}").ToString();
+            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/usertoken/GetAadTokens?userId={userId}&connectionName={connectionName}").ToString();
             tokenUrl = tokenUrl.Replace("{userId}", Uri.EscapeDataString(userId));
             tokenUrl = tokenUrl.Replace("{connectionName}", Uri.EscapeDataString(connectionName));
 
@@ -520,7 +525,7 @@ namespace Microsoft.Bot.Connector
                 }
                 else
                 {
-                    var ex = new ErrorResponseException(string.Format("Operation returned an invalid status code '{0}'", statusCode));
+                    var ex = new ErrorResponseException(string.Format(CultureInfo.InvariantCulture, "Operation returned an invalid status code '{0}'", statusCode));
                     string responseContent = null;
                     try
                     {
@@ -567,7 +572,7 @@ namespace Microsoft.Bot.Connector
             string invocationId = null;
             if (shouldTrace)
             {
-                invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("emulateOAuthCards", emulateOAuthCards);
                 ServiceClientTracing.Enter(invocationId, this, "SendEmulateOAuthCards", tracingParameters);
@@ -576,7 +581,7 @@ namespace Microsoft.Bot.Connector
             var cancellationToken = default(CancellationToken);
 
             // Construct URL
-            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/") ? string.Empty : "/")), "api/usertoken/emulateOAuthCards?emulate={emulate}").ToString();
+            var tokenUrl = new Uri(new Uri(_uri + (_uri.EndsWith("/", StringComparison.OrdinalIgnoreCase) ? string.Empty : "/")), "api/usertoken/emulateOAuthCards?emulate={emulate}").ToString();
             tokenUrl = tokenUrl.Replace("{emulate}", emulateOAuthCards.ToString());
 
             // Create HTTP transport objects
@@ -602,5 +607,7 @@ namespace Microsoft.Bot.Connector
                 ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
             }
         }
+#pragma warning restore CA2000 // Dispose objects before losing scope
+#pragma warning restore CA1801 // Review unused parameters
     }
 }


### PR DESCRIPTION
Addresses part of #2367 

- Enables FxCop Analyzer for the Connector library and addressed violations.
- Marked OAuthClientOld as obsolete.
- Marked a lot of private methods in AdalAuthenticator as statics (that's the big diff here)