### PR TITLE
Added initial cut at daily build spec

### DIFF
--- a/specs/DailyBuildProposal.md
+++ b/specs/DailyBuildProposal.md
@@ -1,0 +1,68 @@
+# Daily Build Propsal for .Net BotBuilder SDK 
+
+This proposal describes our pland for how to publish daily builds for consumption. The goals of this are:
+1. Make it easy for developers (1P and 3P) to consume our daily builds. 
+2. Exercise our release to Nuget process frequently, so issues don't arise at critical times. 
+
+Use the [ASP.Net Team](https://github.com/dotnet/aspnetcore/blob/master/docs/DailyBuilds.md) as inspiration, and draft off the work they do. 
+
+# Summary - Daily Builds
+*Daily Builds* go to Azure Devops feed. ASP.Net core uses the following instructions:
+```json
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="aspnetcore" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+        <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>
+```
+
+All Nuget packages from our daily build would be pushed to the SDK_Public project at [fuselabs.visualstudio.com](https://fuselabs.visualstudio.com). 
+
+    Note: Only a public project on Devops can have a public feed. The public project on our Enterprise Tenant is [SDK_Public](https://fuselabs.visualstudio.com/SDK_Public). 
+
+This means developers could add the package source in Visual Studio or in their .csproj files. 
+
+```json
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="sdk_public_nuget" value="https://fuselabs.pkgs.visualstudio.com/SDK_Public/_packaging/sdk_public_nuget/nuget/v3/index.json" />
+   <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+To connect from Visual Studio is equally simple. [Docs are here](https://fuselabs.visualstudio.com/SDK_Public/_packaging?_a=connect&feed=sdk_public_nuget).
+
+## Daily Build Lifecyle
+Daily builds older than 90 days are automatically deleted. 
+
+# Summary - Weekly Builds
+Once per week, preferably on a Monday, a daily build is pushed to Nuget.org. This serves 2 purposes:
+
+1. Keeps Nuget "Fresh" for people that don't want daily builds.
+2. Keeps the release pipelines active and working, and prevents issues. 
+
+These builds will have the "-preview" tag, just like the daily builds. 
+
+This pipeline should be the EXACT same pipeline that releases our production bits. 
+
+## Adding packages to the feed
+Our existing Release pipelines would add packages to the feed. From the Azure Artifacts docs, this would be:
+
+```json
+nuget.exe push -Source "sdk_public_nuget" -ApiKey az <packagePath>
+```
+
+# Versioning
+All core packages maintain the basic semver scheme. For production packages, there are no changes. 
+
+
+
+
+# Migration from MyGet
+# 

--- a/specs/DailyBuildProposal.md
+++ b/specs/DailyBuildProposal.md
@@ -1,25 +1,23 @@
 # Daily Build Propsal for .Net BotBuilder SDK 
 
-This proposal describes our pland for how to publish daily builds for consumption. The goals of this are:
+This proposal describes our plan to publish daily builds for consumption. The goals of this are:
 1. Make it easy for developers (1P and 3P) to consume our daily builds. 
 2. Exercise our release to Nuget process frequently, so issues don't arise at critical times. 
+3. Meet Developers where they are.
 
 Use the [ASP.Net Team](https://github.com/dotnet/aspnetcore/blob/master/docs/DailyBuilds.md) as inspiration, and draft off the work they do. 
 
-# Summary - Daily Builds
-*Daily Builds* go to Azure Devops feed. ASP.Net core uses the following instructions:
-```json
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <clear />
-        <add key="aspnetcore" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
-        <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    </packageSources>
-</configuration>
-```
+# Versioning
+Move to semver2. This [file in ASp.Net Core](https://github.com/dotnet/aspnetcore/blob/3787d7e7f070543cc9368d589a504fa8c4bd4830/eng/Versions.props) can be looked at to learn more. 
 
-All Nuget packages from our daily build would be pushed to the SDK_Public project at [fuselabs.visualstudio.com](https://fuselabs.visualstudio.com). 
+The tags we use for preview versions are:
+* -preview.<yyyymmdd>.{incrementing value}
+* -rc.{0}
+
+Note: use of "." rather than "-" to follow semver2 sorting rules. 
+
+# Daily Builds
+Copying what the ASP.Net team does, all our Nuget packages would be pushed to the SDK_Public project at [fuselabs.visualstudio.com](https://fuselabs.visualstudio.com). 
 
     Note: Only a public project on Devops can have a public feed. The public project on our Enterprise Tenant is [SDK_Public](https://fuselabs.visualstudio.com/SDK_Public). 
 
@@ -35,8 +33,14 @@ This means developers could add the package source in Visual Studio or in their 
   </packageSources>
 </configuration>
 ```
-
 To connect from Visual Studio is equally simple. [Docs are here](https://fuselabs.visualstudio.com/SDK_Public/_packaging?_a=connect&feed=sdk_public_nuget).
+
+## Debugging
+To debug daily builds using Visual Studio
+* Enable Source Link support in Visual Studio should be enabled.
+* Enable source server support in Visual should be enabled.
+* Enable Just My Code should be disabled
+* Under Symbols enable the Microsoft Symbol Servers setting.
 
 ## Daily Build Lifecyle
 Daily builds older than 90 days are automatically deleted. 
@@ -47,9 +51,11 @@ Once per week, preferably on a Monday, a daily build is pushed to Nuget.org. Thi
 1. Keeps Nuget "Fresh" for people that don't want daily builds.
 2. Keeps the release pipelines active and working, and prevents issues. 
 
-These builds will have the "-preview" tag, just like the daily builds. 
+These builds will have the "-preview" tag and ARE the the daily build. 
 
-This pipeline should be the EXACT same pipeline that releases our production bits. 
+**This release pipeline should be the EXACT same pipeline that releases our production bits.**
+
+Weekly builds older than 1 year should be automatically delisted. 
 
 ## Adding packages to the feed
 Our existing Release pipelines would add packages to the feed. From the Azure Artifacts docs, this would be:
@@ -58,11 +64,8 @@ Our existing Release pipelines would add packages to the feed. From the Azure Ar
 nuget.exe push -Source "sdk_public_nuget" -ApiKey az <packagePath>
 ```
 
-# Versioning
-All core packages maintain the basic semver scheme. For production packages, there are no changes. 
-
-
-
-
 # Migration from MyGet
-# 
+
+1. Initially, our daily builds should go to both MyGet and Azure Devops. 
+2. Our docs are updated once builds are in both locations. 
+3. Towards the end of 2020, we stop publising to MyGet.


### PR DESCRIPTION
Part of #4114. 

Spec / document detailing changes around how daily builds, weekly builds, and final versions are created, versioned, and pushed to package repositories. 

The summary:
1. Copy with the ASP.Net Core team is doing where possible
2. Push daily builds to Azure Devops
3. Push a weekly build to exercise our release pipeline
4. Clearly define use of tags (-preview, -rc)