### PR TITLE
Update OAuthInput.cs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -224,10 +225,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 }
                 else if (this.MaxTurnCount == null || turnCount < this.MaxTurnCount.GetValue(dc.State))
                 {
-                    // increase the turnCount as last step
-                    dc.State.SetValue(TURN_COUNT_PROPERTY, turnCount + 1);
-                    var prompt = await this.OnRenderPromptAsync(dc, inputState, cancellationToken).ConfigureAwait(false);
-                    await dc.Context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+                    if (!interrupted)
+                    { 
+                        // increase the turnCount as last step
+                        dc.State.SetValue(TURN_COUNT_PROPERTY, turnCount + 1);
+                        var prompt = await this.OnRenderPromptAsync(dc, inputState, cancellationToken).ConfigureAwait(false);
+                        await dc.Context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+                    }
+
                     await SendOAuthCardAsync(dc, promptOptions?.Prompt, cancellationToken).ConfigureAwait(false);
                     return Dialog.EndOfTurn;
                 }


### PR DESCRIPTION
Fixes #3963 

The fix is: If this turn is interrupted, it won't prompt for invalid or unrecognized prompt.

The OAuthInput Invalid/Unrecognized prompt are different from Other Inputs. OAuthInput don't have a prompt, it only prompts OAuthCard when BeginDialog or RepromptDialog.

After this fix the Invalid Prompt will only show if it is invalid and not from an interruption.  

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->

![image](https://user-images.githubusercontent.com/32191031/84982729-d74c3680-b169-11ea-9b2e-4d9d1b24db64.png)
