### PR TITLE
Make content type check more robust

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
             var requestContentType = request.Headers["Content-Type"].ToString();
 
-            if (requestContentType == "application/x-www-form-urlencoded")
+            if (requestContentType.StartsWith("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
             {
                 var postValues = SlackHelper.QueryStringToDictionary(body);
 
@@ -296,7 +296,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                     activity = await SlackHelper.CommandToActivityAsync(payload, _slackClient, cancellationToken).ConfigureAwait(false);
                 }
             }
-            else if (requestContentType == "application/json")
+            else if (requestContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
             {
                 var bodyObject = JObject.Parse(body);
 


### PR DESCRIPTION
Fixes #4124 

Ensures content type check within the adapter doesn't fail if encoding info is included in the header.