### PR TITLE
Add ToAttachment method for OAuthCard

### DIFF
--- a/libraries/Microsoft.Bot.Schema/CardEx.cs
+++ b/libraries/Microsoft.Bot.Schema/CardEx.cs
@@ -78,6 +78,16 @@ namespace Microsoft.Bot.Schema
             return CreateAttachment(card, AnimationCard.ContentType);
         }
 
+        /// <summary>
+        /// Creates a new attachment from <see cref="OAuthCard"/>.
+        /// </summary>
+        /// <param name="card"> The instance of <see cref="OAuthCard"/>.</param>
+        /// <returns> The generated attachment.</returns>
+        public static Attachment ToAttachment(this OAuthCard card)
+        {
+            return CreateAttachment(card, OAuthCard.ContentType);
+        }
+
         private static Attachment CreateAttachment<T>(T card, string contentType)
         {
             return new Attachment

--- a/tests/Microsoft.Bot.Schema.Tests/CardExTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/CardExTest.cs
@@ -2,26 +2,22 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.Bot.Builder;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Schema.Tests
 {
     /// <summary>
     /// Tests to ensure that Card Extension methods work as expected.
     /// </summary>
-    [TestClass]
     public class CardExTest
     {
-        private static readonly List<Attachment> _attachments = new List<Attachment>();
-
         /// <summary>
-        /// Ensures that the <see cref="HeroCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="HeroCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void HeroCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var heroCard = new HeroCard
             {
@@ -31,19 +27,19 @@ namespace Microsoft.Bot.Schema.Tests
                 Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
             };
 
-            message.Attachments.Add(heroCard.ToAttachment());
+            attachments.Add(heroCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.hero", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.hero", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="ThumbnailCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="ThumbnailCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ThumbnailCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var thumbnailCard = new ThumbnailCard
             {
@@ -53,19 +49,19 @@ namespace Microsoft.Bot.Schema.Tests
                 Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
             };
 
-            message.Attachments.Add(thumbnailCard.ToAttachment());
+            attachments.Add(thumbnailCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.thumbnail", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.thumbnail", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="SigninCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="SigninCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void SigninCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var signinCard = new SigninCard
             {
@@ -73,19 +69,19 @@ namespace Microsoft.Bot.Schema.Tests
                 Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Sign-in", value: "https://login.microsoftonline.com/") },
             };
 
-            message.Attachments.Add(signinCard.ToAttachment());
+            attachments.Add(signinCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.signin", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.signin", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="ReceiptCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="ReceiptCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ReceiptCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var receiptCard = new ReceiptCard
             {
@@ -116,19 +112,19 @@ namespace Microsoft.Bot.Schema.Tests
                 },
             };
 
-            message.Attachments.Add(receiptCard.ToAttachment());
+            attachments.Add(receiptCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.receipt", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.receipt", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="AudioCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="AudioCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void AudioCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var audioCard = new AudioCard
             {
@@ -157,19 +153,19 @@ namespace Microsoft.Bot.Schema.Tests
                 },
             };
 
-            message.Attachments.Add(audioCard.ToAttachment());
+            attachments.Add(audioCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.audio", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.audio", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="VideoCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="VideoCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void VideoCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var videoCard = new VideoCard
             {
@@ -198,19 +194,19 @@ namespace Microsoft.Bot.Schema.Tests
                 },
             };
 
-            message.Attachments.Add(videoCard.ToAttachment());
+            attachments.Add(videoCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.video", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.video", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="AnimationCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="AnimationCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void AnimationCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
+            var attachments = new List<Attachment>();
 
             var animationCard = new AnimationCard
             {
@@ -229,20 +225,20 @@ namespace Microsoft.Bot.Schema.Tests
                 },
             };
 
-            message.Attachments.Add(animationCard.ToAttachment());
+            attachments.Add(animationCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.animation", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.animation", attachments[0].ContentType);
         }
 
         /// <summary>
-        /// Ensures that the <see cref="OAuthCard"/> can be added as an attachment in a message.
+        /// Ensures that the <see cref="OAuthCard"/> can be used as an attachment.
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void OAuthCardToAttachmentTest()
         {
-            var message = MessageFactory.Attachment(_attachments);
-            
+            var attachments = new List<Attachment>();
+
             var oauthCard = new OAuthCard
             {
                 Text = "Please, sign in",
@@ -250,10 +246,10 @@ namespace Microsoft.Bot.Schema.Tests
                 Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Login", value: "https://login.microsoftonline.com/") },
             };
 
-            message.Attachments.Add(oauthCard.ToAttachment());
+            attachments.Add(oauthCard.ToAttachment());
 
-            Assert.IsNotNull(message.Attachments);
-            Assert.AreEqual("application/vnd.microsoft.card.oauth", message.Attachments[0].ContentType);
+            Assert.NotEmpty(attachments);
+            Assert.Equal("application/vnd.microsoft.card.oauth", attachments[0].ContentType);
         }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/CardExTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/CardExTest.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Builder;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Bot.Schema.Tests
+{
+    /// <summary>
+    /// Tests to ensure that Card Extension methods work as expected.
+    /// </summary>
+    [TestClass]
+    public class CardExTest
+    {
+        private static readonly List<Attachment> _attachments = new List<Attachment>();
+
+        /// <summary>
+        /// Ensures that the <see cref="HeroCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void HeroCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var heroCard = new HeroCard
+            {
+                Title = "Hero Card Title",
+                Subtitle = "Hero Card Subtitle",
+                Text = "Testing Text.",
+                Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
+            };
+
+            message.Attachments.Add(heroCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.hero", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="ThumbnailCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void ThumbnailCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var thumbnailCard = new ThumbnailCard
+            {
+                Title = "Thumbnail Card Title",
+                Subtitle = "Thumbnail Card Subtitle",
+                Text = "Testing Text.",
+                Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
+            };
+
+            message.Attachments.Add(thumbnailCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.thumbnail", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="SigninCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void SigninCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var signinCard = new SigninCard
+            {
+                Text = "Testing Text.",
+                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Sign-in", value: "https://login.microsoftonline.com/") },
+            };
+
+            message.Attachments.Add(signinCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.signin", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="ReceiptCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void ReceiptCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var receiptCard = new ReceiptCard
+            {
+                Title = "John Doe",
+                Facts = new List<Fact> { new Fact("Order Number", "1234"), new Fact("Payment Method", "VISA 5555-****") },
+                Items = new List<ReceiptItem>
+                {
+                    new ReceiptItem(
+                        "Data Transfer",
+                        price: "$ 38.45",
+                        quantity: "368",
+                        image: new CardImage(url: "https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png")),
+                    new ReceiptItem(
+                        "App Service",
+                        price: "$ 45.00",
+                        quantity: "720",
+                        image: new CardImage(url: "https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png")),
+                },
+                Tax = "$ 7.50",
+                Total = "$ 90.95",
+                Buttons = new List<CardAction>
+                {
+                    new CardAction(
+                        ActionTypes.OpenUrl,
+                        "More information",
+                        "https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png",
+                        value: "https://azure.microsoft.com/en-us/pricing/"),
+                },
+            };
+
+            message.Attachments.Add(receiptCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.receipt", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="AudioCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void AudioCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var audioCard = new AudioCard
+            {
+                Title = "Audio Card Title",
+                Subtitle = "Audio Card Subtitle",
+                Text = "Testing text.",
+                Image = new ThumbnailUrl
+                {
+                    Url = "https://upload.wikimedia.org/wikipedia/en/3/3c/SW_-_Empire_Strikes_Back.jpg",
+                },
+                Media = new List<MediaUrl>
+                {
+                    new MediaUrl()
+                    {
+                        Url = "http://www.wavlist.com/movies/004/father.wav",
+                    },
+                },
+                Buttons = new List<CardAction>
+                {
+                    new CardAction()
+                    {
+                        Title = "Read More",
+                        Type = ActionTypes.OpenUrl,
+                        Value = "https://en.wikipedia.org/wiki/The_Empire_Strikes_Back",
+                    },
+                },
+            };
+
+            message.Attachments.Add(audioCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.audio", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="VideoCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void VideoCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var videoCard = new VideoCard
+            {
+                Title = "Audio Card Title",
+                Subtitle = "Audio Card Subtitle",
+                Text = "Testing text.",
+                Image = new ThumbnailUrl
+                {
+                    Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Big_buck_bunny_poster_big.jpg/220px-Big_buck_bunny_poster_big.jpg",
+                },
+                Media = new List<MediaUrl>
+                {
+                    new MediaUrl()
+                    {
+                        Url = "http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4",
+                    },
+                },
+                Buttons = new List<CardAction>
+                {
+                    new CardAction()
+                    {
+                        Title = "Learn More",
+                        Type = ActionTypes.OpenUrl,
+                        Value = "https://peach.blender.org/",
+                    },
+                },
+            };
+
+            message.Attachments.Add(videoCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.video", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="AnimationCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void AnimationCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+
+            var animationCard = new AnimationCard
+            {
+                Title = "Animation Card Title",
+                Subtitle = "Animation Card SubtTitle",
+                Image = new ThumbnailUrl
+                {
+                    Url = "https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png",
+                },
+                Media = new List<MediaUrl>
+                {
+                    new MediaUrl()
+                    {
+                        Url = "http://i.giphy.com/Ki55RUbOV5njy.gif",
+                    },
+                },
+            };
+
+            message.Attachments.Add(animationCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.animation", message.Attachments[0].ContentType);
+        }
+
+        /// <summary>
+        /// Ensures that the <see cref="OAuthCard"/> can be added as an attachment in a message.
+        /// </summary>
+        [TestMethod]
+        public void OAuthCardToAttachmentTest()
+        {
+            var message = MessageFactory.Attachment(_attachments);
+            
+            var oauthCard = new OAuthCard
+            {
+                Text = "Please, sign in",
+                ConnectionName = "testConnection",
+                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Login", value: "https://login.microsoftonline.com/") },
+            };
+
+            message.Attachments.Add(oauthCard.ToAttachment());
+
+            Assert.IsNotNull(message.Attachments);
+            Assert.AreEqual("application/vnd.microsoft.card.oauth", message.Attachments[0].ContentType);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -10,10 +10,14 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
 		<ProjectReference Include="..\..\libraries\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj" />
 	</ItemGroup>
 

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -13,6 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\..\libraries\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
 		<ProjectReference Include="..\..\libraries\Microsoft.Bot.Schema\Microsoft.Bot.Schema.csproj" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fixes #4040

## Description
- Add the **_ToAttachment_** method for OAuthCard in _CardEx_ class.
- Add unit tests for all the ToAttachment methods.

## Testing
In the image below we can see the [CardsBot](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/csharp_dotnetcore/06.using-cards) sample using an OAuthCard as an attachment.

![image](https://user-images.githubusercontent.com/44245136/85039039-aebe3f80-b15d-11ea-95f6-25792fe41c32.png)
