### PR TITLE
Add missing code docs for the webex adapter

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/AttachmentActionData.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/AttachmentActionData.cs
@@ -5,6 +5,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
+    /// <summary>
+    /// Represents an Attachment Action - Users create attachment actions by interacting with
+    /// message attachments such as clicking on a submit button in a card.
+    /// https://developer.webex.com/docs/api/v1/attachment-actions.
+    /// </summary>
     public class AttachmentActionData
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
@@ -24,8 +24,7 @@
 
   <PropertyGroup>
     <!-- CS8002: The Thrzn41.WebexTeams package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY Thrzn41.WebexTeams. -->
-    <!-- CS1591: These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS8002;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS8002;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -19,6 +19,9 @@ using Thrzn41.WebexTeams.Version1;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
+    /// <summary>
+    /// BotAdapter to allow for handling Webex Teams app payloads and responses via the Webex Teams API.
+    /// </summary>
     public class WebexAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
         private readonly WebexClientWrapper _webexClient;

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -18,6 +18,9 @@ using Thrzn41.WebexTeams.Version1;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
+    /// <summary>
+    /// A client for interacting with the Webex Teams API.
+    /// </summary>
     public class WebexClientWrapper
     {
         private const string WebhookUrl = "https://api.ciscospark.com/v1/webhooks";
@@ -49,6 +52,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             _api = TeamsAPI.CreateVersion1Client(Options.WebexAccessToken);
         }
 
+        /// <summary>
+        /// Gets the options collection for the adapter.
+        /// </summary>
+        /// <value>A WebexAdapterOptions class exposing properties for each of the available options.</value>
         public WebexAdapterOptions Options { get; }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexMessageRequest.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexMessageRequest.cs
@@ -7,6 +7,9 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
 {
+    /// <summary>
+    /// Represents the payload received when a Webex Message is sent to the bot.
+    /// </summary>
     public class WebexMessageRequest
     {
         /// <summary>


### PR DESCRIPTION
Towards #4052 

Adds missing code docs and removes the error suppression for code docs in the webex adapter project.