### PR TITLE
Fix LuisRecognizer to not return intents if there is no utterance

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV2.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV2.cs
@@ -62,9 +62,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             {
                 recognizerResult = new RecognizerResult
                 {
-                    Text = utterance,
-                    Intents = new Dictionary<string, IntentScore>() { { string.Empty, new IntentScore() { Score = 1.0 } } },
-                    Entities = new JObject(),
+                    Text = utterance
                 };
             }
             else

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
@@ -111,9 +111,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             {
                 recognizerResult = new RecognizerResult
                 {
-                    Text = utterance,
-                    Intents = new Dictionary<string, IntentScore>() { { string.Empty, new IntentScore() { Score = 1.0 } } },
-                    Entities = new JObject(),
+                    Text = utterance
                 };
             }
             else

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
@@ -57,8 +57,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             var recognizerResult = new RecognizerResult()
             {
                 Text = text,
-                Intents = new Dictionary<string, IntentScore>(),
             };
+            
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                // nothing to recognize, return empty recognizerResult
+                return recognizerResult;
+            }
 
             // add entities from regexrecgonizer to the entities pool
             var entityPool = new List<Entity>();

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -138,9 +138,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.IsNull(result.AlteredText);
             Assert.AreEqual(utterance, result.Text);
             Assert.IsNotNull(result.Intents);
-            Assert.AreEqual(1, result.Intents.Count);
-            Assert.IsNotNull(result.Intents[string.Empty]);
-            Assert.AreEqual(result.GetTopScoringIntent(), (string.Empty, 1.0));
+            Assert.AreEqual(0, result.Intents.Count);
             Assert.IsNotNull(result.Entities);
             Assert.AreEqual(0, result.Entities.Count);
         }

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -108,9 +108,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.IsNull(result.AlteredText);
             Assert.AreEqual(utterance, result.Text);
             Assert.IsNotNull(result.Intents);
-            Assert.AreEqual(1, result.Intents.Count);
-            Assert.IsNotNull(result.Intents[string.Empty]);
-            Assert.AreEqual(result.GetTopScoringIntent(), (string.Empty, 1.0));
+            Assert.AreEqual(0, result.Intents.Count);
             Assert.IsNotNull(result.Entities);
             Assert.AreEqual(0, result.Entities.Count);
         }


### PR DESCRIPTION
Fixes #4117 

## Description
Luis Recognizer returns an intent of string.empty with a perfect score of 1.0.  This messes up logic downstream in RecognizerSet because it thinks it has a perfect intent.

## Specific Changes
* Changed LuisRecognizer to return empy RecognizerResult (no intents or entities) when there is no utterance.

## Testing
Changed RegexRecognizer to behave just like LuisRecognizer so that ValueRecognizer tests are valid check.