### PR TITLE
Added FxCop to Microsoft.BotBuilder and addressed errors.

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -6,11 +6,16 @@
     <Rule Id="UseAsyncSuffix" Action="Error" />
     <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>
-  
-  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
-    <Rule Id="IDE0003" Action="None" />
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1054" Action="None" /> <!-- UriParametersShouldNotBeStrings -->
+    <Rule Id="CA1062" Action="None" /> <!-- ValidateArgumentsOfPublicMethods -->
   </Rules>
-
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1303" Action="None" /> <!-- DoNotPassLiteralsAsLocalizedParameters -->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.CSharp.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
+    <Rule Id="CA1309" Action="Error" /> <!-- Use ordinal StringComparison -->
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA0002" Action="Error" />
@@ -186,15 +191,6 @@
     <Rule Id="SA1648" Action="Error" />
     <Rule Id="SA1649" Action="Error" />
     <Rule Id="SA1651" Action="Error" />
+	<Rule Id="SX1309" Action="Error" /> <!-- FieldNamesShouldBeginWithUnderscores -->
   </Rules>
-
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
-	<Rule Id="CA1054" Action="None" /> <!-- UriParametersShouldNotBeStrings -->	
-	<Rule Id="CA1062" Action="None" /> <!-- ValidateArgumentsOfPublicMethods -->	
-  </Rules>
-
-  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
-	<Rule Id="CA1303" Action="None" /> <!-- DoNotPassLiteralsAsLocalizedParameters -->
-  </Rules>  
-
 </RuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,7 +59,7 @@
       Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
       replace PackageLicenseUrl with PackageLicenseExpression.
     -->
-    <NoWarn>NU5125</NoWarn>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/FunctionalTests/Directory.Build.props
+++ b/FunctionalTests/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
   <!-- Contains common properties that apply to projects under the FunctionalTests folder -->
   <PropertyGroup>
-    <!-- For tests, we don't generate documentation. Supress related rules. -->
-    <NoWarn>$(NoWarn);SA0001;CS1573,CS1591,CS1712</NoWarn>
+    <!-- SA0001;CS1573,CS1591,CS1712: For tests, we don't generate documentation. Supress related rules. -->
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);SA0001;CS1573;CS1591;CS1712;SX1309</NoWarn>
   </PropertyGroup>
 
   <!-- This ensures that Directory.Build.props in parent folders are merged with this one -->

--- a/libraries/Adapters/Directory.Build.props
+++ b/libraries/Adapters/Directory.Build.props
@@ -1,6 +1,10 @@
 <Project>
   <!-- Contains common properties that apply to projects under the Adapters folder -->
   <ItemGroup>
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libraries/Adapters/Directory.Build.props
+++ b/libraries/Adapters/Directory.Build.props
@@ -5,7 +5,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 {
                     var messageOptions = TwilioHelper.ActivityToTwilio(activity, _twilioClient.Options.TwilioNumber);
 
-                    var res = await _twilioClient.SendMessage(messageOptions, cancellationToken).ConfigureAwait(false);
+                    var res = await _twilioClient.SendMessageAsync(messageOptions, cancellationToken).ConfigureAwait(false);
 
                     var response = new ResourceResponse() { Id = res, };
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// <param name="messageOptions">An object containing the parameters for the message to send.</param>
         /// <param name="cancellationToken">A cancellation token for the task.</param>
         /// <returns>The SID of the Twilio message sent.</returns>
-        public virtual async Task<string> SendMessage(CreateMessageOptions messageOptions, CancellationToken cancellationToken)
+        public virtual async Task<string> SendMessageAsync(CreateMessageOptions messageOptions, CancellationToken cancellationToken)
         {
             var messageResource = await MessageResource.CreateAsync(messageOptions).ConfigureAwait(false);
             return messageResource.Sid;

--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -18,7 +18,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
@@ -25,7 +25,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
@@ -24,7 +24,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -22,7 +22,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
@@ -29,7 +29,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -26,7 +26,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
@@ -26,7 +26,8 @@
   
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Microsoft.Bot.Builder.Dialogs.Declarative.csproj
@@ -25,7 +25,8 @@
   
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -27,7 +27,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
@@ -25,7 +25,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
     
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.csproj
+++ b/libraries/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.csproj
@@ -23,7 +23,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -563,10 +563,12 @@ namespace Microsoft.Bot.Builder
             return Task.CompletedTask;
         }
 
+#pragma warning disable CA1064 // Exceptions should be public (we can't change this without breaking binary compat, we may consider making this type public in the future)
         protected class InvokeResponseException : Exception
+#pragma warning restore CA1064 // Exceptions should be public
         {
-            private HttpStatusCode _statusCode;
-            private object _body;
+            private readonly HttpStatusCode _statusCode;
+            private readonly object _body;
 
             public InvokeResponseException(HttpStatusCode statusCode, object body = null)
             {
@@ -574,9 +576,27 @@ namespace Microsoft.Bot.Builder
                 _body = body;
             }
 
+            public InvokeResponseException()
+            {
+            }
+
+            public InvokeResponseException(string message) 
+                : base(message)
+            {
+            }
+
+            public InvokeResponseException(string message, Exception innerException) 
+                : base(message, innerException)
+            {
+            }
+
             public InvokeResponse CreateInvokeResponse()
             {
-                return new InvokeResponse { Status = (int)_statusCode, Body = _body };
+                return new InvokeResponse
+                {
+                    Status = (int)_statusCode,
+                    Body = _body
+                };
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
@@ -125,8 +126,10 @@ namespace Microsoft.Bot.Builder.Adapters
                 ChannelId = "test",
                 ServiceUrl = "https://test.com",
                 Conversation = new ConversationAccount(false, name, name),
-                User = new ChannelAccount(id: user.ToLower(), name: user),
-                Bot = new ChannelAccount(id: bot.ToLower(), name: bot),
+#pragma warning disable CA1308 // Normalize strings to uppercase (it is safe to use lowercase here, this is just for display purposes)
+                User = new ChannelAccount(id: user.ToLowerInvariant(), name: user),
+                Bot = new ChannelAccount(id: bot.ToLowerInvariant(), name: bot),
+#pragma warning restore CA1308 // Normalize strings to uppercase
                 Locale = "en-us"
             };
         }
@@ -174,7 +177,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 activity.Conversation = Conversation.Conversation;
                 activity.ServiceUrl = Conversation.ServiceUrl;
 
-                var id = activity.Id = (_nextId++).ToString();
+                var id = activity.Id = (_nextId++).ToString(CultureInfo.InvariantCulture);
             }
 
             if (activity.Timestamp == null || activity.Timestamp == default(DateTimeOffset))
@@ -370,9 +373,12 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             ActiveQueue.Clear();
             var update = Activity.CreateConversationUpdateActivity();
-            update.Conversation = new ConversationAccount() { Id = Guid.NewGuid().ToString("n") };
-            var context = new TurnContext(this, (Activity)update);
-            return callback(context, cancellationToken);
+            update.ChannelId = channelId;
+            update.Conversation = new ConversationAccount { Id = Guid.NewGuid().ToString("n") };
+            using (var context = new TurnContext(this, (Activity)update))
+            {
+                return callback(context, cancellationToken);
+            }
         }
 
         /// <summary>
@@ -435,7 +441,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 Recipient = Conversation.Bot,
                 Conversation = Conversation.Conversation,
                 ServiceUrl = Conversation.ServiceUrl,
-                Id = (_nextId++).ToString(),
+                Id = (_nextId++).ToString(CultureInfo.InvariantCulture),
                 Text = text,
             };
 
@@ -892,9 +898,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 var rhs = obj as UserTokenKey;
                 if (rhs != null)
                 {
-                    return string.Equals(this.ConnectionName, rhs.ConnectionName) &&
-                        string.Equals(this.UserId, rhs.UserId) &&
-                        string.Equals(this.ChannelId, rhs.ChannelId);
+                    return string.Equals(this.ConnectionName, rhs.ConnectionName, StringComparison.Ordinal) &&
+                        string.Equals(this.UserId, rhs.UserId, StringComparison.Ordinal) &&
+                        string.Equals(this.ChannelId, rhs.ChannelId, StringComparison.Ordinal);
                 }
 
                 return base.Equals(obj);
@@ -917,7 +923,7 @@ namespace Microsoft.Bot.Builder.Adapters
                 var rhs = obj as ExchangableTokenKey;
                 if (rhs != null)
                 {
-                    return string.Equals(this.ExchangableItem, rhs.ExchangableItem) &&
+                    return string.Equals(this.ExchangableItem, rhs.ExchangableItem, StringComparison.Ordinal) &&
                         base.Equals(obj);
                 }
 

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestFlow.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             if (userSays == null)
             {
-                throw new ArgumentNullException("You have to pass a userSays parameter");
+                throw new ArgumentNullException(nameof(userSays), "You have to pass a userSays parameter");
             }
 
             return new TestFlow(
@@ -145,7 +145,7 @@ namespace Microsoft.Bot.Builder.Adapters
         {
             if (userActivity == null)
             {
-                throw new ArgumentNullException("You have to pass an Activity");
+                throw new ArgumentNullException(nameof(userActivity), "You have to pass an Activity");
             }
 
             return new TestFlow(
@@ -314,7 +314,9 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="timeout">The amount of time in milliseconds within which a response is expected.</param>
         /// <returns>A new <see cref="TestFlow"/> object that appends this assertion to the modeled exchange.</returns>
         /// <remarks>This method does not modify the original <see cref="TestFlow"/> object.</remarks>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove this withouth breaking binary compat)
         public TestFlow AssertReply(Action<IActivity> validateActivity, [CallerMemberName] string description = null, uint timeout = 3000)
+#pragma warning restore CA1801 // Review unused parameters
         {
             return new TestFlow(
                 async () =>
@@ -530,9 +532,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 timeout);
         }
 
-        private bool IsReply(IActivity activity)
+        private static bool IsReply(IActivity activity)
         {
-            return string.Equals("bot", activity.From?.Role, StringComparison.InvariantCultureIgnoreCase);
+            return string.Equals("bot", activity.From?.Role, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/BotAssert.cs
+++ b/libraries/Microsoft.Bot.Builder/BotAssert.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Bot.Builder
     /// <summary>
     /// Provides methods for debugging Bot Builder code.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class BotAssert
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Checks that an activity object is not <c>null</c>.

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder
             Use(new TenantIdWorkaroundForTeamsMiddleware());
 
             // DefaultRequestHeaders are not thread safe so set them up here because this adapter should be a singleton.
-            ConnectorClient.AddDefaultRequestHeaders(customHttpClient ?? DefaultHttpClient);
+            ConnectorClient.AddDefaultRequestHeaders(_httpClient);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder
             Use(new TenantIdWorkaroundForTeamsMiddleware());
 
             // DefaultRequestHeaders are not thread safe so set them up here because this adapter should be a singleton.
-            ConnectorClient.AddDefaultRequestHeaders(_httpClient);
+            ConnectorClient.AddDefaultRequestHeaders(customHttpClient ?? DefaultHttpClient);
         }
 
         /// <summary>
@@ -363,7 +363,7 @@ namespace Microsoft.Bot.Builder
                     }
                 }
 
-                var connectorClient = await CreateConnectorClientAsync(reference.ServiceUrl, claimsIdentity, audience, cancellationToken).ConfigureAwait(false);
+                var connectorClient = await CreateConnectorClientAsync(reference.ServiceUrl, claimsIdentity, audience).ConfigureAwait(false);
                 context.TurnState.Add(connectorClient);
 
                 await RunPipelineAsync(context, callback, cancellationToken).ConfigureAwait(false);
@@ -441,7 +441,7 @@ namespace Microsoft.Bot.Builder
                 // The OAuthScope is also stored on the TurnState to get the correct AppCredentials if fetching a token is required.
                 var scope = SkillValidation.IsSkillClaim(claimsIdentity.Claims) ? JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims) : GetBotFrameworkOAuthScope();
                 context.TurnState.Add(OAuthScopeKey, scope);
-                var connectorClient = await CreateConnectorClientAsync(activity.ServiceUrl, claimsIdentity, scope, cancellationToken).ConfigureAwait(false);
+                var connectorClient = await CreateConnectorClientAsync(activity.ServiceUrl, claimsIdentity, scope).ConfigureAwait(false);
                 context.TurnState.Add(connectorClient);
 
                 context.TurnState.Add(callback);
@@ -552,7 +552,9 @@ namespace Microsoft.Bot.Builder
                             var oAuthScope = turnContext.TurnState.Get<string>(OAuthScopeKey);
                             _ = (await GetAppCredentialsAsync(appId, oAuthScope).ConfigureAwait(false)).GetTokenAsync();
                         }
+#pragma warning disable CA1031 // Do not catch general exception types (we just catch and log the exception here)
                         catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             Logger.LogError("Failed to fetch token before processing outgoing activity. " + ex.Message);
                         }
@@ -1153,28 +1155,28 @@ namespace Microsoft.Bot.Builder
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>If the task completes, the exchanged token is returned.</returns>
-        public virtual async Task<TokenResponse> ExchangeTokenAsync(ITurnContext turnContext, AppCredentials oAuthAppCredentials, string connectionName, string userId, TokenExchangeRequest exchangeRequest, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<TokenResponse> ExchangeTokenAsync(ITurnContext turnContext, AppCredentials oAuthAppCredentials, string connectionName, string userId, TokenExchangeRequest exchangeRequest, CancellationToken cancellationToken = default)
         {
             BotAssert.ContextNotNull(turnContext);
 
             if (string.IsNullOrWhiteSpace(connectionName))
             {
-                LogAndThrowException(new ArgumentException(nameof(connectionName)));
+                LogAndThrowException(new ArgumentException($"{nameof(connectionName)} is null or empty", nameof(connectionName)));
             }
 
             if (string.IsNullOrWhiteSpace(userId))
             {
-                LogAndThrowException(new ArgumentException(nameof(userId)));
+                LogAndThrowException(new ArgumentException($"{nameof(userId)} is null or empty", nameof(userId)));
             }
 
             if (exchangeRequest == null)
             {
-                LogAndThrowException(new ArgumentException(nameof(exchangeRequest)));
+                LogAndThrowException(new ArgumentException($"{nameof(exchangeRequest)} is null or empty", nameof(exchangeRequest)));
             }
 
             if (string.IsNullOrWhiteSpace(exchangeRequest.Token) && string.IsNullOrWhiteSpace(exchangeRequest.Uri))
             {
-                LogAndThrowException(new ArgumentException(nameof(exchangeRequest), "Either a Token or Uri property is required on the TokenExchangeRequest"));
+                LogAndThrowException(new ArgumentException("Either a Token or Uri property is required on the TokenExchangeRequest", nameof(exchangeRequest)));
             }
 
             var activity = turnContext.Activity;
@@ -1191,13 +1193,11 @@ namespace Microsoft.Bot.Builder
             {
                 return tokenResponse;
             }
-            else
-            {
-                LogAndThrowException(new InvalidOperationException($"ExchangeAsyncAsync returned improper result: {result.GetType()}"));
 
-                // even though LogAndThrowException always throws, compiler gives an error about not all code paths returning a value.
-                return null;
-            }
+            LogAndThrowException(new InvalidOperationException($"ExchangeAsyncAsync returned improper result: {result.GetType()}"));
+
+            // even though LogAndThrowException always throws, compiler gives an error about not all code paths returning a value.
+            return null;
         }
 
         /// <summary>
@@ -1309,7 +1309,7 @@ namespace Microsoft.Bot.Builder
 
         Task<IConnectorClient> IConnectorClientBuilder.CreateConnectorClientAsync(string serviceUrl, ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
         {
-            return CreateConnectorClientAsync(serviceUrl, claimsIdentity, audience, cancellationToken);
+            return CreateConnectorClientAsync(serviceUrl, claimsIdentity, audience);
         }
 
         /// <summary>
@@ -1321,7 +1321,7 @@ namespace Microsoft.Bot.Builder
         protected virtual async Task<OAuthClient> CreateOAuthApiClientAsync(ITurnContext turnContext, AppCredentials oAuthAppCredentials)
         {
             if (!OAuthClientConfig.EmulateOAuthCards &&
-                string.Equals(turnContext.Activity.ChannelId, Channels.Emulator, StringComparison.InvariantCultureIgnoreCase) &&
+                string.Equals(turnContext.Activity.ChannelId, Channels.Emulator, StringComparison.OrdinalIgnoreCase) &&
                 (await CredentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false)))
             {
                 OAuthClientConfig.EmulateOAuthCards = true;
@@ -1335,7 +1335,7 @@ namespace Microsoft.Bot.Builder
             var appCredentials = oAuthAppCredentials ?? await GetAppCredentialsAsync(appId, oAuthScope).ConfigureAwait(false);
 
             if (!OAuthClientConfig.EmulateOAuthCards &&
-                string.Equals(turnContext.Activity.ChannelId, Channels.Emulator, StringComparison.InvariantCultureIgnoreCase) &&
+                string.Equals(turnContext.Activity.ChannelId, Channels.Emulator, StringComparison.OrdinalIgnoreCase) &&
                 (await CredentialProvider.IsAuthenticationDisabledAsync().ConfigureAwait(false)))
             {
                 OAuthClientConfig.EmulateOAuthCards = true;
@@ -1422,6 +1422,28 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
+        /// Gets the AppId of the Bot out of the TurnState.
+        /// </summary>
+        /// <param name="turnContext">The context object for the turn.</param>
+        /// <returns>Bot's AppId.</returns>
+        private static string GetBotAppId(ITurnContext turnContext)
+        {
+            var botIdentity = (ClaimsIdentity)turnContext.TurnState.Get<IIdentity>(BotIdentityKey);
+            if (botIdentity == null)
+            {
+                throw new InvalidOperationException("An IIdentity is required in TurnState for this operation.");
+            }
+
+            var appId = botIdentity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim)?.Value;
+            if (string.IsNullOrWhiteSpace(appId))
+            {
+                throw new InvalidOperationException("Unable to get the bot AppId from the audience claim.");
+            }
+
+            return appId;
+        }
+
+        /// <summary>
         /// Generates the CallerId property for the activity based on
         /// https://github.com/microsoft/botframework-obi/blob/master/protocols/botframework-activity/botframework-activity.md#appendix-v---caller-id-values.
         /// </summary>
@@ -1463,10 +1485,9 @@ namespace Microsoft.Bot.Builder
         /// <param name="serviceUrl">The service URL.</param>
         /// <param name="claimsIdentity">The claims claimsIdentity.</param>
         /// <param name="audience">The target audience for the connector.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>ConnectorClient instance.</returns>
         /// <exception cref="NotSupportedException">ClaimsIdentity cannot be null. Pass Anonymous ClaimsIdentity if authentication is turned off.</exception>
-        private async Task<IConnectorClient> CreateConnectorClientAsync(string serviceUrl, ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken = default)
+        private async Task<IConnectorClient> CreateConnectorClientAsync(string serviceUrl, ClaimsIdentity claimsIdentity, string audience)
         {
             if (claimsIdentity == null)
             {
@@ -1497,7 +1518,7 @@ namespace Microsoft.Bot.Builder
                         GetBotFrameworkOAuthScope();
                 }
 
-                appCredentials = await GetAppCredentialsAsync(botId, scope, cancellationToken).ConfigureAwait(false);
+                appCredentials = await GetAppCredentialsAsync(botId, scope).ConfigureAwait(false);
             }
 
             return CreateConnectorClient(serviceUrl, appCredentials);
@@ -1544,9 +1565,8 @@ namespace Microsoft.Bot.Builder
         /// </summary>
         /// <param name="appId">The application identifier (AAD ID for the bot).</param>
         /// <param name="oAuthScope">The scope for the token. Skills use the skill's app ID. </param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>App credentials.</returns>
-        private async Task<AppCredentials> GetAppCredentialsAsync(string appId, string oAuthScope, CancellationToken cancellationToken = default)
+        private async Task<AppCredentials> GetAppCredentialsAsync(string appId, string oAuthScope)
         {
             if (string.IsNullOrWhiteSpace(appId))
             {
@@ -1576,28 +1596,6 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// Gets the AppId of the Bot out of the TurnState.
-        /// </summary>
-        /// <param name="turnContext">The context object for the turn.</param>
-        /// <returns>Bot's AppId.</returns>
-        private string GetBotAppId(ITurnContext turnContext)
-        {
-            var botIdentity = (ClaimsIdentity)turnContext.TurnState.Get<IIdentity>(BotIdentityKey);
-            if (botIdentity == null)
-            {
-                throw new InvalidOperationException("An IIdentity is required in TurnState for this operation.");
-            }
-
-            var appId = botIdentity.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim)?.Value;
-            if (string.IsNullOrWhiteSpace(appId))
-            {
-                throw new InvalidOperationException("Unable to get the bot AppId from the audience claim.");
-            }
-
-            return appId;
-        }
-
-        /// <summary>
         /// This method returns the correct Bot Framework OAuthScope for AppCredentials.
         /// </summary>
         private string GetBotFrameworkOAuthScope()
@@ -1608,7 +1606,7 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
-        /// Logs and throws an expcetion.
+        /// Logs and throws an exception.
         /// </summary>
         /// <param name="ex"> Exception instance to throw.</param>
         /// <param name="source"> Source method for the exception.</param>
@@ -1630,7 +1628,7 @@ namespace Microsoft.Bot.Builder
         {
             public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
             {
-                if (Channels.Msteams.Equals(turnContext.Activity.ChannelId, StringComparison.InvariantCultureIgnoreCase) && turnContext.Activity.Conversation != null && string.IsNullOrEmpty(turnContext.Activity.Conversation.TenantId) && turnContext.Activity.ChannelData != null)
+                if (Channels.Msteams.Equals(turnContext.Activity.ChannelId, StringComparison.OrdinalIgnoreCase) && turnContext.Activity.Conversation != null && string.IsNullOrEmpty(turnContext.Activity.Conversation.TenantId) && turnContext.Activity.ChannelData != null)
                 {
                     var teamsChannelData = JObject.FromObject(turnContext.Activity.ChannelData);
                     if (teamsChannelData["tenant"]?["id"] != null)

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Bot.Builder
                     { key, cachedState.State },
                 };
                 await _storage.WriteAsync(changes).ConfigureAwait(false);
-                cachedState.Hash = cachedState.ComputeHash(cachedState.State);
+                cachedState.Hash = CachedBotState.ComputeHash(cachedState.State);
                 return;
             }
         }
@@ -230,7 +230,9 @@ namespace Microsoft.Bot.Builder
         /// <remarks>If the task is successful, the result contains the property value, otherwise it will be default(T).</remarks>
         /// <exception cref="ArgumentNullException"><paramref name="turnContext"/> or
         /// <paramref name="propertyName"/> is <c>null</c>.</exception>
+#pragma warning disable CA1801 // Review unused parameters (we can't change this without breaking binary compat)
         protected Task<T> GetPropertyValueAsync<T>(ITurnContext turnContext, string propertyName, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore CA1801 // Review unused parameters
         {
             BotAssert.ContextNotNull(turnContext);
 
@@ -287,7 +289,9 @@ namespace Microsoft.Bot.Builder
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="turnContext"/> or
         /// <paramref name="propertyName"/> is <c>null</c>.</exception>
+#pragma warning disable CA1801 // Review unused parameters (we can't change this without breaking binary compat)
         protected Task DeletePropertyValueAsync(ITurnContext turnContext, string propertyName, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore CA1801 // Review unused parameters
         {
             BotAssert.ContextNotNull(turnContext);
 
@@ -312,7 +316,9 @@ namespace Microsoft.Bot.Builder
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="turnContext"/> or
         /// <paramref name="propertyName"/> is <c>null</c>.</exception>
+#pragma warning disable CA1801 // Review unused parameters (we can't change this without breaking binary compat)
         protected Task SetPropertyValueAsync(ITurnContext turnContext, string propertyName, object value, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore CA1801 // Review unused parameters
         {
             BotAssert.ContextNotNull(turnContext);
 
@@ -329,7 +335,9 @@ namespace Microsoft.Bot.Builder
         /// <summary>
         /// Internal cached bot state.
         /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat)
         public class CachedBotState
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             internal CachedBotState(IDictionary<string, object> state = null)
             {
@@ -337,18 +345,20 @@ namespace Microsoft.Bot.Builder
                 Hash = ComputeHash(State);
             }
 
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
             public IDictionary<string, object> State { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
             internal string Hash { get; set; }
+
+            internal static string ComputeHash(object obj)
+            {
+                return JsonConvert.SerializeObject(obj);
+            }
 
             internal bool IsChanged()
             {
                 return Hash != ComputeHash(State);
-            }
-
-            internal string ComputeHash(object obj)
-            {
-                return JsonConvert.SerializeObject(obj);
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder/BotStateSet.cs
+++ b/libraries/Microsoft.Bot.Builder/BotStateSet.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Bot.Builder
         /// Gets or sets the BotStates list for the BotStateSet.
         /// </summary>
         /// <value>The BotState objects managed by this class.</value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<BotState> BotStates { get; set; } = new List<BotState>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Adds a bot state object to the set.

--- a/libraries/Microsoft.Bot.Builder/ComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder/ComponentRegistration.cs
@@ -4,10 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
 
 namespace Microsoft.Bot.Builder
 {
@@ -33,9 +29,11 @@ namespace Microsoft.Bot.Builder
     ///      ComponentRegistration.Add(new MyComponentRegistration());
     /// </code>
     /// </remarks>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ComponentRegistration
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
-        private static ConcurrentDictionary<Type, ComponentRegistration> components = new ConcurrentDictionary<Type, ComponentRegistration>();
+        private static readonly ConcurrentDictionary<Type, ComponentRegistration> _components = new ConcurrentDictionary<Type, ComponentRegistration>();
 
         /// <summary>
         /// Gets list of all ComponentRegistration objects registered.
@@ -43,7 +41,7 @@ namespace Microsoft.Bot.Builder
         /// <value>
         /// A numeration of ComponentRegistration objects.
         /// </value>
-        public static IEnumerable<object> Components => components.Values;
+        public static IEnumerable<object> Components => _components.Values;
 
         /// <summary>
         /// Add a component which implements registration methods.
@@ -52,7 +50,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="componentRegistration">componentRegistration.</param>
         public static void Add(ComponentRegistration componentRegistration)
         {
-            components[componentRegistration.GetType()] = componentRegistration;
+            _components[componentRegistration.GetType()] = componentRegistration;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/ConversationState.cs
+++ b/libraries/Microsoft.Bot.Builder/ConversationState.cs
@@ -37,8 +37,9 @@ namespace Microsoft.Bot.Builder
         /// <see cref="Schema.ConversationAccount.Id"/> is missing.</exception>
         protected override string GetStorageKey(ITurnContext turnContext)
         {
-            var channelId = turnContext.Activity.ChannelId ?? throw new ArgumentNullException("invalid activity-missing channelId");
-            var conversationId = turnContext.Activity.Conversation?.Id ?? throw new ArgumentNullException("invalid activity-missing Conversation.Id");
+            var channelId = turnContext.Activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
+            var conversationId = turnContext.Activity.Conversation?.Id ?? throw new InvalidOperationException("invalid activity-missing Conversation.Id");
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             return $"{channelId}/conversations/{conversationId}";
         }
     }

--- a/libraries/Microsoft.Bot.Builder/IMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/IMiddleware.cs
@@ -50,6 +50,8 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
+#pragma warning disable CA1716 // Identifiers should not match keywords (we can't change this without breaking binary compat)
         Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken));
+#pragma warning restore CA1716 // Identifiers should not match keywords
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Inspection/InspectionSession.cs
+++ b/libraries/Microsoft.Bot.Builder/Inspection/InspectionSession.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Net.Http;
@@ -12,11 +12,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Bot.Builder
 {
-    internal class InspectionSession
+    internal class InspectionSession : IDisposable
     {
+        private readonly ConnectorClient _connectorClient;
         private readonly ConversationReference _conversationReference;
         private readonly ILogger _logger;
-        private readonly ConnectorClient _connectorClient;
 
         public InspectionSession(ConversationReference conversationReference, MicrosoftAppCredentials credentials, HttpClient httpClient, ILogger logger)
         {
@@ -31,15 +31,22 @@ namespace Microsoft.Bot.Builder
 
             try
             {
-                var resourceResponse = await _connectorClient.Conversations.SendToConversationAsync(activity, cancellationToken).ConfigureAwait(false);
+                await _connectorClient.Conversations.SendToConversationAsync(activity, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception err)
+#pragma warning disable CA1031 // Do not catch general exception types (we just log the exception in this case and return false)
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                _logger.LogWarning($"Exception '{err.ToString()}' while attempting to call Emulator for inspection, check it is running, and you have correct credentials in the Emulator and the InspectionMiddleware.");
+                _logger.LogWarning($"Exception '{ex}' while attempting to call Emulator for inspection, check it is running, and you have correct credentials in the Emulator and the InspectionMiddleware.");
                 return false;
             }
 
             return true;
+        }
+
+        public void Dispose()
+        {
+            _connectorClient?.Dispose();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Inspection/InterceptionMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Inspection/InterceptionMiddleware.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder
             Logger = logger ?? NullLogger.Instance;
         }
 
-        protected ILogger Logger { get; private set; }
+        protected ILogger Logger { get; }
 
         async Task IMiddleware.OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken)
         {
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder
                 catch (Exception e)
                 {
                     await InvokeTraceExceptionAsync(turnContext, e.TraceActivity(), cancellationToken).ConfigureAwait(false);
-                    throw e;
+                    throw;
                 }
             }
 
@@ -80,9 +80,11 @@ namespace Microsoft.Bot.Builder
             {
                 return await InboundAsync(turnContext, traceActivity, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e)
+#pragma warning disable CA1031 // Do not catch general exception types (exception are logged and ignored)
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogWarning($"Exception in inbound interception {e.Message}");
+                Logger.LogWarning($"Exception in inbound interception {ex.Message}");
                 return (true, false);
             }
         }
@@ -93,9 +95,11 @@ namespace Microsoft.Bot.Builder
             {
                 await OutboundAsync(turnContext, traceActivities, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e)
+#pragma warning disable CA1031 // Do not catch general exception types (exception are logged and ignored)
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogWarning($"Exception in outbound interception {e.Message}");
+                Logger.LogWarning($"Exception in outbound interception {ex.Message}");
             }
         }
 
@@ -110,9 +114,11 @@ namespace Microsoft.Bot.Builder
             {
                 await TraceStateAsync(turnContext, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e)
+#pragma warning disable CA1031 // Do not catch general exception types (exception are logged and ignored)
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogWarning($"Exception in state interception {e.Message}");
+                Logger.LogWarning($"Exception in state interception {ex.Message}");
             }
         }
 
@@ -122,9 +128,11 @@ namespace Microsoft.Bot.Builder
             {
                 await OutboundAsync(turnContext, new Activity[] { traceActivity }, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e)
+#pragma warning disable CA1031 // Do not catch general exception types (exception are logged and ignored)
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                Logger.LogWarning($"Exception in exception interception {e.Message}");
+                Logger.LogWarning($"Exception in exception interception {ex.Message}");
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder/Integration/MessageSerializerSettings.cs
+++ b/libraries/Microsoft.Bot.Builder/Integration/MessageSerializerSettings.cs
@@ -11,8 +11,10 @@ namespace Microsoft.Bot.Builder.Integration
     {
         public static JsonSerializerSettings Create()
         {
-            var connector = new ConnectorClient(new Uri("http://localhost/"));
-            return connector.DeserializationSettings;
+            using (var connector = new ConnectorClient(new Uri("http://localhost/")))
+            {
+                return connector.DeserializationSettings;
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/IntentScore.cs
+++ b/libraries/Microsoft.Bot.Builder/IntentScore.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Bot.Builder
         /// Any extra properties to include in the results.
         /// </value>
         [JsonExtensionData(ReadData = true, WriteData = true)]
+#pragma warning disable CA2227 // Collection properties should be read only  (we can't change this without breaking binary compat)
         public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -160,7 +161,7 @@ namespace Microsoft.Bot.Builder
                             throw new Exception($"Etag conflict.\r\n\r\nOriginal: {newStoreItem.ETag}\r\nCurrent: {oldStateETag}");
                         }
 
-                        newState["eTag"] = (_eTag++).ToString();
+                        newState["eTag"] = (_eTag++).ToString(CultureInfo.InvariantCulture);
                     }
 
                     _memory[change.Key] = newState;

--- a/libraries/Microsoft.Bot.Builder/MemoryTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryTranscriptStore.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder
         {
             if (activity == null)
             {
-                throw new ArgumentNullException("activity cannot be null for LogActivity()");
+                throw new ArgumentNullException(nameof(activity), "activity cannot be null for LogActivity()");
             }
 
             lock (_channels)
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder
                                 .Take(20)
                                 .ToArray();
 
-                            if (pagedResult.Items.Count() == 20)
+                            if (pagedResult.Items.Length == 20)
                             {
                                 pagedResult.ContinuationToken = pagedResult.Items.Last().Id;
                             }
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder
                                 .Take(20)
                                 .ToArray();
 
-                            if (pagedResult.Items.Count() == 20)
+                            if (pagedResult.Items.Length == 20)
                             {
                                 pagedResult.ContinuationToken = pagedResult.Items.Last().Id;
                             }
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder
                         .Take(20)
                         .ToArray();
 
-                        if (pagedResult.Items.Count() == 20)
+                        if (pagedResult.Items.Length == 20)
                         {
                             pagedResult.ContinuationToken = pagedResult.Items.Last().Id;
                         }
@@ -250,7 +250,7 @@ namespace Microsoft.Bot.Builder
                             .Take(20)
                             .ToArray();
 
-                        if (pagedResult.Items.Count() == 20)
+                        if (pagedResult.Items.Length == 20)
                         {
                             pagedResult.ContinuationToken = pagedResult.Items.Last().Id;
                         }

--- a/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
+++ b/libraries/Microsoft.Bot.Builder/Microsoft.Bot.Builder.csproj
@@ -34,6 +34,10 @@
     <PackageReference Include="Microsoft.Bot.Streaming" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Connector" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/libraries/Microsoft.Bot.Builder/PagedResult.cs
+++ b/libraries/Microsoft.Bot.Builder/PagedResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder
 {
     /// <summary>
@@ -15,7 +17,9 @@ namespace Microsoft.Bot.Builder
         /// <value>
         /// The array of items.
         /// </value>
-        public T[] Items { get; set; } = new T[0];
+#pragma warning disable CA1819 // Properties should not return arrays (can't change this without breaking binary compat)
+        public T[] Items { get; set; } = Array.Empty<T>();
+#pragma warning restore CA1819 // Properties should not return arrays
 
         /// <summary>
         /// Gets or sets a token for retrieving the next page of results.

--- a/libraries/Microsoft.Bot.Builder/PrivateConversationState.cs
+++ b/libraries/Microsoft.Bot.Builder/PrivateConversationState.cs
@@ -39,9 +39,9 @@ namespace Microsoft.Bot.Builder
         /// </exception>
         protected override string GetStorageKey(ITurnContext turnContext)
         {
-            var channelId = turnContext.Activity.ChannelId ?? throw new ArgumentNullException("invalid activity-missing channelId");
-            var conversationId = turnContext.Activity.Conversation?.Id ?? throw new ArgumentNullException("invalid activity-missing Conversation.Id");
-            var userId = turnContext.Activity.From?.Id ?? throw new ArgumentNullException("invalid activity-missing From.Id");
+            var channelId = turnContext.Activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
+            var conversationId = turnContext.Activity.Conversation?.Id ?? throw new InvalidOperationException("invalid activity-missing Conversation.Id");
+            var userId = turnContext.Activity.From?.Id ?? throw new InvalidOperationException("invalid activity-missing From.Id");
             return $"{channelId}/conversations/{conversationId}/users/{userId}";
         }
     }

--- a/libraries/Microsoft.Bot.Builder/RecognizerResult.cs
+++ b/libraries/Microsoft.Bot.Builder/RecognizerResult.cs
@@ -38,7 +38,9 @@ namespace Microsoft.Bot.Builder
         /// Mapping from intent to information about the intent.
         /// </value>
         [JsonProperty("intents")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, IntentScore> Intents { get; set; } = new Dictionary<string, IntentScore>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets the recognized top-level entities.
@@ -47,7 +49,9 @@ namespace Microsoft.Bot.Builder
         /// Object with each top-level recognized entity as a key.
         /// </value>
         [JsonProperty("entities")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public JObject Entities { get; set; } = new JObject();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets properties that are not otherwise defined by the <see cref="RecognizerResult"/> type but that
@@ -58,7 +62,9 @@ namespace Microsoft.Bot.Builder
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <inheritdoc />
         public void Convert(dynamic result)

--- a/libraries/Microsoft.Bot.Builder/RecognizerResultExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder/RecognizerResultExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder
 
             if (result.Intents == null)
             {
-                throw new ArgumentNullException(nameof(result.Intents));
+                throw new InvalidOperationException(nameof(result.Intents));
             }
 
             var topIntent = (string.Empty, 0.0d);

--- a/libraries/Microsoft.Bot.Builder/RegisterClassMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/RegisterClassMiddleware.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder
     public class RegisterClassMiddleware<T> : IMiddleware
         where T : class
     {
-        private string key;
+        private readonly string _key;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegisterClassMiddleware{T}"/> class.
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder
         public RegisterClassMiddleware(T service, string key)
         {
             this.Service = service;
-            this.key = key;
+            this._key = key;
         }
 
         /// <summary>
@@ -53,9 +53,9 @@ namespace Microsoft.Bot.Builder
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextTurn, CancellationToken cancellationToken)
         {
             // Register service
-            if (this.key != null)
+            if (this._key != null)
             {
-                turnContext.TurnState.Add(this.key, this.Service);
+                turnContext.TurnState.Add(this._key, this.Service);
             }
             else
             {

--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -55,27 +55,27 @@ namespace Microsoft.Bot.Builder
         /// <seealso cref="Bot.Schema.IActivity"/>
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken)
         {
-            CancellationTokenSource cts = null;
-            try
+            using (var cts = new CancellationTokenSource())
             {
-                // If the incoming activity is a MessageActivity, start a timer to periodically send the typing activity
-                if (turnContext.Activity.Type == ActivityTypes.Message)
+                Task typingTask = null;
+                try
                 {
-                    cts = new CancellationTokenSource();
-                    cancellationToken.Register(() => cts.Cancel());
+                    // If the incoming activity is a MessageActivity, start a timer to periodically send the typing activity.
+                    if (turnContext.Activity.Type == ActivityTypes.Message)
+                    {
+                        // do not await task - we want this to run in the background and we will cancel it when its done
+                        typingTask = SendTypingAsync(turnContext, _delay, _period, cts.Token);
+                    }
 
-                    // do not await task - we want this to run in the background and we will cancel it when its done
-                    var task = Task.Run(() => SendTypingAsync(turnContext, _delay, _period, cts.Token), cancellationToken);
+                    await next(cancellationToken).ConfigureAwait(false);
                 }
-
-                await next(cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                if (cts != null)
+                finally
                 {
-                    cts.Cancel();
-                    cts.Dispose();
+                    if (typingTask != null && !typingTask.IsCanceled)
+                    {
+                        // Cancel the typing loop.
+                        cts.Cancel();
+                    }
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder
                     await Task.Delay(period, cancellationToken).ConfigureAwait(false);
                 }
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 // do nothing
             }

--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Bot.Builder
                 if (cts != null)
                 {
                     cts.Cancel();
+                    cts.Dispose();
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -20,13 +20,17 @@ namespace Microsoft.Bot.Builder.Teams
         public static async Task<TeamDetails> GetTeamDetailsAsync(ITurnContext turnContext, string teamId = null, CancellationToken cancellationToken = default)
         {
             var t = teamId ?? turnContext.Activity.TeamsGetTeamInfo()?.Id ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
+#pragma warning disable CA2000 // Dispose objects before losing scope (we need to review this, disposing the connectorClient may have unintended consequences)
             return await GetTeamsConnectorClient(turnContext).Teams.FetchTeamDetailsAsync(t, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
         }
 
         public static async Task<IList<ChannelInfo>> GetTeamChannelsAsync(ITurnContext turnContext, string teamId = null, CancellationToken cancellationToken = default)
         {
             var t = teamId ?? turnContext.Activity.TeamsGetTeamInfo()?.Id ?? throw new InvalidOperationException("This method is only valid within the scope of MS Teams Team.");
+#pragma warning disable CA2000 // Dispose objects before losing scope (we need to review this, disposing the connectorClient may have unintended consequences)
             var channelList = await GetTeamsConnectorClient(turnContext).Teams.FetchChannelListAsync(t, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             return channelList.Conversations;
         }
 
@@ -102,7 +106,7 @@ namespace Microsoft.Bot.Builder.Teams
 
             if (turnContext.Activity == null)
             {
-                throw new ArgumentNullException(nameof(turnContext.Activity));
+                throw new InvalidOperationException(nameof(turnContext.Activity));
             }
 
             if (string.IsNullOrEmpty(teamsChannelId))

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -324,7 +324,9 @@ namespace Microsoft.Bot.Builder
         /// <param name="activity">The Activity object deleted by bot.</param>
         /// <param name="additionalProperties">Additional properties to add to the event.</param>
         /// <returns>The properties and their values to log when the bot deletes a message it sent previously.</returns>
+#pragma warning disable CA1822 // Mark members as static (can't change this without breaking binary compat)
         protected Task<Dictionary<string, string>> FillDeleteEventPropertiesAsync(IMessageDeleteActivity activity, Dictionary<string, string> additionalProperties = null)
+#pragma warning restore CA1822 // Mark members as static
         {
             var properties = new Dictionary<string, string>()
                 {

--- a/libraries/Microsoft.Bot.Builder/TokenResolver.cs
+++ b/libraries/Microsoft.Bot.Builder/TokenResolver.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
@@ -14,7 +13,6 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder
 {
@@ -24,71 +22,63 @@ namespace Microsoft.Bot.Builder
 
         public static void CheckForOAuthCards(BotFrameworkAdapter adapter, ILogger logger, ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
         {
-            if (activity == null || activity.Attachments == null)
+            if (activity?.Attachments == null)
             {
                 return;
             }
 
+            var pollTokenTasks = new List<Task>();
             foreach (var attachment in activity.Attachments.Where(a => a.ContentType == OAuthCard.ContentType))
             {
-                OAuthCard oauthCard = attachment.Content as OAuthCard;
-                if (oauthCard != null)
+                if (attachment.Content is OAuthCard oauthCard)
                 {
                     if (string.IsNullOrWhiteSpace(oauthCard.ConnectionName))
                     {
                         throw new InvalidOperationException("The OAuthPrompt's ConnectionName property is missing a value.");
                     }
 
-                    // Poll as a background task
-#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler (need to think this one through, ignoring for now)
-                    Task.Run(() => PollForTokenAsync(adapter, logger, turnContext, oauthCard.ConnectionName, cancellationToken))
-                        .ContinueWith(t =>
-                        {
-                            if (t.Exception != null)
-                            {
-                                logger.LogError(t.Exception.InnerException ?? t.Exception, "PollForTokenAsync threw an exception", oauthCard.ConnectionName);
-                            }
-                        });
-#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+                    // Poll as a background task and add to the list (we don't call await here, we await all the calls together later).
+                    pollTokenTasks.Add(PollForTokenAsync(adapter, logger, turnContext, oauthCard.ConnectionName, cancellationToken));
                 }
+            }
+
+            if (pollTokenTasks.Any())
+            {
+                // Wait for all the poll operations to complete.
+                Task.WaitAll(pollTokenTasks.ToArray());
             }
         }
 
         private static async Task PollForTokenAsync(BotFrameworkAdapter adapter, ILogger logger, ITurnContext turnContext, string connectionName, CancellationToken cancellationToken)
         {
-            TokenResponse tokenResponse = null;
-            bool shouldEndPolling = false;
-            var pollingTimeout = TurnStateConstants.OAuthLoginTimeoutValue;
-            var pollingRequestsInterval = PollingInterval;
-            var loginTimeout = turnContext.TurnState.Get<object>(TurnStateConstants.OAuthLoginTimeoutKey);
-            bool sentToken = false;
-
-            // Override login timeout with value set from the OAuthPrompt or by the developer
-            if (turnContext.TurnState.ContainsKey(TurnStateConstants.OAuthLoginTimeoutKey))
+            try
             {
-                pollingTimeout = (TimeSpan)turnContext.TurnState.Get<object>(TurnStateConstants.OAuthLoginTimeoutKey);
-            }
+                var shouldEndPolling = false;
+                var pollingTimeout = TurnStateConstants.OAuthLoginTimeoutValue;
+                var pollingRequestsInterval = PollingInterval;
+                var sentToken = false;
 
-            var stopwatch = Stopwatch.StartNew();
-            var oauthClient = turnContext.TurnState.Get<OAuthClient>();
-
-            while (stopwatch.Elapsed < pollingTimeout && !shouldEndPolling)
-            {
-                tokenResponse = await adapter.GetUserTokenAsync(turnContext, oauthClient?.Credentials as AppCredentials, connectionName, null, cancellationToken).ConfigureAwait(false);
-
-                if (tokenResponse != null)
+                // Override login timeout with value set from the OAuthPrompt or by the developer
+                if (turnContext.TurnState.ContainsKey(TurnStateConstants.OAuthLoginTimeoutKey))
                 {
-                    // This can be used to short-circuit the polling loop.
-                    if (tokenResponse.Properties != null)
+                    pollingTimeout = (TimeSpan)turnContext.TurnState.Get<object>(TurnStateConstants.OAuthLoginTimeoutKey);
+                }
+
+                var stopwatch = Stopwatch.StartNew();
+                var oauthClient = turnContext.TurnState.Get<OAuthClient>();
+
+                while (stopwatch.Elapsed < pollingTimeout && !shouldEndPolling)
+                {
+                    var tokenResponse = await adapter.GetUserTokenAsync(turnContext, oauthClient?.Credentials as AppCredentials, connectionName, null, cancellationToken).ConfigureAwait(false);
+
+                    if (tokenResponse != null)
                     {
-                        JToken tokenPollingSettingsToken = null;
-                        TokenPollingSettings tokenPollingSettings = null;
-                        tokenResponse.Properties.TryGetValue(TurnStateConstants.TokenPollingSettingsKey, out tokenPollingSettingsToken);
-
-                        if (tokenPollingSettingsToken != null)
+                        // This can be used to short-circuit the polling loop.
+                        if (tokenResponse.Properties != null)
                         {
-                            tokenPollingSettings = tokenPollingSettingsToken.ToObject<TokenPollingSettings>();
+                            tokenResponse.Properties.TryGetValue(TurnStateConstants.TokenPollingSettingsKey, out var tokenPollingSettingsToken);
 
+                            var tokenPollingSettings = tokenPollingSettingsToken?.ToObject<TokenPollingSettings>();
                             if (tokenPollingSettings != null)
                             {
                                 logger.LogInformation($"PollForTokenAsync received new polling settings: timeout={tokenPollingSettings.Timeout}, interval={tokenPollingSettings.Interval}", tokenPollingSettings);
@@ -96,34 +86,40 @@ namespace Microsoft.Bot.Builder
                                 pollingRequestsInterval = tokenPollingSettings.Interval > 0 ? TimeSpan.FromMilliseconds(tokenPollingSettings.Interval) : pollingRequestsInterval; // Only overrides if it is set.
                             }
                         }
+
+                        // once there is a token, send it to the bot and stop polling
+                        if (tokenResponse.Token != null)
+                        {
+                            var tokenResponseActivityEvent = CreateTokenResponse(turnContext.Activity.GetConversationReference(), tokenResponse.Token, connectionName);
+                            var identity = turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) as ClaimsIdentity;
+                            var callback = turnContext.TurnState.Get<BotCallbackHandler>();
+                            await adapter.ProcessActivityAsync(identity, tokenResponseActivityEvent, callback, cancellationToken).ConfigureAwait(false);
+                            shouldEndPolling = true;
+                            sentToken = true;
+
+                            logger.LogInformation("PollForTokenAsync completed with a token", turnContext.Activity);
+                        }
                     }
 
-                    // once there is a token, send it to the bot and stop polling
-                    if (tokenResponse.Token != null)
+                    if (!shouldEndPolling)
                     {
-                        var tokenResponseActivityEvent = CreateTokenResponse(turnContext.Activity.GetConversationReference(), tokenResponse.Token, connectionName);
-                        var identity = turnContext.TurnState.Get<IIdentity>(BotFrameworkAdapter.BotIdentityKey) as ClaimsIdentity;
-                        var callback = turnContext.TurnState.Get<BotCallbackHandler>();
-                        await adapter.ProcessActivityAsync(identity, tokenResponseActivityEvent, callback, cancellationToken).ConfigureAwait(false);
-                        shouldEndPolling = true;
-                        sentToken = true;
-
-                        logger.LogInformation("PollForTokenAsync completed with a token", turnContext.Activity);
+                        await Task.Delay(pollingRequestsInterval, cancellationToken).ConfigureAwait(false);
                     }
                 }
 
-                if (!shouldEndPolling)
+                if (!sentToken)
                 {
-                    await Task.Delay(pollingRequestsInterval, cancellationToken).ConfigureAwait(false);
+                    logger.LogInformation("PollForTokenAsync completed without receiving a token", turnContext.Activity);
                 }
-            }
 
-            if (!sentToken)
+                stopwatch.Stop();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types (for new we just log the exception and continue)
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
-                logger.LogInformation("PollForTokenAsync completed without receiving a token", turnContext.Activity);
+                logger.LogError(ex, "PollForTokenAsync threw an exception", connectionName);
             }
-
-            stopwatch.Stop();
         }
 
         private static Activity CreateTokenResponse(ConversationReference relatesTo, string token, string connectionName)

--- a/libraries/Microsoft.Bot.Builder/TraceTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/TraceTranscriptLogger.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Bot.Builder
     /// </summary>
     public class TraceTranscriptLogger : ITranscriptLogger
     {
-        private static JsonSerializerSettings serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
+        private static readonly JsonSerializerSettings _serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
 
-        private bool traceActivity;
+        private readonly bool _traceActivity;
 
         public TraceTranscriptLogger()
             : this(true)
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder
 
         public TraceTranscriptLogger(bool traceActivity)
         {
-            this.traceActivity = traceActivity;
+            this._traceActivity = traceActivity;
         }
 
         /// <summary>
@@ -35,9 +35,9 @@ namespace Microsoft.Bot.Builder
         public Task LogActivityAsync(IActivity activity)
         {
             BotAssert.ActivityNotNull(activity);
-            if (traceActivity)
+            if (_traceActivity)
             {
-                Trace.TraceInformation(JsonConvert.SerializeObject(activity, serializationSettings));
+                Trace.TraceInformation(JsonConvert.SerializeObject(activity, _serializationSettings));
             }
             else
             {

--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -401,6 +401,16 @@ namespace Microsoft.Bot.Builder
         /// </summary>
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Dispose any disposable objects owned by the class here.
+            }
         }
 
         private async Task<ResourceResponse> UpdateActivityInternalAsync(
@@ -412,11 +422,11 @@ namespace Microsoft.Bot.Builder
             BotAssert.ActivityNotNull(activity);
             if (updateHandlers == null)
             {
-                throw new ArgumentException(nameof(updateHandlers));
+                throw new ArgumentException($"{nameof(updateHandlers)} is null.", nameof(updateHandlers));
             }
 
             // No middleware to run.
-            if (updateHandlers.Count() == 0)
+            if (!updateHandlers.Any())
             {
                 if (callAtBottom != null)
                 {
@@ -452,11 +462,11 @@ namespace Microsoft.Bot.Builder
 
             if (deleteHandlers == null)
             {
-                throw new ArgumentException(nameof(deleteHandlers));
+                throw new ArgumentException($"{nameof(deleteHandlers)} is null", nameof(deleteHandlers));
             }
 
             // No middleware to run.
-            if (deleteHandlers.Count() == 0)
+            if (!deleteHandlers.Any())
             {
                 if (callAtBottom != null)
                 {

--- a/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
@@ -133,6 +133,16 @@ namespace Microsoft.Bot.Builder
 
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Dispose any disposable objects owned by the class here.
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/UserState.cs
+++ b/libraries/Microsoft.Bot.Builder/UserState.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Bot.Builder
         /// <see cref="Schema.ConversationAccount.Id"/> is missing.</exception>
         protected override string GetStorageKey(ITurnContext turnContext)
         {
-            var channelId = turnContext.Activity.ChannelId ?? throw new ArgumentNullException("invalid activity-missing channelId");
-            var userId = turnContext.Activity.From?.Id ?? throw new ArgumentNullException("invalid activity-missing From.Id");
+            var channelId = turnContext.Activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
+            var userId = turnContext.Activity.From?.Id ?? throw new InvalidOperationException("invalid activity-missing From.Id");
             return $"{channelId}/users/{userId}";
         }
     }

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -23,7 +23,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -54,7 +54,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>
         /// A valid ClaimsIdentity.
         /// </returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await AuthenticateChannelToken(authHeader, credentials, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -75,7 +77,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>
         /// A valid ClaimsIdentity.
         /// </returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {
@@ -145,7 +149,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -162,7 +168,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -92,7 +92,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await AuthenticateEmulatorToken(authHeader, credentials, channelProvider, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -114,7 +116,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <remarks>
         /// A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
         /// </remarks>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateEmulatorToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await AuthenticateChannelToken(authHeader, credentials, channelProvider, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -60,7 +62,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {
@@ -82,7 +86,9 @@ namespace Microsoft.Bot.Connector.Authentication
             return identity;
         }
 
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task ValidateIdentity(ClaimsIdentity identity, ICredentialProvider credentials, string serviceUrl)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (identity == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -44,7 +44,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// setup and teardown, so a shared HttpClient is recommended.</param>
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <returns>ClaimsIdentity.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await AuthenticateChannelToken(authHeader, credentials, serviceUrl, httpClient, channelId, new AuthenticationConfiguration()).ConfigureAwait(false);
         }
@@ -61,7 +63,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>ClaimsIdentity.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {
@@ -88,7 +92,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="credentials">The user defined set of valid credentials, such as the AppId.</param>
         /// <param name="serviceUrl">The service url from the request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task ValidateIdentity(ClaimsIdentity identity, ICredentialProvider credentials, string serviceUrl)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (identity == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Bot.Connector.Authentication
             // [0] = "Bearer"
             // [1] = "[Big Long String]"
             var authScheme = parts[0];
-            if (!authScheme.Equals("Bearer", StringComparison.InvariantCultureIgnoreCase))
+            if (!authScheme.Equals("Bearer", StringComparison.OrdinalIgnoreCase))
             {
                 // The scheme MUST be "Bearer"
                 return false;

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -30,7 +30,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateRequest(IActivity activity, string authHeader, ICredentialProvider credentials, IChannelProvider provider, HttpClient httpClient = null)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await AuthenticateRequest(activity, authHeader, credentials, provider, new AuthenticationConfiguration(), httpClient).ConfigureAwait(false);
         }
@@ -48,7 +50,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateRequest(IActivity activity, string authHeader, ICredentialProvider credentials, IChannelProvider provider, AuthenticationConfiguration authConfig, HttpClient httpClient = null)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {
@@ -89,7 +93,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, string serviceUrl = null, HttpClient httpClient = null)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             return await ValidateAuthHeader(authHeader, credentials, channelProvider, channelId, new AuthenticationConfiguration(), serviceUrl, httpClient).ConfigureAwait(false);
         }
@@ -107,7 +113,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the task completes successfully, the result contains the claims-based
         /// identity for the request.</remarks>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> ValidateAuthHeader(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, AuthenticationConfiguration authConfig, string serviceUrl = null, HttpClient httpClient = null)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (string.IsNullOrEmpty(authHeader))
             {
@@ -121,7 +129,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             httpClient = httpClient ?? _httpClient;
 
-            var identity = await AuthenticateToken(authHeader, credentials, channelProvider, channelId, authConfig, serviceUrl, httpClient).ConfigureAwait(false);
+            var identity = await AuthenticateTokenAsync(authHeader, credentials, channelProvider, channelId, authConfig, serviceUrl, httpClient).ConfigureAwait(false);
 
             await ValidateClaimsAsync(authConfig, identity.Claims).ConfigureAwait(false);
 
@@ -222,7 +230,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// Authenticates the auth header token from the request.
         /// </summary>
-        private static async Task<ClaimsIdentity> AuthenticateToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, AuthenticationConfiguration authConfig, string serviceUrl, HttpClient httpClient)
+        private static async Task<ClaimsIdentity> AuthenticateTokenAsync(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, string channelId, AuthenticationConfiguration authConfig, string serviceUrl, HttpClient httpClient)
         {
             if (SkillValidation.IsSkillToken(authHeader))
             {

--- a/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/Retry.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Bot.Connector.Authentication
 {
     public static class Retry
     {
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<TResult> Run<TResult>(Func<Task<TResult>> task, Func<Exception, int, RetryParams> retryExceptionHandler)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             RetryParams retry;
             var exceptions = new List<Exception>();

--- a/libraries/Microsoft.Bot.Connector/Authentication/SimpleChannelProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SimpleChannelProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>True if this channel provider represents a channel on US Government Azure.</returns>
         public bool IsGovernment()
         {
-            return string.Equals(GovernmentAuthenticationConstants.ChannelService, ChannelService, StringComparison.InvariantCultureIgnoreCase);
+            return string.Equals(GovernmentAuthenticationConstants.ChannelService, ChannelService, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             var audience = claimsList.FirstOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim)?.Value;
-            if (string.IsNullOrWhiteSpace(audience) || AuthenticationConstants.ToBotFromChannelTokenIssuer.Equals(audience, StringComparison.InvariantCulture))
+            if (string.IsNullOrWhiteSpace(audience) || AuthenticationConstants.ToBotFromChannelTokenIssuer.Equals(audience, StringComparison.OrdinalIgnoreCase))
             {
                 // The audience is https://api.botframework.com and not an appId.
                 return false;

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -124,7 +124,9 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelId">The ID of the channel to validate.</param>
         /// <param name="authConfig">The authentication configuration.</param>
         /// <returns>A <see cref="ClaimsIdentity"/> instance if the validation is successful.</returns>
+#pragma warning disable UseAsyncSuffix // Use Async suffix (can't change this without breaking binary compat)
         public static async Task<ClaimsIdentity> AuthenticateChannelToken(string authHeader, ICredentialProvider credentials, IChannelProvider channelProvider, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig)
+#pragma warning restore UseAsyncSuffix // Use Async suffix
         {
             if (authConfig == null)
             {

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -39,6 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />

--- a/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
+++ b/libraries/Microsoft.Bot.Connector/Microsoft.Bot.Connector.csproj
@@ -24,7 +24,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
+++ b/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
@@ -23,7 +23,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1573;CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1573;CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
+++ b/libraries/Microsoft.Bot.Schema/Microsoft.Bot.Schema.csproj
@@ -28,6 +28,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
@@ -25,8 +25,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- CS1591: These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Streaming/RequestHandler.cs
+++ b/libraries/Microsoft.Bot.Streaming/RequestHandler.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Bot.Streaming
     /// </summary>
     public abstract class RequestHandler
     {
-    #pragma warning disable IDE0034
         /// <summary>
         /// The method that must be implemented in order to handle incoming requests.
         /// </summary>
@@ -22,6 +21,5 @@ namespace Microsoft.Bot.Streaming
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>A <see cref="Task"/> that will produce a <see cref="StreamingResponse"/> on successful completion.</returns>
         public abstract Task<StreamingResponse> ProcessRequestAsync(ReceiveRequest request, ILogger<RequestHandler> logger, object context = null, CancellationToken cancellationToken = default(CancellationToken));
-    #pragma warning restore IDE0034
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -24,7 +24,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
@@ -25,7 +25,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -23,7 +23,8 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
@@ -20,7 +20,8 @@
   
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             const string resourceIdentifier = "Mocked Resource Identifier";
             var twilioApi = new Mock<TwilioClientWrapper>(_testOptions);
-            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
+            twilioApi.Setup(x => x.SendMessageAsync(It.IsAny<CreateMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
 
             var twilioAdapter = new TwilioAdapter(twilioApi.Object);
             var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default).ConfigureAwait(false);
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             const string resourceIdentifier = "Mocked Resource Identifier";
             var twilioApi = new Mock<TwilioClientWrapper>(_testOptions);
-            twilioApi.Setup(x => x.SendMessage(It.IsAny<CreateMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
+            twilioApi.Setup(x => x.SendMessageAsync(It.IsAny<CreateMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
 
             var twilioAdapter = new TwilioAdapter(twilioApi.Object);
             var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default).ConfigureAwait(false);

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
   <!-- Contains common properties that apply to projects under the Tests folder -->
   <PropertyGroup>
-    <!-- For tests, we don't generate documentation. Supress related rules. -->
-    <NoWarn>$(NoWarn);SA0001;CS1573,CS1591,CS1712</NoWarn>
+    <!-- SA0001;CS1573,CS1591,CS1712: For tests, we don't generate documentation. Supress related rules. -->
+    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
+    <NoWarn>$(NoWarn);SA0001;CS1573;CS1591;CS1712;SX1309</NoWarn>
   </PropertyGroup>
 
   <!-- This ensures that Directory.Build.props in parent folders are merged with this one -->

--- a/tests/Microsoft.Bot.Builder.Tests/Adapters/TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapters/TestAdapterTests.cs
@@ -16,24 +16,6 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
 {
     public class TestAdapterTests
     {
-        public async Task MyBotLogic(ITurnContext turnContext, CancellationToken cancellationToken)
-        {
-            switch (turnContext.Activity.AsMessageActivity().Text)
-            {
-                case "count":
-                    await turnContext.SendActivityAsync(turnContext.Activity.CreateReply("one"));
-                    await turnContext.SendActivityAsync(turnContext.Activity.CreateReply("two"));
-                    await turnContext.SendActivityAsync(turnContext.Activity.CreateReply("three"));
-                    break;
-                case "ignore":
-                    break;
-                default:
-                    await turnContext.SendActivityAsync(
-                        turnContext.Activity.CreateReply($"echo:{turnContext.Activity.AsMessageActivity().Text}"));
-                    break;
-            }
-        }
-
         [Fact]
         public async Task TestAdapter_ExceptionTypesOnTest()
         {
@@ -577,6 +559,24 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
             var reply = sut.GetNextReply();
             Assert.Equal(targetChannel, receivedChannelId);
             Assert.Equal(targetChannel, reply.ChannelId);
+        }
+
+        private async Task MyBotLogic(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            switch (turnContext.Activity.AsMessageActivity().Text)
+            {
+                case "count":
+                    await turnContext.SendActivityAsync(turnContext.Activity.CreateReply("one"));
+                    await turnContext.SendActivityAsync(turnContext.Activity.CreateReply("two"));
+                    await turnContext.SendActivityAsync(turnContext.Activity.CreateReply("three"));
+                    break;
+                case "ignore":
+                    break;
+                default:
+                    await turnContext.SendActivityAsync(
+                        turnContext.Activity.CreateReply($"echo:{turnContext.Activity.AsMessageActivity().Text}"));
+                    break;
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
@@ -610,7 +610,7 @@ namespace Microsoft.Bot.Builder.Tests
             var context = TestUtilities.CreateEmptyContext();
             context.Activity.From = null;
             var testProperty = userState.CreateProperty<TestPocoState>("test");
-            await Assert.ThrowsAsync<ArgumentNullException>(() => testProperty.GetAsync(context));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => testProperty.GetAsync(context));
         }
 
         [Fact]
@@ -621,7 +621,7 @@ namespace Microsoft.Bot.Builder.Tests
             var context = TestUtilities.CreateEmptyContext();
             context.Activity.Conversation = null;
             var testProperty = userState.CreateProperty<TestPocoState>("test");
-            await Assert.ThrowsAsync<ArgumentNullException>(() => testProperty.GetAsync(context));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => testProperty.GetAsync(context));
         }
 
         [Fact]
@@ -633,7 +633,7 @@ namespace Microsoft.Bot.Builder.Tests
             context.Activity.Conversation = null;
             context.Activity.From = null;
             var testProperty = userState.CreateProperty<TestPocoState>("test");
-            await Assert.ThrowsAsync<ArgumentNullException>(() => testProperty.GetAsync(context));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => testProperty.GetAsync(context));
         }
 
         [Fact]
@@ -644,7 +644,7 @@ namespace Microsoft.Bot.Builder.Tests
             var context = TestUtilities.CreateEmptyContext();
             context.Activity.Conversation = null;
             var testProperty = userState.CreateProperty<TestPocoState>("test");
-            await Assert.ThrowsAsync<ArgumentNullException>(() => testProperty.GetAsync(context));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => testProperty.GetAsync(context));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
@@ -619,7 +619,7 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException), "bad activity should throw ArgumentNullException")]
+        [ExpectedException(typeof(InvalidOperationException), "bad activity should throw InvalidOperationException")]
         public async Task UserState_BadFromThrows()
         {
             var dictionary = new Dictionary<string, JObject>();
@@ -631,8 +631,8 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException), "bad activity should throw ArgumentNullException")]
-        public async Task ConversationState_BadConverationThrows()
+        [ExpectedException(typeof(InvalidOperationException), "bad activity should throw InvalidOperationException")]
+        public async Task ConversationState_BadConversationThrows()
         {
             var dictionary = new Dictionary<string, JObject>();
             var userState = new ConversationState(new MemoryStorage(dictionary));
@@ -643,7 +643,7 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException), "bad activity should throw ArgumentNullException")]
+        [ExpectedException(typeof(InvalidOperationException), "bad activity should throw InvalidOperationException")]
         public async Task PrivateConversationState_BadActivityFromThrows()
         {
             var dictionary = new Dictionary<string, JObject>();
@@ -656,7 +656,7 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException), "bad activity should throw ArgumentNullException")]
+        [ExpectedException(typeof(InvalidOperationException), "bad activity should throw InvalidOperationException")]
         public async Task PrivateConversationState_BadActivityConversationThrows()
         {
             var dictionary = new Dictionary<string, JObject>();


### PR DESCRIPTION
Relates to #2367 

- Added FxCop to Microsoft.BotBuilder and addressed errors.
- Added AsyncUsage analyzers to Adapters, BoitBuilder, Connector and Schema and addressed issues whenever possible.
- Enabled the SX1309 (FieldNamesShouldBeginWithUnderscores) stylecop rule and addressed the violations on BotBuilder but excluded it from the other projects for now to avoid collisions.
- Enabled CA1309 (Use ordinal StringComparison) to the main ruleset and addressed violations.
- Added ($NoWarn) to root dir props to make sure tests take this value.
- Refactored some code to use await/async instead of Task.Run to avoid creating unnecessary threads. 