### PR TITLE
Add empty recognizer support for CrosstrainedRecognizer (composer scenario)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                 throw new ArgumentNullException(nameof(activity));
             }
 
-            if (Recognizers.Count() == 0)
+            if (Recognizers.Any() == false)
             {
                 return new RecognizerResult()
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
@@ -79,6 +79,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                 throw new ArgumentNullException(nameof(activity));
             }
 
+            if (Recognizers.Count() == 0)
+            {
+                return new RecognizerResult()
+                {
+                    Intents = new Dictionary<string, IntentScore>() { { NoneIntent, new IntentScore() { Score = 1.0 } } }
+                };
+            }
+
             EnsureRecognizerIds();
 
             // run all of the recognizers in parallel

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/CrossTrainedRecognizerSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/CrossTrainedRecognizerSetTests.cs
@@ -52,5 +52,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         {
             await TestUtils.RunTestScript(ResourceExplorer);
         }
+
+        [TestMethod]
+        public async Task CrossTrainedRecognizerSetTests_Empty()
+        {
+            await TestUtils.RunTestScript(ResourceExplorer);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/CrossTrainedRecognizerSetTests/CrossTrainedRecognizerSetTests_Empty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/CrossTrainedRecognizerSetTests/CrossTrainedRecognizerSetTests_Empty.test.dialog
@@ -1,0 +1,52 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$schema": "../../../tests.schema",
+            "$kind": "Microsoft.CrossTrainedRecognizerSet",
+            "recognizers": [
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "UnknownIntent:${turn.recognized.intent}"
+                    }
+                ]
+            }
+        ],
+        "defaultResultProperty": "dialog.result"
+    },
+    "locale": "",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "UnknownIntent:None"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "x"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "UnknownIntent:None"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "y"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "UnknownIntent:None"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

We plan to set default recognizer in composer as Luis+QnA CrosstrainedRecognizer. 
And it will fit into different recognizer types by the .lu/.qna content.

Recognizer: "dialogname.lu.qna"

dialogname.lu.qna,dialog will be generated as the following rule:

.lu and .qna both not empty =>
```
{ 
    "$kind": "Microsoft.CrossTrainedRecognizerSet" 
    recongizers:[ 
        "dialogname.lu", 
        "dialogname.qna” 
   ] 
} 
```

.lu and .qna both empty =>
```
{ 
    "$kind": "Microsoft.CrossTrainedRecognizerSet" 
    recongizers:[ 
   ] 
} 
```

.lu empty =>
```
{ 
    "$kind": "Microsoft.CrossTrainedRecognizerSet" 
    recongizers:[ 
        "dialogname.qna” 
   ] 
} 
```
 .qna empty =>
```
{ 
    "$kind": "Microsoft.CrossTrainedRecognizerSet" 
    recongizers:[ 
        "dialogname.lu"
   ] 
} 
```
This change is to support the empty recognizer scenario in CrossTrainedRecognizer. 

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->