### PR TITLE
SwitchCondition with number throws an exception when compared against a string

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SwitchCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SwitchCondition.cs
@@ -114,32 +114,36 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 {
                     this.caseExpressions = new Dictionary<string, Expression>();
 
-                    foreach (var cse in this.Cases)
+                    foreach (var @case in this.Cases)
                     {
-                        Expression caseExpression = null;
-
-                        // Values for cases are always coerced to constant
-                        if (long.TryParse(cse.Value, out long i))
+                        if (long.TryParse(@case.Value, out long intVal))
                         {
-                            caseExpression = Expression.ConstantExpression(i);
+                            // you don't have to put quotes around numbers, "23" => 23 OR "23"
+                            this.caseExpressions[@case.Value] = Expression.OrExpression(
+                                Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(intVal)),
+                                Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(@case.Value)));
                         }
-                        else if (float.TryParse(cse.Value, out float f))
+                        else if (float.TryParse(@case.Value, out float floatVal))
                         {
-                            caseExpression = Expression.ConstantExpression(f);
+                            // you don't have to put quotes around numbers, "23" => 23 OR "23"
+                            this.caseExpressions[@case.Value] = Expression.OrExpression(
+                                Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(floatVal)),
+                                Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(@case.Value)));
                         }
-                        else if (bool.TryParse(cse.Value, out bool b))
+                        else if (bool.TryParse(@case.Value, out bool boolVal))
                         {
-                            caseExpression = Expression.ConstantExpression(b);
+                            // you don't have to put quotes around bools, "true" => true OR "true"
+                            this.caseExpressions[@case.Value] = Expression.OrExpression(
+                                Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(boolVal)),
+                                Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(@case.Value)));
                         }
                         else
                         {
-                            caseExpression = Expression.ConstantExpression(cse.Value);
+                            // if someone does "=23" that will be numeric comparison or "='23'" that will be string comparison, or it can be a 
+                            // real expression bound to memory.
+                            var (value, _) = new ValueExpression(@case.Value).TryGetValue(dc.State);
+                            this.caseExpressions[@case.Value] = Expression.EqualsExpression(this.Condition, Expression.ConstantExpression(value));
                         }
-
-                        var caseCondition = Expression.EqualsExpression(this.Condition, caseExpression);
-
-                        // Map of expression to actions
-                        this.caseExpressions[cse.Value] = caseCondition;
                     }
                 }
             }
@@ -150,13 +154,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             {
                 var (value, error) = this.caseExpressions[caseScope.Value].TryEvaluate(dc.State);
 
-                if (error != null)
-                {
-                    throw new Exception($"Expression evaluation resulted in an error. Expression: {caseExpressions[caseScope.Value].ToString()}. Error: {error}");
-                }
-
                 // Compare both expression results. The current switch case triggers if the comparison is true.
-                if (((bool)value) == true)
+                if (value != null && ((bool)value) == true)
                 {
                     actionScope = caseScope;
                     break;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Switch.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Switch.test.dialog
@@ -13,45 +13,19 @@
                         "property": "user.name",
                         "value": "='frank'"
                     },
+                    "SwitchString",
                     {
-                        "$kind": "Microsoft.SwitchCondition",
-                        "condition": "user.name",
-                        "default": [
-                            {
-                                "$kind": "Microsoft.SendActivity",
-                                "activity": "Who are you?"
-                            }
-                        ],
-                        "cases": [
-                            {
-                                "value": "susan",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "hi susan"
-                                    }
-                                ]
-                            },
-                            {
-                                "value": "bob",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "hi bob"
-                                    }
-                                ]
-                            },
-                            {
-                                "value": "frank",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "hi frank"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.name",
+                        "value": "frank"
+                    },
+                    "SwitchString",
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.name",
+                        "value": "23"
+                    },
+                    "SwitchString"
                 ]
             }
         ],
@@ -66,6 +40,14 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "hi frank"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "hi frank"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "hi 23"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Switch_Bool.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Switch_Bool.test.dialog
@@ -11,38 +11,15 @@
                     {
                         "$kind": "Microsoft.SetProperty",
                         "property": "user.isVip",
-                        "value": "=true"
+                        "value": true
                     },
+                    "SwitchBool",
                     {
-                        "$kind": "Microsoft.SwitchCondition",
-                        "condition": "user.isVip",
-                        "default": [
-                            {
-                                "$kind": "Microsoft.SendActivity",
-                                "activity": "Who are you?"
-                            }
-                        ],
-                        "cases": [
-                            {
-                                "value": "true",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "User is VIP"
-                                    }
-                                ]
-                            },
-                            {
-                                "value": "false",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "User is NOT VIP"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.isVip",
+                        "value": "=false"
+                    },
+                    "SwitchBool"
                 ]
             }
         ],
@@ -57,6 +34,10 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "User is VIP"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "User is NOT VIP"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Switch_Number.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Switch_Number.test.dialog
@@ -13,45 +13,13 @@
                         "property": "user.age",
                         "value": "=22"
                     },
+                    "SwitchNumber",
                     {
-                        "$kind": "Microsoft.SwitchCondition",
-                        "condition": "user.age",
-                        "default": [
-                            {
-                                "$kind": "Microsoft.SendActivity",
-                                "activity": "Who are you?"
-                            }
-                        ],
-                        "cases": [
-                            {
-                                "value": "21",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "Age is 21"
-                                    }
-                                ]
-                            },
-                            {
-                                "value": "22",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "Age is 22"
-                                    }
-                                ]
-                            },
-                            {
-                                "value": "23",
-                                "actions": [
-                                    {
-                                        "$kind": "Microsoft.SendActivity",
-                                        "activity": "Age is 23"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.age",
+                        "value": "23"
+                    },
+                    "SwitchNumber"
                 ]
             }
         ],
@@ -66,6 +34,10 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "Age is 22"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Age is 23"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/SwitchBool.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/SwitchBool.dialog
@@ -1,0 +1,31 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.SwitchCondition",
+    "condition": "user.isVip",
+    "default": [
+        {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "Who are you?"
+        }
+    ],
+    "cases": [
+        {
+            "value": "true",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "User is VIP"
+                }
+            ]
+        },
+        {
+            "value": "false",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "User is NOT VIP"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/SwitchNumber.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/SwitchNumber.dialog
@@ -1,0 +1,40 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.SwitchCondition",
+    "condition": "user.age",
+    "default": [
+        {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "Who are you?"
+        }
+    ],
+    "cases": [
+        {
+            "value": "21",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Age is 21"
+                }
+            ]
+        },
+        {
+            "value": "22",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Age is 22"
+                }
+            ]
+        },
+        {
+            "value": "23",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Age is 23"
+                }
+            ]
+        }
+    ]
+} 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/SwitchString.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/SwitchString.dialog
@@ -1,0 +1,49 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.SwitchCondition",
+    "condition": "user.name",
+    "default": [
+        {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "Who are you?"
+        }
+    ],
+    "cases": [
+        {
+            "value": "susan",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "hi susan"
+                }
+            ]
+        },
+        {
+            "value": "bob",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "hi bob"
+                }
+            ]
+        },
+        {
+            "value": "frank",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "hi frank"
+                }
+            ]
+        },
+        {
+            "value": "23",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "hi 23"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
             var dm = new DialogManager(dialog)
                 .UseResourceExplorer(resourceExplorer)
                 .UseLanguageGeneration();
-            dm.InitialTurnState.Add<IQnAMakerClient>(new MockQnAMakerClient()); 
+            dm.InitialTurnState.Add<IQnAMakerClient>(new MockQnAMakerClient());
 
             return new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {


### PR DESCRIPTION
Fixes #4071 

## Description
SwitchCondition treated errors as exceptions when all that was happening was an comparison which was false. In addition, it was always assuming that a quoted number should be compared as a number. 

## Specific Changes
* Fix switch to not treat expression errors as exceptions but instead as false condition
* Fix switch to treat ambiguity in string case definition more robustly by comparing for both value type and string of value type. (23 OR "23")

## Testing
updated unit test cases to cover this.