### PR TITLE
Change deployment template endpoint to .../api/mybot from .../api/messages

### DIFF
--- a/FunctionalTests/ExportedTemplate/template-with-preexisting-rg.json
+++ b/FunctionalTests/ExportedTemplate/template-with-preexisting-rg.json
@@ -75,7 +75,7 @@
     "resourcesLocation": "[parameters('appServicePlanLocation')]",
     "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
     "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/mybot')]"
   },
   "resources": [
     {

--- a/FunctionalTests/ExportedTemplate/template.json
+++ b/FunctionalTests/ExportedTemplate/template.json
@@ -76,7 +76,7 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/mybot')]"
     },
     "resources": [
         {


### PR DESCRIPTION
This fixes the Windows functional test error "Assert.AreEqual failed. Expected:<Echo: Testing Azure Bot GUID: d882954f-e6dc-4c84-b370-60d146e4ebdc>. Actual:<Where would you like to travel to?>.".

