### PR TITLE
Enabled FxCop on the Dialogs project and Integration folder

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -191,6 +191,6 @@
     <Rule Id="SA1648" Action="Error" />
     <Rule Id="SA1649" Action="Error" />
     <Rule Id="SA1651" Action="Error" />
-	<Rule Id="SX1309" Action="Error" /> <!-- FieldNamesShouldBeginWithUnderscores -->
+    <Rule Id="SX1309" Action="Error" /> <!-- FieldNamesShouldBeginWithUnderscores -->
   </Rules>
 </RuleSet>

--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -105,6 +105,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.Langu
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B6AFE9D-6FA5-4699-B0EB-62335FD431C8}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		bot.png = bot.png
 		bot_icon.png = bot_icon.png
 		BotBuilder-DotNet.ruleset = BotBuilder-DotNet.ruleset

--- a/Microsoft.Bot.Builder.sln
+++ b/Microsoft.Bot.Builder.sln
@@ -28,6 +28,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Connector.Tests", "tests\Microsoft.Bot.Connector.Tests\Microsoft.Bot.Connector.Tests.csproj", "{BF414C86-DB3B-4022-9B29-DCE8AA954C12}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{276EBE79-A13A-46BD-A566-B01DC0477A9B}"
+	ProjectSection(SolutionItems) = preProject
+		libraries\integration\Directory.Build.props = libraries\integration\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Builder.AI.Luis", "libraries\Microsoft.Bot.Builder.AI.LUIS\Microsoft.Bot.Builder.AI.Luis.csproj", "{67AA3C00-E2C5-4D13-BA5E-72EB0E5B8DAA}"
 EndProject

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
     /// <summary>
     /// Methods for determining channel specific functionality.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class Channel
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Determine if a number of Suggested Actions are supported by a Channel.
@@ -97,7 +99,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// </summary>
         /// <param name="channelId">The Channel to determine Maximum Action Title Length.</param>
         /// <returns>The total number of characters allowed for an Action Title on a specific Channel.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the channelId parameter without breaking binary compatibility)
         public static int MaxActionTitleLength(string channelId) => 20;
+#pragma warning restore CA1801 // Review unused parameters
 
         /// <summary>
         /// Get the Channel Id from the current Activity on the Turn Context.
@@ -105,13 +109,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="turnContext">The Turn Context to retrieve the Activity's Channel Id from.</param>
         /// <returns>The Channel Id from the Turn Context's Activity.</returns>
         public static string GetChannelId(ITurnContext turnContext) => string.IsNullOrEmpty(turnContext.Activity.ChannelId)
-            ? string.Empty : turnContext.Activity.ChannelId;
+            ? string.Empty
+            : turnContext.Activity.ChannelId;
 
         // This class has been deprecated in favor of the class in Microsoft.Bot.Connector.Channels located
         // at https://github.com/Microsoft/botbuilder-dotnet/libraries/Microsoft.Bot.Connector/Channels.cs.
         // This change is non-breaking and this class now inherits from the class in the connector library.
         [Obsolete("This class is deprecated. Please use Microsoft.Bot.Connector.Channels.")]
+#pragma warning disable CA1034 // Nested types should not be visible (this type is deprecated, ignoring)
+#pragma warning disable CA1724 // Namespace name conflict (this type is deprecated, ignoring)
         public class Channels : Connector.Channels
+#pragma warning restore CA1724 // Namespace name conflict
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
     /// <summary>
     /// Represents a choice for a choice prompt.
     /// </summary>
+#pragma warning disable CA1724 // Namespace name conflict (we can't change this without breaking binary compat)
     public class Choice
+#pragma warning restore CA1724 // Namespace name conflict
     {
         public Choice(string value = null)
         {
@@ -43,6 +45,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// The list of synonyms to recognize in addition to the value.
         /// </value>
         [JsonProperty("synonyms")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<string> Synonyms { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
     /// <summary>
     /// Assists with formatting a message activity that contains a list of choices.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ChoiceFactory
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Creates a message activity that includes a list of choices formatted based on the capabilities of a given channel.
@@ -29,9 +31,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// list; otherwise, a numbered list.</para></remarks>
         public static IMessageActivity ForChannel(string channelId, IList<Choice> list, string text = null, string speak = null, ChoiceFactoryOptions options = null)
         {
-            channelId = channelId ?? string.Empty;
-
-            list = list ?? new List<Choice>();
+            channelId ??= string.Empty;
+            list ??= new List<Choice>();
 
             // Find maximum title length
             var maxTitleLength = 0;
@@ -57,22 +58,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 // support them (e.g. Teams, Cortana) we should use a HeroCard with CardActions
                 return HeroCard(list, text, speak);
             }
-            else if (!longTitles && supportsSuggestedActions)
+
+            if (!longTitles && supportsSuggestedActions)
             {
                 // We always prefer showing choices using suggested actions. If the titles are too long, however,
                 // we'll have to show them as a text list.
                 return SuggestedAction(list, text, speak);
             }
-            else if (!longTitles && list.Count <= 3)
+
+            if (!longTitles && list.Count <= 3)
             {
                 // If the titles are short and there are 3 or less choices we'll use an inline list.
                 return Inline(list, text, speak, options);
             }
-            else
-            {
-                // Show a numbered list.
-                return List(list, text, speak, options);
-            }
+
+            // Show a numbered list.
+            return List(list, text, speak, options);
         }
 
         /// <summary>
@@ -85,8 +86,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <returns>The created message activity.</returns>
         public static Activity Inline(IList<Choice> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
         {
-            choices = choices ?? new List<Choice>();
-            options = options ?? new ChoiceFactoryOptions();
+            choices ??= new List<Choice>();
+            options ??= new ChoiceFactoryOptions();
 
             var opt = new ChoiceFactoryOptions
             {
@@ -115,7 +116,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 }
 
                 txtBuilder.Append(title);
-                if (index == (choices.Count - 2))
+                if (index == choices.Count - 2)
                 {
                     connector = (index == 0 ? opt.InlineOr : opt.InlineOrMore) ?? string.Empty;
                 }
@@ -144,8 +145,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
         public static Activity List(IList<Choice> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
         {
-            choices = choices ?? new List<Choice>();
-            options = options ?? new ChoiceFactoryOptions();
+            choices ??= new List<Choice>();
+            options ??= new ChoiceFactoryOptions();
 
             var includeNumbers = options.IncludeNumbers ?? true;
 
@@ -158,7 +159,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             {
                 var choice = choices[index];
 
-                var title = choice.Action != null && choice.Action.Title != null ? choice.Action.Title : choice.Value;
+                var title = choice.Action?.Title ?? choice.Value;
 
                 txtBuilder.Append(connector);
                 if (includeNumbers)
@@ -204,33 +205,29 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
 
         public static IList<Choice> ToChoices(IList<string> choices)
         {
-            return (choices == null)
-                    ?
-                new List<Choice>()
-                    :
-                choices.Select(choice => new Choice { Value = choice }).ToList();
+            return choices == null
+                ? new List<Choice>()
+                : choices.Select(choice => new Choice { Value = choice }).ToList();
         }
 
         private static List<CardAction> ExtractActions(IList<Choice> choices)
         {
-            choices = choices ?? new List<Choice>();
+            choices ??= new List<Choice>();
 
             // Map choices to actions
-            return choices.Select((choice) =>
+            return choices.Select(choice =>
             {
                 if (choice.Action != null)
                 {
                     return choice.Action;
                 }
-                else
+
+                return new CardAction
                 {
-                    return new CardAction
-                    {
-                        Type = ActionTypes.ImBack,
-                        Value = choice.Value,
-                        Title = choice.Value,
-                    };
-                }
+                    Type = ActionTypes.ImBack,
+                    Value = choice.Value,
+                    Title = choice.Value,
+                };
             }).ToList();
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Tokenizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Tokenizer.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
     /// <summary>
     /// Provides a default tokenizer implementation.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class Tokenizer
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Gets the default <see cref="TokenizerFunction"/> implementation.
@@ -39,7 +41,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             Token token = null;
 
             // Parse text
-            var length = text != null ? text.Length : 0;
+            var length = text?.Length ?? 0;
             var i = 0;
 
             while (i < length)
@@ -47,10 +49,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 // Get both the UNICODE value of the current character and the complete character itself
                 // which can potentially be multiple segments.
                 var codePoint = char.IsSurrogatePair(text, i)
-                        ?
-                    char.ConvertToUtf32(text, i)
-                        :
-                    Convert.ToInt32(text[i]);
+                    ? char.ConvertToUtf32(text, i)
+                    : Convert.ToInt32(text[i]);
 
                 var chr = char.ConvertFromUtf32(codePoint);
 
@@ -102,18 +102,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             if (token != null)
             {
                 token.End = end;
-                token.Normalized = token.Text.ToLower();
+#pragma warning disable CA1308 // Normalize strings to uppercase (the normalized token should be lowercase, ignoring)
+                token.Normalized = token.Text.ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
                 tokens.Add(token);
             }
         }
 
         private static bool IsBreakingChar(int codePoint) => IsBetween(codePoint, 0x0000, 0x002F) ||
-                    IsBetween(codePoint, 0x003A, 0x0040) ||
-                    IsBetween(codePoint, 0x005B, 0x0060) ||
-                    IsBetween(codePoint, 0x007B, 0x00BF) ||
-                    IsBetween(codePoint, 0x02B9, 0x036F) ||
-                    IsBetween(codePoint, 0x2000, 0x2BFF) ||
-                    IsBetween(codePoint, 0x2E00, 0x2E7F);
+                                                             IsBetween(codePoint, 0x003A, 0x0040) ||
+                                                             IsBetween(codePoint, 0x005B, 0x0060) ||
+                                                             IsBetween(codePoint, 0x007B, 0x00BF) ||
+                                                             IsBetween(codePoint, 0x02B9, 0x036F) ||
+                                                             IsBetween(codePoint, 0x2000, 0x2BFF) ||
+                                                             IsBetween(codePoint, 0x2E00, 0x2E7F);
 
         private static bool IsBetween(int value, int from, int to) => value >= from && value <= to;
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     {
         public const string PersistedDialogState = "dialogs";
 
-        private bool initialized = false;
+        private bool _initialized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ComponentDialog"/> class.
@@ -254,9 +254,9 @@ namespace Microsoft.Bot.Builder.Dialogs
 
         protected async Task EnsureInitializedAsync(DialogContext outerDc)
         {
-            if (!this.initialized)
+            if (!this._initialized)
             {
-                this.initialized = true;
+                this._initialized = true;
                 await OnInitializeAsync(outerDc).ConfigureAwait(false);
             }
         }
@@ -378,22 +378,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             return outerDc.EndDialogAsync(result, cancellationToken);
         }
 
-        private DialogContext CreateInnerDc(DialogContext outerDc, DialogInstance instance)
-        {
-            var state = BuildDialogState(instance);
-
-            return new DialogContext(this.Dialogs, outerDc, state);
-        }
-
-        // NOTE: You should only call this if you don't have a dc to work with (such as OnResume()) 
-        private DialogContext CreateInnerDc(ITurnContext turnContext, DialogInstance instance)
-        {
-            var state = BuildDialogState(instance);
-
-            return new DialogContext(this.Dialogs, turnContext, state);
-        }
-
-        private DialogState BuildDialogState(DialogInstance instance)
+        private static DialogState BuildDialogState(DialogInstance instance)
         {
             DialogState state;
 
@@ -413,6 +398,21 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             return state;
+        }
+
+        private DialogContext CreateInnerDc(DialogContext outerDc, DialogInstance instance)
+        {
+            var state = BuildDialogState(instance);
+
+            return new DialogContext(this.Dialogs, outerDc, state);
+        }
+
+        // NOTE: You should only call this if you don't have a dc to work with (such as OnResume()) 
+        private DialogContext CreateInnerDc(ITurnContext turnContext, DialogInstance instance)
+        {
+            var state = BuildDialogState(instance);
+
+            return new DialogContext(this.Dialogs, turnContext, state);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         private IBotTelemetryClient _telemetryClient;
 
         [JsonProperty("id")]
-        private string id;
+        private string _id;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Dialog"/> class.
@@ -50,13 +50,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             get
             {
-                id = id ?? OnComputeId();
-                return id;
+                _id = _id ?? OnComputeId();
+                return _id;
             }
 
             set
             {
-                id = value;
+                _id = value;
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Memory;
-using static Microsoft.Bot.Builder.Dialogs.Debugging.DebugSupport;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -144,7 +143,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// DialogStateManager with unified memory view of all memory scopes.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public DialogStateManager State { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets the services collection which is contextual to this dialog context.
@@ -333,10 +334,8 @@ namespace Microsoft.Bot.Builder.Dialogs
                 await this.DebuggerStepAsync(dialog, "ResumeDialog", cancellationToken).ConfigureAwait(false);
                 return await dialog.ResumeDialogAsync(this, DialogReason.EndCalled, result: result, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                return new DialogTurnResult(DialogTurnStatus.Complete, result);
-            }
+
+            return new DialogTurnResult(DialogTurnStatus.Complete, result);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContextVisibleState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContextVisibleState.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -10,12 +12,18 @@ namespace Microsoft.Bot.Builder.Dialogs
     public class DialogContextVisibleState
     {
         [JsonProperty(PropertyName = "user")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> User { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         [JsonProperty(PropertyName = "conversation")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> Conversation { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         [JsonProperty(PropertyName = "dialog")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> Dialog { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
@@ -3,7 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class DialogEvents
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Event fired when a dialog beginDialog() is called.
@@ -24,7 +26,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Event fired when an activity is received from the adapter (or a request to reprocess an activity).
         /// </summary>
         public const string ActivityReceived = "activityReceived";
-        
+
         /// <summary>
         /// Event which is fired when the system has detected that deployed code has changed the execution of dialogs between turns.
         /// </summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -30,7 +29,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// The instance's persisted state.
         /// </value>
         [JsonProperty("state")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> State { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets a stack index. Positive values are indexes within the current DC and negative values are 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManagerResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManagerResult.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Bot.Builder.Dialogs
     {
         public DialogTurnResult TurnResult { get; set; }
 
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
         public Activity[] Activities { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
 
         public PersistedState NewState { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,10 +15,10 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public class DialogSet
     {
-        private readonly IStatePropertyAccessor<DialogState> _dialogState;
         private readonly IDictionary<string, Dialog> _dialogs = new Dictionary<string, Dialog>();
-        private string _version;
+        private readonly IStatePropertyAccessor<DialogState> _dialogState;
         private IBotTelemetryClient _telemetryClient;
+        private string _version;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DialogSet"/> class.
@@ -72,22 +71,22 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>Version will change when any of the child dialogs version changes.</returns>
         public virtual string GetVersion()
         {
-            if (this._version == null)
+            if (_version == null)
             {
-                StringBuilder sb = new StringBuilder();
-                foreach (var dialog in this._dialogs)
+                var sb = new StringBuilder();
+                foreach (var dialog in _dialogs)
                 {
-                    var v = this._dialogs[dialog.Key].GetVersion();
+                    var v = _dialogs[dialog.Key].GetVersion();
                     if (v != null)
                     {
                         sb.Append(v);
                     }
                 }
 
-                this._version = StringUtils.Hash(sb.ToString());
+                _version = StringUtils.Hash(sb.ToString());
             }
 
-            return this._version;
+            return _version;
         }
 
         /// <summary>
@@ -104,7 +103,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         public DialogSet Add(Dialog dialog)
         {
             // Ensure new version hash is computed
-            this._version = null;
+            _version = null;
 
             if (dialog == null)
             {
@@ -126,17 +125,15 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                 while (true)
                 {
-                    var suffixId = dialog.Id + nextSuffix.ToString();
+                    var suffixId = dialog.Id + nextSuffix;
 
                     if (!_dialogs.ContainsKey(suffixId))
                     {
                         dialog.Id = suffixId;
                         break;
                     }
-                    else
-                    {
-                        nextSuffix++;
-                    }
+
+                    nextSuffix++;
                 }
             }
 
@@ -165,7 +162,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result contains the created <see cref="DialogContext"/>.
         /// </remarks>
-        public async Task<DialogContext> CreateContextAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<DialogContext> CreateContextAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
         {
             BotAssert.ContextNotNull(turnContext);
 
@@ -173,7 +170,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (_dialogState == null)
             {
                 // Note: This shouldn't ever trigger, as the _dialogState is set in the constructor and validated there.
-                throw new InvalidOperationException($"DialogSet.CreateContextAsync(): DialogSet created with a null IStatePropertyAccessor.");
+                throw new InvalidOperationException("DialogSet.CreateContextAsync(): DialogSet created with a null IStatePropertyAccessor.");
             }
 
             // Load/initialize dialog state

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <value>State information for a dialog stack.</value>
         [JsonProperty("dialogStack")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<DialogInstance> DialogStack { get; set; } = new List<DialogInstance>();
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogContextPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogContextPath.cs
@@ -1,6 +1,11 @@
-﻿namespace Microsoft.Bot.Builder.Dialogs
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Dialogs
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class DialogContextPath
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Memory Path to dialogContext's active dialog.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogPath.cs
@@ -1,8 +1,11 @@
-﻿using System.Data;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class DialogPath
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Counter of emitted events.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
     /// MemoryScopes are named root level objects, which can exist either in the dialogcontext or off of turn state
     /// PathResolvers allow for shortcut behavior for mapping things like $foo -> dialog.foo.
     /// </summary>
+#pragma warning disable CA1710 // Identifiers should have correct suffix (We can't rename this class without breaking binary compat)
     public class DialogStateManager : IDictionary<string, object>
+#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         /// <summary>
         /// Information for tracking when path was last modified.
@@ -27,25 +30,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
 
         private static readonly char[] Separators = { ',', '[' };
 
-        private readonly DialogContext dialogContext;
-        private int version = 0;
+        private readonly DialogContext _dialogContext;
+        private int _version;
 
         public DialogStateManager(DialogContext dc, DialogStateManagerConfiguration configuration = null)
         {
             ComponentRegistration.Add(new DialogsComponentRegistration());
 
-            dialogContext = dc ?? throw new ArgumentNullException(nameof(dc));
-            this.Configuration = configuration ?? dc.Context.TurnState.Get<DialogStateManagerConfiguration>();
-            if (this.Configuration == null)
+            _dialogContext = dc ?? throw new ArgumentNullException(nameof(dc));
+            Configuration = configuration ?? dc.Context.TurnState.Get<DialogStateManagerConfiguration>();
+            if (Configuration == null)
             {
-                this.Configuration = new DialogStateManagerConfiguration();
+                Configuration = new DialogStateManagerConfiguration();
 
                 // get all of the component memory scopes
                 foreach (var component in ComponentRegistration.Components.OfType<IComponentMemoryScopes>())
                 {
                     foreach (var memoryScope in component.GetMemoryScopes())
                     {
-                        this.Configuration.MemoryScopes.Add(memoryScope);
+                        Configuration.MemoryScopes.Add(memoryScope);
                     }
                 }
 
@@ -54,20 +57,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
                 {
                     foreach (var pathResolver in component.GetPathResolvers())
                     {
-                        this.Configuration.PathResolvers.Add(pathResolver);
+                        Configuration.PathResolvers.Add(pathResolver);
                     }
                 }
             }
 
             // cache for any other new dialogStatemanager instances in this turn.  
-            dc.Context.TurnState.Set<DialogStateManagerConfiguration>(this.Configuration);
+            dc.Context.TurnState.Set(Configuration);
         }
 
         public DialogStateManagerConfiguration Configuration { get; set; }
 
         public ICollection<string> Keys => Configuration.MemoryScopes.Select(ms => ms.Name).ToList();
 
-        public ICollection<object> Values => Configuration.MemoryScopes.Select(ms => ms.GetMemory(dialogContext)).ToList();
+        public ICollection<object> Values => Configuration.MemoryScopes.Select(ms => ms.GetMemory(_dialogContext)).ToList();
 
         public int Count => Configuration.MemoryScopes.Count;
 
@@ -82,7 +85,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
                 {
                     // Root is handled by SetMemory rather than SetValue
                     var scope = GetMemoryScope(key) ?? throw new ArgumentOutOfRangeException(GetBadScopeMessage(key));
-                    scope.SetMemory(this.dialogContext, JToken.FromObject(value));
+                    scope.SetMemory(_dialogContext, JToken.FromObject(value));
                 }
                 else
                 {
@@ -103,7 +106,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
                 throw new ArgumentNullException(nameof(name));
             }
 
-            return Configuration.MemoryScopes.FirstOrDefault(ms => string.Compare(ms.Name, name, ignoreCase: true) == 0);
+            return Configuration.MemoryScopes.FirstOrDefault(ms => string.Compare(ms.Name, name, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         /// <summary>
@@ -112,7 +115,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <returns>Current version.</returns>
         public string Version()
         {
-            return version.ToString();
+            return _version.ToString(CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -125,8 +128,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             var scope = path;
             var sepIndex = -1;
-            var dot = path.IndexOf(".");
-            var openSquareBracket = path.IndexOf("[");
+            var dot = path.IndexOf(".", StringComparison.OrdinalIgnoreCase);
+            var openSquareBracket = path.IndexOf("[", StringComparison.OrdinalIgnoreCase);
 
             if (dot > 0 && openSquareBracket > 0)
             {
@@ -186,12 +189,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
 
             MemoryScope memoryScope = null;
             string remainingPath;
-            
+
             try
             {
                 memoryScope = ResolveMemoryScope(path, out remainingPath);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (Unable to get the value for some reason, catch, log and return false, ignoring exception)
             catch (Exception err)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Trace.TraceError(err.Message);
                 return false;
@@ -204,7 +209,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
 
             if (string.IsNullOrEmpty(remainingPath))
             {
-                var memory = memoryScope.GetMemory(this.dialogContext);
+                var memory = memoryScope.GetMemory(_dialogContext);
                 if (memory == null)
                 {
                     return false;
@@ -215,8 +220,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             }
 
             // TODO: HACK to support .First() retrieval on turn.recognized.entities.foo, replace with Expressions once expression ship
-            const string first = ".first()";
-            var iFirst = path.ToLower().LastIndexOf(first);
+            const string first = ".FIRST()";
+            var iFirst = path.ToUpperInvariant().LastIndexOf(first, StringComparison.Ordinal);
             if (iFirst >= 0)
             {
                 object entity = null;
@@ -297,7 +302,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <returns>string or null if path is not valid.</returns>
         public string GetStringValue(string pathExpression, string defaultValue = default)
         {
-            return GetValue<string>(pathExpression, () => defaultValue);
+            return GetValue(pathExpression, () => defaultValue);
         }
 
         /// <summary>
@@ -317,14 +322,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
                 value = JToken.FromObject(value);
             }
 
-            path = this.TransformPath(path ?? throw new ArgumentNullException(nameof(path)));
+            path = TransformPath(path ?? throw new ArgumentNullException(nameof(path)));
             if (TrackChange(path, value))
             {
                 ObjectPath.SetPathValue(this, path, value);
             }
 
             // Every set will increase version
-            version++;
+            _version++;
         }
 
         /// <summary>
@@ -333,7 +338,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <param name="path">Path to remove the leaf property.</param>
         public void RemoveValue(string path)
         {
-            path = this.TransformPath(path ?? throw new ArgumentNullException(nameof(path)));
+            path = TransformPath(path ?? throw new ArgumentNullException(nameof(path)));
             if (TrackChange(path, null))
             {
                 ObjectPath.RemovePathValue(this, path);
@@ -348,9 +353,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             var result = new JObject();
 
-            foreach (var scope in Configuration.MemoryScopes.Where(ms => ms.IncludeInSnapshot == true))
+            foreach (var scope in Configuration.MemoryScopes.Where(ms => ms.IncludeInSnapshot))
             {
-                var memory = scope.GetMemory(dialogContext);
+                var memory = scope.GetMemory(_dialogContext);
                 if (memory != null)
                 {
                     result[scope.Name] = JToken.FromObject(memory);
@@ -365,11 +370,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// </summary>
         /// <param name="cancellationToken">cancellationToken.</param>
         /// <returns>Task.</returns>
-        public async Task LoadAllScopesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task LoadAllScopesAsync(CancellationToken cancellationToken = default)
         {
-            foreach (var scope in this.Configuration.MemoryScopes)
+            foreach (var scope in Configuration.MemoryScopes)
             {
-                await scope.LoadAsync(this.dialogContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await scope.LoadAsync(_dialogContext, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -378,11 +383,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// </summary>
         /// <param name="cancellationToken">cancellationToken.</param>
         /// <returns>Task.</returns>
-        public async Task SaveAllChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async Task SaveAllChangesAsync(CancellationToken cancellationToken = default)
         {
-            foreach (var scope in this.Configuration.MemoryScopes)
+            foreach (var scope in Configuration.MemoryScopes)
             {
-                await scope.SaveChangesAsync(this.dialogContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await scope.SaveChangesAsync(_dialogContext, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -392,13 +397,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <param name="name">name of the scope.</param>
         /// <param name="cancellationToken">cancellationToken.</param>
         /// <returns>Task.</returns>
-        public async Task DeleteScopesMemoryAsync(string name, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task DeleteScopesMemoryAsync(string name, CancellationToken cancellationToken = default)
         {
-            name = name.ToLower();
-            var scope = this.Configuration.MemoryScopes.SingleOrDefault(s => s.Name.ToLower() == name);
+            name = name.ToUpperInvariant();
+            var scope = Configuration.MemoryScopes.SingleOrDefault(s => s.Name.ToUpperInvariant() == name);
             if (scope != null)
             {
-                await scope.DeleteAsync(this.dialogContext, cancellationToken).ConfigureAwait(false);
+                await scope.DeleteAsync(_dialogContext, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -409,7 +414,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
 
         public bool ContainsKey(string key)
         {
-            return Configuration.MemoryScopes.Any(ms => ms.Name.ToLower() == key.ToLower());
+            return Configuration.MemoryScopes.Any(ms => ms.Name.ToUpperInvariant() == key.ToUpperInvariant());
         }
 
         public bool Remove(string key)
@@ -419,7 +424,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
 
         public bool TryGetValue(string key, out object value)
         {
-            return this.TryGetValue<object>(key, out value);
+            return TryGetValue<object>(key, out value);
         }
 
         public void Add(KeyValuePair<string, object> item)
@@ -441,7 +446,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             foreach (var ms in Configuration.MemoryScopes)
             {
-                array[arrayIndex++] = new KeyValuePair<string, object>(ms.Name, ms.GetMemory(dialogContext));
+                array[arrayIndex++] = new KeyValuePair<string, object>(ms.Name, ms.GetMemory(_dialogContext));
             }
         }
 
@@ -454,7 +459,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             foreach (var ms in Configuration.MemoryScopes)
             {
-                yield return new KeyValuePair<string, object>(ms.Name, ms.GetMemory(dialogContext));
+                yield return new KeyValuePair<string, object>(ms.Name, ms.GetMemory(_dialogContext));
             }
         }
 
@@ -510,8 +515,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         {
             foreach (var ms in Configuration.MemoryScopes)
             {
-                yield return new KeyValuePair<string, object>(ms.Name, ms.GetMemory(dialogContext));
+                yield return new KeyValuePair<string, object>(ms.Name, ms.GetMemory(_dialogContext));
             }
+        }
+
+        private static bool TryGetFirstNestedValue<T>(ref T value, ref string remainingPath, object memory)
+        {
+            if (ObjectPath.TryGetPathValue<JArray>(memory, remainingPath, out var array))
+            {
+                if (array != null && array.Count > 0)
+                {
+                    if (array[0] is JArray first)
+                    {
+                        if (first.Count > 0)
+                        {
+                            var second = first[0];
+                            value = ObjectPath.MapValueTo<T>(second);
+                            return true;
+                        }
+
+                        return false;
+                    }
+
+                    value = ObjectPath.MapValueTo<T>(array[0]);
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private string GetBadScopeMessage(string path)
@@ -524,15 +555,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             var hasPath = false;
             if (ObjectPath.TryResolvePath(this, path, out var segments))
             {
-                var root = segments.Count() > 1 ? segments[1] as string : string.Empty;
+                var root = segments.Count > 1 ? segments[1] as string : string.Empty;
 
                 // Skip _* as first scope, i.e. _adaptive, _tracker, ...
-                if (!root.StartsWith("_"))
+                if (!root.StartsWith("_", StringComparison.Ordinal))
                 {
                     // Convert to a simple path with _ between segments
                     var pathName = string.Join("_", segments);
                     var trackedPath = $"{PathTracker}.{pathName}";
                     uint? counter = null;
+
                     void Update()
                     {
                         if (TryGetValue<uint>(trackedPath, out var lastChanged))
@@ -553,7 +585,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
                         void CheckChildren(string property, object instance)
                         {
                             // Add new child segment
-                            trackedPath += "_" + property.ToLower();
+#pragma warning disable CA1308 // Normalize strings to uppercase (we assume properties are lowercase). 
+                            trackedPath += "_" + property.ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
                             Update();
                             if (instance is object child)
                             {
@@ -572,33 +606,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             }
 
             return hasPath;
-        }
-
-        private bool TryGetFirstNestedValue<T>(ref T value, ref string remainingPath, object memory)
-        {
-            if (ObjectPath.TryGetPathValue<JArray>(memory, remainingPath, out var array))
-            {
-                if (array != null && array.Count > 0)
-                {
-                    var first = array[0] as JArray;
-                    if (first != null)
-                    {
-                        if (first.Count > 0)
-                        {
-                            var second = first[0];
-                            value = ObjectPath.MapValueTo<T>(second);
-                            return true;
-                        }
-
-                        return false;
-                    }
-
-                    value = ObjectPath.MapValueTo<T>(array[0]);
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManagerConfiguration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManagerConfiguration.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory
@@ -13,7 +14,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <value>
         /// PathResolvers (aka shortcuts) to load into the dialog state manager context.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<IPathResolver> PathResolvers { get; set; } = new List<IPathResolver>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets MemoryScopes.
@@ -21,6 +24,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <value>
         /// MemoryScopes to load into the dialog state manager context.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public List<MemoryScope> MemoryScopes { get; set; } = new List<MemoryScope>();
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IComponentMemoryScopes.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IComponentMemoryScopes.cs
@@ -1,5 +1,6 @@
-﻿// Licensed under the MIT License.
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IComponentPathResolvers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IComponentPathResolvers.cs
@@ -1,5 +1,6 @@
-﻿// Licensed under the MIT License.
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AliasPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AliasPathResolver.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
     /// </summary>
     public class AliasPathResolver : IPathResolver
     {
-        private readonly string prefix;
-        private readonly string postfix;
+        private readonly string _postfix;
+        private readonly string _prefix;
 
         public AliasPathResolver(string alias, string prefix, string postfix = null)
         {
-            this.Alias = alias?.Trim() ?? throw new ArgumentNullException(nameof(alias));
-            this.prefix = prefix?.Trim() ?? throw new ArgumentNullException(nameof(prefix));
-            this.postfix = postfix ?? string.Empty;
+            Alias = alias?.Trim() ?? throw new ArgumentNullException(nameof(alias));
+            _prefix = prefix?.Trim() ?? throw new ArgumentNullException(nameof(prefix));
+            _postfix = postfix ?? string.Empty;
         }
 
         /// <summary>
@@ -36,19 +36,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
             }
 
             path = path.Trim();
-            if (path.StartsWith(Alias) && path.Length > Alias.Length && IsPathChar(path[Alias.Length]))
+            if (path.StartsWith(Alias, StringComparison.Ordinal) && path.Length > Alias.Length && IsPathChar(path[Alias.Length]))
             {
                 // here we only deals with trailing alias, alias in middle be handled in further breakdown
                 // $xxx -> path.xxx
-                return $"{this.prefix}{path.Substring(Alias.Length)}{this.postfix}".TrimEnd('.');
+                return $"{_prefix}{path.Substring(Alias.Length)}{_postfix}".TrimEnd('.');
             }
 
             return path;
         }
 
+#pragma warning disable CA1822 // Mark members as static (we can't change this without breaking binary compat)
         protected bool IsPathChar(char ch)
+#pragma warning restore CA1822 // Mark members as static
         {
-             return char.IsLetter(ch) || ch == '_';
+            return char.IsLetter(ch) || ch == '_';
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AtPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AtPathResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Linq.Expressions;
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
 {
@@ -12,7 +11,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
     public class AtPathResolver : AliasPathResolver
     {
         private const string Prefix = "turn.recognized.entities.";
-        private static readonly char[] Delims = new char[] { '.', '[' };
+
+        private static readonly char[] _delims = { '.', '[' };
 
         public AtPathResolver()
             : base("@", string.Empty)
@@ -27,9 +27,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
             }
 
             path = path.Trim();
-            if (path.StartsWith("@") && path.Length > 1 && IsPathChar(path[1]))
+            if (path.StartsWith("@", StringComparison.Ordinal) && path.Length > 1 && IsPathChar(path[1]))
             {
-                var end = path.IndexOfAny(Delims);
+                var end = path.IndexOfAny(_delims);
                 if (end == -1)
                 {
                     end = path.Length;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ScopePath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ScopePath.cs
@@ -1,8 +1,13 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ScopePath
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// User memory scope root path.
@@ -49,21 +54,28 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public const string Turn = "turn";
 
-        [Obsolete]
+        [Obsolete("This property is deprecated, use ScopePath.User instead.")]
         public const string USER = "user";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.Conversation instead.")]
         public const string CONVERSATION = "conversation";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.Dialog instead.")]
         public const string DIALOG = "dialog";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.DialogClass instead.")]
         public const string DIALOGCLASS = "dialogclass";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.This instead.")]
         public const string THIS = "this";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.Class instead.")]
         public const string CLASS = "class";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.Settings instead.")]
         public const string SETTINGS = "settings";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use ScopePath.Turn instead.")]
         public const string TURN = "turn";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogContextMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogContextMemoryScope.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             }
 
             var memory = new JObject();
-            JArray stack = new JArray();
+            var stack = new JArray();
             var currentDc = dc;
 
             // go to leaf node
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
                 foreach (var item in currentDc.Stack)
                 {
                     // filter out ActionScope items because they are internal bookkeeping.
-                    if (!item.Id.StartsWith("ActionScope["))
+                    if (!item.Id.StartsWith("ActionScope[", StringComparison.Ordinal))
                     {
                         stack.Add(item.Id);
                     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ReadOnlyObject.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ReadOnlyObject.cs
@@ -1,4 +1,5 @@
-﻿#pragma warning disable SA1201 // Elements should appear in the correct order
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections;
@@ -16,8 +17,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </remarks>
     internal class ReadOnlyObject : IDictionary<string, object>
     {
-        private const string NOTSUPPORTED = "This object is readonly.";
-        private readonly object obj;
+        private const string Notsupported = "This object is readonly.";
+        private readonly object _obj;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReadOnlyObject"/> class.
@@ -25,39 +26,39 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
         /// <param name="obj">object to wrap.  Any expression properties on it will be evaluated using the dc.</param>
         public ReadOnlyObject(object obj)
         {
-            this.obj = obj;
+            _obj = obj;
         }
 
-        public object this[string key] { get => GetValue(key); set => throw new NotSupportedException(NOTSUPPORTED); }
+        public ICollection<string> Keys => ObjectPath.GetProperties(_obj).ToList();
 
-        public ICollection<string> Keys => ObjectPath.GetProperties(this.obj).ToList();
+        public ICollection<object> Values => ObjectPath.GetProperties(_obj).Select(propertyName => GetValue(propertyName)).ToList();
 
-        public ICollection<object> Values => ObjectPath.GetProperties(this.obj).Select(propertyName => GetValue(propertyName)).ToList();
-
-        public int Count => ObjectPath.GetProperties(this.obj).Count();
+        public int Count => ObjectPath.GetProperties(_obj).Count();
 
         public bool IsReadOnly => true;
 
+        public object this[string key] { get => GetValue(key); set => throw new NotSupportedException(Notsupported); }
+
         public void Add(string key, object value)
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public void Add(KeyValuePair<string, object> item)
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public void Clear()
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public override bool Equals(object other)
         {
             if (other is ReadOnlyObject esp)
             {
-                return this.obj.Equals(esp.obj);
+                return _obj.Equals(esp._obj);
             }
 
             return false;
@@ -65,42 +66,42 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
 
         public override int GetHashCode()
         {
-            return this.obj.GetHashCode();
+            return _obj.GetHashCode();
         }
 
         public bool Contains(KeyValuePair<string, object> item)
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public bool ContainsKey(string key)
         {
-            return ObjectPath.GetProperties(this.obj).Any(propertyName => propertyName.Equals(key, StringComparison.InvariantCultureIgnoreCase));
+            return ObjectPath.GetProperties(_obj).Any(propertyName => propertyName.Equals(key, StringComparison.OrdinalIgnoreCase));
         }
 
         public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
-            return ObjectPath.GetProperties(this.obj).Select(propertyName => new KeyValuePair<string, object>(propertyName, GetValue(propertyName))).GetEnumerator();
+            return ObjectPath.GetProperties(_obj).Select(propertyName => new KeyValuePair<string, object>(propertyName, GetValue(propertyName))).GetEnumerator();
         }
 
         public bool Remove(string key)
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public bool Remove(KeyValuePair<string, object> item)
         {
-            throw new NotSupportedException(NOTSUPPORTED);
+            throw new NotSupportedException(Notsupported);
         }
 
         public bool TryGetValue(string name, out object value)
         {
-            return ObjectPath.TryGetPathValue<object>(this.obj, name, out value);
+            return ObjectPath.TryGetPathValue(_obj, name, out value);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -110,8 +111,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
 
         private object GetValue(string name)
         {
-            object val;
-            if (TryGetValue(name, out val))
+            if (TryGetValue(name, out var val))
             {
                 return new ReadOnlyObject(val);
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ThisPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ThisPath.cs
@@ -1,15 +1,20 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ThisPath
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// The options that were passed to the active dialog via options argument of BeginDialog.
         /// </summary>
         public const string Options = "this.options";
 
-        [Obsolete]
+        [Obsolete("This property is deprecated, use ThisPath.Options instead.")]
         public const string OPTIONS = "this.options";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
@@ -1,8 +1,13 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (We can't change this without breaking binary compat)
     public class TurnPath
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// The result from the last dialog that was called.
@@ -19,7 +24,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public const string Recognized = "turn.recognized";
 
-         /// <summary>
+        /// <summary>
         /// Path to the top intent.
         /// </summary>
         public const string TopIntent = "turn.recognized.intent";
@@ -50,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         public const string Interrupted = "turn.interrupted";
 
         /// <summary>
-        /// The current dialog event (set during event processings).
+        /// The current dialog event (set during event processing).
         /// </summary>
         public const string DialogEvent = "turn.dialogEvent";
 
@@ -64,29 +69,40 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public const string ActivityProcessed = "turn.activityProcessed";
 
-        [Obsolete]
+        [Obsolete("This property is deprecated, use TurnPath.LastResult instead.")]
         public const string LASTRESULT = "turn.lastresult";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.Activity instead.")]
         public const string ACTIVITY = "turn.activity";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.Recognized instead.")]
         public const string RECOGNIZED = "turn.recognized";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.TopIntent instead.")]
         public const string TOPINTENT = "turn.recognized.intent";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.TopScore instead.")]
         public const string TOPSCORE = "turn.recognized.score";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.Text instead.")]
         public const string TEXT = "turn.recognized.text";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.UnrecognizedText instead.")]
         public const string UNRECOGNIZEDTEXT = "turn.unrecognizedText";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.RecognizedEntities instead.")]
         public const string RECOGNIZEDENTITIES = "turn.recognizedEntities";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.Interrupted instead.")]
         public const string INTERRUPTED = "turn.interrupted";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.DialogEvent instead.")]
         public const string DIALOGEVENT = "turn.dialogEvent";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.RepeatedIds instead.")]
         public const string REPEATEDIDS = "turn.repeatedIds";
-        [Obsolete]
+
+        [Obsolete("This property is deprecated, use TurnPath.ActivityProcessed instead.")]
         public const string ACTIVITYPROCESSED = "turn.activityProcessed";
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -27,14 +27,20 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.2.9" />
     <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.9" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs/PersistedState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/PersistedState.cs
@@ -1,5 +1,5 @@
-﻿// Licensed under the MIT License.
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -10,8 +10,8 @@ namespace Microsoft.Bot.Builder.Dialogs
     {
         public PersistedState()
         {
-            this.UserState = new Dictionary<string, object>();
-            this.ConversationState = new Dictionary<string, object>();
+            UserState = new Dictionary<string, object>();
+            ConversationState = new Dictionary<string, object>();
         }
 
         public PersistedState(PersistedStateKeys keys, IDictionary<string, object> data)
@@ -20,8 +20,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             ConversationState = data.ContainsKey(keys.ConversationState) ? (IDictionary<string, object>)data[keys.ConversationState] : new ConcurrentDictionary<string, object>();
         }
 
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> UserState { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> ConversationState { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -54,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result indicates whether the prompt is still
         /// active after the turn has been processed by the prompt.</remarks>
-        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default)
         {
             if (dc == null)
             {
@@ -107,7 +108,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// active after the turn has been processed by the dialog.
         /// <para>The prompt generally continues to receive the user's replies until it accepts the
         /// user's reply as valid input for the prompt.</para></remarks>
-        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             if (dc == null)
             {
@@ -122,7 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // Increment attempt count
             // Convert.ToInt32 For issue https://github.com/Microsoft/botbuilder-dotnet/issues/1859
-            state[Prompt<int>.AttemptCountKey] = Convert.ToInt32(state[Prompt<int>.AttemptCountKey]) + 1;
+            state[Prompt<int>.AttemptCountKey] = Convert.ToInt32(state[Prompt<int>.AttemptCountKey], CultureInfo.InvariantCulture) + 1;
 
             // Validate the return value
             var isValid = false;
@@ -141,10 +142,8 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 return await dc.EndDialogAsync(recognized.Value, cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                await OnPromptAsync(dc.Context, state, options, true, cancellationToken).ConfigureAwait(false);
-            }
+
+            await OnPromptAsync(dc.Context, state, options, true, cancellationToken).ConfigureAwait(false);
 
             return EndOfTurn;
         }
@@ -162,7 +161,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result indicates whether the dialog is still
         /// active after the turn has been processed by the dialog.</remarks>
-        public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
         {
             if (result is CancellationToken)
             {
@@ -175,7 +174,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             // To avoid the prompt prematurely ending we need to implement this method and
             // simply re-prompt the user.
             await RepromptDialogAsync(dc.Context, dc.ActiveDialog, cancellationToken).ConfigureAwait(false);
-            return Dialog.EndOfTurn;
+            return EndOfTurn;
         }
 
         /// <summary>
@@ -186,7 +185,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public override async Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default)
         {
             var state = (IDictionary<string, object>)instance.State[PersistedState];
             var options = (PromptOptions)instance.State[PersistedOptions];
@@ -203,7 +202,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected virtual async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default)
             => await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
 
         protected virtual async Task OnPromptAsync(
@@ -211,7 +210,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             IDictionary<string, object> state,
             PromptOptions options,
             bool isRetry,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             if (turnContext == null)
             {
@@ -244,7 +243,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result describes the result of the recognition attempt.</remarks>
-        protected virtual Task<PromptRecognizerResult<Activity>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual Task<PromptRecognizerResult<Activity>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new PromptRecognizerResult<Activity>
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/DatetimePrompt.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             return Task.FromResult(result);
         }
 
-        private DateTimeResolution ReadResolution(IDictionary<string, string> resolution)
+        private static DateTimeResolution ReadResolution(IDictionary<string, string> resolution)
         {
             var result = new DateTimeResolution();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,7 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result indicates whether the prompt is still
         /// active after the turn has been processed by the prompt.</remarks>
-        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options, CancellationToken cancellationToken = default)
         {
             if (dc == null)
             {
@@ -116,7 +117,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// active after the turn has been processed by the dialog.
         /// <para>The prompt generally continues to receive the user's replies until it accepts the
         /// user's reply as valid input for the prompt.</para></remarks>
-        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             if (dc == null)
             {
@@ -137,7 +138,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             // Increment attempt count
             // Convert.ToInt32 For issue https://github.com/Microsoft/botbuilder-dotnet/issues/1859
-            state[AttemptCountKey] = Convert.ToInt32(state[AttemptCountKey]) + 1;
+            state[AttemptCountKey] = Convert.ToInt32(state[AttemptCountKey], CultureInfo.InvariantCulture) + 1;
 
             // Validate the return value
             var isValid = false;
@@ -178,7 +179,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result indicates whether the dialog is still
         /// active after the turn has been processed by the dialog.</remarks>
-        public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
         {
             if (result is CancellationToken)
             {
@@ -202,7 +203,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public override async Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default)
         {
             var state = (IDictionary<string, object>)instance.State[PersistedState];
             var options = (PromptOptions)instance.State[PersistedOptions];
@@ -215,7 +216,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 // Perform base recognition
                 var state = dc.ActiveDialog.State;
-                var recognized = await this.OnRecognizeAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions]).ConfigureAwait(false);
+                var recognized = await OnRecognizeAsync(dc.Context, (IDictionary<string, object>)state[PersistedState], (PromptOptions)state[PersistedOptions]).ConfigureAwait(false);
                 return recognized.Succeeded;
             }
 
@@ -234,7 +235,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected abstract Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// When overridden in a derived class, attempts to recognize the user's input.
@@ -247,7 +248,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result describes the result of the recognition attempt.</remarks>
-        protected abstract Task<PromptRecognizerResult<T>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken));
+        protected abstract Task<PromptRecognizerResult<T>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// When overridden in a derived class, appends choices to the activity when the user is prompted for input.
@@ -261,7 +262,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result contains the updated activity.</remarks>
-        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, CancellationToken cancellationToken = default)
         {
             // Get base prompt text (if any)
             var text = prompt != null && !string.IsNullOrEmpty(prompt.Text) ? prompt.Text : string.Empty;
@@ -323,11 +324,9 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                 return prompt;
             }
-            else
-            {
-                msg.InputHint = InputHints.ExpectingInput;
-                return msg;
-            }
+
+            msg.InputHint = InputHints.ExpectingInput;
+            return msg;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -179,7 +179,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
         /// <returns>Normalized locale.</returns>
         public static string MapToNearestLanguage(string cultureCode)
         {
+#pragma warning disable CA1308 // Normalize strings to uppercase (culture codes are expected to be in lowercase, ignoring)
             cultureCode = cultureCode.ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
 
             if (SupportedLocales.All(o => o != cultureCode))
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -32,7 +32,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Gets or sets a list of choices for the user to choose from, for use with a <see cref="ChoicePrompt"/>.
         /// </summary>
         /// <value>The list of available choices.</value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IList<Choice> Choices { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets the <see cref="ListStyle"/> for a <see cref="ChoicePrompt"/>.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptValidatorContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -58,7 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     return 0;
                 }
 
-                return Convert.ToInt32(State[Prompt<T>.AttemptCountKey]);
+                return Convert.ToInt32(State[Prompt<T>.AttemptCountKey], CultureInfo.InvariantCulture);
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -28,11 +31,19 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             if (!string.IsNullOrEmpty(callerPath))
             {
-                DebugSupport.SourceMap.Add(this, new SourceRange()
+                DebugSupport.SourceMap.Add(this, new SourceRange
                 {
                     Path = callerPath,
-                    StartPoint = new SourcePoint() { LineIndex = callerLine, CharIndex = 0 },
-                    EndPoint = new SourcePoint() { LineIndex = callerLine + 1, CharIndex = 0 },
+                    StartPoint = new SourcePoint
+                    {
+                        LineIndex = callerLine,
+                        CharIndex = 0
+                    },
+                    EndPoint = new SourcePoint
+                    {
+                        LineIndex = callerLine + 1,
+                        CharIndex = 0
+                    },
                 });
             }
         }
@@ -60,7 +71,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the LuisResult event.</param>
         /// <returns>Analysis of utterance.</returns>
+#pragma warning disable CA1068 // CancellationToken parameters must come last (we can't change this without breaking binary compat)
         public virtual Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+#pragma warning restore CA1068 // CancellationToken parameters must come last
         {
             throw new NotImplementedException();
         }
@@ -75,11 +88,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the LuisResult event.</param>
         /// <returns>Analysis of utterance.</returns>
+#pragma warning disable CA1068 // CancellationToken parameters must come last (we can't change this without breaking binary compat)
         public virtual async Task<T> RecognizeAsync<T>(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+#pragma warning restore CA1068 // CancellationToken parameters must come last
             where T : IRecognizerConvert, new()
         {
             var result = new T();
-            result.Convert(await this.RecognizeAsync(dialogContext, activity, cancellationToken).ConfigureAwait(false));
+            result.Convert(await RecognizeAsync(dialogContext, activity, cancellationToken).ConfigureAwait(false));
             return result;
         }
 
@@ -92,7 +107,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A dictionary that can be included when calling the TrackEvent method on the TelemetryClient.</returns>
         protected virtual Dictionary<string, string> FillRecognizerResultTelemetryProperties(RecognizerResult recognizerResult, Dictionary<string, string> telemetryProperties, DialogContext dialogContext = null)
         {
-            var properties = new Dictionary<string, string>()
+            var properties = new Dictionary<string, string>
             {
                 { "Text", recognizerResult.Text },
                 { "AlteredText", recognizerResult.AlteredText },
@@ -107,8 +122,8 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (telemetryProperties != null)
             {
                 return telemetryProperties.Concat(properties)
-                           .GroupBy(kv => kv.Key)
-                           .ToDictionary(g => g.Key, g => g.First().Value);
+                    .GroupBy(kv => kv.Key)
+                    .ToDictionary(g => g.Key, g => g.First().Value);
             }
 
             return properties;
@@ -123,13 +138,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="telemetryMetrics">The metrics to be included as part of the event tracking.</param>
         protected void TrackRecognizerResult(DialogContext dialogContext, string eventName, Dictionary<string, string> telemetryProperties, Dictionary<string, double> telemetryMetrics)
         {
-            if (this.TelemetryClient is NullBotTelemetryClient)
+            if (TelemetryClient is NullBotTelemetryClient)
             {
                 var turnStateTelemetryClient = dialogContext.Context.TurnState.Get<IBotTelemetryClient>();
-                this.TelemetryClient = turnStateTelemetryClient ?? this.TelemetryClient;
+                TelemetryClient = turnStateTelemetryClient ?? TelemetryClient;
             }
 
-            this.TelemetryClient.TrackEvent(eventName, telemetryProperties, telemetryMetrics);
+            TelemetryClient.TrackEvent(eventName, telemetryProperties, telemetryMetrics);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <summary>
         /// Validates the required properties are set in the options argument passed to the BeginDialog call.
         /// </summary>
-        private BeginSkillDialogOptions ValidateBeginDialogArgs(object options)
+        private static BeginSkillDialogOptions ValidateBeginDialogArgs(object options)
         {
             if (options == null)
             {
@@ -202,7 +202,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                     else if (await InterceptOAuthCardsAsync(context, activityFromSkill, DialogOptions.ConnectionName, cancellationToken).ConfigureAwait(false))
                     {
-                        // do nothing. Token exchange succeeded, so no oauthcard needs to be shown to the user
+                        // do nothing. Token exchange succeeded, so no OAuthCard needs to be shown to the user
                     }
                     else
                     {
@@ -261,7 +261,9 @@ namespace Microsoft.Bot.Builder.Dialogs
                             return await SendTokenExchangeInvokeToSkillAsync(activity, oauthCard.TokenExchangeResource.Id, oauthCard.ConnectionName, result.Token, cancellationToken).ConfigureAwait(false);
                         }
                     }
+#pragma warning disable CA1031 // Do not catch general exception types (ignoring, see comment below)
                     catch
+#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         // Failures in token exchange are not fatal. They simply mean that the user needs to be shown the OAuth card.
                         return false;

--- a/libraries/integration/Directory.Build.props
+++ b/libraries/integration/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- Contains common properties that apply to projects under the Adapters folder -->
+  <!-- Contains common properties that apply to projects under the Integration folder -->
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
       <PrivateAssets>all</PrivateAssets>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -24,8 +24,7 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -38,7 +37,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.ApplicationInsights" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,6 +15,8 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
     // This class has been deprecated in favor of using TelemetryInitializerMiddleware in
     // Microsoft.Bot.Integration.ApplicationInsights.Core and Microsoft.Bot.Integration.ApplicationInsights.WebApi
     [Obsolete("This class is deprecated. Please add TelemetryInitializerMiddleware to your adapter's middleware pipeline instead.")]
+    [SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "This class is deprecated, we won't fix FxCop issues")]
+    [SuppressMessage("AsyncUsage.CSharp.Naming", "UseAsyncSuffix:Use Async suffix", Justification = "This class is deprecated, we won't fix FxCop issues")]
     public class TelemetrySaveBodyASPMiddleware
     {
         private readonly RequestDelegate _next;
@@ -37,7 +40,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
                 {
                     using (var reader = new StreamReader(request.Body, Encoding.UTF8, true, 4096, true))
                     {
-                        var body = await reader.ReadToEndAsync();
+                        var body = await reader.ReadToEndAsync().ConfigureAwait(false);
                         var jsonObject = JObject.Parse(body);
 
                         // Save data in cache.
@@ -55,7 +58,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
                 }
             }
 
-            await _next(httpContext);
+            await _next(httpContext).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
@@ -25,8 +25,7 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -35,11 +34,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.6" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="2.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.8.1" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/TelemetryBotIdInitializer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi
             }
         }
 
-        private void CacheBody()
+        private static void CacheBody()
         {
             var httpContext = HttpContext.Current;
             var request = httpContext.Request;

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -189,6 +189,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             var appPassword = await CredentialProvider.GetAppPasswordAsync(appId).ConfigureAwait(false);
             return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
         }
+        
+        private static T GetBodyContent<T>(string content)
+        {
+            return JsonConvert.DeserializeObject<T>(content);
+        }
 
         private async Task<InvokeResponse<T>> SecurePostActivityAsync<T>(Uri toUrl, Activity activity, string token, CancellationToken cancellationToken)
         {
@@ -216,11 +221,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     }
                 }
             }
-        }
-
-        private T GetBodyContent<T>(string content)
-        {
-            return JsonConvert.DeserializeObject<T>(content);
         }
 
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     {
         protected override async Task<InvokeResponse> ProcessMessageRequestAsync(HttpRequest request, IAdapterIntegration adapter, BotCallbackHandler botCallbackHandler, CancellationToken cancellationToken)
         {
-            var activity = default(Activity);
+            Activity activity;
 
             using (var memoryStream = new MemoryStream())
             {
@@ -35,17 +35,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
                 // NOTE: We explicitly leave the stream open here so others can still access it (in case buffering was enabled); ASP.NET runtime will always dispose of it anyway
                 using (var bodyReader = new JsonTextReader(new StreamReader(memoryStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true)))
                 {
-                    activity = BotMessageHandlerBase.BotMessageSerializer.Deserialize<Activity>(bodyReader);
+                    activity = BotMessageSerializer.Deserialize<Activity>(bodyReader);
                 }
             }
 
-#pragma warning disable UseConfigureAwait // Use ConfigureAwait
             var invokeResponse = await adapter.ProcessActivityAsync(
-                    request.Headers["Authorization"],
-                    activity,
-                    botCallbackHandler,
-                    cancellationToken);
-#pragma warning restore UseConfigureAwait // Use ConfigureAwait
+                request.Headers["Authorization"],
+                activity,
+                botCallbackHandler,
+                cancellationToken).ConfigureAwait(false);
 
             return invokeResponse;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
@@ -56,14 +56,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
 
             try
             {
-                // TODO wire up cancellation
-#pragma warning disable UseConfigureAwait // Use ConfigureAwait
                 var invokeResponse = await ProcessMessageRequestAsync(
                     request,
                     adapter,
                     bot.OnTurnAsync,
-                    default(CancellationToken));
-#pragma warning restore UseConfigureAwait // Use ConfigureAwait
+                    default(CancellationToken)).ConfigureAwait(false);
 
                 if (invokeResponse == null)
                 {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ChannelServiceExceptionFilterAttribute.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ChannelServiceExceptionFilterAttribute.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 {
+    [AttributeUsage(AttributeTargets.Class)]
     internal class ChannelServiceExceptionFilterAttribute : Attribute, IExceptionFilter
     {
         public void OnException(ExceptionContext context)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -23,8 +23,7 @@
 
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -40,13 +39,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandler.cs
@@ -21,13 +21,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
         {
             var activity = await request.Content.ReadAsAsync<Activity>(BotMessageHandlerBase.BotMessageMediaTypeFormatters, cancellationToken).ConfigureAwait(false);
 
-#pragma warning disable UseConfigureAwait // Use ConfigureAwait
             var invokeResponse = await adapter.ProcessActivityAsync(
                 request.Headers.Authorization?.ToString(),
                 activity,
                 botCallbackHandler,
-                cancellationToken);
-#pragma warning restore UseConfigureAwait // Use ConfigureAwait
+                cancellationToken).ConfigureAwait(false);
 
             return invokeResponse;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotMessageHandlerBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,15 +13,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 {
     public abstract class BotMessageHandlerBase : HttpMessageHandler
     {
-        public static readonly MediaTypeFormatter[] BotMessageMediaTypeFormatters = new[]
+        public static readonly MediaTypeFormatter[] BotMessageMediaTypeFormatters =
         {
             new JsonMediaTypeFormatter
             {
                 SerializerSettings = MessageSerializerSettings.Create(),
                 SupportedMediaTypes =
                 {
-                    new System.Net.Http.Headers.MediaTypeHeaderValue("application/json") { CharSet = "utf-8" },
-                    new System.Net.Http.Headers.MediaTypeHeaderValue("text/json") { CharSet = "utf-8" },
+                    new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" },
+                    new MediaTypeHeaderValue("text/json") { CharSet = "utf-8" },
                 },
             },
         };
@@ -53,7 +54,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
 
             try
             {
-#pragma warning disable UseConfigureAwait // Use ConfigureAwait
                 var invokeResponse = await ProcessMessageRequestAsync(
                     request,
                     _adapter,
@@ -69,37 +69,34 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi.Handlers
                         }
                         catch (Exception exception)
                         {
-                            throw new Exception($"An exception occurred attempting to resolve an {typeof(IBot).Name} service via the dependency resolver. Please check the inner exception for more details.", exception);
+                            throw new Exception($"An exception occurred attempting to resolve an {nameof(IBot)} service via the dependency resolver. Please check the inner exception for more details.", exception);
                         }
 
                         if (bot == null)
                         {
-                            throw new InvalidOperationException($"Did not find an {typeof(IBot).Name} service via the dependency resolver. Please make sure you have registered your bot with your dependency injection container.");
+                            throw new InvalidOperationException($"Did not find an {nameof(IBot)} service via the dependency resolver. Please make sure you have registered your bot with your dependency injection container.");
                         }
 
-                        return bot.OnTurnAsync(context);
+                        return bot.OnTurnAsync(context, ct);
                     },
-                    cancellationToken);
-#pragma warning restore UseConfigureAwait // Use ConfigureAwait
+                    cancellationToken).ConfigureAwait(false);
 
                 if (invokeResponse == null)
                 {
                     return request.CreateResponse(HttpStatusCode.OK);
                 }
-                else
+
+                var response = request.CreateResponse((HttpStatusCode)invokeResponse.Status);
+
+                if (invokeResponse.Body != null)
                 {
-                    var response = request.CreateResponse((HttpStatusCode)invokeResponse.Status);
-
-                    if (invokeResponse.Body != null)
-                    {
-                        response.Content = new ObjectContent(
-                            invokeResponse.Body.GetType(),
-                            invokeResponse.Body,
-                            BotMessageMediaTypeFormatters[0]);
-                    }
-
-                    return response;
+                    response.Content = new ObjectContent(
+                        invokeResponse.Body.GetType(),
+                        invokeResponse.Body,
+                        BotMessageMediaTypeFormatters[0]);
                 }
+
+                return response;
             }
             catch (UnauthorizedAccessException e)
             {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpConfigurationExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/HttpConfigurationExtensions.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
                     baseUrl.Trim('/') + "/" + options.Paths.MessagesPath.Trim('/'),
                     defaults: null,
                     constraints: null,
+#pragma warning disable CA2000 // Dispose objects before losing scope (we will let ASP.Net core deal with disposing this handler)
                     handler: new BotMessageHandler(adapter));
+#pragma warning restore CA2000 // Dispose objects before losing scope
         }
 
         private static ICredentialProvider ResolveCredentialProvider(BotFrameworkOptions options)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/Microsoft.Bot.Builder.Integration.AspNet.WebApi.csproj
@@ -20,8 +20,7 @@
   
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -30,11 +29,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.6" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Relates to #2367 

- Enabled FxCop on the Dialogs project and fixed errors.
- Created a DirProps file with FxCop, AsyncAnalyzers and Source link and placed it in the Integration folder. Removed local references to packages in the dirprops file from the 4 projects in the folder and fixed some errors. 