### PR TITLE
Extend 'getProperty' builtin function to support accessing top memory.

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -1135,7 +1135,7 @@ namespace AdaptiveExpressions
                     // get root value from memory
                     if (!(firstItem is string))
                     {
-                        error = $"if GetProperty contains only one parameter, please make sure it is string. But get {firstItem?.GetType()?.Name ?? "null"}";
+                        error = $"Single parameter {children[0]} is not a string.";
                     }
                     else
                     {

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -1123,17 +1123,33 @@ namespace AdaptiveExpressions
         {
             object value = null;
             string error;
-            object instance;
+            object firstItem;
             object property;
 
             var children = expression.Children;
-            (instance, error) = children[0].TryEvaluate(state, options);
+            (firstItem, error) = children[0].TryEvaluate(state, options);
             if (error == null)
             {
-                (property, error) = children[1].TryEvaluate(state, options);
-                if (error == null)
+                if (children.Length == 1)
                 {
-                    (value, error) = WrapGetValue(MemoryFactory.Create(instance), (string)property, options);
+                    // get root value from memory
+                    if (!(firstItem is string))
+                    {
+                        error = $"if GetProperty contains only one parameter, please make sure it is string. But get {firstItem?.GetType()?.Name ?? "null"}";
+                    }
+                    else
+                    {
+                        (value, error) = WrapGetValue(state, (string)firstItem, options);
+                    }
+                }
+                else
+                {
+                    // get the peoperty value from the instance
+                    (property, error) = children[1].TryEvaluate(state, options);
+                    if (error == null)
+                    {
+                        (value, error) = WrapGetValue(MemoryFactory.Create(firstItem), (string)property, options);
+                    }
                 }
             }
 
@@ -4375,7 +4391,7 @@ namespace AdaptiveExpressions
 
                 // Misc
                 new ExpressionEvaluator(ExpressionType.Accessor, Accessor, ReturnType.Object, ValidateAccessor),
-                new ExpressionEvaluator(ExpressionType.GetProperty, GetProperty, ReturnType.Object, (expr) => ValidateOrder(expr, null, ReturnType.Object, ReturnType.String)),
+                new ExpressionEvaluator(ExpressionType.GetProperty, GetProperty, ReturnType.Object, (expr) => ValidateOrder(expr, new[] { ReturnType.String }, ReturnType.Object)),
                 new ExpressionEvaluator(ExpressionType.If, (expression, state, options) => If(expression, state, options), ReturnType.Object, (expression) => ValidateArityAndAnyType(expression, 3, 3)),
                 new ExpressionEvaluator(
                     ExpressionType.Rand,

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -385,6 +385,7 @@ namespace AdaptiveExpressions.Tests
 
             #region Memory access test
             Test("getProperty(bag, 1)"), // second param should be string
+            Test("getProperty(1)"), // if getProperty contains only one parameter, the parameter should be string
             Test("Accessor(1)"), // first param should be string
             Test("Accessor(bag, 1)"), // second should be object
             Test("one[0]"),  // one is not list

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -30,6 +30,9 @@ namespace AdaptiveExpressions.Tests
                 "alist", new List<A>() { new A("item1"), new A("item2") }
             },
             {
+                "a:b", "stringa:b"
+            },
+            {
                 "emptyList", new List<object>()
             },
             {
@@ -923,6 +926,7 @@ namespace AdaptiveExpressions.Tests
             #region  Memory access
             Test("getProperty(bag, concat('na','me'))", "mybag"),
             Test("getProperty('bag').index", 3),
+            Test("getProperty('a:b')", "stringa:b"),
             Test("getProperty(concat('he', 'llo'))", "hello"),
             Test("items[2]", "two", new HashSet<string> { "items[2]" }),
             Test("bag.list[bag.index - 2]", "blue", new HashSet<string> { "bag.list", "bag.index" }),

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -922,6 +922,8 @@ namespace AdaptiveExpressions.Tests
 
             #region  Memory access
             Test("getProperty(bag, concat('na','me'))", "mybag"),
+            Test("getProperty('bag').index", 3),
+            Test("getProperty(concat('he', 'llo'))", "hello"),
             Test("items[2]", "two", new HashSet<string> { "items[2]" }),
             Test("bag.list[bag.index - 2]", "blue", new HashSet<string> { "bag.list", "bag.index" }),
             Test("items[nestedItems[1].x]", "two", new HashSet<string> { "items", "nestedItems[1].x" }),


### PR DESCRIPTION
Fixes #4029
Originally, `getProperty` accepts two parameters, the first parameter is an instance, and the second parameter is the property name which user wants to access the value from. In this mode, the user can not access the top-level memory from dynamic/special string property.

After this change, `getProperty` accepts only one parameter, that presents the root property from the memory.

Example: 
Scope is :
```
{
"a:b": "value"
}
```
`getProperty('a:b')` would get string "value", 

