### PR TITLE
Remove Slack from the list of channels that support Suggested Actions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 case Connector.Channels.Kik:
                     return buttonCnt <= 20;
 
-                case Connector.Channels.Slack:
                 case Connector.Channels.Telegram:
                 case Connector.Channels.Emulator:
                 case Connector.Channels.Directline:


### PR DESCRIPTION
Fixes #2291 

Removing Slack from the list of channels that do not support suggested actions.