### PR TITLE
Update missing code docs for the Azure library

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
@@ -8,12 +8,17 @@ using System.Text;
 
 namespace Microsoft.Bot.Builder.Azure
 {
+    /// <summary>
+    /// Helper methods for escaping keys used for Cosmos DB.
+    /// </summary>
     public static class CosmosDbKeyEscape
     {
-        // Older libraries had a max key length of 255.
-        // The limit is now 1023. In this library, 255 remains the default for backwards compat.
-        // To override this behavior, and use the longer limit, set CosmosDbPartitionedStorageOptions.CompatibilityMode to false.
-        // https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits
+        /// <summary>
+        /// Older libraries had a max key length of 255.
+        /// The limit is now 1023. In this library, 255 remains the default for backwards compat.
+        /// To override this behavior, and use the longer limit, set CosmosDbPartitionedStorageOptions.CompatibilityMode to false.
+        /// https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-item-limits.
+        /// </summary>
         public const int MaxKeyLength = 255;
 
         // The list of illegal characters for Cosmos DB Keys comes from this list on
@@ -46,11 +51,10 @@ namespace Microsoft.Bot.Builder.Azure
         /// </summary>
         /// <param name="key">The key to escape.</param>
         /// <param name="suffix">The string to add at the end of all row keys.</param>
-        /// <param name="compatibilityMode ">True if running in compatability mode and keys should
+        /// <param name="compatibilityMode">True if running in compatability mode and keys should
         /// be truncated in order to support previous CosmosDb max key length of 255. 
         /// This behavior can be overridden by setting
-        /// <see cref="CosmosDbPartitionedStorageOptions.CompatibilityMode"/> to false.
-        /// </param>
+        /// <see cref="CosmosDbPartitionedStorageOptions.CompatibilityMode"/> to false.</param>
         /// <returns>An escaped key that can be used safely with CosmosDB.</returns>
         public static string EscapeKey(string key, string suffix, bool compatibilityMode)
         {

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -91,6 +91,13 @@ namespace Microsoft.Bot.Builder.Azure
             _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
         }
 
+        /// <summary>
+        /// Reads one or more items with matching keys from the Cosmos DB container.
+        /// </summary>
+        /// <param name="keys">A collection of Ids for each item to be retrieved.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>A dictionary containing the retrieved items.</returns>
+        /// <exception cref="ArgumentNullException">Exception thrown if the array of keys (Ids for the items to be retrieved) is null.</exception>
         public async Task<IDictionary<string, object>> ReadAsync(string[] keys, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (keys == null)
@@ -151,6 +158,15 @@ namespace Microsoft.Bot.Builder.Azure
             return storeItems;
         }
 
+        /// <summary>
+        /// Inserts or updates one or more items into the Cosmos DB container. 
+        /// </summary>
+        /// <param name="changes">A dictionary of items to be inserted or updated. The dictionary item key
+        /// is used as the ID for the inserted / updated item.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+        /// <returns>A Task representing the work to be executed.</returns>
+        /// <exception cref="ArgumentNullException">Exception thrown if the changes dictionary is null.</exception>
+        /// <exception cref="Exception">Exception thrown is the etag is empty on any of the items within the changes dictionary.</exception>
         public async Task WriteAsync(IDictionary<string, object> changes, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (changes == null)
@@ -208,6 +224,13 @@ namespace Microsoft.Bot.Builder.Azure
             }
         }
 
+        /// <summary>
+        /// Deletes one or more items from the Cosmos DB container.
+        /// </summary>
+        /// <param name="keys">An array of Ids for the items to be deleted.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+        /// <returns>A Task representing the work to be executed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the array of Ids to be deleted is null.</exception>
         public async Task DeleteAsync(string[] keys, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (keys == null)

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorage.cs
@@ -140,6 +140,11 @@ namespace Microsoft.Bot.Builder.Azure
             _client.ConnectionPolicy.UserAgentSuffix = $"Microsoft-BotFramework {version}";
         }
 
+        /// <summary>
+        /// Escapes a given key to be compatible for use with Cosmos DB. 
+        /// </summary>
+        /// <param name="key">The key to be sanitized (escaped).</param>
+        /// <returns>An appropriately escaped version of the key.</returns>
         [Obsolete("Replaced by CosmosDBKeyEscape.EscapeKey.")]
         public static string SanitizeKey(string key) => CosmosDbKeyEscape.EscapeKey(key);
 

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -22,12 +22,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- The KeyVault package, picked up as a transitive dependency of the Azure Storage libraries
         doesn't yet support NetStandard20. I confirmed with the Azure Storage team that this warning
         is fine, and can be supressed.

--- a/libraries/Microsoft.Bot.Builder.Azure/Queues/ContinueConversationLater.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/Queues/ContinueConversationLater.cs
@@ -26,15 +26,23 @@ namespace Microsoft.Bot.Builder.Azure.Queues
     ///   - processing the activity directly via adapter.ProcessActivity(activity, ...); 
     ///     NOTE: adapter.ProcessActivity() understands that EventActivity(Name=ConversationUpdate) should be processed as ContinueConversation() pipeline.
     /// 
-    /// This dialog returns the reciept information for the queued activity as the result of the dialog.
+    /// This dialog returns the receipt information for the queued activity as the result of the dialog.
     /// </remarks>
     public class ContinueConversationLater : Dialog
     {
+        /// <summary>
+        /// The Kind name for this dialog.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "AzureQueues.ContinueConversationLater";
 
         private static JsonSerializerSettings jsonSettings = new JsonSerializerSettings() { Formatting = Formatting.Indented, NullValueHandling = NullValueHandling.Ignore };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContinueConversationLater"/> class.
+        /// </summary>
+        /// <param name="callerPath">The full path of the source file that contains this called.</param>
+        /// <param name="callerLine">The line within the source file that contains this caller.</param>
         [JsonConstructor]
         public ContinueConversationLater([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -87,6 +95,7 @@ namespace Microsoft.Bot.Builder.Azure.Queues
         [JsonProperty("queueName")]
         public StringExpression QueueName { get; set; } = "activities";
 
+        /// <inheritdoc/>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (options is CancellationToken)
@@ -136,6 +145,7 @@ namespace Microsoft.Bot.Builder.Azure.Queues
             return await dc.EndDialogAsync(result: reciept.Value, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <inheritdoc/>
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}({Date?.ToString()}s)";


### PR DESCRIPTION
Towards #4052.

Adds missing code docs for Azure librariy.

Also removes the suppression of CS1309 as part of https://github.com/microsoft/botframework-sdk/issues/5933