### PR TITLE
Add missing code docs for Configuration lib

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfigurationExtensions.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfigurationExtensions.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Bot.Configuration
     using System.IO;
     using System.Linq;
 
+    /// <summary>
+    /// Extension methods for <see cref="BotConfiguration"/>.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public static class BotConfigurationExtensions
     {

--- a/libraries/Microsoft.Bot.Configuration/EncryptUtilities.cs
+++ b/libraries/Microsoft.Bot.Configuration/EncryptUtilities.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Bot.Configuration.Encryption
     using System.IO;
     using System.Security.Cryptography;
 
+    /// <summary>
+    /// Helper methods to assist with encryption of connected service keys.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public static class EncryptUtilities
     {

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -21,12 +21,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/libraries/Microsoft.Bot.Configuration/ServiceTypes.cs
+++ b/libraries/Microsoft.Bot.Configuration/ServiceTypes.cs
@@ -5,18 +5,60 @@ using System;
 
 namespace Microsoft.Bot.Configuration
 {
+    /// <summary>
+    /// Constants for Azure service types.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class ServiceTypes
     {
+        /// <summary>
+        /// Application Insights.
+        /// </summary>
         public const string AppInsights = "appInsights";
+
+        /// <summary>
+        /// Blob Storage.
+        /// </summary>
         public const string BlobStorage = "blob";
+
+        /// <summary>
+        /// Cosmos DB.
+        /// </summary>
         public const string CosmosDB = "cosmosdb";
+
+        /// <summary>
+        /// Azure Bot Service.
+        /// </summary>
         public const string Bot = "abs";
+
+        /// <summary>
+        /// Generic service.
+        /// </summary>
         public const string Generic = "generic";
+
+        /// <summary>
+        /// Dispatch.
+        /// </summary>
         public const string Dispatch = "dispatch";
+
+        /// <summary>
+        /// Bot Endpoint. 
+        /// </summary>
         public const string Endpoint = "endpoint";
+
+        /// <summary>
+        /// File service.
+        /// </summary>
         public const string File = "file";
+
+        /// <summary>
+        /// LUIS Cognitive Service.
+        /// </summary>
         public const string Luis = "luis";
+
+        /// <summary>
+        /// QnA Maker Cognitive Service.
+        /// </summary>
         public const string QnA = "qna";
     }
 }

--- a/libraries/Microsoft.Bot.Configuration/Services/AppInsightsService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/AppInsightsService.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Bot.Configuration
     using Microsoft.Bot.Configuration.Encryption;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Represents the configuration properties for an Application Insights service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class AppInsightsService : AzureService
     {

--- a/libraries/Microsoft.Bot.Configuration/Services/AzureService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/AzureService.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Bot.Configuration
     using System;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Represents the base configuration for an Azure service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class AzureService : ConnectedService
     {

--- a/libraries/Microsoft.Bot.Configuration/Services/BlobStorageService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/BlobStorageService.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Bot.Configuration
     using Microsoft.Bot.Configuration.Encryption;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Configuration properties for a Azure Blob Storage service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class BlobStorageService : AzureService
     {

--- a/libraries/Microsoft.Bot.Configuration/Services/BotService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/BotService.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Bot.Configuration
     using System;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Configuration properties for a connected Azure Bot Service bot registration.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class BotService : AzureService
     {

--- a/libraries/Microsoft.Bot.Configuration/Services/ConnectedService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/ConnectedService.cs
@@ -7,9 +7,16 @@ namespace Microsoft.Bot.Configuration
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
+    /// <summary>
+    /// Base configuration properties for a connected service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class ConnectedService
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectedService"/> class.
+        /// </summary>
+        /// <param name="type">The connected service type.</param>
         public ConnectedService(string type)
         {
             this.Type = type;

--- a/libraries/Microsoft.Bot.Configuration/Services/CosmosDbService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/CosmosDbService.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Bot.Configuration
     using Microsoft.Bot.Configuration.Encryption;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Configuration properties for a connected Cosmos DB database.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class CosmosDbService : AzureService
     {

--- a/libraries/Microsoft.Bot.Configuration/Services/DispatchService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/DispatchService.cs
@@ -7,9 +7,15 @@ namespace Microsoft.Bot.Configuration
     using System.Collections.Generic;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Configuration properties for a connected Dispatch Service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class DispatchService : LuisService
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DispatchService"/> class.
+        /// </summary>
         public DispatchService()
         {
             this.Type = ServiceTypes.Dispatch;

--- a/libraries/Microsoft.Bot.Configuration/Services/EndpointService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/EndpointService.cs
@@ -7,9 +7,15 @@ namespace Microsoft.Bot.Configuration
     using Microsoft.Bot.Configuration.Encryption;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// An Endpoint service containing configuration properties defining the endpoint for a bot (Azure or Government).
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class EndpointService : ConnectedService
-    {
+    { 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EndpointService"/> class.
+        /// </summary>
         public EndpointService()
             : base(ServiceTypes.Endpoint)
         {

--- a/libraries/Microsoft.Bot.Configuration/Services/FileService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/FileService.cs
@@ -6,9 +6,15 @@ namespace Microsoft.Bot.Configuration
     using System;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Configuration properties for a connected File service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class FileService : ConnectedService
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileService"/> class.
+        /// </summary>
         public FileService()
             : base(ServiceTypes.File)
         {

--- a/libraries/Microsoft.Bot.Configuration/Services/GenericService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/GenericService.cs
@@ -9,9 +9,15 @@ namespace Microsoft.Bot.Configuration
     using Microsoft.Bot.Configuration.Encryption;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// An Generic service containing configuration properties for the service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class GenericService : ConnectedService
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericService"/> class.
+        /// </summary>
         public GenericService()
             : base(ServiceTypes.Generic)
         {

--- a/libraries/Microsoft.Bot.Configuration/Services/LuisService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/LuisService.cs
@@ -7,6 +7,9 @@ namespace Microsoft.Bot.Configuration
     using Microsoft.Bot.Configuration.Encryption;
     using Newtonsoft.Json;
 
+    /// <summary>
+    /// Configuration properties for a connected LUIS Service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class LuisService : ConnectedService
     {

--- a/libraries/Microsoft.Bot.Configuration/Services/QnAMakerService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/QnAMakerService.cs
@@ -7,6 +7,9 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Configuration
 {
+    /// <summary>
+    /// Configuration properties for a connected LUIS service.
+    /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
     public class QnAMakerService : ConnectedService
     {


### PR DESCRIPTION
Towards #4052.

Adds missing code docs for configuration library.

Also removes the suppression of CS1309 as part of microsoft/botframework-sdk#5933