### PR TITLE
properly escape slashes in constant strings with StringExpression/ValueExpression

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionProperties/StringExpression.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/StringExpression.cs
@@ -101,7 +101,7 @@ namespace AdaptiveExpressions.Properties
                 }
 
                 // keep the string as quoted expression, which will be literal unless string interpolation is used.
-                this.ExpressionText = $"=`{stringOrExpression}`";
+                this.ExpressionText = $"=`{stringOrExpression.Replace("\\", "\\\\")}`";
                 return;
             }
         }

--- a/libraries/AdaptiveExpressions/ExpressionProperties/ValueExpression.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/ValueExpression.cs
@@ -42,7 +42,7 @@ namespace AdaptiveExpressions.Properties
             : base(value)
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ValueExpression"/> class.
         /// </summary>
@@ -67,7 +67,7 @@ namespace AdaptiveExpressions.Properties
         public static implicit operator ValueExpression(bool value) => new ValueExpression(value);
 
         public static implicit operator ValueExpression(JToken valueOrExpression) => new ValueExpression(valueOrExpression);
-        
+
         public static implicit operator ValueExpression(Expression expression) => new ValueExpression(expression);
 
         public override void SetValue(object value)
@@ -91,7 +91,7 @@ namespace AdaptiveExpressions.Properties
                 }
 
                 // keep the string as quoted expression, which will be literal unless string interpolation is used.
-                this.ExpressionText = $"=`{stringOrExpression}`";
+                this.ExpressionText = $"=`{stringOrExpression.Replace("\\", "\\\\")}`";
                 return;
             }
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
@@ -361,10 +361,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             Assert.Equal("Hello joe", result);
             Assert.Null(error);
 
-            str = new StringExpression(@"c:\test\test\test");
-            Assert.Equal(@"=`c:\\test\\test\\test`", str.ExpressionText);
+            // slashes are the chars
+            str = new StringExpression("c:\\test\\test\\test");
             (result, error) = str.TryGetValue(data);
-            Assert.Equal(@"c:\test\test\test", result);
+            Assert.Equal("c:\\test\\test\\test", result);
+            Assert.Null(error);
+
+            // tabs are the chars
+            str = new StringExpression("c:\test\test\test");
+            (result, error) = str.TryGetValue(data);
+            Assert.Equal("c:\test\test\test", result);
             Assert.Null(error);
         }
 
@@ -408,10 +414,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             Assert.Equal("Hello 13", result);
             Assert.Null(error);
 
-            val = new ValueExpression(@"c:\test\test\test");
-            Assert.Equal(@"=`c:\\test\\test\\test`", val.ExpressionText);
+            // slashes are the chars
+            val = new ValueExpression("c:\\test\\test\\test");
             (result, error) = val.TryGetValue(data);
-            Assert.Equal(@"c:\test\test\test", result);
+            Assert.Equal("c:\\test\\test\\test", result);
+            Assert.Null(error);
+
+            // tabs are the chars
+            val = new ValueExpression("c:\test\test\test");
+            (result, error) = val.TryGetValue(data);
+            Assert.Equal("c:\test\test\test", result);
             Assert.Null(error);
         }
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
     public class ExpressionPropertyTests
-    { 
+    {
         private object data = new
         {
             test = "hello",
@@ -360,6 +360,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             (result, error) = str.TryGetValue(data);
             Assert.Equal("Hello joe", result);
             Assert.Null(error);
+
+            str = new StringExpression(@"c:\test\test\test");
+            Assert.Equal(@"=`c:\\test\\test\\test`", str.ExpressionText);
+            (result, error) = str.TryGetValue(data);
+            Assert.Equal(@"c:\test\test\test", result);
+            Assert.Null(error);
         }
 
         [Fact]
@@ -400,6 +406,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             Assert.Equal(val.ToString(), JsonConvert.DeserializeObject<ValueExpression>(JsonConvert.SerializeObject(val, settings: settings), settings: settings).ToString());
             (result, error) = val.TryGetValue(data);
             Assert.Equal("Hello 13", result);
+            Assert.Null(error);
+
+            val = new ValueExpression(@"c:\test\test\test");
+            Assert.Equal(@"=`c:\\test\\test\\test`", val.ExpressionText);
+            (result, error) = val.TryGetValue(data);
+            Assert.Equal(@"c:\test\test\test", result);
             Assert.Null(error);
         }
 
@@ -738,19 +750,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         public class ImplicitCastTest
         {
-            public StringExpression Str { get; set; } 
+            public StringExpression Str { get; set; }
 
-            public IntExpression Int { get; set; } 
+            public IntExpression Int { get; set; }
 
-            public EnumExpression<TestEnum> Enm { get; set; } 
+            public EnumExpression<TestEnum> Enm { get; set; }
 
-            public NumberExpression Number { get; set; } 
+            public NumberExpression Number { get; set; }
 
-            public ValueExpression Value { get; set; } 
+            public ValueExpression Value { get; set; }
 
             public BoolExpression Bool { get; set; }
 
-            public ArrayExpression<string> Strings { get; set; } 
+            public ArrayExpression<string> Strings { get; set; }
         }
 
         [JsonConverter(typeof(StringEnumConverter), /*camelCase*/ true)]


### PR DESCRIPTION
Fixes #4192 
 
## Description
When encoding a string as an expression we need to properly handle slash.


## Testing
* tests updated to validate round-trip slashes