### PR TITLE
Add ImageAltText to CardAction

### DIFF
--- a/libraries/Microsoft.Bot.Schema/CardAction.cs
+++ b/libraries/Microsoft.Bot.Schema/CardAction.cs
@@ -109,5 +109,10 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "channelData")]
         public object ChannelData { get; set; }
 
+        /// <summary>
+        /// Gets or sets alternate image text to be used in place of the `image` field
+        /// </summary>
+        [JsonProperty(PropertyName = "imageAltText")]
+        public string ImageAltText { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #4041

This does not add the field to the constructor, since we are moving away from the huge constructor pattern.

Verified the new field is passed through to WebChat:

![image](https://user-images.githubusercontent.com/11055362/86056302-1bfd8a80-ba12-11ea-82fe-8700d6c4612d.png)

