### PR TITLE
Add null check for locale into MultiLanguageRecognizer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             var policy = new List<string>();
-            if (LanguagePolicy.TryGetValue(activity.Locale, out string[] targetpolicy))
+            if (activity.Locale != null && LanguagePolicy.TryGetValue(activity.Locale, out string[] targetpolicy))
             {
                 policy.AddRange(targetpolicy);
             }


### PR DESCRIPTION
Fixes #4219 

Adds null check for activity.Locale before calling LanguagePolicy.TryGetValue to avoid an exception being thrown.