### PR TITLE
add directlinespeech support to prompts

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 case Connector.Channels.Telegram:
                 case Connector.Channels.Emulator:
                 case Connector.Channels.Directline:
+                case Connector.Channels.DirectlineSpeech:
                 case Connector.Channels.Webchat:
                     return buttonCnt <= 100;
 
@@ -67,6 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 case Connector.Channels.Slack:
                 case Connector.Channels.Emulator:
                 case Connector.Channels.Directline:
+                case Connector.Channels.DirectlineSpeech:
                 case Connector.Channels.Webchat:
                 case Connector.Channels.Cortana:
                     return buttonCnt <= 100;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
@@ -70,6 +70,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        public void ShouldReturnTrueForSupportsSuggestedActionsWithDirectLineSpeechAnd100()
+        {
+            var supports = Channel.SupportsSuggestedActions(Channels.DirectlineSpeech, 100);
+            Assert.IsTrue(supports);
+        }
+
+        [TestMethod]
+        public void ShouldReturnTrueForSupportsCardActionsWithDirectLineSpeechAnd99()
+        {
+            var supports = Channel.SupportsCardActions(Channels.DirectlineSpeech, 99);
+            Assert.IsTrue(supports);
+        }
+
+        [TestMethod]
         public void ShouldReturnTrueForSupportsCardActionsWithLineAnd99()
         {
             var supports = Channel.SupportsCardActions(Channels.Line, 99);


### PR DESCRIPTION
Fixes in dotnet: microsoft/botframework-sdk#5950

## Description
Adds directlinespeech to Channel.cs which determines the SuggestedAction and CardAction support in the prompts.

The buttonCount limits follow Web Chat and Direct Line because this is in the context of Direct Line Speech via Web Chat.

## Specific Changes
- Adds directlinespeech to Channel.cs helper functions
- Add tests for Channel.cs changes

## Testing
Tested using Direct Line Speech and Web Chat via the repository's Microsoft.Bot.Builder.TestBot project.

Modified the Startup.cs to `UseWebSockets()` and used some of the [MainDialog code](https://github.com/microsoft/BotBuilder-Samples/blob/3738ec761d4e169d8ce31d28256e9e861d1bf634/samples/csharp_dotnetcore/06.using-cards/Dialogs/MainDialog.cs#L42-L52) from [06.using-cards](https://github.com/microsoft/BotBuilder-Samples/tree/3738ec761d4e169d8ce31d28256e9e861d1bf634/samples/csharp_dotnetcore/06.using-cards) so that the initial WaterfallDialog in TestBot instead began with a ChoicePrompt.

<details>

<summary><strong>Modified TestBot's MainDialog.cs</strong></summary>

```cs
// Copyright (c) Microsoft Corporation. All rights reserved.
// Licensed under the MIT License.

using System.Collections.Generic;
using System.Linq;
using System.Threading;
using System.Threading.Tasks;
using Microsoft.Bot.Builder;
using Microsoft.Bot.Builder.Dialogs;
using Microsoft.Bot.Builder.Dialogs.Choices;
using Microsoft.Bot.Schema;
using Microsoft.BotBuilderSamples.CognitiveModels;
using Microsoft.Extensions.Logging;

namespace Microsoft.BotBuilderSamples
{
    // A root dialog responsible of understanding user intents and dispatching them sub tasks.
    public class MainDialog : ComponentDialog
    {
        private readonly ILogger _logger;
        private readonly IRecognizer _luisRecognizer;

        public MainDialog(ILogger<MainDialog> logger, BookingDialog bookingDialog)
            : this(logger, null, bookingDialog)
        {
        }

        public MainDialog(ILogger<MainDialog> logger, IRecognizer luisRecognizer, BookingDialog bookingDialog)
            : base(nameof(MainDialog))
        {
            _logger = logger;
            _luisRecognizer = luisRecognizer;

            AddDialog(new TextPrompt(nameof(TextPrompt)));

            // Add bookingDialog intents
            AddDialog(bookingDialog);

            // Create and add waterfall for main conversation loop
            // NOTE: we use a different task step if LUIS is not configured.
            WaterfallStep[] steps;
            if (luisRecognizer == null)
            {
                steps = new WaterfallStep[]
                {
                    PromptForTaskActionAsync,
                    InvokeTaskActionAsyncNoLuis,
                    ResumeMainLoopActionAsync,
                };
            }
            else
            {
                // LUIS is configured
                steps = new WaterfallStep[]
                {
                    PromptForTaskActionAsync,
                    InvokeTaskActionAsync,
                    ResumeMainLoopActionAsync,
                };
            }

            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), steps));
            AddDialog(new ChoicePrompt(nameof(ChoicePrompt)));

            // The initial child Dialog to run.
            InitialDialogId = nameof(WaterfallDialog);
        }

        private async Task<DialogTurnResult> PromptForTaskActionAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
        {
            // Create the PromptOptions which contain the prompt and re-prompt messages.
            // PromptOptions also contains the list of choices available to the user.
            var options = new PromptOptions()
            {
                Prompt = MessageFactory.Text("What card would you like to see? You can click or type the card name"),
                RetryPrompt = MessageFactory.Text("That was not a valid choice, please select a card or number from 1 to 9."),
                Choices = GetChoices(),
            };

            // Prompt the user with the configured PromptOptions.
            return await stepContext.PromptAsync(nameof(ChoicePrompt), options, cancellationToken);

            if (_luisRecognizer == null)
            {
                var activity = MessageFactory.Text("NOTE: LUIS is not configured. To enable all capabilities, add 'LuisAppId', 'LuisAPIKey' and 'LuisAPIHostName' to the appsettings.json file.");
                activity.InputHint = InputHints.IgnoringInput;
                await stepContext.Context.SendActivityAsync(activity, cancellationToken);
            }

            // Use the text provided in ResumeMainLoopActionAsync or the default if it is the first time.
            var promptText = stepContext.Options?.ToString() ?? "What can I help you with today?";

            return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text(promptText) }, cancellationToken);
        }

        private async Task<DialogTurnResult> InvokeTaskActionAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
        {
            var luisResult = await _luisRecognizer.RecognizeAsync<FlightBooking>(stepContext.Context, cancellationToken);

            switch (luisResult.TopIntent().intent)
            {
                case FlightBooking.Intent.BookFlight:
                    // Initialize BookingDetails with any entities we may have found in the response.
                    var bookingDetails = new BookingDetails()
                    {
                        // Get destination and origin from the composite entities arrays.
                        Destination = luisResult.Entities.To?.FirstOrDefault()?.Airport?.FirstOrDefault()?.FirstOrDefault(),
                        Origin = luisResult.Entities.From?.FirstOrDefault()?.Airport?.FirstOrDefault()?.FirstOrDefault(),

                        // This value will be a TIMEX. And we are only interested in a Date so grab the first result and drop the Time part.
                        // TIMEX is a format that represents DateTime expressions that include some ambiguity. e.g. missing a Year.
                        TravelDate = luisResult.Entities.datetime?.FirstOrDefault()?.Expressions.FirstOrDefault()?.Split('T')[0],
                    };

                    // Run the BookingDialog giving it whatever details we have from the LUIS call, it will fill out the remainder.
                    return await stepContext.BeginDialogAsync(nameof(BookingDialog), bookingDetails, cancellationToken);

                case FlightBooking.Intent.GetWeather:
                    // We haven't implemented the GetWeatherDialog so we just display a TODO message.
                    await stepContext.Context.SendActivityAsync("TODO: get weather flow here", cancellationToken: cancellationToken);
                    break;

                default:
                    // Catch all for unhandled intents
                    await stepContext.Context.SendActivityAsync($"Sorry, I didn't get that. Please try asking in a different way (intent was {luisResult.TopIntent().intent})", cancellationToken: cancellationToken);
                    break;
            }

            return await stepContext.NextAsync(null, cancellationToken);
        }

        private async Task<DialogTurnResult> InvokeTaskActionAsyncNoLuis(WaterfallStepContext stepContext, CancellationToken cancellationToken)
        {
            // We only handle book a flight if LUIS is not configured
            return await stepContext.BeginDialogAsync(nameof(BookingDialog), new BookingDetails(), cancellationToken);
        }

        private async Task<DialogTurnResult> ResumeMainLoopActionAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
        {
            // We have completed the task (or the user cancelled), we restart main dialog with a different prompt text.
            var promptMessage = "What else can I do for you?";
            return await stepContext.ReplaceDialogAsync(Id, promptMessage, cancellationToken);
        }

        private IList<Choice> GetChoices()
        {
            var cardOptions = new List<Choice>()
            {
                new Choice() { Value = "Adaptive Card", Synonyms = new List<string>() { "adaptive" } },
                new Choice() { Value = "Animation Card", Synonyms = new List<string>() { "animation" } },
                new Choice() { Value = "Audio Card", Synonyms = new List<string>() { "audio" } },
                new Choice() { Value = "Hero Card", Synonyms = new List<string>() { "hero" } },
                new Choice() { Value = "OAuth Card", Synonyms = new List<string>() { "oauth" } },
                new Choice() { Value = "Receipt Card", Synonyms = new List<string>() { "receipt" } },
                new Choice() { Value = "Signin Card", Synonyms = new List<string>() { "signin" } },
                new Choice() { Value = "Thumbnail Card", Synonyms = new List<string>() { "thumbnail", "thumb" } },
                new Choice() { Value = "Video Card", Synonyms = new List<string>() { "video" } },
                new Choice() { Value = "All cards", Synonyms = new List<string>() { "all" } },
            };

            return cardOptions;
        }
    }
}
```

</details>

<details>
<summary><b>Screenshot of E2E test</b></summary>

![image](https://user-images.githubusercontent.com/14935595/86498892-c8a27980-bd3c-11ea-8af5-7e8eecf5a0ea.png)

</details>


