### PR TITLE
Add support for Facebook Message Read event

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookRead.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookRead.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
+{
+    /// <summary>A Facebook read message, including watermark of messages that were read.</summary>
+    public class FacebookRead
+    {
+        /// <summary>
+        /// Gets or sets the timestamp were messages were read.
+        /// </summary>
+        /// <value>
+        /// All messages that were sent before or at this timestamp were read.
+        /// </value>
+        [JsonProperty("watermark")]
+        public long Watermark { get; set; }
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
@@ -141,5 +141,13 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// <value>A <see cref="FacebookRequestThreadControl"/> holding the contents of the pass_thread_control property.</value>.
         [JsonProperty(PropertyName = "request_thread_control")]
         public FacebookRequestThreadControl RequestThreadControl { get; set; }
+
+        /// <summary>
+        ///  Gets or sets the contents of the message_reads property.
+        /// </summary>
+        /// <value>A <see cref="FacebookRead"/> holding the contents of the message_reads property.
+        /// See https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/message-reads. </value>.
+        [JsonProperty(PropertyName = "read")]
+        public FacebookRead Reads { get; set; }
     }
 }


### PR DESCRIPTION
See https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/message-reads

## Description
Add support for Facebook Read Message.
It may not be used by the Bot yet but it helps to better support the Facebook events and allow better reusability of the library outside of the "Bot" context in another project for example.

## Specific Changes
  - added FacebookRead.cs class for deserialisation of Facebook Event message_reads
  - added new property Reads on FacebookMessage
