### PR TITLE
Add code owners for /**/*.schema

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -116,3 +116,10 @@
 /libraries/Microsoft.Bot.Builder/Teams/**                                           @microsoft/bf-teams
 /tests/Microsoft.Bot.Builder.Tests/Teams/**                                         @microsoft/bf-teams
 /tests/Teams/**                                                                     @microsoft/bf-teams
+
+# Ownership by specific files or file types
+# This section MUST stay at the bottom of the CODEOWNERS file. For more information, see
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file
+
+# .schema files
+/**/*.schema                                                                        @chrimc62 @tomlm


### PR DESCRIPTION
## Description
Adds @chrimc62 & @tomlm as code owners for `/**/*.schema` at the **end** of the `CODEOWNERS` file to override all other code owners.

### Context
This change is to prevent the requiring of many code owners for the semi-ubiquitous `.schema` files as in https://github.com/microsoft/botbuilder-dotnet/pull/4243.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->