### PR TITLE
Added new Telemetry Track Event action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TelemetryTrackEventAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/TelemetryTrackEventAction.cs
@@ -1,0 +1,86 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
+{
+    /// <summary>
+    /// Track a custom event using IBotTelemetryClient.
+    /// </summary>
+    public class TelemetryTrackEventAction : Dialog
+    {
+        [JsonProperty("$kind")]
+        public const string Kind = "Microsoft.TelemetryTrackEventAction";
+
+        [JsonConstructor]
+        public TelemetryTrackEventAction(string eventName, Dictionary<string, StringExpression> properties = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        {
+            this.RegisterSourceLocation(callerPath, callerLine);
+            this.EventName = eventName;
+            this.Properties = properties;
+        }
+
+        /// <summary>
+        /// Gets or sets an optional expression which if is true will disable this action.
+        /// </summary>
+        /// <example>
+        /// "user.age > 18".
+        /// </example>
+        /// <value>
+        /// A boolean expression. 
+        /// </value>
+        [JsonProperty("disabled")]
+        public BoolExpression Disabled { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a name to use for the event.
+        /// </summary>
+        /// <value>The event name to use.</value>
+        [JsonProperty]
+        public StringExpression EventName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the properties to attach to the tracked event.
+        /// </summary>
+        /// <value>
+        /// A collection of properties to attach to the tracked event.
+        /// </value>
+        [JsonProperty]
+        public Dictionary<string, StringExpression> Properties { get; set; }
+
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (options is CancellationToken)
+            {
+                throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
+            }
+
+            if (this.Disabled != null && this.Disabled.GetValue(dc.State) == true)
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            if (this.EventName != null)
+            {
+                TelemetryClient.TrackEvent(
+                    this.EventName.GetValue(dc.State),
+                    this.Properties?.ToDictionary(kv => kv.Key, kv => kv.Value.GetValue(dc.State)));
+            }
+
+            return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override string OnComputeId()
+        {
+            return $"{this.GetType().Name}({EventName?.ToString()})";
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new DeclarativeType<GetActivityMembers>(GetActivityMembers.Kind);
             yield return new DeclarativeType<GetConversationMembers>(GetConversationMembers.Kind);
             yield return new DeclarativeType<SignOutUser>(SignOutUser.Kind);
+            yield return new DeclarativeType<TelemetryTrackEventAction>(TelemetryTrackEventAction.Kind);
 
             // Inputs
             yield return new DeclarativeType<AttachmentInput>(AttachmentInput.Kind);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -39,10 +39,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Schemas\Actions\Microsoft.TelemetryTrackEvent.schema" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -39,6 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Schemas\Actions\Microsoft.TelemetryTrackEvent.schema" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TelemetryTrackEvent.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TelemetryTrackEvent.schema
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+    "$role": "implements(Microsoft.IDialog)",
+    "type": "object",
+    "title": "Telemetry - Track Event",
+    "description": "Track a custom event using the registered Telemetry Client.",
+    "required": [
+        "url",
+        "method"
+    ],
+    "properties": {
+        "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Optional id for the dialog"
+        },
+        "disabled": {
+            "$ref": "schema:#/definitions/booleanExpression",
+            "title": "Disabled",
+            "description": "Optional condition which if true will disable this action.",
+            "examples": [
+                "user.age > 3"
+            ]
+        },
+        "eventName": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "Event Name",
+            "description": "The name of the event to track.",
+            "examples": [
+                "MyEventStarted",
+                "MyEventCompleted"
+            ]
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "schema:#/definitions/stringExpression"
+            },
+            "title": "Properties",
+            "description": "One or more properties to attach to the event being tracked."
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RichardSzalay.MockHttp;
@@ -547,6 +548,55 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     .AssertReply("test3")
                     .AssertReply("done")
                 .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task Action_TelemetryTrackEvent()
+        {
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
+
+            var testAdapter = new TestAdapter()
+                .UseStorage(new MemoryStorage())
+                .UseBotState(new ConversationState(new MemoryStorage()), new UserState(new MemoryStorage()));
+
+            var rootDialog = new AdaptiveDialog
+            {
+                Triggers = new List<OnCondition>()
+                {
+                    new OnBeginDialog()
+                    {
+                        Actions = new List<Dialog>()
+                        {
+                            new TelemetryTrackEventAction("testEvent")
+                            {
+                                Properties =
+                                    new Dictionary<string, AdaptiveExpressions.Properties.
+                                        StringExpression>()
+                                    {
+                                        { "prop1", "value1" }, 
+                                        { "prop2", "value2" }
+                                    }
+                            },
+                        }
+                    }
+                },
+                TelemetryClient = mockTelemetryClient.Object
+            };
+
+            var dm = new DialogManager(rootDialog)
+                .UseResourceExplorer(new ResourceExplorer())
+                .UseLanguageGeneration();
+            
+            await new TestFlow((TestAdapter)testAdapter, dm.OnTurnAsync)
+                .SendConversationUpdate()
+                .StartTestAsync();
+
+            var testEventInvocation = mockTelemetryClient.Invocations.FirstOrDefault(i => i.Arguments[0]?.ToString() == "testEvent");
+
+            Assert.IsNotNull(testEventInvocation);
+            Assert.IsTrue(((Dictionary<string, string>)testEventInvocation.Arguments[1]).Count == 2);
+            Assert.AreEqual(((Dictionary<string, string>)testEventInvocation.Arguments[1])["prop1"], "value1");
+            Assert.AreEqual(((Dictionary<string, string>)testEventInvocation.Arguments[1])["prop2"], "value2");
         }
     }
 }


### PR DESCRIPTION
Fixes #4234 

This adds an action, which will be surfaced within Composer, to allow a user to track a custom event using the telemetry client, along side the existing passive event tracking already present.