### PR TITLE
Dialog Abstraction

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return StringUtils.Hash(sb.ToString());
         }
 
-        public virtual IEnumerable<Dialog> GetDependencies()
+        public virtual IEnumerable<IDialog> GetDependencies()
         {
             foreach (var action in Actions)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("activityProcessed")]
         public BoolExpression ActivityProcessed { get; set; } = true;
 
-        public virtual IEnumerable<Dialog> GetDependencies()
+        public virtual IEnumerable<IDialog> GetDependencies()
         {
             if (Dialog?.Value != null)
             {
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// </summary>
         /// <param name="dc">dialogcontext.</param>
         /// <returns>dialog.</returns>
-        protected virtual Dialog ResolveDialog(DialogContext dc)
+        protected virtual IDialog ResolveDialog(DialogContext dc)
         {
             if (this.Dialog?.Value != null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EditActions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("changeType")]
         public EnumExpression<ActionChangeType> ChangeType { get; set; } = new EnumExpression<ActionChangeType>();
 
-        public virtual IEnumerable<Dialog> GetDependencies()
+        public virtual IEnumerable<IDialog> GetDependencies()
         {
             return this.Actions;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/IfCondition.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
-        public virtual IEnumerable<Dialog> GetDependencies()
+        public virtual IEnumerable<IDialog> GetDependencies()
         {
             yield return this.TrueScope;
             yield return this.FalseScope;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SwitchCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SwitchCondition.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
         }
 
-        public virtual IEnumerable<Dialog> GetDependencies()
+        public virtual IEnumerable<IDialog> GetDependencies()
         {
             yield return this.DefaultScope;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             return null;
         }
 
-        public IEnumerable<Dialog> GetDependencies()
+        public IEnumerable<IDialog> GetDependencies()
         {
             EnsureDependenciesInstalled();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return $"{this.GetType().Name}()";
         }
 
-        public virtual IEnumerable<Dialog> GetDependencies()
+        public virtual IEnumerable<IDialog> GetDependencies()
         {
             yield return this.ActionScope;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -208,6 +208,25 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
+        /// Adds a new <see cref="IDialog"/> to the component dialog and returns the updated component.
+        /// </summary>
+        /// <param name="dialog">The dialog to add.</param>
+        /// <returns>The <see cref="ComponentDialog"/> after the operation is complete.</returns>
+        /// <remarks>The added dialog's <see cref="Dialog.TelemetryClient"/> is set to the
+        /// <see cref="DialogContainer.TelemetryClient"/> of the component dialog.</remarks>
+        public ComponentDialog AddDialog(IDialog dialog)
+        {
+            this.Dialogs.Add(dialog);
+
+            if (this.InitialDialogId == null)
+            {
+                this.InitialDialogId = dialog.Id;
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Adds a new <see cref="Dialog"/> to the component dialog and returns the updated component.
         /// </summary>
         /// <param name="dialog">The dialog to add.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         /// <param name="more">label.</param>
         /// <param name="cancellationToken">cancellation token for async operations.</param>
         /// <returns>async task.</returns>
-        public static async Task DebuggerStepAsync(this DialogContext context, Dialog dialog, string more, CancellationToken cancellationToken)
+        public static async Task DebuggerStepAsync(this DialogContext context, IDialog dialog, string more, CancellationToken cancellationToken)
         {
             await context.GetDebugger().StepAsync(context, dialog, more, cancellationToken).ConfigureAwait(false);
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// Base class for all dialogs.
     /// </summary>
     [DebuggerDisplay("{Id}")]
-    public abstract class Dialog
+    public abstract class Dialog : IDialog
     {
         /// <summary>
         /// A <see cref="DialogTurnResult"/> that indicates that the current dialog is still

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Dialogs
 
         public abstract DialogContext CreateChildContext(DialogContext dc);
 
-        public virtual Dialog FindDialog(string dialogId)
+        public virtual IDialog FindDialog(string dialogId)
         {
             return this.Dialogs.Find(dialogId);
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <param name="dialogId">dialog id to find.</param>
         /// <returns>dialog with that id.</returns>
-        public Dialog FindDialog(string dialogId)
+        public IDialog FindDialog(string dialogId)
         {
             try
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// Root dialog to use to start conversation.
         /// </value>
-        public Dialog RootDialog
+        public IDialog RootDialog
         {
             get
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -11,11 +11,11 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Dialogs
 {
     /// <summary>
-    /// A collection of <see cref="Dialog"/> objects that can all call each other.
+    /// A collection of <see cref="IDialog"/> objects that can all call each other.
     /// </summary>
     public class DialogSet
     {
-        private readonly IDictionary<string, Dialog> _dialogs = new Dictionary<string, Dialog>();
+        private readonly IDictionary<string, IDialog> _dialogs = new Dictionary<string, IDialog>();
         private readonly IStatePropertyAccessor<DialogState> _dialogState;
         private IBotTelemetryClient _telemetryClient;
         private string _version;
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>The dialog set after the operation is complete.</returns>
         /// <remarks>The added dialog's <see cref="Dialog.TelemetryClient"/> is set to the
         /// <see cref="TelemetryClient"/> of the dialog set.</remarks>
-        public DialogSet Add(Dialog dialog)
+        public DialogSet Add(IDialog dialog)
         {
             // Ensure new version hash is computed
             _version = null;
@@ -181,11 +181,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
-        /// Searches the current <see cref="DialogSet"/> for a <see cref="Dialog"/> by its ID.
+        /// Searches the current <see cref="DialogSet"/> for a <see cref="IDialog"/> by its ID.
         /// </summary>
         /// <param name="dialogId">ID of the dialog to search for.</param>
         /// <returns>The dialog if found; otherwise <c>null</c>.</returns>
-        public Dialog Find(string dialogId)
+        public IDialog Find(string dialogId)
         {
             if (string.IsNullOrWhiteSpace(dialogId))
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             return null;
         }
 
-        public IEnumerable<Dialog> GetDialogs()
+        public IEnumerable<IDialog> GetDialogs()
         {
             return _dialogs.Values;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/IDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/IDialog.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
+
+namespace Microsoft.Bot.Builder.Dialogs
+{
+    public interface IDialog
+    {
+        public string Id { get; set; }
+
+        public IBotTelemetryClient TelemetryClient { get; set; }
+
+        public SourceRange Source { get; }
+
+        public abstract Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default);
+
+        public Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default);
+
+        public Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default);
+
+        public Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default);
+
+        public Task EndDialogAsync(ITurnContext turnContext, DialogInstance instance, DialogReason reason, CancellationToken cancellationToken = default);
+
+        public string GetVersion();
+
+        public Task<bool> OnDialogEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken);
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs/IDialogDependencies.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/IDialogDependencies.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Enumerate child dialog dependencies so they can be added to the containers dialogset.
         /// </summary>
         /// <returns>dialog enumeration.</returns>
-        IEnumerable<Dialog> GetDependencies();
+        IEnumerable<IDialog> GetDependencies();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// ## Prompt Usage
     ///
     /// When used with your bot's <see cref="DialogSet"/> you can simply add a new instance of the prompt as a named
-    /// dialog using <see cref="DialogSet.Add(Dialog)"/>. You can then start the prompt from a waterfall step using either
+    /// dialog using <see cref="DialogSet.Add(IDialog)"/>. You can then start the prompt from a waterfall step using either
     /// <see cref="DialogContext.BeginDialogAsync(string, object, CancellationToken)"/> or
     /// <see cref="DialogContext.PromptAsync(string, PromptOptions, CancellationToken)"/>. The user
     /// will be prompted to signin as needed and their access token will be passed as an argument to

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <typeparam name="T">The type of value the prompt returns.</typeparam>
     /// <remarks>When the prompt ends, it should return a <typeparamref name="T"/> object that
     /// represents the value that was prompted for.
-    /// Use <see cref="DialogSet.Add(Dialog)"/> or <see cref="ComponentDialog.AddDialog(Dialog)"/>
+    /// Use <see cref="DialogSet.Add(IDialog)"/> or <see cref="ComponentDialog.AddDialog(Dialog)"/>
     /// to add a prompt to a dialog set or component dialog, respectively.
     /// Use <see cref="DialogContext.PromptAsync(string, PromptOptions, CancellationToken)"/> or
     /// <see cref="DialogContext.BeginDialogAsync(string, object, CancellationToken)"/> to start the prompt.

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -1625,7 +1625,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
                 }
             }
 
-            public IEnumerable<Dialog> GetDependencies()
+            public IEnumerable<IDialog> GetDependencies()
             {
                 return Dialogs.GetDialogs();
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
@@ -425,7 +425,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     .ConfigureAwait(false);
             }
 
-            public IEnumerable<Dialog> GetDependencies()
+            public IEnumerable<IDialog> GetDependencies()
             {
                 return Dialogs.GetDialogs();
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 return await dc.BeginDialogAsync("d2", options: new { test = "123" });
             }
 
-            public IEnumerable<Dialog> GetDependencies()
+            public IEnumerable<IDialog> GetDependencies()
             {
                 return this.Dialogs.GetDialogs();
             }
@@ -562,7 +562,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 return await dc.BeginDialogAsync("d1");
             }
 
-            public IEnumerable<Dialog> GetDependencies()
+            public IEnumerable<IDialog> GetDependencies()
             {
                 return Dialogs.GetDialogs();
             }


### PR DESCRIPTION
Fixes #4260

## Description
The current Dialog structure is highly dependable on implementations, and not on abstractions. I.e.: If it's needed to add child dialogs into a Waterfall Dialog, a Dialog instance will have to be provided to the method `ComponentDialog.AddDialog(Dialog dialog)`. That prevents child Dialogs to be injected into the Parent Dialog constructor and to be used in the _AddDialog()_ method.

## Specific Changes
Abstracted the Dialog class into an IDialog interface. Created a public Interface called IDialog, and implemented it on _Dialog.cs_. The interface contains all the public members that are currently in _Dialog.cs_. _DialogSet.cs_ now have an IDictionary<string, IDialog> _dialogs, and all other references to Dialog.cs are abstract, pointing to IDialog instead. Extended the method ComponentDialog AddDialog(Dialog dialog), by adding ComponentDialog AddDialog(IDialog dialog). This prevents breaking changes.

Now it's possible to create IMyCustomDialog, implementing IDialog, and register it on my DI container. Then inject the child dialogs into the parent dialogs without having to concern about their dependencies. In Parent Dialog constructor, change the MyCustomDialog.Id to what's needed, and use it in AddDialog(MyCustomDialog).

## Testing
All unit tests are passing. No breaking changes detected.