### PR TITLE
Send trace for unhandled dialog events

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -64,8 +64,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Trace unhandled "versionChanged" and "error" events.
             if (!handled && (e.Name == DialogEvents.VersionChanged || e.Name == DialogEvents.Error))
             {
-                dc.Dialogs.TelemetryClient.TrackTrace($"Unhandled dialog event: {e.Name}. Active Dialog: {dc.ActiveDialog.Id}", Severity.Warning, null);
-                await dc.Context.TraceActivityAsync($"Unhandled dialog event: {e.Name}. Active Dialog: {dc.ActiveDialog.Id}", cancellationToken: cancellationToken)
+                var traceMessage = $"Unhandled dialog event: {e.Name}. Active Dialog: {dc.ActiveDialog.Id}";
+
+                dc.Dialogs.TelemetryClient.TrackTrace(traceMessage, Severity.Warning, null);
+
+                await dc.Context.TraceActivityAsync(traceMessage, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             var handled = await base.OnDialogEventAsync(dc, e, cancellationToken).ConfigureAwait(false);
 
-            // Trace unhandled "versionChanged" and "error" events.
-            if (!handled && (e.Name == DialogEvents.VersionChanged || e.Name == DialogEvents.Error))
+            // Trace unhandled "versionChanged" events.
+            if (!handled && e.Name == DialogEvents.VersionChanged)
             {
                 var traceMessage = $"Unhandled dialog event: {e.Name}. Active Dialog: {dc.ActiveDialog.Id}";
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -50,6 +50,13 @@ namespace Microsoft.Bot.Builder.Dialogs
             return this.Dialogs.Find(dialogId);
         }
 
+        /// <summary>
+        /// Called when an event has been raised, using `DialogContext.emitEvent()`, by either the current dialog or a dialog that the current dialog started.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of conversation.</param>
+        /// <param name="e">The event being raised.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>True if the event is handled by the current dialog and bubbling should stop.</returns>
         public override async Task<bool> OnDialogEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {
             var handled = await base.OnDialogEventAsync(dc, e, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #4269

Sends a trace activity and tracks a trace event, via the telemetry client, for unhandled versionChanged and error events.