### PR TITLE
Added FxCop and Async analyzers to the LUIS project.

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -9,6 +9,7 @@
   <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
     <Rule Id="CA1054" Action="None" /> <!-- UriParametersShouldNotBeStrings -->
     <Rule Id="CA1062" Action="None" /> <!-- ValidateArgumentsOfPublicMethods -->
+    <Rule Id="CA1822" Action="None" /> <!-- Mark members as static -->
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
     <Rule Id="CA1303" Action="None" /> <!-- DoNotPassLiteralsAsLocalizedParameters -->

--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -9,7 +9,7 @@
   <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
     <Rule Id="CA1054" Action="None" /> <!-- UriParametersShouldNotBeStrings -->
     <Rule Id="CA1062" Action="None" /> <!-- ValidateArgumentsOfPublicMethods -->
-    <Rule Id="CA1822" Action="None" /> <!-- Mark members as static -->
+    <Rule Id="CA1822" Action="None" /> <!-- Ignore Mark members as static -->
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
     <Rule Id="CA1303" Action="None" /> <!-- DoNotPassLiteralsAsLocalizedParameters -->

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.AI.Luis.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.AI.Luis.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/DynamicList.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/DynamicList.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// The lists to append on the extended list entity.
         /// </value>
         [JsonProperty(PropertyName = "list")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IList<ListElement> List { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Generator/GeographyV2.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Generator/GeographyV2.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <summary>
         /// Different types of geographic locations.
         /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat)
         public static class Types
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             /// <summary>
             /// Constant for LUIS geographic location type of POI.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Generator/InstanceData.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Generator/InstanceData.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// Any extra properties.
         /// </value>
         [JsonExtensionData(ReadData = true, WriteData = true)]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> Properties { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Generator/OrdinalV2.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Generator/OrdinalV2.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// <summary>
         /// Possible anchors for offsets.
         /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat)
         public static class Anchor
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             /// <summary>
             /// Constant for Offset anchor type of Current.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptiveRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptiveRecognizer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -97,15 +98,18 @@ namespace Microsoft.Bot.Builder.AI.Luis
             var wrapper = new LuisRecognizer(RecognizerOptions(dialogContext), HttpClient);
 
             // temp clone of turn context because luisrecognizer always pulls activity from turn context.
-            var tempContext = new TurnContext(dialogContext.Context.Adapter, activity);
-            foreach (var keyValue in dialogContext.Context.TurnState)
+            RecognizerResult result;
+            using (var tempContext = new TurnContext(dialogContext.Context.Adapter, activity))
             {
-                tempContext.TurnState[keyValue.Key] = keyValue.Value;
+                foreach (var keyValue in dialogContext.Context.TurnState)
+                {
+                    tempContext.TurnState[keyValue.Key] = keyValue.Value;
+                }
+
+                result = await wrapper.RecognizeAsync(tempContext, cancellationToken).ConfigureAwait(false);
             }
 
-            var result = await wrapper.RecognizeAsync(tempContext, cancellationToken).ConfigureAwait(false);
-
-            this.TrackRecognizerResult(dialogContext, "LuisResult", this.FillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext), telemetryMetrics);
+            TrackRecognizerResult(dialogContext, "LuisResult", FillRecognizerResultTelemetryProperties(result, telemetryProperties, dialogContext), telemetryMetrics);
 
             return result;
         }
@@ -159,9 +163,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
             {
                 { LuisTelemetryConstants.ApplicationIdProperty, applicationId },
                 { LuisTelemetryConstants.IntentProperty, topTwoIntents?[0].Key ?? string.Empty },
-                { LuisTelemetryConstants.IntentScoreProperty, topTwoIntents?[0].Value.Score?.ToString("N2") ?? "0.00" },
-                { LuisTelemetryConstants.Intent2Property, (topTwoIntents?.Count() > 1) ? topTwoIntents?[1].Key ?? string.Empty : string.Empty },
-                { LuisTelemetryConstants.IntentScore2Property, (topTwoIntents?.Count() > 1) ? topTwoIntents?[1].Value.Score?.ToString("N2") ?? "0.00" : "0.00" },
+                { LuisTelemetryConstants.IntentScoreProperty, topTwoIntents?[0].Value.Score?.ToString("N2", CultureInfo.InvariantCulture) ?? "0.00" },
+                { LuisTelemetryConstants.Intent2Property, (topTwoIntents?.Length > 1) ? topTwoIntents?[1].Key ?? string.Empty : string.Empty },
+                { LuisTelemetryConstants.IntentScore2Property, (topTwoIntents?.Length > 1) ? topTwoIntents?[1].Value.Score?.ToString("N2", CultureInfo.InvariantCulture) ?? "0.00" : "0.00" },
                 { LuisTelemetryConstants.FromIdProperty, dc.Context.Activity.From.Id },
             };
 

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         {
             if (!Uri.TryCreate(applicationEndpoint, UriKind.Absolute, out var uri))
             {
-                throw new ArgumentException(nameof(applicationEndpoint));
+                throw new ArgumentException($"Unable to create the LUIS endpoint with the given {applicationEndpoint}.", nameof(applicationEndpoint));
             }
 
             var applicationId = string.Empty;

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisDelegatingHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisDelegatingHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             // Bot Builder Package name and version.
-            var assemblyName = this.GetType().Assembly.GetName();
+            var assemblyName = GetType().Assembly.GetName();
             request.Headers.UserAgent.Add(new ProductInfoHeaderValue(assemblyName.Name, assemblyName.Version.ToString()));
 
             // Platform information: OS and language runtime.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisExtensions.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Bot.Builder.AI.Luis
@@ -41,7 +39,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
             }
 
             var di = new DirectoryInfo(botRoot);
-            foreach (var file in di.GetFiles($"luis.settings.{environment.ToLower()}.{luisRegion}.json", SearchOption.AllDirectories))
+#pragma warning disable CA1308 // Normalize strings to uppercase (file names are normalized as lowercase, ignoring)
+            foreach (var file in di.GetFiles($"luis.settings.{environment.ToLowerInvariant()}.{luisRegion}.json", SearchOption.AllDirectories))
+#pragma warning restore CA1308 // Normalize strings to uppercase
             {
                 var relative = file.FullName.Substring(di.FullName.Length);
                 if (!relative.Contains("bin\\") && !relative.Contains("obj\\"))

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV2.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV2.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
 
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +10,6 @@ using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.AI.Luis
 {
@@ -63,28 +61,24 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
             if (string.IsNullOrWhiteSpace(utterance))
             {
-                recognizerResult = new RecognizerResult
-                {
-                    Text = utterance
-                };
+                recognizerResult = new RecognizerResult { Text = utterance };
             }
             else
             {
                 var credentials = new ApiKeyServiceClientCredentials(Application.EndpointKey);
-                var runtime = new LUISRuntimeClient(credentials, httpClient, false)
+                using (var runtime = new LUISRuntimeClient(credentials, httpClient, false) { Endpoint = Application.Endpoint })
                 {
-                    Endpoint = Application.Endpoint,
-                };
-                luisResult = await runtime.Prediction.ResolveAsync(
-                    Application.ApplicationId,
-                    utterance,
-                    timezoneOffset: PredictionOptions.TimezoneOffset,
-                    verbose: PredictionOptions.IncludeAllIntents,
-                    staging: PredictionOptions.Staging,
-                    spellCheck: PredictionOptions.SpellCheck,
-                    bingSpellCheckSubscriptionKey: PredictionOptions.BingSpellCheckSubscriptionKey,
-                    log: PredictionOptions.Log ?? true,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    luisResult = await runtime.Prediction.ResolveAsync(
+                        Application.ApplicationId,
+                        utterance,
+                        timezoneOffset: PredictionOptions.TimezoneOffset,
+                        verbose: PredictionOptions.IncludeAllIntents,
+                        staging: PredictionOptions.Staging,
+                        spellCheck: PredictionOptions.SpellCheck,
+                        bingSpellCheckSubscriptionKey: PredictionOptions.BingSpellCheckSubscriptionKey,
+                        log: PredictionOptions.Log ?? true,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
 
                 recognizerResult = new RecognizerResult
                 {

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/Microsoft.Bot.Builder.AI.Luis.csproj
@@ -32,7 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
@@ -42,6 +45,10 @@
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Bot.Builder.Dialogs.Declarative\Microsoft.Bot.Builder.Dialogs.Declarative.csproj" />

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/DynamicList.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/DynamicList.cs
@@ -46,7 +46,9 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// The lists to append on the extended list entity.
         /// </value>
         [JsonProperty(PropertyName = "requestLists")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IList<ListElement> List { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Validate the object.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/ListElement.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/ListElement.cs
@@ -46,7 +46,9 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// The synonyms of the canonical form.
         /// </value>
         [JsonProperty(PropertyName = "synonyms")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IList<string> Synonyms { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Validate the object.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisApplication.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisApplication.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         {
             if (!Uri.TryCreate(applicationEndpoint, UriKind.Absolute, out var uri))
             {
-                throw new ArgumentException(nameof(applicationEndpoint));
+                throw new ArgumentException($"Unable to create the LUIS endpoint with the given {applicationEndpoint}.", nameof(applicationEndpoint));
             }
 
             string applicationId = null;

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisPredictionOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisPredictionOptions.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// <value>
         /// Dynamic lists of things like contact names to recognize at query time.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IList<DynamicList> DynamicLists { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets external entities recognized in the query.
@@ -82,7 +84,9 @@ namespace Microsoft.Bot.Builder.AI.LuisV3
         /// <value>
         /// External entities recognized in query.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IList<ExternalEntity> ExternalEntities { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets a value indicating whether external entities should override other means of recognizing entities.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/V3/LuisRecognizerOptions.cs
@@ -4,14 +4,13 @@
 using System;
 using System.Net.Http;
 using Newtonsoft.Json;
-using LuisV2 = Microsoft.Bot.Builder.AI.Luis;
 
 namespace Microsoft.Bot.Builder.AI.LuisV3
 {
     /// <summary>
     /// Optional parameters for a LUIS recognizer.
     /// </summary>
-     [Obsolete]
+     [Obsolete("This class has been deprecated, use Microsoft.Bot.Builder.AI.Luis.LuisRecognizerOptionsV2 or Microsoft.Bot.Builder.AI.Luis.LuisRecognizerOptionsV3 instead.")]
      public class LuisRecognizerOptions
     {
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             var recognizerWithTimeout = new LuisRecognizer(opts);
             Assert.IsNotNull(recognizerWithTimeout);
-            Assert.AreEqual(expectedTimeout, LuisRecognizer.DefaultHttpClient.Timeout.Milliseconds);
+            Assert.AreEqual(expectedTimeout, recognizerWithTimeout.HttpClient.Timeout.Milliseconds);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             };
             var recognizerWithTimeout = new LuisRecognizer(options);
             Assert.IsNotNull(recognizerWithTimeout);
-            Assert.AreEqual(expectedTimeout, LuisRecognizer.DefaultHttpClient.Timeout.Milliseconds);
+            Assert.AreEqual(expectedTimeout, recognizerWithTimeout.HttpClient.Timeout.Milliseconds);
         }
 
         [TestMethod]


### PR DESCRIPTION
Relates to #2367

- Added FxCop and Async analyzers to the LUIS project.
- I suppressed some Dispose warnings for now, we will address those once we start using HttpClientFactory in a future release.
- Deprecated the DefaultHttpClient static property in LuisRecognizeer and crated an internal HttpClient instance property that can be seen for testing (that's the only reason why is there).
- Added AssemblyInfo to make internal methods visible to tests.
- Added exclude for rule CA1822 (Mark members as static) as requested by Tom.
