### PR TITLE
Added FxCop Analyzers to the AdaptiveExpressions library.

### DIFF
--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -20,7 +20,7 @@
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
     <!-- CA2225: Operator overloads have named alternates, excluding for now, we should address this if we want to support other platforms than C#
-    see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019 -->
+    see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019 .-->
     <!-- CA1308: Normalize strings to uppercase. AdaptiveExpressions assumes all strings are normalized to lowercase 
     (see for details on this https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1308?view=vs-2019 rule) -->
     <NoWarn>$(NoWarn);CS1591;SX1309;CA2225;CA1308</NoWarn>

--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -19,9 +19,13 @@
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
+    <!-- CA2225: Operator overloads have named alternates, excluding for now, we should address this if we want to support other platforms than C#
+    see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019 -->
+    <!-- CA1308: Normalize strings to uppercase. AdaptiveExpressions assumes all strings are normalized to lowercase 
+    (see for details on this https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1308?view=vs-2019 rule) -->
+    <NoWarn>$(NoWarn);CS1591;SX1309;CA2225;CA1308</NoWarn>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>AdaptiveExpressions</PackageId>
@@ -38,7 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="Antlr4.CodeGenerator" Version="4.6.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -47,6 +50,10 @@
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.9" />

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Add.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Add.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -49,19 +50,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalAdd(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (a.IsInteger() && b.IsInteger())
             {
-                return Convert.ToInt64(a) + Convert.ToInt64(b);
+                return Convert.ToInt64(a, CultureInfo.InvariantCulture) + Convert.ToInt64(b, CultureInfo.InvariantCulture);
             }
-            else
-            {
-                return FunctionUtils.CultureInvariantDoubleConvert(a) + FunctionUtils.CultureInvariantDoubleConvert(b);
-            }
+
+            return FunctionUtils.CultureInvariantDoubleConvert(a) + FunctionUtils.CultureInvariantDoubleConvert(b);
         }
 
         private static void Validator(Expression expression)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/AddOrdinal.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/AddOrdinal.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -41,7 +42,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
         private static string EvalAddOrdinal(int num)
         {
             var hasResult = false;
-            var ordinalResult = num.ToString();
+            var ordinalResult = num.ToString(CultureInfo.InvariantCulture);
             if (num > 0)
             {
                 switch (num % 100)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/AddToTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/AddToTime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AdaptiveExpressions.Memory;
 
@@ -26,10 +27,10 @@ namespace AdaptiveExpressions.BuiltinFunctions
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {
-                var format = (args.Count() == 4) ? (string)args[3] : FunctionUtils.DefaultDateTimeFormat;
+                var format = (args.Count == 4) ? (string)args[3] : FunctionUtils.DefaultDateTimeFormat;
                 if (args[1].IsInteger() && args[2] is string timeUnit)
                 {
-                    (value, error) = EvalAddToTime(args[0], Convert.ToInt64(args[1]), timeUnit, format);
+                    (value, error) = EvalAddToTime(args[0], Convert.ToInt64(args[1], CultureInfo.InvariantCulture), timeUnit, format);
                 }
                 else
                 {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/And.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/And.cs
@@ -9,7 +9,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// Check whether all expressions are true. Return true if all expressions are true,
     /// or return false if at least one expression is false.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class And : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public And()
             : base(ExpressionType.And, Evaluator, ReturnType.Boolean, FunctionUtils.ValidateAtLeastOne)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Average.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Average.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -22,7 +23,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         args =>
                         {
                             var operands = FunctionUtils.ResolveListValue(args[0]).OfType<object>().ToList();
-                            return operands.Average(u => Convert.ToSingle(u));
+                            return operands.Average(u => Convert.ToSingle(u, CultureInfo.InvariantCulture));
                         },
                         FunctionUtils.VerifyNumericList);
         }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Binary.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Binary.cs
@@ -6,7 +6,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Return the binary version of a string.
     /// </summary>
+#pragma warning disable CA1724 // Type names should not match namespaces (by design and we can't change this without breaking binary compat)
     public class Binary : ExpressionEvaluator
+#pragma warning restore CA1724 // Type names should not match namespaces
     {
         public Binary()
             : base(ExpressionType.Binary, Evaluator(), ReturnType.Object, FunctionUtils.ValidateUnary)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Ceiling.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Ceiling.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -18,7 +19,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object Function(IReadOnlyList<object> args)
         {
-            return Math.Ceiling(Convert.ToDouble(args[0]));
+            return Math.Ceiling(Convert.ToDouble(args[0], CultureInfo.InvariantCulture));
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/ComparisonEvaluator.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/ComparisonEvaluator.cs
@@ -52,7 +52,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         {
                             result = function(args);
                         }
+#pragma warning disable CA1031 // Do not catch general exception types (we are capturing the exception and returning it)
                         catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             // NOTE: This should not happen in normal execution
                             error = e.Message;

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
@@ -26,7 +26,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {
-                var format = (args.Count() == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
+                var format = (args.Count == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
                 if (args[1] is string targetTimeZone)
                 {
                     (value, error) = EvalConvertFromUTC(args[0], targetTimeZone, format);

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertToUtc.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertToUtc.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AdaptiveExpressions.Memory;
 
@@ -26,10 +27,10 @@ namespace AdaptiveExpressions.BuiltinFunctions
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {
-                var format = (args.Count() == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
+                var format = (args.Count == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
                 if (args[1] is string sourceTimeZone)
                 {
-                    (value, error) = EvalConvertToUTC(args[0], sourceTimeZone, format);
+                    (value, error) = EvalConvertToUtc(args[0], sourceTimeZone, format);
                 }
                 else
                 {
@@ -40,7 +41,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             return (value, error);
         }
 
-        private static (string, string) EvalConvertToUTC(object sourceTimestamp, string sourceTimezone, string format)
+        private static (string, string) EvalConvertToUtc(object sourceTimestamp, string sourceTimezone, string format)
         {
             string error = null;
             string result = null;
@@ -49,14 +50,16 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (sourceTimestamp is string st)
                 {
-                    srcDt = DateTime.Parse(st);
+                    srcDt = DateTime.Parse(st, CultureInfo.InvariantCulture);
                 }
                 else
                 {
                     srcDt = (DateTime)sourceTimestamp;
                 }
             }
+#pragma warning disable CA1031 // Do not catch general exception types (we should probably do something about this but ignoring it for not)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = $"illegal time-stamp representation {sourceTimestamp}";
             }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/DataUriToString.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/DataUriToString.cs
@@ -17,7 +17,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static EvaluateExpressionDelegate Evaluator()
         {
-            return FunctionUtils.Apply(args => System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(args[0].ToString().Substring(args[0].ToString().IndexOf(",") + 1))), FunctionUtils.VerifyString);
+            return FunctionUtils.Apply(args => System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(args[0].ToString().Substring(args[0].ToString().IndexOf(",", StringComparison.Ordinal) + 1))), FunctionUtils.VerifyString);
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Date.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Date.cs
@@ -8,7 +8,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Return the date of a specified timestamp in m/dd/yyyy format.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class Date : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public Date()
             : base(ExpressionType.Date, Evaluator(), ReturnType.String, FunctionUtils.ValidateUnary)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/DateReadBack.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/DateReadBack.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using Microsoft.Recognizers.Text.DataTypes.TimexExpression;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -31,7 +32,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         if (error == null)
                         {
                             var timestamp2 = (DateTime)result;
-                            var timex = new TimexProperty(timestamp2.ToString("yyyy-MM-dd"));
+                            var timex = new TimexProperty(timestamp2.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
                             result = TimexRelativeConvert.ConvertTimexToStringRelative(timex, timestamp1);
                         }
                     }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Divide.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Divide.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -24,7 +25,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
         private static string Verify(object val, Expression expression, int pos)
         {
             var error = FunctionUtils.VerifyNumber(val, expression, pos);
-            if (error == null && (pos > 0 && Convert.ToSingle(val) == 0.0))
+            if (error == null && (pos > 0 && Convert.ToSingle(val, CultureInfo.InvariantCulture) == 0.0))
             {
                 error = $"Cannot divide by 0 from {expression}";
             }
@@ -34,19 +35,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalDivide(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (a.IsInteger() && b.IsInteger())
             {
-                return Convert.ToInt64(a) / Convert.ToInt64(b);
+                return Convert.ToInt64(a, CultureInfo.InvariantCulture) / Convert.ToInt64(b, CultureInfo.InvariantCulture);
             }
-            else
-            {
-                return FunctionUtils.CultureInvariantDoubleConvert(a) / FunctionUtils.CultureInvariantDoubleConvert(b);
-            }
+
+            return FunctionUtils.CultureInvariantDoubleConvert(a) / FunctionUtils.CultureInvariantDoubleConvert(b);
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/EndsWith.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/EndsWith.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace AdaptiveExpressions.BuiltinFunctions
 {
     /// <summary>
@@ -22,7 +24,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         {
                             var rawStr = FunctionUtils.ParseStringOrNull(args[0]);
                             var seekStr = FunctionUtils.ParseStringOrNull(args[1]);
-                            return rawStr.EndsWith(seekStr);
+                            return rawStr.EndsWith(seekStr, StringComparison.Ordinal);
                         }, FunctionUtils.VerifyStringOrNull);
         }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
@@ -53,7 +53,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 return args[0] == args[1] || (args[0] != null && args[0].Equals(args[1]));
             }
+#pragma warning disable CA1031 // Do not catch general exception types (we return false if it fails for whatever reason)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 return false;
             }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Float.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Float.cs
@@ -6,7 +6,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Convert the string version of a floating-point number to a floating-point number. You can use this function only when passing custom parameters to an app, such as a logic app.
     /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (by design and can't change this because of backward compat)
     public class Float : ExpressionEvaluator
+#pragma warning restore CA1720 // Identifier contains type name
     {
         public Float()
             : base(ExpressionType.Float, Evaluator(), ReturnType.Number, FunctionUtils.ValidateUnary)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Floor.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Floor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -18,7 +19,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object Function(IReadOnlyList<object> args)
         {
-            return Math.Floor(Convert.ToDouble(args[0]));
+            return Math.Floor(Convert.ToDouble(args[0], CultureInfo.InvariantCulture));
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/FormatDateTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/FormatDateTime.cs
@@ -27,11 +27,11 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             var timestamp = args[0];
                             if (timestamp is string tsString)
                             {
-                                (result, error) = ParseTimestamp(tsString, dt => dt.ToString(args.Count() == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture));
+                                (result, error) = ParseTimestamp(tsString, dt => dt.ToString(args.Count == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture));
                             }
                             else if (timestamp is DateTime dt)
                             {
-                                result = dt.ToString(args.Count() == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture);
+                                result = dt.ToString(args.Count == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture);
                             }
                             else
                             {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/FormatEpoch.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/FormatEpoch.cs
@@ -28,8 +28,8 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             if (timestamp.IsNumber())
                             {
                                 var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-                                dateTime = dateTime.AddSeconds(Convert.ToDouble(timestamp));
-                                result = dateTime.ToString(args.Count() == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture);
+                                dateTime = dateTime.AddSeconds(Convert.ToDouble(timestamp, CultureInfo.InvariantCulture));
+                                result = dateTime.ToString(args.Count == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture);
                             }
                             else
                             {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/FormatNumber.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/FormatNumber.cs
@@ -41,11 +41,13 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                 (precision, error) = FunctionUtils.ParseInt32(args[1]);
                                 try
                                 {
-                                    var number = Convert.ToDouble(args[0]);
+                                    var number = Convert.ToDouble(args[0], CultureInfo.InvariantCulture);
                                     var locale = args.Count == 3 ? new CultureInfo(args[2] as string) : CultureInfo.InvariantCulture;
-                                    result = number.ToString("N" + precision.ToString(), locale);
+                                    result = number.ToString("N" + precision, locale);
                                 }
+#pragma warning disable CA1031 // Do not catch general exception types (we are capturing the exception and returning it)
                                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                                 {
                                     error = $"{args[3]} is not a valid locale for formatNumber";
                                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/FormatTicks.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/FormatTicks.cs
@@ -27,13 +27,13 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             var timestamp = args[0];
                             if (timestamp.IsInteger())
                             {
-                                var ticks = Convert.ToInt64(timestamp);
+                                var ticks = Convert.ToInt64(timestamp, CultureInfo.InvariantCulture);
                                 var dateTime = new DateTime(ticks);
-                                result = dateTime.ToString(args.Count() == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture);
+                                result = dateTime.ToString(args.Count == 2 ? args[1].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture);
                             }
                             else
                             {
-                                error = $"formatTicks first arugment {timestamp} must be an integer";
+                                error = $"formatTicks first argument {timestamp} must be an integer";
                             }
 
                             return (result, error);

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetFutureTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetFutureTime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AdaptiveExpressions.Memory;
 
@@ -28,12 +29,12 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (args[0].IsInteger() && args[1] is string string1)
                 {
-                    var format = (args.Count() == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
+                    var format = (args.Count == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
                     Func<DateTime, DateTime> timeConverter;
-                    (timeConverter, error) = FunctionUtils.DateTimeConverter(Convert.ToInt64(args[0]), string1, false);
+                    (timeConverter, error) = FunctionUtils.DateTimeConverter(Convert.ToInt64(args[0], CultureInfo.InvariantCulture), string1, false);
                     if (error == null)
                     {
-                        value = timeConverter(DateTime.UtcNow).ToString(format);
+                        value = timeConverter(DateTime.UtcNow).ToString(format, CultureInfo.InvariantCulture);
                     }
                 }
                 else

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetPastTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetPastTime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AdaptiveExpressions.Memory;
 
@@ -28,12 +29,12 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (args[0].IsInteger() && args[1] is string string1)
                 {
-                    var format = (args.Count() == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
+                    var format = (args.Count == 3) ? (string)args[2] : FunctionUtils.DefaultDateTimeFormat;
                     Func<DateTime, DateTime> timeConverter;
-                    (timeConverter, error) = FunctionUtils.DateTimeConverter(Convert.ToInt64(args[0]), string1);
+                    (timeConverter, error) = FunctionUtils.DateTimeConverter(Convert.ToInt64(args[0], CultureInfo.InvariantCulture), string1);
                     if (error == null)
                     {
-                        value = timeConverter(DateTime.UtcNow).ToString(format);
+                        value = timeConverter(DateTime.UtcNow).ToString(format, CultureInfo.InvariantCulture);
                     }
                 }
                 else

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/If.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/If.cs
@@ -8,7 +8,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Check whether an expression is true or false. Based on the result, return a specified value.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class If : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public If()
             : base(ExpressionType.If, Evaluator, ReturnType.Object, Validator)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/IndexOf.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/IndexOf.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections;
 using AdaptiveExpressions.Memory;
 
@@ -26,7 +27,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     if (args[1] is string || args[1] == null)
                     {
-                        result = FunctionUtils.ParseStringOrNull(args[0]).IndexOf(FunctionUtils.ParseStringOrNull(args[1]));
+                        result = FunctionUtils.ParseStringOrNull(args[0]).IndexOf(FunctionUtils.ParseStringOrNull(args[1]), StringComparison.Ordinal);
                     }
                     else
                     {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Int.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Int.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
     /// <summary>
     /// Return the integer version of a string.
     /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (by design and can't change this because of backward compat)
     public class Int : ExpressionEvaluator
+#pragma warning restore CA1720 // Identifier contains type name
     {
         public Int()
             : base(ExpressionType.Int, Evaluator(), ReturnType.Number, FunctionUtils.ValidateUnary)
@@ -17,7 +20,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static EvaluateExpressionDelegate Evaluator()
         {
-            return FunctionUtils.Apply(args => Convert.ToInt64(args[0]));
+            return FunctionUtils.Apply(args => Convert.ToInt64(args[0], CultureInfo.InvariantCulture));
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/JPath.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/JPath.cs
@@ -34,7 +34,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     jsonObj = JObject.Parse(jsonStr);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (we should probably do something about this but ignoring it for now)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = $"{jsonStr} is not a valid JSON string";
                 }
@@ -54,7 +56,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     value = jsonObj.SelectTokens(jpath);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (we should probably do something about this but ignoring for now)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = $"{jpath} is not a valid path";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
@@ -10,7 +10,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Return the JavaScript Object Notation (JSON) type value or object of a string or XML.
     /// </summary>
+#pragma warning disable CA1724 // Type names should not match namespaces (by design and we can't change this without breaking binary compat)
     public class Json : ExpressionEvaluator
+#pragma warning restore CA1724 // Type names should not match namespaces
     {
         public Json()
             : base(ExpressionType.Json, Evaluator(), ReturnType.Object, Validator)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/LastIndexOf.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/LastIndexOf.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections;
 using System.Linq;
 using AdaptiveExpressions.Memory;
@@ -28,7 +29,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     if (args[1] is string || args[1] == null)
                     {
-                        result = FunctionUtils.ParseStringOrNull(args[0]).LastIndexOf(FunctionUtils.ParseStringOrNull(args[1]));
+                        result = FunctionUtils.ParseStringOrNull(args[0]).LastIndexOf(FunctionUtils.ParseStringOrNull(args[1]), StringComparison.Ordinal);
                     }
                     else
                     {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Max.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Max.cs
@@ -60,19 +60,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalMax(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (FunctionUtils.CultureInvariantDoubleConvert(a) > FunctionUtils.CultureInvariantDoubleConvert(b))
             {
                 return a;
             }
-            else
-            {
-                return b;
-            }
+
+            return b;
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Min.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Min.cs
@@ -60,19 +60,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalMin(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (FunctionUtils.CultureInvariantDoubleConvert(a) <= FunctionUtils.CultureInvariantDoubleConvert(b))
             {
                 return a;
             }
-            else
-            {
-                return b;
-            }
+
+            return b;
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Mod.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Mod.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
     /// <summary>
     /// Return the remainder from dividing two numbers. 
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class Mod : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public Mod()
             : base(ExpressionType.Mod, Evaluator(), ReturnType.Number, FunctionUtils.ValidateBinaryNumber)
@@ -22,7 +25,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         {
                             object value = null;
                             string error;
-                            if (Convert.ToInt64(args[1]) == 0)
+                            if (Convert.ToInt64(args[1], CultureInfo.InvariantCulture) == 0)
                             {
                                 error = $"Cannot mod by 0";
                             }
@@ -39,19 +42,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalMod(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (a.IsInteger() && b.IsInteger())
             {
-                return Convert.ToInt64(a) % Convert.ToInt64(b);
+                return Convert.ToInt64(a, CultureInfo.InvariantCulture) % Convert.ToInt64(b, CultureInfo.InvariantCulture);
             }
-            else
-            {
-                return FunctionUtils.CultureInvariantDoubleConvert(a) % FunctionUtils.CultureInvariantDoubleConvert(b);
-            }
+
+            return FunctionUtils.CultureInvariantDoubleConvert(a) % FunctionUtils.CultureInvariantDoubleConvert(b);
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Multiply.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Multiply.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -23,19 +24,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalMultiply(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (a.IsInteger() && b.IsInteger())
             {
-                return Convert.ToInt64(a) * Convert.ToInt64(b);
+                return Convert.ToInt64(a, CultureInfo.InvariantCulture) * Convert.ToInt64(b, CultureInfo.InvariantCulture);
             }
-            else
-            {
-                return FunctionUtils.CultureInvariantDoubleConvert(a) * FunctionUtils.CultureInvariantDoubleConvert(b);
-            }
+
+            return FunctionUtils.CultureInvariantDoubleConvert(a) * FunctionUtils.CultureInvariantDoubleConvert(b);
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Not.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Not.cs
@@ -9,7 +9,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// Check whether an expression is false.
     /// Return true if the expression is false, or return false if true.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class Not : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public Not()
             : base(ExpressionType.Not, Evaluator, ReturnType.Boolean, FunctionUtils.ValidateUnary)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/NotEqual.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/NotEqual.cs
@@ -52,7 +52,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 return args[0] == args[1] || (args[0] != null && args[0].Equals(args[1]));
             }
+#pragma warning disable CA1031 // Do not catch general exception types (we return false if the operation fails for whatever reason)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 return false;
             }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Optional.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Optional.cs
@@ -9,7 +9,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// For the MostSpecificSelector, this is a short hand so that instead of having to do A &amp; B and A you can do A &amp; optional(B) to mean the same thing.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class Optional : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public Optional()
             : base(ExpressionType.Optional, Evaluator, ReturnType.Boolean, FunctionUtils.ValidateUnaryBoolean)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Or.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Or.cs
@@ -9,7 +9,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// Check whether at least one expression is true.
     /// Return true if at least one expression is true, or return false if all are false.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class Or : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public Or()
             : base(ExpressionType.Or, Evaluator, ReturnType.Boolean, FunctionUtils.ValidateAtLeastOne)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/RemoveProperty.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/RemoveProperty.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json.Linq;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -20,7 +21,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             return FunctionUtils.Apply(args =>
             {
                 var newJobj = (JObject)args[0];
-                newJobj.Property(args[1].ToString()).Remove();
+                newJobj.Property(args[1].ToString(), StringComparison.Ordinal).Remove();
                 return newJobj;
             });
         }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Round.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Round.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -43,7 +44,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                     }
                                     else
                                     {
-                                        result = Math.Round(Convert.ToDouble(args[0]), digits);
+                                        result = Math.Round(Convert.ToDouble(args[0], CultureInfo.InvariantCulture), digits);
                                     }
                                 }
                             }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Select.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Select.cs
@@ -6,7 +6,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Operate on each element and return the new collection of transformed elements.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
     public class Select : ExpressionEvaluator
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public Select()
             : base(ExpressionType.Select, FunctionUtils.Foreach, ReturnType.Array, FunctionUtils.ValidateForeach)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Split.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Split.cs
@@ -32,7 +32,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                 seperator = FunctionUtils.ParseStringOrNull(args[1]);
                             }
 
-                            if (seperator == string.Empty)
+                            if (string.IsNullOrWhiteSpace(seperator))
                             {
                                 return inputStr.Select(c => c.ToString()).ToArray();
                             }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StartOfDay.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StartOfDay.cs
@@ -26,7 +26,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {
-                var format = (args.Count() == 2) ? (string)args[1] : FunctionUtils.DefaultDateTimeFormat;
+                var format = (args.Count == 2) ? (string)args[1] : FunctionUtils.DefaultDateTimeFormat;
                 (value, error) = StartOfDayWithError(args[0], format);
             }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StartOfHour.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StartOfHour.cs
@@ -26,7 +26,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {
-                var format = (args.Count() == 2) ? (string)args[1] : FunctionUtils.DefaultDateTimeFormat;
+                var format = (args.Count == 2) ? (string)args[1] : FunctionUtils.DefaultDateTimeFormat;
                 (value, error) = StartOfHourWithError(args[0], format);
             }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StartOfMonth.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StartOfMonth.cs
@@ -26,7 +26,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {
-                var format = (args.Count() == 2) ? (string)args[1] : FunctionUtils.DefaultDateTimeFormat;
+                var format = (args.Count == 2) ? (string)args[1] : FunctionUtils.DefaultDateTimeFormat;
                 (value, error) = StartOfMonthWithError(args[0], format);
             }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StartsWith.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StartsWith.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace AdaptiveExpressions.BuiltinFunctions
 {
     /// <summary>
@@ -21,7 +23,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         {
                             string rawStr = FunctionUtils.ParseStringOrNull(args[0]);
                             string seekStr = FunctionUtils.ParseStringOrNull(args[1]);
-                            return rawStr.StartsWith(seekStr);
+                            return rawStr.StartsWith(seekStr, StringComparison.Ordinal);
                         }, FunctionUtils.VerifyStringOrNull);
         }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/String.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/String.cs
@@ -8,7 +8,11 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Return the string version of a value.
     /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and can't break binary compat, excluding)
+#pragma warning disable CA1720 // Identifier contains type name (by design and can't change this because of backward compat)
     public class String : ExpressionEvaluator
+#pragma warning restore CA1720 // Identifier contains type name
+#pragma warning restore CA1716 // Identifiers should not match keywords
     {
         public String()
             : base(ExpressionType.String, Evaluator(), ReturnType.String, FunctionUtils.ValidateUnary)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Subtract.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Subtract.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -23,19 +24,22 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static object EvalSubtract(object a, object b)
         {
-            if (a == null || b == null)
+            if (a == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(a));
+            }
+
+            if (b == null)
+            {
+                throw new ArgumentNullException(nameof(b));
             }
 
             if (a.IsInteger() && b.IsInteger())
             {
-                return Convert.ToInt64(a) - Convert.ToInt64(b);
+                return Convert.ToInt64(a, CultureInfo.InvariantCulture) - Convert.ToInt64(b, CultureInfo.InvariantCulture);
             }
-            else
-            {
-                return FunctionUtils.CultureInvariantDoubleConvert(a) - FunctionUtils.CultureInvariantDoubleConvert(b);
-            }
+
+            return FunctionUtils.CultureInvariantDoubleConvert(a) - FunctionUtils.CultureInvariantDoubleConvert(b);
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/SubtractFromTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/SubtractFromTime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AdaptiveExpressions.Memory;
 
@@ -28,12 +29,12 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (args[1].IsInteger() && args[2] is string string2)
                 {
-                    var format = (args.Count() == 4) ? (string)args[3] : FunctionUtils.DefaultDateTimeFormat;
+                    var format = (args.Count == 4) ? (string)args[3] : FunctionUtils.DefaultDateTimeFormat;
                     Func<DateTime, DateTime> timeConverter;
-                    (timeConverter, error) = FunctionUtils.DateTimeConverter(Convert.ToInt64(args[1]), string2);
+                    (timeConverter, error) = FunctionUtils.DateTimeConverter(Convert.ToInt64(args[1], CultureInfo.InvariantCulture), string2);
                     if (error == null)
                     {
-                        (value, error) = FunctionUtils.NormalizeToDateTime(args[0], dt => (timeConverter(dt).ToString(format), null));
+                        (value, error) = FunctionUtils.NormalizeToDateTime(args[0], dt => (timeConverter(dt).ToString(format, CultureInfo.InvariantCulture), null));
                     }
                 }
                 else

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Sum.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Sum.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -22,7 +23,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         args =>
                         {
                             var operands = FunctionUtils.ResolveListValue(args[0]).OfType<object>().ToList();
-                            return operands.All(u => u.IsInteger()) ? operands.Sum(u => Convert.ToInt64(u)) : operands.Sum(u => Convert.ToSingle(u));
+                            return operands.All(u => u.IsInteger()) ? operands.Sum(u => Convert.ToInt64(u, CultureInfo.InvariantCulture)) : operands.Sum(u => Convert.ToSingle(u, CultureInfo.InvariantCulture));
                         },
                         FunctionUtils.VerifyNumericList);
         }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/TicksToDays.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/TicksToDays.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using AdaptiveExpressions.Memory;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -29,7 +30,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (args[0].IsInteger())
                 {
-                    value = Convert.ToDouble(args[0]) / TicksPerDay;
+                    value = Convert.ToDouble(args[0], CultureInfo.InvariantCulture) / TicksPerDay;
                 }
                 else
                 {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/TicksToHours.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/TicksToHours.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using AdaptiveExpressions.Memory;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -29,7 +30,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (args[0].IsInteger())
                 {
-                    value = Convert.ToDouble(args[0]) / TicksPerHour;
+                    value = Convert.ToDouble(args[0], CultureInfo.InvariantCulture) / TicksPerHour;
                 }
                 else
                 {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/TicksToMinutes.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/TicksToMinutes.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using AdaptiveExpressions.Memory;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -29,7 +30,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 if (args[0].IsInteger())
                 {
-                    value = Convert.ToDouble(args[0]) / TicksPerMinute;
+                    value = Convert.ToDouble(args[0], CultureInfo.InvariantCulture) / TicksPerMinute;
                 }
                 else
                 {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/TimeTransformEvaluator.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/TimeTransformEvaluator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -34,7 +35,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     if (args[1].IsInteger())
                     {
-                        var formatString = (args.Count() == 3 && args[2] is string string1) ? string1 : FunctionUtils.DefaultDateTimeFormat;
+                        var formatString = (args.Count == 3 && args[2] is string string1) ? string1 : FunctionUtils.DefaultDateTimeFormat;
                         (value, error) = FunctionUtils.NormalizeToDateTime(args[0], dt => 
                         {
                             var result = dt;
@@ -49,7 +50,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
                         if (error == null)
                         {
-                            value = Convert.ToDateTime(value).ToString(formatString);
+                            value = Convert.ToDateTime(value, CultureInfo.InvariantCulture).ToString(formatString, CultureInfo.InvariantCulture);
                         }
                     }
                     else

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UriHost.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UriHost.cs
@@ -50,7 +50,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     var host = uriBase.Host;
                     result = host.ToString();
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (we are capturing the exception and returning a generic error for all failures)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = "invalid operation, input uri should be an absolute URI";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UriPath.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UriPath.cs
@@ -49,7 +49,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     var uriBase = (Uri)result;
                     result = uriBase.AbsolutePath.ToString();
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (return generic error if the operation fails for whatever reason)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = "invalid operation, input uri should be an absolute URI";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UriPathAndQuery.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UriPathAndQuery.cs
@@ -47,7 +47,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 uriBase = new Uri(uri);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic error)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = "illegal URI string";
             }
@@ -59,7 +61,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     var pathAndQuery = uriBase.PathAndQuery;
                     result = pathAndQuery.ToString();
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic error)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = "invalid operation, input uri should be an absolute URI";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UriPort.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UriPort.cs
@@ -49,7 +49,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     var port = uriBase.Port;
                     result = Convert.ToInt32(port);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types  (capture any exception and return generic error)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = "invalid operation, input uri should be an absolute URI";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UriQuery.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UriQuery.cs
@@ -49,7 +49,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     var query = uriBase.Query;
                     result = query.ToString();
                 }
+#pragma warning disable CA1031 // Do not catch general exception types  (capture any exception and return generic error)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = "invalid operation, input uri should be an absolute URI";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UriScheme.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UriScheme.cs
@@ -50,7 +50,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     var scheme = uriBase.Scheme;
                     result = scheme.ToString();
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic error)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = "invalid operation, input uri should be an absolute URI";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/UtcNow.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/UtcNow.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Linq;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -18,7 +18,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static EvaluateExpressionDelegate Evaluator()
         {
-            return FunctionUtils.Apply(args => DateTime.UtcNow.ToString(args.Count() == 1 ? args[0].ToString() : FunctionUtils.DefaultDateTimeFormat));
+            return FunctionUtils.Apply(args => DateTime.UtcNow.ToString(args.Count == 1 ? args[0].ToString() : FunctionUtils.DefaultDateTimeFormat, CultureInfo.InvariantCulture));
         }
 
         private static void Validator(Expression expression)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/XPath.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/XPath.cs
@@ -11,7 +11,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// Check XML for nodes or values that match an XPath (XML Path Language) expression, and return the matching nodes or values.
     /// An XPath expression (referred to as XPath) helps you navigate an XML document structure so that you can select nodes or compute values in the XML content.
     /// </summary>
+#pragma warning disable CA1724 // Type names should not match namespaces (by design and we can't change this without breaking binary compat)
     public class XPath : ExpressionEvaluator
+#pragma warning restore CA1724 // Type names should not match namespaces
     {
         public XPath()
             : base(ExpressionType.XPath, Evaluator(), ReturnType.Object, Validator)
@@ -33,7 +35,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 doc.LoadXml(xmlObj.ToString());
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic error)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = "not valid xml input";
             }
@@ -65,7 +69,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         }
                     }
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic error)
                 catch
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = $"cannot evaluate the xpath query expression: {xpath.ToString()}";
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Xml.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Xml.cs
@@ -11,7 +11,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// <summary>
     /// Return the XML version of a string that contains a JSON object.
     /// </summary>
+#pragma warning disable CA1724 // Type names should not match namespaces (by design and we can't change this without breaking binary compat)
     public class Xml : ExpressionEvaluator
+#pragma warning restore CA1724 // Type names should not match namespaces
     {
         public Xml()
             : base(ExpressionType.Xml, Evaluator(), ReturnType.String, FunctionUtils.ValidateUnary)
@@ -26,22 +28,30 @@ namespace AdaptiveExpressions.BuiltinFunctions
         private static (object, string) ToXml(object contentToConvert)
         {
             string error = null;
-            XDocument xml;
             string result = null;
             try
             {
+                XDocument xml;
                 if (contentToConvert is string str)
                 {
-                    xml = XDocument.Load(JsonReaderWriterFactory.CreateJsonReader(Encoding.ASCII.GetBytes(str), new XmlDictionaryReaderQuotas()));
+                    using (var xmlDictionaryReader = JsonReaderWriterFactory.CreateJsonReader(Encoding.ASCII.GetBytes(str), new XmlDictionaryReaderQuotas()))
+                    {
+                        xml = XDocument.Load(xmlDictionaryReader);
+                    }
                 }
                 else
                 {
-                    xml = XDocument.Load(JsonReaderWriterFactory.CreateJsonReader(Encoding.ASCII.GetBytes(contentToConvert.ToString()), new XmlDictionaryReaderQuotas()));
+                    using (var xmlDictionaryReader = JsonReaderWriterFactory.CreateJsonReader(Encoding.ASCII.GetBytes(contentToConvert.ToString()), new XmlDictionaryReaderQuotas()))
+                    {
+                        xml = XDocument.Load(xmlDictionaryReader);
+                    }
                 }
 
                 result = xml.ToString().TrimStart('{').TrimEnd('}');
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic error)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = "Invalid json";
             }

--- a/libraries/AdaptiveExpressions/CommonRegex.cs
+++ b/libraries/AdaptiveExpressions/CommonRegex.cs
@@ -49,7 +49,9 @@ namespace AdaptiveExpressions
             {
                 AntlrParse(pattern);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (return false if parsing fails)
             catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 return false;
             }

--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -19,7 +19,9 @@ namespace AdaptiveExpressions
     /// Type expected from evaluating an expression.
     /// </summary>
     [Flags]
+#pragma warning disable CA1714 // Flags enums should have plural names (we can't change this without breaking binary compat)
     public enum ReturnType
+#pragma warning restore CA1714 // Flags enums should have plural names
     {
         /// <summary>
         /// True or false boolean value.
@@ -34,12 +36,16 @@ namespace AdaptiveExpressions
         /// <summary>
         /// Any value is possible.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (we can't change this without breaking binary compat)
         Object = 4,
+#pragma warning restore CA1720 // Identifier contains type name
 
         /// <summary>
         /// String value.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (we can't change this without breaking binary compat)
         String = 8,
+#pragma warning restore CA1720 // Identifier contains type name
 
         /// <summary>
         /// Array value.
@@ -112,7 +118,9 @@ namespace AdaptiveExpressions
         /// <value>
         /// Children expressions.
         /// </value>
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
         public Expression[] Children { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
 
         /// <summary>
         /// Gets expected result of evaluating expression.
@@ -192,7 +200,9 @@ namespace AdaptiveExpressions
                 {
                     value = function(state);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (capture the exception and return in in the error)
                 catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     error = e.Message;
                 }
@@ -242,7 +252,7 @@ namespace AdaptiveExpressions
         /// <returns>New expression.</returns>
         public static Expression AndExpression(params Expression[] children)
         {
-            if (children.Count() > 1)
+            if (children.Length > 1)
             {
                 return Expression.MakeExpression(ExpressionType.And, children);
             }
@@ -257,7 +267,7 @@ namespace AdaptiveExpressions
         /// <returns>New expression.</returns>
         public static Expression OrExpression(params Expression[] children)
         {
-            if (children.Count() > 1)
+            if (children.Length > 1)
             {
                 return Expression.MakeExpression(ExpressionType.Or, children);
             }
@@ -305,15 +315,15 @@ namespace AdaptiveExpressions
                 eq = this.Type == other.Type;
                 if (eq)
                 {
-                    eq = this.Children.Count() == other.Children.Count();
+                    eq = this.Children.Length == other.Children.Length;
                     if (this.Type == ExpressionType.And || this.Type == ExpressionType.Or)
                     {
                         // And/Or do not depend on order
-                        for (var i = 0; eq && i < this.Children.Count(); ++i)
+                        for (var i = 0; eq && i < this.Children.Length; ++i)
                         {
                             var primary = this.Children[i];
                             var found = false;
-                            for (var j = 0; j < this.Children.Count(); ++j)
+                            for (var j = 0; j < this.Children.Length; ++j)
                             {
                                 if (primary.DeepEquals(other.Children[j]))
                                 {
@@ -327,7 +337,7 @@ namespace AdaptiveExpressions
                     }
                     else
                     {
-                        for (var i = 0; eq && i < this.Children.Count(); ++i)
+                        for (var i = 0; eq && i < this.Children.Length; ++i)
                         {
                             eq = this.Children[i].DeepEquals(other.Children[i]);
                         }
@@ -440,7 +450,7 @@ namespace AdaptiveExpressions
                     var iteratorName = (string)(children[1].Children[0] as Constant).Value;
 
                     // filter references found in children 2 with iterator name
-                    var nonLocalRefs2 = refs2.Where(x => !(x.Equals(iteratorName) || x.StartsWith(iteratorName + '.') || x.StartsWith(iteratorName + '[')))
+                    var nonLocalRefs2 = refs2.Where(x => !(x.Equals(iteratorName, StringComparison.Ordinal) || x.StartsWith(iteratorName + '.', StringComparison.Ordinal) || x.StartsWith(iteratorName + '[', StringComparison.Ordinal)))
                                              .ToList();
 
                     refs.UnionWith(refs0);
@@ -565,52 +575,52 @@ namespace AdaptiveExpressions
 
                 if (typeof(T) == typeof(bool))
                 {
-                    return ((T)(object)Convert.ToBoolean(result), error);
+                    return ((T)(object)Convert.ToBoolean(result, CultureInfo.InvariantCulture), error);
                 }
 
                 if (typeof(T) == typeof(byte))
                 {
-                    return ((T)(object)Convert.ToByte(result), (Convert.ToByte(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToByte(result, CultureInfo.InvariantCulture), (Convert.ToByte(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(short))
                 {
-                    return ((T)(object)Convert.ToInt16(result), (Convert.ToInt16(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToInt16(result, CultureInfo.InvariantCulture), (Convert.ToInt16(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(int))
                 {
-                    return ((T)(object)Convert.ToInt32(result), (Convert.ToInt32(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToInt32(result, CultureInfo.InvariantCulture), (Convert.ToInt32(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(long))
                 {
-                    return ((T)(object)Convert.ToInt64(result), (Convert.ToInt64(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToInt64(result, CultureInfo.InvariantCulture), (Convert.ToInt64(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(ushort))
                 {
-                    return ((T)(object)Convert.ToUInt16(result), (Convert.ToUInt16(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToUInt16(result, CultureInfo.InvariantCulture), (Convert.ToUInt16(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(uint))
                 {
-                    return ((T)(object)Convert.ToUInt32(result), (Convert.ToUInt32(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToUInt32(result, CultureInfo.InvariantCulture), (Convert.ToUInt32(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(ulong))
                 {
-                    return ((T)(object)Convert.ToUInt64(result), (Convert.ToUInt64(result) == Convert.ToDouble(result)) ? null : Error<T>(result));
+                    return ((T)(object)Convert.ToUInt64(result, CultureInfo.InvariantCulture), (Convert.ToUInt64(result, CultureInfo.InvariantCulture) == Convert.ToDouble(result, CultureInfo.InvariantCulture)) ? null : Error<T>(result));
                 }
 
                 if (typeof(T) == typeof(float))
                 {
-                    return ((T)(object)Convert.ToSingle(Convert.ToDecimal(result)), null);
+                    return ((T)(object)Convert.ToSingle(Convert.ToDecimal(result, CultureInfo.InvariantCulture)), null);
                 }
 
                 if (typeof(T) == typeof(double))
                 {
-                    return ((T)(object)Convert.ToDouble(Convert.ToDecimal(result)), null);
+                    return ((T)(object)Convert.ToDouble(Convert.ToDecimal(result, CultureInfo.InvariantCulture)), null);
                 }
 
                 if (result == null)
@@ -620,7 +630,9 @@ namespace AdaptiveExpressions
 
                 return (JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(result)), null);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (just return an error)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 return (default(T), Error<T>(result));
             }
@@ -665,7 +677,7 @@ namespace AdaptiveExpressions
             // Generic version
             if (!valid)
             {
-                var infix = Type.Length > 0 && !char.IsLetter(Type[0]) && Children.Count() >= 2;
+                var infix = Type.Length > 0 && !char.IsLetter(Type[0]) && Children.Length >= 2;
                 if (!infix)
                 {
                     builder.Append(Type);
@@ -710,7 +722,11 @@ namespace AdaptiveExpressions
         /// <summary>
         /// FunctionTable is a dictionary which merges BuiltinFunctions.Functions with a CustomDictionary.
         /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat)
+#pragma warning disable CA1710 // Identifiers should have correct suffix (we can't change this without breaking binary compat)
         public class FunctionTable : IDictionary<string, ExpressionEvaluator>
+#pragma warning restore CA1710 // Identifiers should have correct suffix
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             private readonly ConcurrentDictionary<string, ExpressionEvaluator> customFunctions = new ConcurrentDictionary<string, ExpressionEvaluator>(StringComparer.InvariantCultureIgnoreCase);
 

--- a/libraries/AdaptiveExpressions/ExpressionProperties/ExpressionProperty.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/ExpressionProperty.cs
@@ -14,7 +14,7 @@ namespace AdaptiveExpressions.Properties
     /// <typeparam name="T">type of object the expression should evaluate to.</typeparam>
     public class ExpressionProperty<T> : IExpressionProperty
     {
-        private Expression expression;
+        private Expression _expression;
 
         public ExpressionProperty()
         {
@@ -22,7 +22,9 @@ namespace AdaptiveExpressions.Properties
 
         public ExpressionProperty(object value)
         {
+#pragma warning disable CA2214 // Do not call overridable methods in constructors (fixing this would require further redesign of this class and derived types, excluding it for now).
             SetValue(value);
+#pragma warning restore CA2214 // Do not call overridable methods in constructors
         }
 
         /// <summary>
@@ -31,7 +33,9 @@ namespace AdaptiveExpressions.Properties
         /// <value>
         /// the value to return when someone calls GetValue().
         /// </value>
+#pragma warning disable CA1721 // Property names should not match get methods (by design and we can't change it because of binary compat)
         public T Value { get; protected set; } = default(T);
+#pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets or sets the expression text to evaluate to get the value.
@@ -63,27 +67,27 @@ namespace AdaptiveExpressions.Properties
         /// <returns>expression.</returns>
         public virtual Expression ToExpression()
         {
-            if (this.expression != null)
+            if (this._expression != null)
             {
-                return expression;
+                return _expression;
             }
 
             if (this.ExpressionText != null)
             {
-                this.expression = Expression.Parse(this.ExpressionText.TrimStart('='));
-                return expression;
+                this._expression = Expression.Parse(this.ExpressionText.TrimStart('='));
+                return _expression;
             }
 
             if (this.Value == null || this.Value is string || this.Value.IsNumber() || this.Value.IsInteger() || this.Value is bool || this.Value.GetType().IsEnum)
             {
                 // return expression as constant
-                this.expression = Expression.Parse(this.Value.ToString());
-                return expression;
+                this._expression = Expression.Parse(this.Value.ToString());
+                return _expression;
             }
 
             // return expression for json object
-            this.expression = Expression.Parse($"json({JsonConvert.SerializeObject(this.Value)})");
-            return expression;
+            this._expression = Expression.Parse($"json({JsonConvert.SerializeObject(this.Value)})");
+            return _expression;
         }
 
         /// <summary>
@@ -103,14 +107,14 @@ namespace AdaptiveExpressions.Properties
         /// <returns>value.</returns>
         public virtual (T Value, string Error) TryGetValue(object data)
         {
-            if (expression == null && ExpressionText != null)
+            if (_expression == null && ExpressionText != null)
             {
-                this.expression = Expression.Parse(this.ExpressionText.TrimStart('='));
+                this._expression = Expression.Parse(this.ExpressionText.TrimStart('='));
             }
 
-            if (expression != null)
+            if (_expression != null)
             {
-                return expression.TryEvaluate<T>(data);
+                return _expression.TryEvaluate<T>(data);
             }
 
             return (Value, null);
@@ -122,7 +126,7 @@ namespace AdaptiveExpressions.Properties
         /// <param name="value">value to set.</param>
         public virtual void SetValue(object value)
         {
-            this.expression = null;
+            this._expression = null;
             this.Value = default(T);
             this.ExpressionText = null;
 
@@ -133,7 +137,7 @@ namespace AdaptiveExpressions.Properties
 
             if (value is Expression exp)
             {
-                this.expression = exp;
+                this._expression = exp;
                 this.ExpressionText = exp.ToString();
                 return;
             }

--- a/libraries/AdaptiveExpressions/ExpressionProperties/StringExpression.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/StringExpression.cs
@@ -89,12 +89,12 @@ namespace AdaptiveExpressions.Properties
             if (stringOrExpression != null)
             {
                 // if it starts with = it always is an expression
-                if (stringOrExpression.StartsWith("="))
+                if (stringOrExpression.StartsWith("=", StringComparison.Ordinal))
                 {
                     ExpressionText = stringOrExpression;
                     return;
                 }
-                else if (stringOrExpression.StartsWith("\\="))
+                else if (stringOrExpression.StartsWith("\\=", StringComparison.Ordinal))
                 {
                     // then trim off the escape char for equals (\=foo) should simply be the string (=foo), and not an expression (but it could still be stringTemplate)
                     stringOrExpression = stringOrExpression.TrimStart('\\');

--- a/libraries/AdaptiveExpressions/ExpressionProperties/ValueExpression.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/ValueExpression.cs
@@ -79,12 +79,12 @@ namespace AdaptiveExpressions.Properties
             if (stringOrExpression != null)
             {
                 // if it starts with = it always is an expression
-                if (stringOrExpression.StartsWith("="))
+                if (stringOrExpression.StartsWith("=", StringComparison.Ordinal))
                 {
                     ExpressionText = stringOrExpression;
                     return;
                 }
-                else if (stringOrExpression.StartsWith("\\="))
+                else if (stringOrExpression.StartsWith("\\=", StringComparison.Ordinal))
                 {
                     // then trim off the escape char for equals (\=foo) should simply be the string (=foo), and not an expression (but it could still be stringTemplate)
                     stringOrExpression = stringOrExpression.TrimStart('\\');

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -122,9 +122,15 @@ namespace AdaptiveExpressions
         public const string IsPresent = "isPresent";
 
         // Conversions
+#pragma warning disable CA1720 // Identifier contains type name (by design and can't change this because of backward compat)
         public const string Float = "float";
+#pragma warning restore CA1720 // Identifier contains type name
+#pragma warning disable CA1720 // Identifier contains type name (by design and can't change this because of backward compat)
         public const string Int = "int";
+#pragma warning restore CA1720 // Identifier contains type name
+#pragma warning disable CA1720 // Identifier contains type name (by design and can't change this because of backward compat)
         public const string String = "string";
+#pragma warning restore CA1720 // Identifier contains type name
         public const string Bool = "bool";
         public const string Binary = "binary";
         public const string Base64 = "base64";

--- a/libraries/AdaptiveExpressions/ExtensionsRewriters.cs
+++ b/libraries/AdaptiveExpressions/ExtensionsRewriters.cs
@@ -77,7 +77,7 @@ namespace AdaptiveExpressions
                         foreach (var child in expression.Children)
                         {
                             var clauses = Conjunctions(child).ToList();
-                            if (clauses.Count() == 0)
+                            if (!clauses.Any())
                             {
                                 // Encountered false
                                 sofar.Clear();

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -75,7 +75,7 @@ namespace AdaptiveExpressions
         {
             if (optional == null)
             {
-                optional = new ReturnType[0];
+                optional = Array.Empty<ReturnType>();
             }
 
             if (expression.Children.Length < types.Length || expression.Children.Length > types.Length + optional.Length)
@@ -209,7 +209,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking backward compat)
         public static string VerifyNumber(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!value.IsNumber())
@@ -227,7 +229,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyNumericList(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!TryParseList(value, out var list))
@@ -256,7 +260,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyNumericListOrNumber(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (value.IsNumber())
@@ -290,7 +296,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyContainer(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!(value is string) && !(value is IList) && !(value is IEnumerable))
@@ -308,7 +316,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyList(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!TryParseList(value, out var _))
@@ -345,7 +355,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyInteger(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!value.IsInteger())
@@ -363,7 +375,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyString(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!(value is string))
@@ -381,7 +395,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">expression.</param>
         /// <param name="number">number.</param>
         /// <returns>error message.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyStringOrNull(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (!(value is string) && value != null)
@@ -399,7 +415,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyNotNull(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (value == null)
@@ -417,7 +435,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyNumberOrString(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (value == null || (!value.IsNumber() && !(value is string)))
@@ -435,7 +455,9 @@ namespace AdaptiveExpressions
         /// <param name="expression">Expression that led to value.</param>
         /// <param name="number">No function.</param>
         /// <returns>Error.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
         public static string VerifyNumberOrStringOrNull(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
         {
             string error = null;
             if (value != null && !value.IsNumber() && !(value is string))
@@ -507,7 +529,9 @@ namespace AdaptiveExpressions
                     {
                         value = function(args);
                     }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return it in the error)
                     catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         error = e.Message;
                     }
@@ -538,7 +562,9 @@ namespace AdaptiveExpressions
                     {
                         (value, error) = function(args);
                     }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return it in the error)
                     catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         error = e.Message;
                     }
@@ -733,7 +759,7 @@ namespace AdaptiveExpressions
             value = null;
             if (instance != null)
             {
-                property = property.ToLower();
+                property = property.ToLowerInvariant();
 
                 // NOTE: what about other type of TKey, TValue?
                 if (instance is IDictionary<string, object> idict)
@@ -741,7 +767,7 @@ namespace AdaptiveExpressions
                     if (!idict.TryGetValue(property, out value))
                     {
                         // fall back to case insensitive
-                        var prop = idict.Keys.Where(k => k.ToLower() == property).SingleOrDefault();
+                        var prop = idict.Keys.Where(k => k.ToLowerInvariant() == property).SingleOrDefault();
                         if (prop != null)
                         {
                             isPresent = idict.TryGetValue(prop, out value);
@@ -761,7 +787,7 @@ namespace AdaptiveExpressions
                 {
                     // Use reflection
                     var type = instance.GetType();
-                    var prop = type.GetProperties().Where(p => p.Name.ToLower() == property).SingleOrDefault();
+                    var prop = type.GetProperties().Where(p => p.Name.ToLowerInvariant() == property).SingleOrDefault();
                     if (prop != null)
                     {
                         value = prop.GetValue(instance);
@@ -789,9 +815,11 @@ namespace AdaptiveExpressions
             string error = null;
             try
             {
-                result = Convert.ToInt32(obj);
+                result = Convert.ToInt32(obj, CultureInfo.InvariantCulture);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic message)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = $"{obj} must be a 32-bit signed integer.";
             }
@@ -981,14 +1009,14 @@ namespace AdaptiveExpressions
 
         internal static void ValidateForeach(Expression expression)
         {
-            if (expression.Children.Count() != 3)
+            if (expression.Children.Length != 3)
             {
-                throw new Exception($"foreach expect 3 parameters, found {expression.Children.Count()}");
+                throw new Exception($"foreach expect 3 parameters, found {expression.Children.Length}");
             }
 
             var second = expression.Children[1];
 
-            if (!(second.Type == ExpressionType.Accessor && second.Children.Count() == 1))
+            if (!(second.Type == ExpressionType.Accessor && second.Children.Length == 1))
             {
                 throw new Exception($"Second parameter of foreach is not an identifier : {second}");
             }
@@ -999,7 +1027,7 @@ namespace AdaptiveExpressions
             Func<DateTime, DateTime> converter = (dateTime) => dateTime;
             string error = null;
             var multiFlag = isPast ? -1 : 1;
-            switch (timeUnit.ToLower())
+            switch (timeUnit.ToLowerInvariant())
             {
                 case "second": converter = (dateTime) => dateTime.AddSeconds(multiFlag * interval); break;
                 case "minute": converter = (dateTime) => dateTime.AddMinutes(multiFlag * interval); break;
@@ -1052,7 +1080,9 @@ namespace AdaptiveExpressions
             {
                 convertedTimeZone = TimeZoneInfo.FindSystemTimeZoneById(convertedTimeZoneStr);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic message)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = $"{timezone} is an illegal timezone";
             }
@@ -1068,7 +1098,9 @@ namespace AdaptiveExpressions
             {
                 result = datetime.ToString(format, CultureInfo.InvariantCulture.DateTimeFormat);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic message)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = $"illegal format representation: {format}";
             }
@@ -1085,7 +1117,9 @@ namespace AdaptiveExpressions
             {
                 result = new Uri(uri);
             }
+#pragma warning disable CA1031 // Do not catch general exception types (capture any exception and return generic message)
             catch
+#pragma warning restore CA1031 // Do not catch general exception types
             {
                 error = $"{uri} is an illegal URI string";
             }
@@ -1122,7 +1156,7 @@ namespace AdaptiveExpressions
         {
             if (strToConvert == null)
             {
-                return new byte[] { };
+                return Array.Empty<byte>();
             }
 
             return Encoding.UTF8.GetBytes(strToConvert);
@@ -1198,7 +1232,7 @@ namespace AdaptiveExpressions
                     styles: DateTimeStyles.RoundtripKind,
                     result: out var parsed))
             {
-                if (parsed.ToString(DefaultDateTimeFormat).Equals(timeStamp, StringComparison.InvariantCultureIgnoreCase))
+                if (parsed.ToString(DefaultDateTimeFormat, CultureInfo.InvariantCulture).Equals(timeStamp, StringComparison.OrdinalIgnoreCase))
                 {
                     (result, error) = transform != null ? transform(parsed) : (parsed, null);
                 }

--- a/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/SimpleObjectMemory.cs
@@ -210,7 +210,7 @@ namespace AdaptiveExpressions.Memory
             {
                 // Use reflection
                 var type = instance.GetType();
-                var prop = type.GetProperties().Where(p => p.Name.ToLower() == property).SingleOrDefault();
+                var prop = type.GetProperties().Where(p => p.Name.ToLowerInvariant() == property).SingleOrDefault();
                 if (prop != null)
                 {
                     if (prop.CanWrite)

--- a/libraries/AdaptiveExpressions/Memory/StackedMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/StackedMemory.cs
@@ -11,7 +11,11 @@ namespace AdaptiveExpressions.Memory
     /// Stack implements of <see cref="IMemory"/>.
     /// Memory variables have a hierarchical relationship.
     /// </summary>
+#pragma warning disable CA1710 // Identifiers should have correct suffix (we can't change this without breaking binary compat)
+#pragma warning disable CA1010 // Generic interface should also be implemented (excluding for now, the designers of this package should evaluate complying in the future, for more info see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1010?view=vs-2019)
     public class StackedMemory : Stack<IMemory>, IMemory
+#pragma warning restore CA1010 // Generic interface should also be implemented
+#pragma warning restore CA1710 // Identifiers should have correct suffix
     {
         public static StackedMemory Wrap(IMemory memory)
         {

--- a/libraries/AdaptiveExpressions/TriggerTrees/Clause.cs
+++ b/libraries/AdaptiveExpressions/TriggerTrees/Clause.cs
@@ -41,7 +41,9 @@ namespace AdaptiveExpressions.TriggerTrees
         {
         }
 
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public Dictionary<string, string> AnyBindings { get => anyBindings; set => anyBindings = value; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         internal bool Subsumed { get; set; } = false;
 
@@ -94,9 +96,9 @@ namespace AdaptiveExpressions.TriggerTrees
         {
             var soFar = RelationshipType.Incomparable;
             var shorter = this;
-            var shorterCount = shorter.Children.Count();
+            var shorterCount = shorter.Children.Length;
             var longer = other;
-            var longerCount = longer.Children.Count();
+            var longerCount = longer.Children.Length;
             var swapped = false;
             if (longerCount < shorterCount)
             {

--- a/libraries/AdaptiveExpressions/TriggerTrees/Node.cs
+++ b/libraries/AdaptiveExpressions/TriggerTrees/Node.cs
@@ -175,7 +175,7 @@ namespace AdaptiveExpressions.TriggerTrees
             var op = Operation.None;
             if (!ops.TryGetValue(this, out op))
             {
-                var trigger = triggerNode.Triggers.First();
+                var trigger = triggerNode.Triggers[0];
                 var relationship = Relationship(triggerNode);
 #if TraceTree
                 if (Node.ShowTrace)
@@ -212,7 +212,7 @@ namespace AdaptiveExpressions.TriggerTrees
                             {
                                 _allTriggers.Add(trigger);
                                 var add = true;
-                                for (var i = 0; i < _triggers.Count();)
+                                for (var i = 0; i < _triggers.Count;)
                                 {
                                     var existing = _triggers[i];
                                     var reln = trigger.Relationship(existing, Tree.Comparers);

--- a/libraries/AdaptiveExpressions/TriggerTrees/Trigger.cs
+++ b/libraries/AdaptiveExpressions/TriggerTrees/Trigger.cs
@@ -221,7 +221,7 @@ namespace AdaptiveExpressions.TriggerTrees
                     foreach (var child in expression.Children)
                     {
                         var clauses = GenerateClauses(child);
-                        if (clauses.Count() == 0)
+                        if (!clauses.Any())
                         {
                             // Encountered false
                             soFar.Clear();
@@ -301,15 +301,15 @@ namespace AdaptiveExpressions.TriggerTrees
         private void RemoveDuplicatedPredicates()
         {
             // Rewrite clauses to remove duplicated tests
-            for (var i = 0; i < _clauses.Count(); ++i)
+            for (var i = 0; i < _clauses.Count; ++i)
             {
                 var clause = _clauses[i];
                 var children = new List<Expression>();
-                for (var p = 0; p < clause.Children.Count(); ++p)
+                for (var p = 0; p < clause.Children.Length; ++p)
                 {
                     var pred = clause.Children[p];
                     var found = false;
-                    for (var q = p + 1; q < clause.Children.Count(); ++q)
+                    for (var q = p + 1; q < clause.Children.Length; ++q)
                     {
                         if (pred.DeepEquals(clause.Children[q]))
                         {
@@ -331,12 +331,12 @@ namespace AdaptiveExpressions.TriggerTrees
         // Mark clauses that are more specific than another clause as subsumed and also remove any = clauses.
         private void MarkSubsumedClauses()
         {
-            for (var i = 0; i < _clauses.Count(); ++i)
+            for (var i = 0; i < _clauses.Count; ++i)
             {
                 var clause = _clauses[i];
                 if (!clause.Subsumed)
                 {
-                    for (var j = i + 1; j < _clauses.Count(); ++j)
+                    for (var j = i + 1; j < _clauses.Count; ++j)
                     {
                         var other = _clauses[j];
                         if (!other.Subsumed)
@@ -407,7 +407,7 @@ namespace AdaptiveExpressions.TriggerTrees
             var newExpr = expression;
             changed = false;
             if (expression.Type == ExpressionType.Accessor
-                && expression.Children.Count() == 1
+                && expression.Children.Length == 1
                 && expression.Children[0] is Constant cnst
                 && cnst.Value is string str
                 && str == variable)
@@ -526,10 +526,10 @@ namespace AdaptiveExpressions.TriggerTrees
             {
                 // NOTE: This is quadratic in clause length but GetHashCode is not equal for expressions and we expect the number of clauses to be small.
                 var predicates = new List<Expression>(clause.Children);
-                for (var i = 0; i < predicates.Count(); ++i)
+                for (var i = 0; i < predicates.Count; ++i)
                 {
                     var first = predicates[i];
-                    for (var j = i + 1; j < predicates.Count();)
+                    for (var j = i + 1; j < predicates.Count;)
                     {
                         var second = predicates[j];
                         if (first.DeepEquals(second))

--- a/libraries/AdaptiveExpressions/TriggerTrees/TriggerTree.cs
+++ b/libraries/AdaptiveExpressions/TriggerTrees/TriggerTree.cs
@@ -245,7 +245,9 @@ namespace AdaptiveExpressions.TriggerTrees
             return badNode;
         }
 
+#pragma warning disable CA1812 // Internal class that is apparently never instantiated (we can't remove the number parameter without breaking backward compat)
         private class Debugger
+#pragma warning restore CA1812 // Internal class that is apparently never instantiated
         {
             public Debugger(TriggerTree triggers)
             {

--- a/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
+++ b/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
@@ -129,7 +129,7 @@ namespace AdaptiveExpressions
             {
                 Expression result;
                 var symbol = context.GetText();
-                var normalized = symbol.ToLower();
+                var normalized = symbol.ToLowerInvariant();
                 if (normalized == "false")
                 {
                     result = Expression.ConstantExpression(false);
@@ -198,11 +198,11 @@ namespace AdaptiveExpressions
             public override Expression VisitStringAtom([NotNull] ExpressionAntlrParser.StringAtomContext context)
             {
                 var text = context.GetText();
-                if (text.StartsWith("'") && text.EndsWith("'"))
+                if (text.StartsWith("'", StringComparison.Ordinal) && text.EndsWith("'", StringComparison.Ordinal))
                 {
                     text = text.Substring(1, text.Length - 2).Replace("\\'", "'");
                 }
-                else if (text.StartsWith("\"") && text.EndsWith("\""))
+                else if (text.StartsWith("\"", StringComparison.Ordinal) && text.EndsWith("\"", StringComparison.Ordinal))
                 {
                     text = text.Substring(1, text.Length - 2).Replace("\\\"", "\"");
                 }
@@ -326,7 +326,7 @@ namespace AdaptiveExpressions
             {
                 var result = expression.Trim().TrimStart('$').Trim();
 
-                if (result.StartsWith("{") && result.EndsWith("}"))
+                if (result.StartsWith("{", StringComparison.Ordinal) && result.EndsWith("}", StringComparison.Ordinal))
                 {
                     result = result.Substring(1, result.Length - 2);
                 }


### PR DESCRIPTION
Relates to #2367

- Added project level exclusion for CA2225: Operator overloads have named alternates. This should be addressed as a separate issue if we want to support it (see https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2225?view=vs-2019 for additional details).
- Added project level exclusion for CA1308: Normalize strings to uppercase. This library assumes lowercase across the board.
- Added a lot of missing CultureInfo and StringComparision in string conversion calls.
- Added comments (the best I could) for all the places where we catch generic exceptions.
- Added #pragmas for several things that we can't change because of backward compat or design decisions (like creating classes that have the same names as native types in dotnet).
- Added comment and exclude in ExpressionProperty<T> related to CA2214 Do not call overridable methods in constructor (this should not be done but it will require redesigning the class and derived classes).
- Replaced calls to LINQ to Count() and Length() by their Count and Length properties where it applied.

