### PR TITLE
Support deep data binding for some properties

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             {
                 JToken value = null;
 
-                // evalute the value
+                // evaluate the value
                 var (val, error) = new ValueExpression(binding.Value).TryGetValue(dc.State);
 
                 if (error != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -103,13 +103,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             foreach (var binding in bindingOptions)
             {
+                JToken value = null;
+
                 // evalute the value
-                var (value, error) = new ValueExpression(binding.Value).TryGetValue(dc.State);
+                var (val, error) = new ValueExpression(binding.Value).TryGetValue(dc.State);
 
                 if (error != null)
                 {
                     throw new Exception(error);
                 }
+
+                if (val != null)
+                {
+                    value = JToken.FromObject(val).DeepClone();
+                }
+
+                value = value?.ReplaceJTokenRecursively(dc.State);
 
                 // and store in options as the result
                 ObjectPath.SetPathValue(boundOptions, binding.Key, value);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
@@ -79,10 +79,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     value = JToken.FromObject(result).DeepClone();
                 }
 
-                if (value != null)
-                {
-                    value = await value.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
-                }
+                value = value?.ReplaceJTokenRecursively(dc.State);
 
                 return await EndParentDialogAsync(dc, value, cancellationToken).ConfigureAwait(false);
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             if (this.Value != null)
             {
-                JToken value;
+                JToken value = null;
                 var (result, error) = this.Value.TryGetValue(dc.State);
 
                 if (error != null)
@@ -74,14 +74,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     throw new Exception($"Expression evaluation resulted in an error. Expression: {this.Value.ToString()}. Error: {error}");
                 }
 
-                value = JToken.FromObject(result).DeepClone();
+                if (result != null)
+                {
+                    value = JToken.FromObject(result).DeepClone();
+                }
 
                 if (value != null)
                 {
                     value = await value.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
                 }
 
-                return await EndParentDialogAsync(dc, result, cancellationToken).ConfigureAwait(false);
+                return await EndParentDialogAsync(dc, value, cancellationToken).ConfigureAwait(false);
             }
 
             return await EndParentDialogAsync(dc, result: null, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/EndDialog.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
@@ -65,7 +66,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             if (this.Value != null)
             {
+                JToken value;
                 var (result, error) = this.Value.TryGetValue(dc.State);
+
+                if (error != null)
+                {
+                    throw new Exception($"Expression evaluation resulted in an error. Expression: {this.Value.ToString()}. Error: {error}");
+                }
+
+                value = JToken.FromObject(result).DeepClone();
+
+                if (value != null)
+                {
+                    value = await value.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
+                }
+
                 return await EndParentDialogAsync(dc, result, cancellationToken).ConfigureAwait(false);
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             // Bind each string token to the data in state
             if (instanceBody != null)
             {
-                instanceBody = await ReplaceJTokenRecursivelyAsync(dc.State, instanceBody, cancellationToken).ConfigureAwait(false);
+                instanceBody = await instanceBody.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
             }
 
             // Set headers
@@ -383,50 +383,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         protected override string OnComputeId()
         {
             return $"{this.GetType().Name}[{Method} {Url?.ToString()}]";
-        }
-
-        private async Task<JToken> ReplaceJTokenRecursivelyAsync(object state, JToken token, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            switch (token.Type)
-            {
-                case JTokenType.Object:
-                    // NOTE: ToList() is required because JToken.Replace will break the enumeration.
-                    foreach (var child in token.Children<JProperty>().ToList())
-                    {
-                        child.Replace(await ReplaceJTokenRecursivelyAsync(state, child, cancellationToken).ConfigureAwait(false));
-                    }
-
-                    break;
-
-                case JTokenType.Array:
-                    // NOTE: ToList() is required because JToken.Replace will break the enumeration.
-                    foreach (var child in token.Children().ToList())
-                    {
-                        child.Replace(await ReplaceJTokenRecursivelyAsync(state, child, cancellationToken).ConfigureAwait(false));
-                    }
-
-                    break;
-
-                case JTokenType.Property:
-                    JProperty property = (JProperty)token;
-                    property.Value = await ReplaceJTokenRecursivelyAsync(state, property.Value, cancellationToken).ConfigureAwait(false);
-                    break;
-
-                default:
-                    if (token.Type == JTokenType.String)
-                    {
-                        // if it is a "{bindingpath}" then run through expression parser and treat as a value
-                        var (result, error) = new ValueExpression(token).TryGetValue(state);
-                        if (error == null)
-                        {
-                            token = JToken.FromObject(result);
-                        }
-                    }
-
-                    break;
-            }
-
-            return token;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -228,10 +228,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
 
             // Bind each string token to the data in state
-            if (instanceBody != null)
-            {
-                instanceBody = await instanceBody.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
-            }
+            instanceBody = instanceBody?.ReplaceJTokenRecursively(dc.State);
 
             // Set headers
             if (instanceHeaders != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
@@ -64,14 +64,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             foreach (var propValue in this.Assignments)
             {
-                JToken value;
+                JToken value = null;
                 var (val, valueError) = propValue.Value.TryGetValue(dc.State);
                 if (valueError != null)
                 {
                     throw new Exception($"Expression evaluation resulted in an error. Expression: {propValue.Value.ToString()}. Error: {valueError}");
                 }
 
-                value = JToken.FromObject(val).DeepClone();
+                if (val != null)
+                {
+                    value = JToken.FromObject(val).DeepClone();
+                }
 
                 if (value != null)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
@@ -76,10 +76,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     value = JToken.FromObject(val).DeepClone();
                 }
 
-                if (value != null)
-                {
-                    value = await value.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
-                }
+                value = value?.ReplaceJTokenRecursively(dc.State);
 
                 dc.State.SetValue(propValue.Property.GetValue(dc.State), value);
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 value = JToken.FromObject(val).DeepClone();
             }
 
+            if (value != null)
+            {
+                value = await value.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
+            }
+
             dc.State.SetValue(this.Property.GetValue(dc.State), value);
 
             dc.State.SetValue(DialogPath.Retries, 0);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
@@ -68,7 +69,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
 
             // SetProperty evaluates the "Value" expression and returns it as the result of the dialog
-            object value = null;
+            JToken value = null;
             if (this.Value != null)
             {
                 var (val, valueError) = this.Value.TryGetValue(dc.State);
@@ -77,7 +78,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     throw new Exception($"Expression evaluation resulted in an error. Expression: {this.Value.ToString()}. Error: {valueError}");
                 }
 
-                value = val;
+                value = JToken.FromObject(val).DeepClone();
             }
 
             dc.State.SetValue(this.Property.GetValue(dc.State), value);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -84,10 +84,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 }
             }
 
-            if (value != null)
-            {
-                value = await value.ReplaceJTokenRecursivelyAsync(dc.State, cancellationToken).ConfigureAwait(false);
-            }
+            value = value?.ReplaceJTokenRecursively(dc.State);
 
             dc.State.SetValue(this.Property.GetValue(dc.State), value);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -78,7 +78,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     throw new Exception($"Expression evaluation resulted in an error. Expression: {this.Value.ToString()}. Error: {valueError}");
                 }
 
-                value = JToken.FromObject(val).DeepClone();
+                if (val != null)
+                {
+                    value = JToken.FromObject(val).DeepClone();
+                }
             }
 
             if (value != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
@@ -24,10 +24,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         }
 
         /// <summary>
-        /// Achieve deep data binding with recursion.
+        /// Replaces the binding paths in a JSON Token value with the evaluated results recursively. Returns the final JSON Token value.
         /// </summary>
-        /// <param name="token">Input token.</param>
-        /// <param name="state">Memory scope.</param>
+        /// <param name="token">A JSON Token value which may have some binding paths.</param>
+        /// <param name="state">A scope for looking up variables.</param>
         /// <returns>Deep data binding result.</returns>
         public static JToken ReplaceJTokenRecursively(this JToken token, object state)
         {
@@ -41,7 +41,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     }
 
                     break;
-
                 case JTokenType.Array:
                     // NOTE: ToList() is required because JToken.Replace will break the enumeration.
                     foreach (var child in token.Children().ToList())
@@ -50,12 +49,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     }
 
                     break;
-
                 case JTokenType.Property:
                     JProperty property = (JProperty)token;
                     property.Value = property.Value.ReplaceJTokenRecursively(state);
                     break;
-
                 default:
                     if (token.Type == JTokenType.String)
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
@@ -28,9 +28,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <param name="token">Input token.</param>
         /// <param name="state">Memory scope.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Deep data binding result.</returns>
-        public static async Task<JToken> ReplaceJTokenRecursivelyAsync(this JToken token, object state, CancellationToken cancellationToken = default(CancellationToken))
+        public static JToken ReplaceJTokenRecursively(this JToken token, object state)
         {
             switch (token.Type)
             {
@@ -38,7 +37,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     // NOTE: ToList() is required because JToken.Replace will break the enumeration.
                     foreach (var child in token.Children<JProperty>().ToList())
                     {
-                        child.Replace(await child.ReplaceJTokenRecursivelyAsync(state, cancellationToken).ConfigureAwait(false));
+                        child.Replace(child.ReplaceJTokenRecursively(state));
                     }
 
                     break;
@@ -47,14 +46,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     // NOTE: ToList() is required because JToken.Replace will break the enumeration.
                     foreach (var child in token.Children().ToList())
                     {
-                        child.Replace(await child.ReplaceJTokenRecursivelyAsync(state, cancellationToken).ConfigureAwait(false));
+                        child.Replace(child.ReplaceJTokenRecursively(state));
                     }
 
                     break;
 
                 case JTokenType.Property:
                     JProperty property = (JProperty)token;
-                    property.Value = await property.Value.ReplaceJTokenRecursivelyAsync(state, cancellationToken).ConfigureAwait(false);
+                    property.Value = property.Value.ReplaceJTokenRecursively(state);
                     break;
 
                 default:

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/JsonExtensions.cs
@@ -1,6 +1,10 @@
 ﻿// Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
@@ -17,6 +21,57 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Achieve deep data binding with recursion.
+        /// </summary>
+        /// <param name="token">Input token.</param>
+        /// <param name="state">Memory scope.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Deep data binding result.</returns>
+        public static async Task<JToken> ReplaceJTokenRecursivelyAsync(this JToken token, object state, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    // NOTE: ToList() is required because JToken.Replace will break the enumeration.
+                    foreach (var child in token.Children<JProperty>().ToList())
+                    {
+                        child.Replace(await child.ReplaceJTokenRecursivelyAsync(state, cancellationToken).ConfigureAwait(false));
+                    }
+
+                    break;
+
+                case JTokenType.Array:
+                    // NOTE: ToList() is required because JToken.Replace will break the enumeration.
+                    foreach (var child in token.Children().ToList())
+                    {
+                        child.Replace(await child.ReplaceJTokenRecursivelyAsync(state, cancellationToken).ConfigureAwait(false));
+                    }
+
+                    break;
+
+                case JTokenType.Property:
+                    JProperty property = (JProperty)token;
+                    property.Value = await property.Value.ReplaceJTokenRecursivelyAsync(state, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                default:
+                    if (token.Type == JTokenType.String)
+                    {
+                        // if it is a "{bindingpath}" then run through expression parser and treat as a value
+                        var (result, error) = new ValueExpression(token).TryGetValue(state);
+                        if (error == null)
+                        {
+                            token = JToken.FromObject(result);
+                        }
+                    }
+
+                    break;
+            }
+
+            return token;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperties.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperties.test.dialog
@@ -28,10 +28,14 @@
                                 "value": "='billybob'"
                             },
                             {
+                                "property": "user.profile.userName",
+                                "value": "jack"
+                            },
+                            {
                                 "property": "user.profile",
                                 "value":
                                 {
-                                    "name": "${sentenceCase('jack')}",
+                                    "name": "${sentenceCase(user.profile.userName)}",
                                     "age": "${10 * 2}"
                                 }
                             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperties.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperties.test.dialog
@@ -26,6 +26,14 @@
                             {
                                 "property": "$p4",
                                 "value": "='billybob'"
+                            },
+                            {
+                                "property": "user.profile",
+                                "value":
+                                {
+                                    "name": "${sentenceCase('jack')}",
+                                    "age": "${10 * 2}"
+                                }
                             }
                         ]
                     },
@@ -44,6 +52,10 @@
                     {
                         "$kind": "Microsoft.SendActivity",
                         "activity": "${$p4}"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${user.profile.name}"
                     }
                 ]
             }
@@ -68,6 +80,10 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "billybob"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Jack"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
@@ -73,9 +73,14 @@
                     },
                     {
                         "$kind": "Microsoft.SetProperty",
+                        "property": "user.profile.userName",
+                        "value": "jack"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
                         "property": "user.profile",
                         "value": {
-                            "name": "${sentenceCase('jack')}",
+                            "name": "${sentenceCase(user.profile.userName)}",
                             "age": "${10 * 2}"
                         }
                     },

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SetProperty.test.dialog
@@ -70,6 +70,18 @@
                     {
                         "$kind": "Microsoft.SendActivity",
                         "activity": "${user.$instance.name}"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.profile",
+                        "value": {
+                            "name": "${sentenceCase('jack')}",
+                            "age": "${10 * 2}"
+                        }
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${user.profile.name}"
                     }
                 ]
             }
@@ -90,6 +102,10 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "name"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Jack"
         }
     ]
 }


### PR DESCRIPTION
Fixes #4050

## Description
support deep data binding for the following properties:
- `Value` property in `SetProperty`
- `Assignments` (for `SetProperties`)
- `Value` property in `EndDialog`
- `Body` in `HTTPRequest`
- `options` in `BeginDialog` action

 For example, `Value` property in `SetProperty` action, 
```
{
    "$kind": "Microsoft.SetProperty",
    "property": "user.profile",
    "value": {
        "name": "${sentenceCase('jack')}",
        "age": "${10 * 2}"
    }
}
```
Before, Object 
```
{
    "name": "${sentenceCase('jack')}",
    "age": "${10 * 2}"
}
```
would assign to variable `user.profile`, and the result of `user.profile.name` is `${sentenceCase('jack')}`

After, Object
```
{
    "name": "Jack",
    "age": "20"
}
```
would assign to variable `user.profile`, and the result of `user.profile.name` is `Jack`

The same with other 4 properties, arbitrary depth data binding is enabled.