### PR TITLE
Added FxCop to Dialogs.Debugging.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/SemaphoreSlimExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/SemaphoreSlimExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// <summary>
     /// Extension method implementing await for <see cref="SemaphoreSlim"/>.
     /// </summary>
-    public static partial class Extensions
+    public static class SemaphoreSlimExtensions
     {
         public static async Task<Releaser> WithWaitAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken)
         {
@@ -18,7 +18,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             return new Releaser(semaphore);
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
+#pragma warning disable CA1815 // Override equals and operator equals on value types (we don't seem to need this in code, excluding for now)
         public struct Releaser : IDisposable
+#pragma warning restore CA1815 // Override equals and operator equals on value types
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Releaser(SemaphoreSlim semaphore)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ICoercion.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ICoercion.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
@@ -19,13 +20,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
         object ICoercion.Coerce(object source, Type target)
         {
-            var token = source as JToken;
-            if (token != null)
+            if (source is JToken token)
             {
                 return token.ToObject(target);
             }
 
-            return Convert.ChangeType(source, target);
+            return Convert.ChangeType(source, target, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebugTransport.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebugTransport.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -10,13 +11,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging.Debug;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public abstract class DebugTransport
+    public abstract class DebugTransport : IDisposable
     {
         private const string Prefix = @"Content-Length: ";
         private static readonly Encoding Encoding = Encoding.ASCII;
@@ -27,12 +27,52 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         private StreamReader reader;
         private StreamWriter writer;
 
+        // To detect redundant calls to dispose
+        private bool _disposed;
+        
         protected DebugTransport(ILogger logger)
         {
             this.Logger = logger ?? NullLogger.Instance;
         }
 
         protected ILogger Logger { get; set; }
+
+        /// <summary>
+        /// Disposes the object instance a releases any related objects owned by the class.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes objected used by the class.
+        /// </summary>
+        /// <param name="disposing">A Boolean that indicates whether the method call comes from a Dispose method (its value is true) or from a finalizer (its value is false).</param>
+        /// <remarks>
+        /// The disposing parameter should be false when called from a finalizer, and true when called from the IDisposable.Dispose method.
+        /// In other words, it is true when deterministically called and false when non-deterministically called.
+        /// </remarks>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // Dispose managed objects owned by the class here.
+                connected?.Dispose();
+                readable?.Dispose();
+                writable?.Dispose();
+                reader?.Dispose();
+                writer?.Dispose();
+            }
+
+            _disposed = true;
+        }
 
         protected async Task ListenAsync(IPEndPoint point, CancellationToken cancellationToken)
         {
@@ -77,7 +117,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                             }
                         }
                     }
+#pragma warning disable CA1031 // Do not catch general exception types (we just log the exception and we continue the execution)
                     catch (Exception error)
+#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         this.Logger.LogError(error, error.Message);
                     }
@@ -112,12 +154,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                         throw new InvalidOperationException();
                     }
 
-                    if (!line.StartsWith(Prefix))
+                    if (!line.StartsWith(Prefix, StringComparison.Ordinal))
                     {
                         throw new InvalidOperationException();
                     }
 
-                    var count = int.Parse(line.Substring(Prefix.Length));
+                    var count = int.Parse(line.Substring(Prefix.Length), CultureInfo.InvariantCulture);
 
                     var buffer = new char[count];
                     int index = 0;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
@@ -188,13 +188,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
         private static bool PathEquals(string one, string two)
         {
-            var ext1 = Path.GetExtension(one).ToLower();
+            var ext1 = Path.GetExtension(one).ToLowerInvariant();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // we want to be case insensitive on windows
-                one = one.ToLower();
-                two = two.ToLower();
+                one = one.ToLowerInvariant();
+                two = two.ToLowerInvariant();
             }
 
             // if it's resource path, we only care about resource name
@@ -301,7 +301,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public sealed class Row
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Row(Protocol.Source source, Protocol.SourceBreakpoint sourceBreakpoint)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
@@ -22,7 +20,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         /// <param name="codeModel">ICodeModel to use (default is internal implementation).</param>
         /// <param name="dataModel">IDataModel to use (default is internal implementation).</param>
         /// <param name="logger">ILogger to use (Default is NullLogger).</param>
-        /// <param name="coercion">ICoercion to use (default is internal implementation).</param>
         /// <returns>The <see cref="BotAdapter"/>.</returns>
         public static BotAdapter UseDebugger(
             this BotAdapter botAdapter, 
@@ -33,13 +30,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             IEvents events = null, 
             ICodeModel codeModel = null, 
             IDataModel dataModel = null, 
-            ILogger logger = null, 
-            ICoercion coercion = null)
+            ILogger logger = null)
         {
             codeModel = codeModel ?? new CodeModel();
             DebugSupport.SourceMap = sourceMap ?? new DebuggerSourceMap(codeModel);
 
             return botAdapter.Use(
+#pragma warning disable CA2000 // Dispose objects before losing scope (excluding, the object ownership is transferred to the adapter and the adapter should dispose it)
                 new DialogDebugAdapter(
                     port: port, 
                     sourceMap: DebugSupport.SourceMap, 
@@ -49,6 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                     codeModel: codeModel,
                     dataModel: dataModel, 
                     logger: logger));
+#pragma warning restore CA2000 // Dispose objects before losing scope
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events/IEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events/IEvents.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
     public interface IEvents
     {
+#pragma warning disable CA1819 // Properties should not return arrays (change it without breaking binary compat)
         Protocol.ExceptionBreakpointFilter[] Filters
+#pragma warning restore CA1819 // Properties should not return arrays
         {
             get;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
@@ -23,7 +23,7 @@
     <DebugType>Full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
@@ -31,7 +31,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol.cs
@@ -45,42 +45,56 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public abstract class Message
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public int Seq { get; set; }
 
             public string Type { get; set; }
 
             [JsonExtensionData]
-            public JObject Rest { get; set; }
+            public JObject Rest { get; } = new JObject();
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Request : Message
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string Command { get; set; }
 
             public override string ToString() => Command;
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Request<TArguments> : Request
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public TArguments Arguments { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class LaunchAttach
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public bool BreakOnStart { get; set; } = false;
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Attach : LaunchAttach
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Launch : LaunchAttach
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Initialize
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string ClientID { get; set; }
 
@@ -103,30 +117,46 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public string Locale { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class SetBreakpoints
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Source Source { get; set; }
 
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
             public SourceBreakpoint[] Breakpoints { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
 
             public bool SourceModified { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class SetFunctionBreakpoints
+#pragma warning restore CA1034 // Nested types should not be visible
         {
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
             public FunctionBreakpoint[] Breakpoints { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class SetExceptionBreakpoints
+#pragma warning restore CA1034 // Nested types should not be visible
         {
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
             public string[] Filters { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Threads
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Capabilities
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public bool SupportsConfigurationDoneRequest { get; set; }
 
@@ -136,14 +166,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
             public bool SupportsFunctionBreakpoints { get; set; }
 
+#pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
             public ExceptionBreakpointFilter[] ExceptionBreakpointFilters { get; set; }
+#pragma warning restore CA1819 // Properties should not return arrays
 
             public bool SupportTerminateDebuggee { get; set; }
 
             public bool SupportsTerminateRequest { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class ExceptionBreakpointFilter
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string Filter { get; set; }
 
@@ -152,41 +186,63 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public bool Default { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public abstract class PerThread
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public ulong ThreadId { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class StackTrace : PerThread
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public int? StartFrame { get; set; }
 
             public int? Levels { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and we can't change it without breaking binary compat)
         public class Continue : PerThread
+#pragma warning restore CA1716 // Identifiers should not match keywords
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Pause : PerThread
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and we can't change it without breaking binary compat)
         public class Next : PerThread
+#pragma warning restore CA1716 // Identifiers should not match keywords
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
+#pragma warning disable CA1724 // Type names should not match namespaces (by design and we can't change this without breaking binary compat)
         public class Scopes
+#pragma warning restore CA1724 // Type names should not match namespaces
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public ulong FrameId { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Variables
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public ulong VariablesReference { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class SetVariable
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public ulong VariablesReference { get; set; }
 
@@ -195,30 +251,42 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public string Value { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Evaluate
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public ulong FrameId { get; set; }
 
             public string Expression { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class ConfigurationDone
+#pragma warning restore CA1034 // Nested types should not be visible
         {
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Disconnect
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public bool Restart { get; set; }
 
             public bool TerminateDebuggee { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Terminate
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public bool Restart { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and we can't change it without breaking binary compat)
         public class Event : Message
+#pragma warning restore CA1716 // Identifiers should not match keywords
+#pragma warning restore CA1034 // Nested types should not be visible
         {
 #pragma warning disable SA1300 // Should begin with an uppercase letter.
             public Event(int seq, string @event)
@@ -234,7 +302,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public static Event<TBody> From<TBody>(int seq, string @event, TBody body) => new Event<TBody>(seq, @event) { Body = body };
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
+#pragma warning disable CA1716 // Identifiers should not match keywords (by design and we can't change it without breaking binary compat)
         public class Event<TBody> : Event
+#pragma warning restore CA1716 // Identifiers should not match keywords
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Event(int seq, string @event)
                 : base(seq, @event)
@@ -244,7 +316,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public TBody Body { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Response : Message
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Response(int seq, Request request)
             {
@@ -255,7 +329,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                 this.Command = request.Command;
             }
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores (we can't change this without breaking binary compat)
             public int Request_seq { get; set; }
+#pragma warning restore CA1707 // Identifiers should not contain underscores
 
             public bool Success { get; set; }
 
@@ -268,7 +344,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public static Response<string> Fail(int seq, Request request, string message) => new Response<string>(seq, request) { Body = message, Message = message, Success = false };
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Response<TBody> : Response
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Response(int seq, Request request)
                 : base(seq, request)
@@ -278,12 +356,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public TBody Body { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public abstract class Reference
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public ulong Id { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Range : Reference
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string Item { get; set; }
 
@@ -302,24 +384,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public int? EndColumn { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class Breakpoint : Range
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public bool Verified { get; set; }
 
             public string Message { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public class StackFrame : Range
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string Name { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public sealed class Thread : Reference
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string Name { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public sealed class Source
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public Source(string path)
             {
@@ -332,12 +422,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             public string Path { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public sealed class SourceBreakpoint
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public int Line { get; set; }
         }
 
+#pragma warning disable CA1034 // Nested types should not be visible (we can't change this without breaking binary compat, consider fixing this before we go out of preview)
         public sealed class FunctionBreakpoint
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             public string Name { get; set; }
         }


### PR DESCRIPTION
Relates to #2367

- Made DebugTransport IDisposable and implemented dispose pattern on it and the derived DialogDebugAdapter.
- Added CulturInfo and StringComparison parameters to some string operations.
- Added several #pragma warning disable for [CA1034 (Nested types should not be visible)](https://docs.microsoft.com/en-us/visualstudio/code-quality/CA1034?view=vs-2019)
- Added several #pragma warning disable for [CA1819 (Properties should not return arrays)](https://docs.microsoft.com/en-us/visualstudio/code-quality/CA1819?view=vs-2019)
- Added several #pragma warning disable for [CA1716 (Identifiers should not match keywords)](https://docs.microsoft.com/en-us/visualstudio/code-quality/CA1716?view=vs-2019). Not sure if this can be fixed or if it is by design.

**Note to reviewers and Dialogs.Debugging code owners:**  this library is still in preview and it should be possible to resolve CA1034 (Nested types should not be visible), CA1819 (Properties should not return arrays) and CA1716 (Identifiers should not match keywords). But #2367 is mainly about implementing FxCop so we don't have these issues going forward. 

I made some small changes where the changes were simple or non breaking (implementing IDisposable for example), but there are too many violations of CA1034, CA1819 and CA1716 and I can't test any other changes thoroughly. It would be good if you can create another issue and address CA1034, CA1819 and CA1716 before we remove the preview label.   