### PR TITLE
ActivityPrompt.RepromptDialogAsync call OnPromptAsync with isRetry false

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             var state = (IDictionary<string, object>)instance.State[PersistedState];
             var options = (PromptOptions)instance.State[PersistedOptions];
-            await OnPromptAsync(turnContext, state, options, true, cancellationToken).ConfigureAwait(false);
+            await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -231,7 +231,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="options">A prompt options object constructed from the options initially provided
         /// in the call to <see cref="DialogContext.PromptAsync(string, PromptOptions, CancellationToken)"/>.</param>
         /// <param name="isRetry">true if this is the first time this prompt dialog instance
-        /// on the stack is prompting the user for input; otherwise, false.</param>
+        /// is on the stack is prompting the user for input; otherwise, false. Determines whether
+        /// <see cref="PromptOptions.Prompt"/> or <see cref="PromptOptions.RetryPrompt"/> should be used.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>


### PR DESCRIPTION
Fixes #2449

replaces: https://github.com/microsoft/botbuilder-dotnet/pull/4172

note: isRetry is false when OnPromptAsync is called from RepromptDialogAsync for other prompts:
https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs#L210