### PR TITLE
Adds FxCop to Adaptive.Testing

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
@@ -39,16 +39,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// Url.
         /// </value>
         [JsonProperty("url")]
+#pragma warning disable CA1056 // Uri properties should not be strings (by design, excluding)
         public string Url { get; set; }
+#pragma warning restore CA1056 // Uri properties should not be strings
 
         /// <summary>
-        /// Gets or sets the sequence of responses to reply. The last one will be repeated.
+        /// Gets the sequence of responses to reply. The last one will be repeated.
         /// </summary>
         /// <value>
         /// The sequence of responses to reply.
         /// </value>
         [JsonProperty("responses")]
-        public List<HttpResponseMock> Responses { get; set; }
+        public List<HttpResponseMock> Responses { get;  } = new List<HttpResponseMock>();
 
         public override void Setup(MockHttpMessageHandler handler)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpResponseMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpResponseMock.cs
@@ -4,18 +4,19 @@
 using System.ComponentModel;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using static Microsoft.Bot.Builder.Dialogs.Adaptive.Actions.HttpRequest;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
 {
     public class HttpResponseMock
     {
-        public enum ContentTypes
+        public enum ResponseContentType
         {
             /// <summary>
             /// String response.
             /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name (by design)
             String,
+#pragma warning restore CA1720 // Identifier contains type name
 
             /// <summary>
             /// Byte array response. The content should be the base64 string of the byte array.
@@ -29,10 +30,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// <value>
         /// The content type. Default is String.
         /// </value>
-        [DefaultValue(ContentTypes.String)]
+        [DefaultValue(ResponseContentType.String)]
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty("contentType")]
-        public ContentTypes ContentType { get; set; } = ContentTypes.String;
+        public ResponseContentType ContentType { get; set; } = ResponseContentType.String;
 
         /// <summary>
         /// Gets or sets the content.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/SequenceResponseManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/SequenceResponseManager.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
                 {
                     switch (r.ContentType)
                     {
-                        case HttpResponseMock.ContentTypes.String:
+                        case HttpResponseMock.ResponseContentType.String:
                             return (HttpContent)new StringContent(r.Content == null ? string.Empty : r.Content.ToString());
-                        case HttpResponseMock.ContentTypes.ByteArray:
+                        case HttpResponseMock.ResponseContentType.ByteArray:
                             var bytes = Convert.FromBase64String(r.Content == null ? string.Empty : r.Content.ToString());
                             return (HttpContent)new ByteArrayContent(bytes);
                         default:

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.csproj
@@ -8,10 +8,7 @@
     <Configurations>Debug;Release</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.xml</DocumentationFile>
-    <!-- 
-    TODO: Enable treat warnings as errors once FxCop is enabled and all the issues has been addressed.
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    -->
   </PropertyGroup>
 
   <PropertyGroup>
@@ -42,9 +39,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisLoader.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisLoader.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Testing
         {
             var recognizer = obj.ToObject<LuisAdaptiveRecognizer>(serializer);
             var name = recognizer.ApplicationId.ToString();
-            if (name.StartsWith("="))
+            if (name.StartsWith("=", StringComparison.Ordinal))
             {
                 var start = name.LastIndexOf('.') + 1;
                 name = name.Substring(start);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/PropertiesMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/PropertiesMock.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.PropertyMocks
         }
 
         /// <summary>
-        /// Gets or sets property assignments.
+        /// Gets the property assignments.
         /// </summary>
         /// <value>
         /// Property assignments as property=value pairs. In first match first use order.
         /// </value>
         [JsonProperty("assignments")]
-        public List<PropertyAssignment> Assignments { get; set; } = new List<PropertyAssignment>();
+        public List<PropertyAssignment> Assignments { get; } = new List<PropertyAssignment>();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReply.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReply.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 }
                 else
                 {
-                    if (activity.AsMessageActivity()?.Text.ToLower().Trim().Contains(this.Text.ToLower().Trim()) == false)
+                    if (activity.AsMessageActivity()?.Text.ToLowerInvariant().Trim().Contains(this.Text.ToLowerInvariant().Trim()) == false)
                     {
                         throw new Exception(this.Description ?? $"Text '{activity.Text}' didn't match expected text: '{this.Text}'");
                     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyOneOf.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyOneOf.cs
@@ -21,13 +21,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         }
 
         /// <summary>
-        /// Gets or sets the text variations.
+        /// Gets the text variations.
         /// </summary>
         /// <value>
         /// The text variations.
         /// </value>
         [JsonProperty("text")]
-        public List<string> Text { get; set; } = new List<string>();
+        public List<string> Text { get; } = new List<string>();
 
         /// <summary>
         /// Gets or sets a value indicating whether exact match policy should be used.
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 }
                 else
                 {
-                    if (activity.AsMessageActivity()?.Text.ToLower().Trim().Contains(reply.ToLower().Trim()) == true)
+                    if (activity.AsMessageActivity()?.Text.ToLowerInvariant().Trim().Contains(reply.ToLowerInvariant().Trim()) == true)
                     {
                         found = true;
                         break;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserConversationUpdate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserConversationUpdate.cs
@@ -28,24 +28,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         }
 
         /// <summary>
-        /// Gets or sets the members added names.
+        /// Gets the members added names.
         /// </summary>
         /// <value>The members names.</value>
         [JsonProperty("membersAdded")]
-        public List<string> MembersAdded { get; set; }
+        public List<string> MembersAdded { get; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets the members removed names.
+        /// Gets the members removed names.
         /// </summary>
         /// <value>The members names.</value>
         [JsonProperty("membersRemoved")]
-        public List<string> MembersRemoved { get; set; }
+        public List<string> MembersRemoved { get; } = new List<string>();
 
-        public async override Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback)
+        public override async Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback)
         {
             var activity = adapter.MakeActivity();
             activity.Type = ActivityTypes.ConversationUpdate;
-            if (this.MembersAdded != null)
+            if (this.MembersAdded.Any())
             {
                 activity.MembersAdded = new List<ChannelAccount>();
                 foreach (var member in MembersAdded)
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 }
             }
 
-            if (this.MembersRemoved != null)
+            if (this.MembersRemoved.Any())
             {
                 activity.MembersRemoved = new List<ChannelAccount>();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
@@ -36,15 +36,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.Script";
 
-        private static JsonSerializerSettings serializerSettings = new JsonSerializerSettings()
-        {
-            Formatting = Formatting.Indented,
-            NullValueHandling = NullValueHandling.Ignore,
-            DefaultValueHandling = DefaultValueHandling.Ignore
-        };
-
-        private static IConfiguration defaultConfiguration = new ConfigurationBuilder().Build();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TestScript"/> class.
         /// </summary>
@@ -89,40 +80,40 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         public string Locale { get; set; } = "en-us";
 
         /// <summary>
-        /// Gets or sets the mock data for Microsoft.HttpRequest.
+        /// Gets the mock data for Microsoft.HttpRequest.
         /// </summary>
         /// <value>
         /// A list of mocks. In first match first use order.
         /// </value>
         [JsonProperty("httpRequestMocks")]
-        public List<HttpRequestMock> HttpRequestMocks { get; set; } = new List<HttpRequestMock>();
+        public List<HttpRequestMock> HttpRequestMocks { get; } = new List<HttpRequestMock>();
 
         /// <summary>
-        /// Gets or sets the mock data for Microsoft.OAuthInput.
+        /// Gets the mock data for Microsoft.OAuthInput.
         /// </summary>
         /// <value>
         /// A list of mocks.
         /// </value>
         [JsonProperty("userTokenMocks")]
-        public List<UserTokenMock> UserTokenMocks { get; set; } = new List<UserTokenMock>();
+        public List<UserTokenMock> UserTokenMocks { get; } = new List<UserTokenMock>();
 
         /// <summary>
-        /// Gets or sets the mock data for properties.
+        /// Gets the mock data for properties.
         /// </summary>
         /// <value>
         /// A list of property mocks. In first match first use order.
         /// </value>
         [JsonProperty("propertyMocks")]
-        public List<PropertyMock> PropertyMocks { get; set; } = new List<PropertyMock>();
+        public List<PropertyMock> PropertyMocks { get; } = new List<PropertyMock>();
 
         /// <summary>
-        /// Gets or sets the test script actions.
+        /// Gets the test script actions.
         /// </summary>
         /// <value>
         /// The sequence of test actions to perform to validate the dialog behavior.
         /// </value>
         [JsonProperty("script")]
-        public List<TestAction> Script { get; set; } = new List<TestAction>();
+        public List<TestAction> Script { get; } = new List<TestAction>();
 
         /// <summary>
         /// Gets or sets a value indicating whether trace activities should be passed to the test script.
@@ -137,7 +128,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         /// <param name="resourceExplorer">Resource explorer to use.</param>
         /// <param name="testName">Name of test.</param>
         /// <returns>Test adapter.</returns>
+#pragma warning disable CA1801 // Review unused parameters (excluding for now but consider removing the resourceExplorer parameter if it is not needed)
         public TestAdapter DefaultTestAdapter(ResourceExplorer resourceExplorer, [CallerMemberName] string testName = null)
+#pragma warning restore CA1801 // Review unused parameters
         {
             var storage = new MemoryStorage();
             var convoState = new ConversationState(storage);
@@ -358,7 +351,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         /// <exception cref="Exception">The bot did not respond as expected.</exception>
         public TestScript AssertReplyOneOf(string[] candidates, string description = null, uint timeout = 3000, [CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {
-            this.Script.Add(new AssertReplyOneOf(path: path, line: line) { Text = candidates.ToList<string>(), Description = description, Timeout = timeout, Exact = true });
+            var assertReplyOneOf = new AssertReplyOneOf(path: path, line: line)
+            {
+                Description = description,
+                Timeout = timeout,
+                Exact = true
+            };
+            assertReplyOneOf.Text.AddRange(candidates.ToList());
+            Script.Add(assertReplyOneOf);
             return this;
         }
 
@@ -472,7 +472,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         }
 #endif
 
+#pragma warning disable CA1812 // Internal class is apparently never used (ignoring for now but consider removing it)
         internal class IgnoreEmptyEnumerablesResolver : DefaultContractResolver
+#pragma warning restore CA1812 // Internal class is apparently never used
         {
             protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
             {


### PR DESCRIPTION
Relates to #2367

- Added CultureInfo and StringComparison parameters to some string operations.
- Removed unused fields from TestScript
- Removed several setters from List properties that wheren't set to address CA2227 (Collection properties should be read only).
- Renamed ContentTypes enum in HttpResponseMock to ResponseContentType in order to address CA1717 (Only FlagsAttribute enums should have plural names) and updated usages (had to use ResponseContentType because ContentType was causing collisions with the property name in that class).