### PR TITLE
Added FxCop to LanguageGenreation.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/AnalyzerResult.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/AnalyzerResult.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Variables that this template contains.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public List<string> Variables { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets template references that this template contains.
@@ -37,7 +39,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Template references that this template contains.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public List<string> TemplateReferences { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Combine two analyzer results.

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/EvaluationOptions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                         var value = option.Substring(index + 1).Trim();
                         if (key == strictModeKey)
                         {
-                            if (value.ToLower() == "true")
+                            if (value.ToLowerInvariant() == "true")
                             {
                                 StrictMode = true;
                             }
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                         }
                         else if (key == lineBreakKey)
                         {
-                            LineBreakStyle = value.ToLower() == LGLineBreakStyle.Markdown.ToString().ToLower() ? LGLineBreakStyle.Markdown : LGLineBreakStyle.Default;
+                            LineBreakStyle = value.ToLowerInvariant() == LGLineBreakStyle.Markdown.ToString().ToLowerInvariant() ? LGLineBreakStyle.Markdown : LGLineBreakStyle.Default;
                         }
                     }
                 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var length = switchCaseNodes.Length;
             var switchExprs = switchCaseNodes[0].switchCaseStat().expression();
             var switchErrorPrefix = "Switch '" + switchExprs[0].GetText() + "': ";
-            var switchExprResult = EvalExpression(switchExprs[0].GetText(), switchExprs[0], switchCaseNodes[0].switchCaseStat().GetText(), switchErrorPrefix);
+            var switchExprResult = EvalExpression(switchExprs[0].GetText(), switchCaseNodes[0].switchCaseStat().GetText(), switchErrorPrefix);
             var idx = 0;
             foreach (var switchCaseNode in switchCaseNodes)
             {
@@ -174,7 +174,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                 var caseExprs = switchCaseNode.switchCaseStat().expression();
                 var caseErrorPrefix = "Case '" + caseExprs[0].GetText() + "': ";
-                var caseExprResult = EvalExpression(caseExprs[0].GetText(), caseExprs[0], switchCaseNode.switchCaseStat().GetText(), caseErrorPrefix);
+                var caseExprResult = EvalExpression(caseExprs[0].GetText(), switchCaseNode.switchCaseStat().GetText(), caseErrorPrefix);
                 if (switchExprResult[0] == caseExprResult[0])
                 {
                     return Visit(switchCaseNode.normalTemplateBody());
@@ -203,7 +203,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var isKVPairBody = body.keyValueStructureLine() != null;
                 if (isKVPairBody)
                 {
-                    var property = body.keyValueStructureLine().STRUCTURE_IDENTIFIER().GetText().ToLower();
+                    var property = body.keyValueStructureLine().STRUCTURE_IDENTIFIER().GetText().ToLowerInvariant();
                     var value = VisitStructureValue(body.keyValueStructureLine());
                     if (value.Count > 1) 
                     {
@@ -240,7 +240,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
                 else
                 {
-                    var propertyObjects = EvalExpression(body.expressionInStructure().GetText(), body.expressionInStructure(), body.GetText()).Select(x => JObject.Parse(x)).ToList();
+                    var propertyObjects = EvalExpression(body.expressionInStructure().GetText(), body.GetText()).Select(x => JObject.Parse(x)).ToList();
                     var tempResult = new List<JObject>();
                     foreach (var res in expandedResult)
                     {
@@ -253,7 +253,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                             {
                                 foreach (var item in propertyObject)
                                 {
-                                    if (tempRes.Property(item.Key) == null)
+                                    if (tempRes.Property(item.Key, StringComparison.Ordinal) == null)
                                     {
                                         tempRes[item.Key] = item.Value;
                                     }
@@ -296,7 +296,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 if (child is LGTemplateParser.ExpressionContext expression)
                 {
-                    result = StringListConcat(result, EvalExpression(expression.GetText(), expression, context.GetText(), prefixErrorMsg));
+                    result = StringListConcat(result, EvalExpression(expression.GetText(), context.GetText(), prefixErrorMsg));
                 }
                 else
                 {
@@ -356,7 +356,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             {
                 if (item.IsPureExpression())
                 {
-                    result.Add(EvalExpression(item.expressionInStructure(0).GetText(), item.expressionInStructure(0), context.GetText()));
+                    result.Add(EvalExpression(item.expressionInStructure(0).GetText(), context.GetText()));
                 }
                 else
                 {
@@ -366,7 +366,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                         if (child is LGTemplateParser.ExpressionInStructureContext expression)
                         {
                             var errorPrefix = "Property '" + context.STRUCTURE_IDENTIFIER().GetText() + "':";
-                            itemStringResult = StringListConcat(itemStringResult, EvalExpression(expression.GetText(), expression, context.GetText(), errorPrefix));
+                            itemStringResult = StringListConcat(itemStringResult, EvalExpression(expression.GetText(), context.GetText(), errorPrefix));
                         }
                         else
                         {
@@ -416,7 +416,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             return true;
         }
 
-        private List<string> EvalExpression(string exp, ParserRuleContext context = null, string lineContent = "", string errorPrefix = "")
+        private List<string> EvalExpression(string exp, string lineContent = "", string errorPrefix = "")
         {
             exp = exp.TrimExpression();
             var (result, error) = EvalByAdaptiveExpression(exp, CurrentTarget().Scope);
@@ -488,7 +488,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 return standardFunction;
             }
 
-            if (name.StartsWith("lg."))
+            if (name.StartsWith("lg.", StringComparison.Ordinal))
             {
                 name = name.Substring(3);
             }
@@ -507,21 +507,21 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             const string template = "template";
 
-            if (name.Equals(template))
+            if (name.Equals(template, StringComparison.Ordinal))
             {
                 return new ExpressionEvaluator(template, FunctionUtils.Apply(this.TemplateFunction()), ReturnType.Object, this.ValidateTemplateFunction);
             }
 
             const string fromFile = "fromFile";
 
-            if (name.Equals(fromFile))
+            if (name.Equals(fromFile, StringComparison.Ordinal))
             {
                 return new ExpressionEvaluator(fromFile, FunctionUtils.Apply(this.FromFile()), ReturnType.String, FunctionUtils.ValidateUnaryString);
             }
 
             const string activityAttachment = "ActivityAttachment";
 
-            if (name.Equals(activityAttachment))
+            if (name.Equals(activityAttachment, StringComparison.Ordinal))
             {
                 return new ExpressionEvaluator(
                     activityAttachment,
@@ -532,14 +532,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             const string isTemplate = "isTemplate";
 
-            if (name.Equals(isTemplate))
+            if (name.Equals(isTemplate, StringComparison.Ordinal))
             {
                 return new ExpressionEvaluator(isTemplate, FunctionUtils.Apply(this.IsTemplate()), ReturnType.Boolean, FunctionUtils.ValidateUnaryString);
             }
 
             const string expandText = "expandText";
 
-            if (name.Equals(expandText))
+            if (name.Equals(expandText, StringComparison.Ordinal))
             {
                 return new ExpressionEvaluator(expandText, FunctionUtils.Apply(this.ExpandText()), ReturnType.Object, FunctionUtils.ValidateUnaryString);
             }
@@ -612,7 +612,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception(TemplateErrors.TemplateNotExist(templateName));
             }
 
-            var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count();
+            var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count;
             var actualArgsCount = expression.Children.Length;
 
             if (expectedArgsCount != actualArgsCount)
@@ -635,7 +635,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 foundPrebuiltFunction = true;
             }
 
-            for (var i = 0; i < expanderExpression.Children.Count(); i++)
+            for (var i = 0; i < expanderExpression.Children.Length; i++)
             {
                 expanderExpression.Children[i] = ReconstructExpression(expanderExpression.Children[i], evaluatorExpression.Children[i], foundPrebuiltFunction);
             }
@@ -650,7 +650,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new Exception(TemplateErrors.TemplateNotExist(templateName));
             }
 
-            var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count();
+            var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count;
             var actualArgsCount = children.Count();
 
             if (actualArgsCount != 0 && expectedArgsCount != actualArgsCount)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -76,7 +77,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var result = expression.Trim().TrimStart('$').Trim();
 
-            if (result.StartsWith("{") && result.EndsWith("}"))
+            if (result.StartsWith("{", StringComparison.Ordinal) && result.EndsWith("}", StringComparison.Ordinal))
             {
                 result = result.Substring(1, result.Length - 2);
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Microsoft.Bot.Builder.LanguageGeneration.csproj
@@ -28,7 +28,7 @@
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
     <NoWarn>$(NoWarn);CS1591;SX1309</NoWarn>
   </PropertyGroup>
-    
+
   <ItemGroup>
     <PackageReference Include="Antlr4.CodeGenerator" Version="4.6.6">
       <PrivateAssets>all</PrivateAssets>
@@ -40,6 +40,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             // append empty as fallback to end
-            if (locale != string.Empty && languageFallbackPolicy.ContainsKey(string.Empty))
+            if (!string.IsNullOrEmpty(locale) && languageFallbackPolicy.ContainsKey(string.Empty))
             {
                 fallbackLocales.AddRange(languageFallbackPolicy[string.Empty]);
             }
@@ -130,17 +130,17 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     defaultLanguages = new string[] { string.Empty };
                 }
 
-                var cultureCodes = CultureInfo.GetCultures(CultureTypes.AllCultures).Select(c => c.IetfLanguageTag.ToLower()).ToList();
+                var cultureCodes = CultureInfo.GetCultures(CultureTypes.AllCultures).Select(c => c.IetfLanguageTag.ToLowerInvariant()).ToList();
                 var policy = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
                 foreach (var language in cultureCodes.Distinct())
                 {
-                    var lang = language.ToLower();
+                    var lang = language.ToLowerInvariant();
                     var fallback = new List<string>();
                     while (!string.IsNullOrEmpty(lang))
                     {
                         fallback.Add(lang);
 
-                        var i = lang.LastIndexOf("-");
+                        var i = lang.LastIndexOf("-", StringComparison.Ordinal);
                         if (i > 0)
                         {
                             lang = lang.Substring(0, i);
@@ -151,7 +151,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                         }
                     }
 
-                    if (language == string.Empty)
+                    if (string.IsNullOrEmpty(language))
                     {
                         // here we set the default
                         fallback.AddRange(defaultLanguages);

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var exp = expressionContext.GetText();
             var result = new List<Diagnostic>();
-            if (!exp.EndsWith("}"))
+            if (!exp.EndsWith("}", StringComparison.Ordinal))
             {
                 result.Add(BuildLGDiagnostic(TemplateErrors.NoCloseBracket, context: expressionContext));
             }
@@ -369,7 +369,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     ExpressionParser.Parse(exp);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types (catch any exception and return it in the result)
                 catch (Exception e)
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     var suffixErrorMsg = Evaluator.ConcatErrorMsg(TemplateErrors.ExpressionParseError(exp), e.Message);
                     var errorMsg = Evaluator.ConcatErrorMsg(prefix, suffixErrorMsg);

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -55,7 +55,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Parameter list of this template.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public List<string> Parameters { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets text format of Body of this template. All content except Name and Parameters.

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// <summary>
     /// Centralized Template errors.
     /// </summary>
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't make this type static without breaking binary compat)
     public class TemplateErrors
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         public const string NoTemplate = "LG file must have at least one template definition.";
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateException.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateException.cs
@@ -11,7 +11,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// Template Exception that contains diagnostics.
     /// </summary>
     [Serializable]
+#pragma warning disable CA1032 // Implement standard exception constructors (by design)
+#pragma warning disable CA2229 // Implement serialization constructors (by design)
     public class TemplateException : Exception, ISerializable
+#pragma warning restore CA2229 // Implement serialization constructors
+#pragma warning restore CA1032 // Implement standard exception constructors
     {
         public TemplateException(string message, IList<Diagnostic> diagnostics)
             : base(message)
@@ -25,6 +29,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Diagnostics.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public IList<Diagnostic> Diagnostics { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -97,7 +97,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Import elements that this LG file contains directly.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public IList<TemplateImport> Imports { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets all references that this LG file has from <see cref="Imports"/>.
@@ -108,7 +110,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// All references that this LG file has from <see cref="Imports"/>.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public IList<Templates> References { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets diagnostics.
@@ -116,7 +120,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// Diagnostics.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public IList<Diagnostic> Diagnostics { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets LG content.
@@ -140,7 +146,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <value>
         /// LG file options.
         /// </value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't remove the setter without breaking binary compat)
         public IList<string> Options { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets the evluation options for current LG file.
@@ -229,7 +237,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             // wrap inline string with "# name and -" to align the evaluation process
             var multiLineMark = "```";
 
-            text = !text.Trim().StartsWith(multiLineMark) && text.Contains('\n')
+            text = !text.Trim().StartsWith(multiLineMark, StringComparison.Ordinal) && text.Contains('\n')
                    ? $"{multiLineMark}{text}{multiLineMark}" : text;
 
             var newContent = $"# {InlineTemplateId} {newLine} - {text}";
@@ -506,7 +514,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var lines = GetLinesOfText(templateBody);
             var destList = lines.Select(u =>
             {
-                return u.TrimStart().StartsWith("#") ? $"- {u.TrimStart()}" : u;
+                return u.TrimStart().StartsWith("#", StringComparison.Ordinal) ? $"- {u.TrimStart()}" : u;
             });
 
             return string.Join(newLine, destList);
@@ -516,7 +524,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             if (text == null)
             {
-                return new string[0];
+                return Array.Empty<string>();
             }
 
             return text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
@@ -539,7 +547,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             if (AllDiagnostics != null)
             {
                 var errors = AllDiagnostics.Where(u => u.Severity == DiagnosticSeverity.Error);
-                if (errors.Count() != 0)
+                if (errors.Any())
                 {
                     throw new Exception(string.Join(newLine, errors));
                 }
@@ -554,7 +562,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 if (!string.IsNullOrWhiteSpace(option) && option.Contains("="))
                 {
                     var index = option.IndexOf('=');
-                    var key = option.Substring(0, index).Trim().ToLower();
+                    var key = option.Substring(0, index).Trim().ToLowerInvariant();
                     var value = option.Substring(index + 1).Trim();
                     if (key == nameOfKey)
                     {

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
@@ -244,9 +244,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         }
 
         /// <summary>
-        /// Templates transfeormer. Fullfill more details and body context into the templates object.
+        /// Templates transformer. Fulfill more details and body context into the templates object.
         /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible (we can't move this nested type without breaking binary compat)
         public class TemplatesTransformer : LGFileParserBaseVisitor<object>
+#pragma warning restore CA1034 // Nested types should not be visible
         {
             private static readonly Regex IdentifierRegex = new Regex(@"^[0-9a-zA-Z_]+$");
             private static readonly Regex TemplateNamePartRegex = new Regex(@"^[a-zA-Z_][0-9a-zA-Z_]*$");
@@ -413,8 +415,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                 var templateName = templateNameLine;
                 var parameters = new List<string>();
-                var leftBracketIndex = templateNameLine.IndexOf("(");
-                if (leftBracketIndex >= 0 && templateNameLine.EndsWith(")"))
+                var leftBracketIndex = templateNameLine.IndexOf("(", StringComparison.Ordinal);
+                if (leftBracketIndex >= 0 && templateNameLine.EndsWith(")", StringComparison.Ordinal))
                 {
                     templateName = templateNameLine.Substring(0, leftBracketIndex).Trim();
                     var paramString = templateNameLine.Substring(leftBracketIndex + 1, templateNameLine.Length - leftBracketIndex - 2);


### PR DESCRIPTION
Relates to #2367

- Added several #pragma warning disable for CA2227 (Collection properties should be read only) that we can't change because of binary compat.
- Added several ToLowerInvariant, CultureInfo and StringComparison parameters to string operations.
- Replaced some LINQ Count() and Length() operations by .Any() or Count and Length properties.
- Added CA1032 and CA2229 for TemplateException (we can implement these later if needed.