### PR TITLE
Use RuntimeInformation.FrameworkDescription if TargetFrameworkAttribute.FrameworkName is null

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisDelegatingHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisDelegatingHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,7 +24,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
             var framework = Assembly
                 .GetEntryAssembly()?
                 .GetCustomAttribute<TargetFrameworkAttribute>()?
-                .FrameworkName;
+                .FrameworkName ?? RuntimeInformation.FrameworkDescription;
             var comment = $"({Environment.OSVersion.VersionString};{framework})";
             request.Headers.UserAgent.Add(new ProductInfoHeaderValue(comment));
 

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
@@ -86,7 +87,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             var framework = Assembly
                 .GetEntryAssembly()?
                 .GetCustomAttribute<TargetFrameworkAttribute>()?
-                .FrameworkName;
+                .FrameworkName ?? RuntimeInformation.FrameworkDescription;
             var comment = $"({Environment.OSVersion.VersionString};{framework})";
             platformInfo = new ProductInfoHeaderValue(comment);
         }

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Rest;
@@ -130,7 +131,7 @@ namespace Microsoft.Bot.Connector
             return Assembly
                     .GetEntryAssembly()?
                     .GetCustomAttribute<TargetFrameworkAttribute>()?
-                    .FrameworkName;
+                    .FrameworkName ?? RuntimeInformation.FrameworkDescription;
         }
 
         /// <summary>Gets the assembly version for the Azure Bot Service.</summary>


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4275



![image](https://user-images.githubusercontent.com/11055362/88022250-cafa2700-cae3-11ea-83a1-410de7194d63.png)
