### PR TITLE
Make ActivityPrompt a normal class - remove abstract

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// activities like an event to be received.The validator can ignore received activities until
     /// the expected activity type is received.
     /// </remarks>
-    public abstract class ActivityPrompt : Dialog
+    public class ActivityPrompt : Dialog
     {
         private const string PersistedOptions = "options";
         private const string PersistedState = "state";


### PR DESCRIPTION
Parity with JS: https://github.com/microsoft/botbuilder-js/pull/744

Replaces https://github.com/microsoft/botbuilder-dotnet/pull/4263