### PR TITLE
Only use resource.id as the default dialog id if the dialog doesn't have an id.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -172,9 +172,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                 using (new SourceScope(sourceContext, range))
                 {
                     var result = Load<T>(json, sourceContext);
-                    if (result is Dialog dlg)
+
+                    if (result is Dialog dlg && !((JObject)json).ContainsKey("id"))
                     {
-                        // dialog id's are resource ids
+                        // if there is no jobject.id for the dialog, then the dialog id's should be resource.id
                         dlg.Id = resource.Id;
                     }
 
@@ -526,7 +527,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         private T Load<T>(JToken token, SourceContext sourceContext)
         {
             var converters = new List<JsonConverter>();
-            
+
             // get converters
             foreach (var component in ComponentRegistration.Components.OfType<IComponentDeclarativeTypes>())
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -38,8 +38,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             {
                 explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
 
-                await AssertResourceType(path, explorer, "dialog");
-                var resources = explorer.GetResources("foo").ToArray();
+                var resources = explorer.GetResources(".dialog").ToArray();
+
+                Assert.AreEqual(2, resources.Length);
+                Assert.AreEqual($".dialog", Path.GetExtension(resources[0].Id));
+
+                resources = explorer.GetResources("foo").ToArray();
                 Assert.AreEqual(0, resources.Length);
             }
         }
@@ -65,6 +69,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 {
                     Assert.Fail($"Unknown exception {err2.GetType().Name} thrown");
                 }
+            }
+        }
+
+        [TestMethod]
+        public void TestResourceDialogIdAssignment()
+        {
+            var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
+            using (var explorer = new ResourceExplorer())
+            {
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
+                var dlg1 = explorer.LoadType<Dialog>("test.dialog");
+                Assert.AreEqual("test.dialog", dlg1.Id, "resource .id should be used as default dialog.id if none assigned");
+
+                var dlg2 = explorer.LoadType<Dialog>("test2.dialog");
+                Assert.AreEqual("1234567890", dlg2.Id, "id in the .dialog file should be honored");
             }
         }
 
@@ -192,14 +211,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 AssertResourceNull(explorer, testId);
             }
-        }
-
-        private static async Task AssertResourceType(string path, ResourceExplorer explorer, string resourceType)
-        {
-            var resources = explorer.GetResources(resourceType).ToArray();
-            Assert.AreEqual(1, resources.Length);
-            Assert.AreEqual($".{resourceType}", Path.GetExtension(resources[0].Id));
-            await Task.FromResult<object>(null);
         }
 
         private static void AssertResourceFound(ResourceExplorer explorer, string id)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/resources/test2.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/resources/test2.dialog
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../tests.schema",
+    "$kind": "Microsoft.SendActivity",
+    "activity": "hello",
+    "id": "1234567890"
+}

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -296,6 +296,9 @@
 			"$ref": "#/definitions/Microsoft.SwitchCondition"
 		},
 		{
+			"$ref": "#/definitions/Microsoft.TelemetryTrackEvent"
+		},
+		{
 			"$ref": "#/definitions/Microsoft.TemperatureEntityRecognizer"
 		},
 		{
@@ -2505,7 +2508,7 @@
 					]
 				},
 				"outputFormat": {
-					"$ref": "#/definitions/stringExpression",
+					"$ref": "#/definitions/expression",
 					"title": "Output format",
 					"description": "Expression to use for formatting the output.",
 					"examples": [
@@ -4395,6 +4398,9 @@
 					"$ref": "#/definitions/Microsoft.SwitchCondition"
 				},
 				{
+					"$ref": "#/definitions/Microsoft.TelemetryTrackEvent"
+				},
+				{
 					"$ref": "#/definitions/Microsoft.TraceActivity"
 				},
 				{
@@ -4530,10 +4536,10 @@
 					"type": "string"
 				},
 				{
-					"$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
+					"$ref": "#/definitions/Microsoft.LuisRecognizer"
 				},
 				{
-					"$ref": "#/definitions/Microsoft.LuisRecognizer"
+					"$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
 				},
 				{
 					"$ref": "#/definitions/Microsoft.CrossTrainedRecognizerSet"
@@ -7362,7 +7368,7 @@
 				"extends(Microsoft.OnCondition)"
 			],
 			"title": "On unknown intent",
-			"description": "Action to perform when user input is unrecognized and if none of the 'on intent recognition' triggers match recognized intent.",
+			"description": "Action to perform when user input is unrecognized or if none of the 'on intent recognition' triggers match recognized intent.",
 			"type": "object",
 			"required": [
 				"actions",
@@ -8575,6 +8581,68 @@
 					"type": "string",
 					"pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
 					"const": "Microsoft.SwitchCondition"
+				},
+				"$designer": {
+					"title": "Designer information",
+					"type": "object",
+					"description": "Extra information for the Bot Framework Composer."
+				}
+			}
+		},
+		"Microsoft.TelemetryTrackEvent": {
+			"$role": "implements(Microsoft.IDialog)",
+			"type": "object",
+			"title": "Telemetry - Track Event",
+			"description": "Track a custom event using the registered Telemetry Client.",
+			"required": [
+				"url",
+				"method",
+				"$kind"
+			],
+			"additionalProperties": false,
+			"patternProperties": {
+				"^\\$": {
+					"title": "Tooling property",
+					"description": "Open ended property for tooling."
+				}
+			},
+			"properties": {
+				"id": {
+					"type": "string",
+					"title": "Id",
+					"description": "Optional id for the dialog"
+				},
+				"disabled": {
+					"$ref": "#/definitions/booleanExpression",
+					"title": "Disabled",
+					"description": "Optional condition which if true will disable this action.",
+					"examples": [
+						"user.age > 3"
+					]
+				},
+				"eventName": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Event Name",
+					"description": "The name of the event to track.",
+					"examples": [
+						"MyEventStarted",
+						"MyEventCompleted"
+					]
+				},
+				"properties": {
+					"type": "object",
+					"title": "Properties",
+					"description": "One or more properties to attach to the event being tracked.",
+					"additionalProperties": {
+						"$ref": "#/definitions/stringExpression"
+					}
+				},
+				"$kind": {
+					"title": "Kind of dialog object",
+					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+					"type": "string",
+					"pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+					"const": "Microsoft.TelemetryTrackEvent"
 				},
 				"$designer": {
 					"title": "Designer information",
@@ -11198,6 +11266,7 @@
 			]
 		},
 		"equalsExpression": {
+			"$role": "expression",
 			"type": "string",
 			"title": "Expression",
 			"description": "Expression starting with =.",
@@ -11207,6 +11276,7 @@
 			]
 		},
 		"expression": {
+			"$role": "expression",
 			"type": "string",
 			"title": "Expression",
 			"description": "Expression to evaluate.",


### PR DESCRIPTION
Fixes #4250 

## Description
only apply resource.id as default .id if there is no id in the incoming json payload.

## Specific Changes
Change conditional for auto assigning dialog.id

## Testing
added unit test to verify.
