### PR TITLE
Fix anonymous template name conflict

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var lineOffset = this.currentTemplate != null ? this.currentTemplate.SourceRange.Range.Start.Line : 0;
             var templateNameInfo = string.Empty;
-            if (this.currentTemplate != null && this.currentTemplate.Name != Templates.InlineTemplateId)
+            if (this.currentTemplate != null && this.currentTemplate.Name.StartsWith(Templates.InlineTemplateIdPrefix, StringComparison.InvariantCulture))
             {
                 templateNameInfo = $"[{this.currentTemplate.Name}]";
             }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     public class Templates : List<Template>
     {
         /// <summary>
-        /// Temp Template ID for inline content.
+        /// Temp Template ID prefix for inline content.
         /// </summary>
-        public const string InlineTemplateId = "__temp__";
+        public const string InlineTemplateIdPrefix = "__temp__";
         private readonly string newLine = Environment.NewLine;
         private readonly Regex newLineRegex = new Regex("(\r?\n)");
         private readonly string namespaceKey = "@namespace";
@@ -234,17 +234,19 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             CheckErrors();
 
+            var inlineTemplateId = $"{InlineTemplateIdPrefix}{Guid.NewGuid():N}";
+
             // wrap inline string with "# name and -" to align the evaluation process
             var multiLineMark = "```";
 
             text = !text.Trim().StartsWith(multiLineMark, StringComparison.Ordinal) && text.Contains('\n')
                    ? $"{multiLineMark}{text}{multiLineMark}" : text;
 
-            var newContent = $"# {InlineTemplateId} {newLine} - {text}";
+            var newContent = $"# {inlineTemplateId} {newLine} - {text}";
 
             var newLG = TemplatesParser.ParseTextWithRef(newContent, this);
 
-            return newLG.Evaluate(InlineTemplateId, scope, evalOpt);
+            return newLG.Evaluate(inlineTemplateId, scope, evalOpt);
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -125,6 +125,10 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // - ${length(expandText(@answer))}
             var evaled = templates.Evaluate("template", scope);
             Assert.Equal("hello vivian".Length, evaled);
+
+            // Parse text content
+            evaled = templates.EvaluateText("${length(expandText(@answer))}", scope);
+            Assert.Equal("hello vivian".Length, evaled);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #4328

## Description
Currently, LG uses `__temp__` as the template id when evaluating inline text with `EvaluateText` method.
Later, the `expandText` function was introduced,  which would use the `evaluateText` to achieve the result. So, there would exist two `__temp__` templates.

## Specific Changes

Assign a random ID for template name when evaluating an inline text to support the nested inline text evaluation.
