### PR TITLE
Added FxCop analyzers to Configuration

### DIFF
--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Bot.Configuration
         /// <value>The list of connected services.</value>
         [JsonProperty("services")]
         [JsonConverter(typeof(BotServiceConverter))]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public List<ConnectedService> Services { get; set; } = new List<ConnectedService>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets properties that are not otherwise defined.
@@ -66,7 +68,9 @@ namespace Microsoft.Bot.Configuration
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public JObject Properties { get; set; } = new JObject();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets the location of the configuration.
@@ -192,7 +196,9 @@ namespace Microsoft.Bot.Configuration
             if (string.IsNullOrEmpty(path) && string.IsNullOrEmpty(this.Location))
             {
                 // If location is not set, we expect the path to be provided
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly (this class is obsolete, we won't fix it)
                 throw new ArgumentException(nameof(path));
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
 
             if (!string.IsNullOrEmpty(secret))
@@ -243,7 +249,9 @@ namespace Microsoft.Bot.Configuration
             if (string.IsNullOrEmpty(path) && string.IsNullOrEmpty(this.Location))
             {
                 // If location is not set, we expect the path to be provided
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly (this class is obsolete, we won't fix it)
                 throw new ArgumentException(nameof(path));
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
 
             this.SaveAsAsync(path, secret).GetAwaiter().GetResult();
@@ -276,7 +284,9 @@ namespace Microsoft.Bot.Configuration
                     }
                 }
 
+#pragma warning disable CA1305 // Specify IFormatProvider (this class is obsolete, we won't fix it)
                 newService.Id = (++maxValue).ToString();
+#pragma warning restore CA1305 // Specify IFormatProvider
             }
             else if (this.Services.Where(s => s.Type == newService.Type && s.Id == newService.Id).Any())
             {
@@ -507,7 +517,9 @@ namespace Microsoft.Bot.Configuration
         /// <summary>
         /// Converter for strongly typed connected services.
         /// </summary>
+#pragma warning disable CA1812 // Internal class that is apparently never instantiated (this class is obsolete, we won't fix this)
         internal class BotServiceConverter : JsonConverter
+#pragma warning restore CA1812 // Internal class that is apparently never instantiated
         {
             public override bool CanWrite => false;
 

--- a/libraries/Microsoft.Bot.Configuration/EncryptUtilities.cs
+++ b/libraries/Microsoft.Bot.Configuration/EncryptUtilities.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Bot.Configuration.Encryption
 
             if (string.IsNullOrEmpty(key))
             {
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly (this class is obsolete, we won't fix it)
                 throw new ArgumentNullException("Missing key");
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
 
             // Encrypt the string to an array of bytes.
@@ -65,7 +67,9 @@ namespace Microsoft.Bot.Configuration.Encryption
 
             if (string.IsNullOrEmpty(key))
             {
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly (this class is obsolete, we won't fix it)
                 throw new ArgumentNullException("Missing key");
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
             }
 
             var parts = encryptedText.Split('!');
@@ -115,7 +119,9 @@ namespace Microsoft.Bot.Configuration.Encryption
         /// <param name="key">The 32-byte encryption key to use.</param>
         /// <param name="iv">A 16-byte initialization vector to use.</param>
         /// <returns>The initialization vector and the encrypted bytes.</returns>
+#pragma warning disable CA1707 // Identifiers should not contain underscores (this class is obsolete, we won't fix it)
         public static Tuple<byte[], byte[]> EncryptStringToBytes_Aes(string plainText, byte[] key, byte[] iv = null)
+#pragma warning restore CA1707 // Identifiers should not contain underscores
         {
             // Check arguments.
             if (plainText == null || plainText.Length <= 0)
@@ -171,7 +177,9 @@ namespace Microsoft.Bot.Configuration.Encryption
         /// <param name="key">The 32-byte encryption key to use.</param>
         /// <param name="iv">A 16-byte initialization vector to use.</param>
         /// <returns>The decrypted string.</returns>
+#pragma warning disable CA1707 // Identifiers should not contain underscores (this class is obsolete, we won't fix it)
         public static string DecryptStringFromBytes_Aes(byte[] cipherText, byte[] key, byte[] iv)
+#pragma warning restore CA1707 // Identifiers should not contain underscores
         {
             // Check arguments.
             if (cipherText == null || cipherText.Length <= 0)

--- a/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
+++ b/libraries/Microsoft.Bot.Configuration/Microsoft.Bot.Configuration.csproj
@@ -22,7 +22,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />

--- a/libraries/Microsoft.Bot.Configuration/ServiceTypes.cs
+++ b/libraries/Microsoft.Bot.Configuration/ServiceTypes.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Bot.Configuration
     /// Constants for Azure service types.
     /// </summary>
     [Obsolete("This class is deprecated.  See https://aka.ms/bot-file-basics for more information.", false)]
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (this class is obsolete, we won't fix it)
     public class ServiceTypes
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
         /// Application Insights.

--- a/libraries/Microsoft.Bot.Configuration/Services/AppInsightsService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/AppInsightsService.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Bot.Configuration
         /// </summary>
         /// <value>The Api Keys.</value>
         [JsonProperty("apiKeys")]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public Dictionary<string, string> ApiKeys { get; set; } = new Dictionary<string, string>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <inheritdoc/>
         public override void Encrypt(string secret)

--- a/libraries/Microsoft.Bot.Configuration/Services/ConnectedService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/ConnectedService.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Bot.Configuration
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public JObject Properties { get; set; } = new JObject();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Decrypt properties on this service.

--- a/libraries/Microsoft.Bot.Configuration/Services/DispatchService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/DispatchService.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Bot.Configuration
         /// </summary>
         /// <value>The list of service Ids.</value>
         [JsonProperty("serviceIds")]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public List<string> ServiceIds { get; set; } = new List<string>();
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/libraries/Microsoft.Bot.Configuration/Services/GenericService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/GenericService.cs
@@ -28,14 +28,18 @@ namespace Microsoft.Bot.Configuration
         /// </summary>
         /// <value>The Url to Service.</value>
         [JsonProperty("url")]
+#pragma warning disable CA1056 // Uri properties should not be strings (this class is obsolete, we won't fix it)
         public string Url { get; set; }
+#pragma warning restore CA1056 // Uri properties should not be strings
 
         /// <summary>
         /// Gets or sets configuration.
         /// </summary>
         /// <value>The service configuration.</value>
         [JsonProperty("configuration")]
+#pragma warning disable CA2227 // Collection properties should be read only (this class is obsolete, we won't fix it)
         public Dictionary<string, string> Configuration { get; set; } = new Dictionary<string, string>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <inheritdoc/>
         public override void Encrypt(string secret)

--- a/libraries/Microsoft.Bot.Configuration/Services/LuisService.cs
+++ b/libraries/Microsoft.Bot.Configuration/Services/LuisService.cs
@@ -82,7 +82,9 @@ namespace Microsoft.Bot.Configuration
                 throw new System.NullReferenceException("LuisService.Region cannot be Null");
             }
 
+#pragma warning disable CA1304 // Specify CultureInfo (this class is obsolete, we won't fix it)
             var region = this.Region.ToLower();
+#pragma warning restore CA1304 // Specify CultureInfo
 
             // usgovvirginia is that actual azure region name, but the cognitive service team called their endpoint 'virginia' instead of 'usgovvirginia'
             // We handle both region names as an alias for virginia.api.cognitive.microsoft.us
@@ -92,7 +94,9 @@ namespace Microsoft.Bot.Configuration
             }
 
             // if it starts with usgov or usdod then it is a .us TLD
+#pragma warning disable CA1307 // Specify StringComparison (this class is obsolete, we won't fix it)
             else if (region.StartsWith("usgov") || region.StartsWith("usdod"))
+#pragma warning restore CA1307 // Specify StringComparison
             {
                 return $"https://{this.Region}.api.cognitive.microsoft.us";
             }


### PR DESCRIPTION
Relates to #2367

- Added several #pragma disable for all the FxCop violations (all the affected classes are obsolete but this will allow us to apply FxCop to all the projects in the libraries folder using dirprops)