### PR TITLE
fix null object reference

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                 policy.AddRange(targetpolicy);
             }
 
-            if (activity.Locale?.Length != 0 && LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
+            if (LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
             {
                 // we now explictly add defaultPolicy instead of coding that into target's policy
                 policy.AddRange(defaultPolicy);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                 policy.AddRange(targetpolicy);
             }
 
-            if (activity.Locale.Length != 0 && LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
+            if (activity.Locale?.Length != 0 && LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
             {
                 // we now explictly add defaultPolicy instead of coding that into target's policy
                 policy.AddRange(defaultPolicy);


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotFramework-Composer/issues/3729<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Minor fix, activity from facebook channel take 'null' locale, this line would throw exception:
Object reference not set to an instance of an object.
Since the activity.Locale could be null.

## Specific Changes
<!-- Please list the changes in a concise manner. -->


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->