### PR TITLE
Make Language fallback consistent with current LanguagePolicy

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LGResourceLoader.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LGResourceLoader.cs
@@ -27,43 +27,38 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 var existNames = new HashSet<string>();
                 foreach (var suffix in suffixs)
                 {
-                    if (string.IsNullOrEmpty(locale) || !string.IsNullOrEmpty(suffix))
+                    var resourcesWithSuchSuffix = allResources.Where(u => ParseLGFileName(u.Id).language.ToLowerInvariant() == suffix.ToLowerInvariant());
+                    foreach (var resourceWithSuchSuffix in resourcesWithSuchSuffix)
                     {
-                        var resourcesWithSuchSuffix = allResources.Where(u => ParseLGFileName(u.Id).language == suffix);
-                        foreach (var resourceWithSuchSuffix in resourcesWithSuchSuffix)
+                        var resourceName = resourceWithSuchSuffix.Id;
+                        var length = string.IsNullOrEmpty(suffix) ? 3 : 4;
+                        var prefixName = resourceName.Substring(0, resourceName.Length - suffix.Length - length);
+                        if (!existNames.Contains(prefixName))
                         {
-                            var resourceName = resourceWithSuchSuffix.Id;
-                            var length = string.IsNullOrEmpty(suffix) ? 3 : 4;
-                            var prefixName = resourceName.Substring(0, resourceName.Length - suffix.Length - length);
-                            if (!existNames.Contains(prefixName))
+                            existNames.Add(prefixName);
+                            if (!resourceMapping.ContainsKey(locale))
                             {
-                                existNames.Add(prefixName);
-                                if (!resourceMapping.ContainsKey(locale))
-                                {
-                                    resourceMapping.Add(locale, new List<Resource> { resourceWithSuchSuffix });
-                                }
-                                else
-                                {
-                                    resourceMapping[locale].Add(resourceWithSuchSuffix);
-                                }
+                                resourceMapping.Add(locale, new List<Resource> { resourceWithSuchSuffix });
+                            }
+                            else
+                            {
+                                resourceMapping[locale].Add(resourceWithSuchSuffix);
                             }
                         }
                     }
-                    else
+                }
+
+                if (resourceMapping.ContainsKey(locale))
+                {
+                    var resourcesWithEmptySuffix = allResources.Where(u => ParseLGFileName(u.Id).language.Length == 0);
+                    foreach (var resourceWithEmptySuffix in resourcesWithEmptySuffix)
                     {
-                        if (resourceMapping.ContainsKey(locale))
+                        var resourceName = resourceWithEmptySuffix.Id;
+                        var prefixName = resourceName.Substring(0, resourceName.Length - 3);
+                        if (!existNames.Contains(prefixName))
                         {
-                            var resourcesWithEmptySuffix = allResources.Where(u => ParseLGFileName(u.Id).language.Length == 0);
-                            foreach (var resourceWithEmptySuffix in resourcesWithEmptySuffix)
-                            {
-                                var resourceName = resourceWithEmptySuffix.Id;
-                                var prefixName = resourceName.Substring(0, resourceName.Length - 3);
-                                if (!existNames.Contains(prefixName))
-                                {
-                                    existNames.Add(prefixName);
-                                    resourceMapping[locale].Add(resourceWithEmptySuffix);
-                                }
-                            }
+                            existNames.Add(prefixName);
+                            resourceMapping[locale].Add(resourceWithEmptySuffix);
                         }
                     }
                 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1402
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,30 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var context = GetDialogContext(string.Empty);
             var lg = new TemplateEngineLanguageGenerator();
             await Assert.ThrowsAsync<Exception>(() => lg.GenerateAsync(context, "${tesdfdfsst()}", null));
+        }
+
+        [Fact]
+        public void TestLGResourceGroup()
+        {
+            var resourceExplorer = new ResourceExplorer().LoadProject(GetProjectFolder(), monitorChanges: false);
+
+            // use LG file as entrance
+            var lgResourceGroup = LGResourceLoader.GroupByLocale(resourceExplorer);
+
+            Assert.Contains(string.Empty, lgResourceGroup.Keys.ToList());
+            var resourceNames = lgResourceGroup[string.Empty].Select(u => u.Id);
+            Assert.Equal(8, resourceNames.Count());
+            Assert.Subset(new HashSet<string>() { "a.lg", "b.lg", "c.lg", "inject.lg", "NormalStructuredLG.lg", "root.lg", "subDialog.lg", "test.lg" }, new HashSet<string>(resourceNames));
+
+            Assert.Contains("en-us", lgResourceGroup.Keys.ToList());
+            resourceNames = lgResourceGroup["en-us"].Select(u => u.Id);
+            Assert.Equal(8, resourceNames.Count());
+            Assert.Subset(new HashSet<string>() { "a.en-US.lg", "b.en-us.lg", "c.en.lg", "inject.lg", "NormalStructuredLG.lg", "root.lg", "subDialog.lg", "test.en-US.lg" }, new HashSet<string>(resourceNames));
+
+            Assert.Contains("en", lgResourceGroup.Keys.ToList());
+            resourceNames = lgResourceGroup["en"].Select(u => u.Id);
+            Assert.Equal(8, resourceNames.Count());
+            Assert.Subset(new HashSet<string>() { "a.lg", "b.lg", "c.en.lg", "inject.lg", "NormalStructuredLG.lg", "root.lg", "subDialog.lg", "test.en.lg" }, new HashSet<string>(resourceNames));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #4309

## Description
Original language policy:
en-us -> en-us, en, ''
fr-fr -> fr-fr, fr, ''
'' -> ''

Current default language policy:
en-us -> en-us, en
fr-fr -> fr-fr, fr
'' -> ''

So, it is necessary to update the `GroupByLocale` in `LGResourceLoader` to apply the lastest language policy.

## Specific Changes
Append all other resources those locale not match current entry locale to current locale.
For example：
there exist `a.en-us.lg`, `a.lg`, `b.lg`
At first, we should group all LG resources to make them locale awareness.
Suppose there exists the language policy:
en-us: en-us, en
'' : ''

The final grouped resources should like:
en-us -> a.en-us.lg, b.lg
'' -> a.lg, b.lg