### PR TITLE
Temporarily suppressing XUnit warnings

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -44,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// </value>
         [JsonProperty("url")]
 #pragma warning disable CA1056 // Uri properties should not be strings (by design, excluding)
-        public Uri Url { get; set; }
+        public string Url { get; set; }
 #pragma warning restore CA1056 // Uri properties should not be strings
 
         /// <summary>
@@ -54,7 +53,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// The sequence of responses to reply.
         /// </value>
         [JsonProperty("responses")]
-        public List<HttpResponseMock> Responses { get; } = new List<HttpResponseMock>();
+        public List<HttpResponseMock> Responses { get;  } = new List<HttpResponseMock>();
 
         public override void Setup(MockHttpMessageHandler handler)
         {
@@ -63,11 +62,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
             MockedRequest mocked;
             if (!Method.HasValue)
             {
-                mocked = handler.When(Url.ToString());
+                mocked = handler.When(Url);
             }
             else
             {
-                mocked = handler.When(new HttpMethod(Method.Value.ToString()), Url.ToString());
+                mocked = handler.When(new HttpMethod(Method.Value.ToString()), Url);
             }
 
             mocked.Respond(re => response.GetContent());

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
@@ -43,7 +44,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// </value>
         [JsonProperty("url")]
 #pragma warning disable CA1056 // Uri properties should not be strings (by design, excluding)
-        public string Url { get; set; }
+        public Uri Url { get; set; }
 #pragma warning restore CA1056 // Uri properties should not be strings
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// The sequence of responses to reply.
         /// </value>
         [JsonProperty("responses")]
-        public List<HttpResponseMock> Responses { get;  } = new List<HttpResponseMock>();
+        public List<HttpResponseMock> Responses { get; } = new List<HttpResponseMock>();
 
         public override void Setup(MockHttpMessageHandler handler)
         {
@@ -62,11 +63,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
             MockedRequest mocked;
             if (!Method.HasValue)
             {
-                mocked = handler.When(Url);
+                mocked = handler.When(Url.ToString());
             }
             else
             {
-                mocked = handler.When(new HttpMethod(Method.Value.ToString()), Url);
+                mocked = handler.When(new HttpMethod(Method.Value.ToString()), Url.ToString());
             }
 
             mocked.Respond(re => response.GetContent());

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <!-- SA0001;CS1573,CS1591,CS1712: For tests, we don't generate documentation. Supress related rules. -->
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);SA0001;CS1573;CS1591;CS1712;SX1309</NoWarn>
+    <!-- Supressing xunit warnings and should be fixed as part https://github.com/microsoft/botbuilder-dotnet/issues/4349 -->
+    <NoWarn>$(NoWarn);SA0001;CS1573;CS1591;CS1712;SX1309;xUnit1013;xUnit2000;xUnit2003;xUnit2004;xUnit2009;xUnit2013</NoWarn>
   </PropertyGroup>
 
   <!-- This ensures that Directory.Build.props in parent folders are merged with this one -->


### PR DESCRIPTION
Fixes #4240
Fixes #4239

Opens #4349 for temporarily suppressing xunit warnings.