### PR TITLE
Changing dialog.testing primarily internal

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ReaderWriterLock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ReaderWriterLock.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class ReaderWriterLock : IDisposable
+    internal sealed class ReaderWriterLock : IDisposable
     {
         private readonly SemaphoreSlim reader;
         private readonly SemaphoreSlim writer;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ReferenceEquality.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ReferenceEquality.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class ReferenceEquality<T> : IEqualityComparer<T>
+    internal sealed class ReferenceEquality<T> : IEqualityComparer<T>
     {
         public static readonly IEqualityComparer<T> Instance = new ReferenceEquality<T>();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/SemaphoreSlimExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/SemaphoreSlimExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// <summary>
     /// Extension method implementing await for <see cref="SemaphoreSlim"/>.
     /// </summary>
-    public static class SemaphoreSlimExtensions
+    internal static class SemaphoreSlimExtensions
     {
         public static async Task<Releaser> WithWaitAsync(this SemaphoreSlim semaphore, CancellationToken cancellationToken)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
@@ -7,7 +7,7 @@ using Microsoft.Bot.Builder.Dialogs;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class CodePoint : ICodePoint
+    internal sealed class CodePoint : ICodePoint
     {
         public CodePoint(ICodeModel codeModel, DialogContext dialogContext, object item, string more)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/ICodeModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/ICodeModel.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         object Evaluate(string expression);
     }
 
-    public sealed class CodeModel : ICodeModel
+    internal sealed class CodeModel : ICodeModel
     {
         string ICodeModel.NameFor(object item)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/DataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/DataModel.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class DataModel : IDataModel
+    internal sealed class DataModel : IDataModel
     {
         private readonly ICoercion coercion;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/DataModelBase.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/DataModelBase.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public abstract class DataModelBase<TContext, TName, TValue> : IDataModel
+    internal abstract class DataModelBase<TContext, TName, TValue> : IDataModel
     {
         private readonly ICoercion coercion;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/DictionaryDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/DictionaryDataModel.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class DictionaryDataModel<TKey, TValue> : DataModelBase<IDictionary<TKey, TValue>, TKey, TValue>
+#pragma warning disable CA1812 // Supressing error due to internal being used as intended
+    internal class DictionaryDataModel<TKey, TValue> : DataModelBase<IDictionary<TKey, TValue>, TKey, TValue>
+#pragma warning restore CA1812
     {
         public DictionaryDataModel(ICoercion coercion)
             : base(coercion)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/EnumerableDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/EnumerableDataModel.cs
@@ -7,7 +7,9 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class EnumerableDataModel<T> : DataModelBase<IEnumerable<T>, int, T>
+#pragma warning disable CA1812 // Supressing error due to internal being used as intended
+    internal sealed class EnumerableDataModel<T> : DataModelBase<IEnumerable<T>, int, T>
+#pragma warning restore CA1812 // Supressing error due to internal being used as intended
     {
         public EnumerableDataModel(ICoercion coercion)
             : base(coercion)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ICoercion.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ICoercion.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         object Coerce(object source, Type target);
     }
 
-    public sealed class Coercion : ICoercion
+    internal sealed class Coercion : ICoercion
     {
         public Coercion()
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/JValueDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/JValueDataModel.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class JValueDataModel : IDataModel
+    internal sealed class JValueDataModel : IDataModel
     {
         public static readonly IDataModel Instance = new JValueDataModel();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ListDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ListDataModel.cs
@@ -6,7 +6,9 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class ListDataModel<T> : DataModelBase<IList<T>, int, T>
+#pragma warning disable CA1812 // Supressing error due to internal being used as intended
+    internal sealed class ListDataModel<T> : DataModelBase<IList<T>, int, T>
+#pragma warning restore CA1812 // Supressing error due to internal being used as intended
     {
         public ListDataModel(ICoercion coercion)
             : base(coercion)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/NullDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/NullDataModel.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class NullDataModel : IDataModel
+    internal sealed class NullDataModel : IDataModel
     {
         public static readonly IDataModel Instance = new NullDataModel();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ReadOnlyDictionaryDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ReadOnlyDictionaryDataModel.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class ReadOnlyDictionaryDataModel<TKey, TValue> : DataModelBase<IReadOnlyDictionary<TKey, TValue>, TKey, TValue>
+#pragma warning disable CA1812 // Supressing error due to internal being used as intended
+    internal sealed class ReadOnlyDictionaryDataModel<TKey, TValue> : DataModelBase<IReadOnlyDictionary<TKey, TValue>, TKey, TValue>
+#pragma warning restore CA1812 // Supressing error due to internal being used as intended
     {
         public ReadOnlyDictionaryDataModel(ICoercion coercion)
             : base(coercion)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ReflectionDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ReflectionDataModel.cs
@@ -6,7 +6,9 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class ReflectionDataModel<T> : DataModelBase<object, string, object>
+#pragma warning disable CA1812 // Supressing error due to internal being used as intended
+    internal sealed class ReflectionDataModel<T> : DataModelBase<object, string, object>
+#pragma warning restore CA1812 // Supressing error due to internal being used as intended
     {
         public ReflectionDataModel(ICoercion coercion)
             : base(coercion)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ScalarDataModel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DataModels/ScalarDataModel.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class ScalarDataModel : IDataModel
+    internal sealed class ScalarDataModel : IDataModel
     {
         public static readonly IDataModel Instance = new ScalarDataModel();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class DebuggerSourceMap : ISourceMap, IBreakpoints
+    internal sealed class DebuggerSourceMap : ISourceMap, IBreakpoints
     {
         private readonly ICodeModel codeModel;
         private readonly object gate = new object();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events/Events.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events/Events.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class Events<TDialogEvents> : IEvents
+    internal sealed class Events<TDialogEvents> : IEvents
         where TDialogEvents : DialogEvents
     {
         private readonly ConcurrentDictionary<string, bool> stateByFilter = new ConcurrentDictionary<string, bool>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/IdentifierCache.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/IdentifierCache.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class IdentifierCache<T> : IIdentifier<T>
+    internal sealed class IdentifierCache<T> : IIdentifier<T>
     {
         private readonly IIdentifier<T> inner;
         private readonly int count;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/IdentifierFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/IdentifierFactory.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public static class IdentifierFactory
+    internal static class IdentifierFactory
     {
         public static IIdentifier<T> WithCache<T>(this IIdentifier<T> identifier, int count)
             => new IdentifierCache<T>(identifier, count);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/IdentifierMutex.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/IdentifierMutex.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public sealed class IdentifierMutex<T> : IIdentifier<T>
+    internal sealed class IdentifierMutex<T> : IIdentifier<T>
     {
         private readonly IIdentifier<T> inner;
         private readonly object gate = new object();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/Identifier{T}.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/Identifier{T}.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// For these combined identifiers, we use 7 bit encoding.
     /// </summary>
     /// <typeparam name="T">Datatype of the stored items.</typeparam>
-    public sealed class Identifier<T> : IIdentifier<T>
+    internal sealed class Identifier<T> : IIdentifier<T>
     {
         private readonly Dictionary<T, ulong> codeByItem = new Dictionary<T, ulong>(ReferenceEquality<T>.Instance);
         private readonly Dictionary<ulong, T> itemByCode = new Dictionary<ulong, T>();

--- a/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
@@ -295,6 +295,7 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.True(message.Attachments[1].Name == attachmentName2, "Incorrect Attachment2 Name");
         }
 
+        [Fact]
         public void CarouselUnorderedAttachments()
         {
             var text = Guid.NewGuid().ToString();


### PR DESCRIPTION
To make documentation easier I'm making the majority of the classes in dialog.testing internal. 