### PR TITLE
Update dotnet-ci yaml to condition the API compat execution

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -91,12 +91,12 @@ stages:
        }
        else {
          if ("$(Build.Reason)" -eq 'Manual') {
-           git checkout master-test
+           git checkout master
            $branchSource = "$(Build.SourceBranch)"
            echo $branchSource
            $branchSourcePath = $branchSource -replace "refs/heads/", ""
            git checkout $branchSourcePath
-           $commits = $(git rev-list --count HEAD ^master-test)
+           $commits = $(git rev-list --count HEAD ^master)
            echo "Commits: $commits"
            $updatedFiles = $(git diff HEAD HEAD~$commits --name-only)
          }

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -81,24 +81,57 @@ stages:
   - job: generate_multiconfig_var
     steps:
     - powershell: |
+       if ("$(Build.Reason)" -eq 'Schedule') {
+         $updatedFiles = $env:BotBuilderDll
+       }
+       elseIf ("$(Build.Reason)" -eq 'Manual') {
+         git checkout master
+         $branchSource = "$(Build.SourceBranch)"
+         echo $branchSource
+         $branchSourcePath = $branchSource -replace "refs/heads/", ""
+         git checkout $branchSourcePath
+         $commits = $(git rev-list --count HEAD ^master)
+         echo "Commits: $commits"
+         $updatedFiles = $(git diff HEAD HEAD~$commits --name-only)
+       }
+       else {
+         $updatedFiles = $(git diff HEAD HEAD~ --name-only)
+       }
+
        $multiconfig = '{';
-
-       $env:BotBuilderDll.Split(",") | ForEach {
-           $library = $_.Trim()
-           Write-Host $library
-
-           $threadName = $library.Split(".")[-1];
-           $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $library + "'}, ";
+       $updatedFiles | ForEach-Object {
+         $changedLibrary = ''
+         Switch -Wildcard ($_) {
+           '*/Microsoft.Bot.Builder.AI.Luis/*' { $changedLibrary = 'Microsoft.Bot.Builder.AI.Luis' }
+           '*/Microsoft.Bot.Builder.AI.QnA/*' { $changedLibrary = 'Microsoft.Bot.Builder.AI.QnA' }
+           '*/Microsoft.Bot.Builder.ApplicationInsights/*' { $changedLibrary = 'Microsoft.Bot.Builder.ApplicationInsights' }
+           '*/Microsoft.Bot.Builder.Azure/*' { $changedLibrary = 'Microsoft.Bot.Builder.Azure' }
+           '*/Microsoft.Bot.Builder.Dialogs/*' { $changedLibrary = 'Microsoft.Bot.Builder.Dialogs' }
+           '*/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.ApplicationInsights.Core' }
+           '*/Microsoft.Bot.Builder.Integration.AspNet.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.AspNet.Core' }
+           '*/Microsoft.Bot.Builder.TemplateManager/*' { $changedLibrary = 'Microsoft.Bot.Builder.TemplateManager' }
+           '*/Microsoft.Bot.Builder.Testing/*' { $changedLibrary = 'Microsoft.Bot.Builder.Testing' }
+           '*/Microsoft.Bot.Builder/*' { $changedLibrary = 'Microsoft.Bot.Builder' }
+           '*/Microsoft.Bot.Configuration/*' { $changedLibrary = 'Microsoft.Bot.Configuration' }
+           '*/Microsoft.Bot.Connector/*' { $changedLibrary = 'Microsoft.Bot.Connector' }
+           '*/Microsoft.Bot.Schema/*' { $changedLibrary = 'Microsoft.Bot.Schema' }
+           '*/Microsoft.Bot.Streaming/*' { $changedLibrary = 'Microsoft.Bot.Streaming' }
          }
+         if ($changedLibrary.Length -gt 0) {
+           Write-Host $changedLibrary
+           $threadName = $changedLibrary.Split(".")[-1];
+           $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $changedLibrary + "'}, ";
+         }
+       }
        $multiconfig = $multiconfig.TrimEnd(' ').TrimEnd(',') + "}";
-       $multiconfig
-
+       echo $multiconfig
        "##vso[task.setVariable variable=MULTICONFIG;isOutput=true]$multiconfig"
       name: generate_var
     - script: echo $(generate_var.MULTICONFIG)
 
   - job: check_api_for
     dependsOn: generate_multiconfig_var
+    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
     timeoutInMinutes: 10
     strategy:
       maxParallel: 10
@@ -106,10 +139,9 @@ stages:
     steps:
     - template: ci-api-validation-steps.yml
 
-- stage: Post_Results_to_GitHub
-  dependsOn: API_Compatibility_Validation
-  jobs:
-  - job: Post_to_GitHub
+  - job: post_results_to_gitHub
+    dependsOn: generate_multiconfig_var
+    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
     variables:
       BuildConfiguration: Release-Windows
     steps:

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -81,48 +81,53 @@ stages:
   - job: generate_multiconfig_var
     steps:
     - powershell: |
+       $multiconfig = '{';
        if ("$(Build.Reason)" -eq 'Schedule') {
-         $updatedFiles = $env:BotBuilderDll
-       }
-       elseIf ("$(Build.Reason)" -eq 'Manual') {
-         git checkout master
-         $branchSource = "$(Build.SourceBranch)"
-         echo $branchSource
-         $branchSourcePath = $branchSource -replace "refs/heads/", ""
-         git checkout $branchSourcePath
-         $commits = $(git rev-list --count HEAD ^master)
-         echo "Commits: $commits"
-         $updatedFiles = $(git diff HEAD HEAD~$commits --name-only)
+         $env:BotBuilderDll.Split(",") | ForEach {
+           $library = $_.Trim()
+           $threadName = $library.Split(".")[-1];
+           $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $library + "'}, ";
+         }
        }
        else {
-         $updatedFiles = $(git diff HEAD HEAD~ --name-only)
-       }
-
-       $multiconfig = '{';
-       $updatedFiles | ForEach-Object {
-         $changedLibrary = ''
-         Switch -Wildcard ($_) {
-           '*/Microsoft.Bot.Builder.AI.Luis/*' { $changedLibrary = 'Microsoft.Bot.Builder.AI.Luis' }
-           '*/Microsoft.Bot.Builder.AI.QnA/*' { $changedLibrary = 'Microsoft.Bot.Builder.AI.QnA' }
-           '*/Microsoft.Bot.Builder.ApplicationInsights/*' { $changedLibrary = 'Microsoft.Bot.Builder.ApplicationInsights' }
-           '*/Microsoft.Bot.Builder.Azure/*' { $changedLibrary = 'Microsoft.Bot.Builder.Azure' }
-           '*/Microsoft.Bot.Builder.Dialogs/*' { $changedLibrary = 'Microsoft.Bot.Builder.Dialogs' }
-           '*/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.ApplicationInsights.Core' }
-           '*/Microsoft.Bot.Builder.Integration.AspNet.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.AspNet.Core' }
-           '*/Microsoft.Bot.Builder.TemplateManager/*' { $changedLibrary = 'Microsoft.Bot.Builder.TemplateManager' }
-           '*/Microsoft.Bot.Builder.Testing/*' { $changedLibrary = 'Microsoft.Bot.Builder.Testing' }
-           '*/Microsoft.Bot.Builder/*' { $changedLibrary = 'Microsoft.Bot.Builder' }
-           '*/Microsoft.Bot.Configuration/*' { $changedLibrary = 'Microsoft.Bot.Configuration' }
-           '*/Microsoft.Bot.Connector/*' { $changedLibrary = 'Microsoft.Bot.Connector' }
-           '*/Microsoft.Bot.Schema/*' { $changedLibrary = 'Microsoft.Bot.Schema' }
-           '*/Microsoft.Bot.Streaming/*' { $changedLibrary = 'Microsoft.Bot.Streaming' }
+         if ("$(Build.Reason)" -eq 'Manual') {
+           git checkout master-test
+           $branchSource = "$(Build.SourceBranch)"
+           echo $branchSource
+           $branchSourcePath = $branchSource -replace "refs/heads/", ""
+           git checkout $branchSourcePath
+           $commits = $(git rev-list --count HEAD ^master-test)
+           echo "Commits: $commits"
+           $updatedFiles = $(git diff HEAD HEAD~$commits --name-only)
          }
-         if ($changedLibrary.Length -gt 0) {
-           Write-Host $changedLibrary
-           $threadName = $changedLibrary.Split(".")[-1];
-           $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $changedLibrary + "'}, ";
+         else {
+           $updatedFiles = $(git diff HEAD HEAD~ --name-only)
          }
-       }
+         $updatedFiles | ForEach-Object {
+           $changedLibrary = ''
+           Switch -Wildcard ($_) {
+             '*/Microsoft.Bot.Builder.AI.Luis/*' { $changedLibrary = 'Microsoft.Bot.Builder.AI.Luis' }
+             '*/Microsoft.Bot.Builder.AI.QnA/*' { $changedLibrary = 'Microsoft.Bot.Builder.AI.QnA' }
+             '*/Microsoft.Bot.Builder.ApplicationInsights/*' { $changedLibrary = 'Microsoft.Bot.Builder.ApplicationInsights' }
+             '*/Microsoft.Bot.Builder.Azure/*' { $changedLibrary = 'Microsoft.Bot.Builder.Azure' }
+             '*/Microsoft.Bot.Builder.Dialogs/*' { $changedLibrary = 'Microsoft.Bot.Builder.Dialogs' }
+             '*/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.ApplicationInsights.Core' }
+             '*/Microsoft.Bot.Builder.Integration.AspNet.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.AspNet.Core' }
+             '*/Microsoft.Bot.Builder.TemplateManager/*' { $changedLibrary = 'Microsoft.Bot.Builder.TemplateManager' }
+             '*/Microsoft.Bot.Builder.Testing/*' { $changedLibrary = 'Microsoft.Bot.Builder.Testing' }
+             '*/Microsoft.Bot.Builder/*' { $changedLibrary = 'Microsoft.Bot.Builder' }
+             '*/Microsoft.Bot.Configuration/*' { $changedLibrary = 'Microsoft.Bot.Configuration' }
+             '*/Microsoft.Bot.Connector/*' { $changedLibrary = 'Microsoft.Bot.Connector' }
+             '*/Microsoft.Bot.Schema/*' { $changedLibrary = 'Microsoft.Bot.Schema' }
+             '*/Microsoft.Bot.Streaming/*' { $changedLibrary = 'Microsoft.Bot.Streaming' }
+           }
+           if ($changedLibrary.Length -gt 0) {
+             Write-Host $changedLibrary
+             $threadName = $changedLibrary.Split(".")[-1];
+             $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $changedLibrary + "'}, ";
+           }
+          }
+        }
        $multiconfig = $multiconfig.TrimEnd(' ').TrimEnd(',') + "}";
        echo $multiconfig
        "##vso[task.setVariable variable=MULTICONFIG;isOutput=true]$multiconfig"


### PR DESCRIPTION
Fixes #4320

## Description
This PR updates the [botbuilder-dotnet-ci](https://github.com/microsoft/botbuilder-dotnet/blob/master/build/yaml/botbuilder-dotnet-ci.yml) yaml file adding a script that evaluates which compatibility checks are needed, depending on what libraries have been modified.
If the pipeline is scheduled (Nightly Build) all the API compatibility validations will run.

## Specific Changes
  - Updated the **_API_Compatibility_Validation_** stage in _botbuilder-dotnet-ci_ yaml to add a validation in the PowerShell step that gets the updated files si it only runs the API compat validation on those libraries. 
  - Added a condition to the **_check_api_for_** and **_post_results_to_gitHub_** jobs to run if one or more libraries were updated.
  - Converted the **_Post_Results_to_GitHub_** stage into a job so it can be conditioned to the variable set with the updated libraries (MULTICONFIG).

## Testing
The following image shows a PR triggered pipeline with no changes in the libraries. The API compatibility validations are skipped.
![image](https://user-images.githubusercontent.com/44245136/88844248-c3f4a800-d1b8-11ea-955c-4f4db649da67.png)

The following image shows a PR triggered pipeline with changes in the Dialogs and LUIS libraries.
![image](https://user-images.githubusercontent.com/44245136/88844330-dec71c80-d1b8-11ea-95a5-dc904b497b3b.png)
