### PR TITLE
Fixed diff in descriptions against SDK swagger

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Activity.cs
+++ b/libraries/Microsoft.Bot.Schema/Activity.cs
@@ -357,12 +357,7 @@ namespace Microsoft.Bot.Schema
         public bool? HistoryDisclosed { get; set; }
 
         /// <summary>
-        /// Gets or sets a locale name for the contents of the text field.
-        /// The locale name is a combination of an ISO 639 two- or three-letter
-        /// culture code associated with a language
-        /// and an ISO 3166 two-letter subculture code associated with a
-        /// country or region.
-        /// The locale name can also correspond to a valid BCP-47 language tag.
+        /// Gets or sets a BCP-47 locale name for the contents of the text field.
         /// </summary>
         /// <value>
         /// A locale for the activity.

--- a/libraries/Microsoft.Bot.Schema/CardAction.cs
+++ b/libraries/Microsoft.Bot.Schema/CardAction.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Bot.Schema
         public object ChannelData { get; set; }
 
         /// <summary>
-        /// Gets or sets alternate image text to be used in place of the `image` field
+        /// Gets or sets alternate text to be used for the Image property
         /// </summary>
         [JsonProperty(PropertyName = "imageAltText")]
         public string ImageAltText { get; set; }

--- a/libraries/Microsoft.Bot.Schema/ConversationReference.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationReference.cs
@@ -91,32 +91,32 @@ namespace Microsoft.Bot.Schema
         public ChannelAccount User { get; set; }
 
         /// <summary>
-        /// Gets or sets bot participating in this conversation
+        /// Gets or sets (Optional) Bot participating in this conversation
         /// </summary>
         [JsonProperty(PropertyName = "bot")]
         public ChannelAccount Bot { get; set; }
 
         /// <summary>
-        /// Gets or sets conversation reference
+        /// Gets or sets Reference to the conversation
         /// </summary>
         [JsonProperty(PropertyName = "conversation")]
         public ConversationAccount Conversation { get; set; }
 
         /// <summary>
-        /// Gets or sets channel ID
+        /// Gets or sets ID of the channel in which the referenced conversation exists
         /// </summary>
         [JsonProperty(PropertyName = "channelId")]
         public string ChannelId { get; set; }
         
         /// <summary>
-        /// Gets or sets Locale
+        /// Gets or sets (Optional) A BCP-47 locale name for the referenced conversation
         /// </summary>
         [JsonProperty(PropertyName = "locale")]
         public string Locale { get; set; }
 
         /// <summary>
-        /// Gets or sets service endpoint where operations concerning the
-        /// referenced conversation may be performed
+        /// Gets or sets (Optional) Service endpoint where operations concerning
+        /// the referenced conversation may be performed
         /// </summary>
         [JsonProperty(PropertyName = "serviceUrl")]
         public string ServiceUrl { get; set; }    


### PR DESCRIPTION
With this PR and after conversation with @EricDahlvang the code base will be up to date with the swagger spec json [v3.1.12](https://github.com/microsoft/botframework-sdk/blob/master/specs/botframework-protocol/botframework-channel.json)


After merging this, it would be safe to delete current ConnectorAPI.json under swagger folder.