### PR TITLE
Flush out missing doc comments in Adaptive.Testing assembly

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Actions/AssertCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Actions/AssertCondition.cs
@@ -8,11 +8,22 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Actions
 {
+    /// <summary>
+    /// Dialog action which allows you to add assertions into your dialog flow.
+    /// </summary>
     public class AssertCondition : Dialog
     {
+        /// <summary>
+        /// Kind to use for serialization.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.AssertCondition";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertCondition"/> class.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         [JsonConstructor]
         public AssertCondition([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingComponentRegistration.cs
@@ -15,8 +15,12 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 {
+    /// <summary>
+    /// Component registration for AdaptiveTesting resources.
+    /// </summary>
     public class AdaptiveTestingComponentRegistration : ComponentRegistration, IComponentDeclarativeTypes
     {
+        /// <inheritdoc/>
         public virtual IEnumerable<DeclarativeType> GetDeclarativeTypes(ResourceExplorer resourceExplorer)
         {
             // Action
@@ -37,6 +41,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
             yield return new DeclarativeType<PropertiesMock>(PropertiesMock.Kind);
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerable<JsonConverter> GetConverters(ResourceExplorer resourceExplorer, SourceContext sourceContext)
         {
             yield return new InterfaceConverter<TestAction>(resourceExplorer, sourceContext);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestMock.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// <param name="handler">The global handler.</param>
         public abstract void Setup(MockHttpMessageHandler handler);
 
+        /// <summary>
+        /// helper to register source path with debugger.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         protected void RegisterSourcePath(string path, int line)
         {
             if (!string.IsNullOrEmpty(path))

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpRequestSequenceMock.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.HttpRequestSequenceMock";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpRequestSequenceMock"/> class.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         [JsonConstructor]
         public HttpRequestSequenceMock([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {
@@ -53,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
         /// The sequence of responses to reply.
         /// </value>
         [JsonProperty("responses")]
-        public List<HttpResponseMock> Responses { get;  } = new List<HttpResponseMock>();
+        public List<HttpResponseMock> Responses { get; } = new List<HttpResponseMock>();
 
         public override void Setup(MockHttpMessageHandler handler)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockHttpRequestMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockHttpRequestMiddleware.cs
@@ -10,12 +10,19 @@ using RichardSzalay.MockHttp;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
 {
+    /// <summary>
+    /// Middleware to mock http requests with an adapter.
+    /// </summary>
     public class MockHttpRequestMiddleware : IMiddleware
     {
         private readonly HttpMessageHandler _httpMessageHandler;
 
-        private readonly HttpClient _httpClient; 
+        private readonly HttpClient _httpClient;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockHttpRequestMiddleware"/> class.
+        /// </summary>
+        /// <param name="httpRequestMocks">mocks to use.</param>
         public MockHttpRequestMiddleware(List<HttpRequestMock> httpRequestMocks)
         {
             var handler = new MockHttpMessageHandler();
@@ -29,6 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Mocks
             _httpClient = client;
         }
 
+        /// <inheritdoc/>
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
         {
             turnContext.TurnState.Add(_httpMessageHandler);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisExtensions.cs
@@ -11,6 +11,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Testing
 {
+    /// <summary>
+    /// Helper extensions for mocking luis.
+    /// </summary>
     public static class MockLuisExtensions
     {
         private static readonly Encoding UTF8 = new UTF8Encoding();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisLoader.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisLoader.cs
@@ -10,15 +10,23 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Testing
 {
+    /// <summary>
+    /// Custom json serializer for mocking luis.
+    /// </summary>
     public class MockLuisLoader : ICustomDeserializer
     {
         private IConfiguration configuration;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockLuisLoader"/> class.
+        /// </summary>
+        /// <param name="configuration">configuration to use.</param>
         public MockLuisLoader(IConfiguration configuration)
         {
             this.configuration = configuration;
         }
 
+        /// <inheritdoc/>
         public object Load(JToken obj, JsonSerializer serializer, Type type)
         {
             var recognizer = obj.ToObject<LuisAdaptiveRecognizer>(serializer);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisRecognizer.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Testing
             }
         }
 
+        /// <inheritdoc/>
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             var recognizer = _recognizer.RecognizerOptions(dialogContext);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockedHttpClientHandler.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockedHttpClientHandler.cs
@@ -7,15 +7,23 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.AI.Luis.Testing
 {
+    /// <summary>
+    /// HttpChandler mock.
+    /// </summary>
     public class MockedHttpClientHandler : HttpClientHandler
     {
         private readonly HttpClient client;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockedHttpClientHandler"/> class.
+        /// </summary>
+        /// <param name="client">client to use.</param>
         public MockedHttpClientHandler(HttpClient client)
         {
             this.client = client;
         }
 
+        /// <inheritdoc/>
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/MockSettingsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/MockSettingsMiddleware.cs
@@ -10,13 +10,17 @@ using Microsoft.Extensions.Configuration;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.PropertyMocks
 {
     /// <summary>
-    /// Middleware used for mocking settings properties.
+    /// Middleware which injests mocked settings properties.
     /// </summary>
     public class MockSettingsMiddleware : IMiddleware
     {
         private readonly string prefix = $"{ScopePath.Settings}.";
         private readonly Dictionary<string, string> mockData = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockSettingsMiddleware"/> class.
+        /// </summary>
+        /// <param name="properties">properties to mock.</param>
         public MockSettingsMiddleware(List<PropertyMock> properties)
         {
             foreach (var property in properties)
@@ -47,6 +51,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.PropertyMocks
             }
         }
 
+        /// <inheritdoc/>
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
         {
             if (mockData.Count != 0)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/PropertiesMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/PropertiesMock.cs
@@ -12,9 +12,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.PropertyMocks
     /// </summary>
     public class PropertiesMock : PropertyMock
     {
+        /// <summary>
+        /// Kind to serialize.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.PropertiesMock";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertiesMock"/> class.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         [JsonConstructor]
         public PropertiesMock([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/PropertyMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/PropertyMocks/PropertyMock.cs
@@ -10,6 +10,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.PropertyMocks
     /// </summary>
     public abstract class PropertyMock
     {
+        /// <summary>
+        /// Method to register mock with debugger.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         protected void RegisterSourcePath(string path, int line)
         {
             if (!string.IsNullOrEmpty(path))

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReply.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReply.cs
@@ -7,12 +7,23 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
+    /// <summary>
+    /// Test Script action to assert that the bots' reply matches expectations.
+    /// </summary>
     [DebuggerDisplay("AssertReply{Exact ? \"[Exact]\" : string.Empty}:{GetConditionDescription()}")]
     public class AssertReply : AssertReplyActivity
     {
+        /// <summary>
+        /// Kind for the json object.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.Test.AssertReply";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertReply"/> class.
+        /// </summary>
+        /// <param name="path">path.</param>
+        /// <param name="line">line number.</param>
         [JsonConstructor]
         public AssertReply([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
             : base(path, line)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyActivity.cs
@@ -19,9 +19,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
     [DebuggerDisplay("AssertReplyActivity:{GetConditionDescription()}")]
     public class AssertReplyActivity : TestAction
     {
+        /// <summary>
+        /// Kind for json serialization.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.AssertReplyActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertReplyActivity"/> class.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         [JsonConstructor]
         public AssertReplyActivity([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyOneOf.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyOneOf.cs
@@ -8,12 +8,23 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
+    /// <summary>
+    /// Assertion that reply from the bot matches one of options.
+    /// </summary>
     [DebuggerDisplay("AssertReplyOneOf:{GetConditionDescription()}")]
     public class AssertReplyOneOf : AssertReplyActivity
     {
+        /// <summary>
+        /// kind for serialization.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.Test.AssertReplyOneOf";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertReplyOneOf"/> class.
+        /// </summary>
+        /// <param name="path">path to source.</param>
+        /// <param name="line">line number in source.</param>
         [JsonConstructor]
         public AssertReplyOneOf([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
             : base(path, line)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/TestAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/TestAction.cs
@@ -9,8 +9,17 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 {
+    /// <summary>
+    /// Abstract base class for scripted actions.
+    /// </summary>
     public abstract class TestAction
     {
+        /// <summary>
+        /// Execute the test.
+        /// </summary>
+        /// <param name="adapter">adapter to execute against.</param>
+        /// <param name="callback">logic for the bot to use.</param>
+        /// <returns>async task.</returns>
         public abstract Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback);
 
         protected void RegisterSourcePath(string path, int line)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs
@@ -20,9 +20,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
     /// </summary>
     public class UserActivity : TestAction
     {
+        /// <summary>
+        /// Kind for the serialization.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.UserActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserActivity"/> class.
+        /// </summary>
+        /// <param name="path">path to source.</param>
+        /// <param name="line">line number in source.</param>
         [JsonConstructor]
         public UserActivity([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {
@@ -66,9 +74,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 
             Stopwatch sw = new Stopwatch();
             sw.Start();
-            
+
             await adapter.ProcessActivityAsync(activity, callback, default(CancellationToken)).ConfigureAwait(false);
-            
+
             sw.Stop();
             Trace.TraceInformation($"[Turn Ended => {sw.ElapsedMilliseconds} ms processing UserActivity: {this.Activity.Text} ]");
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserConversationUpdate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserConversationUpdate.cs
@@ -15,12 +15,23 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
+    /// <summary>
+    /// Action to script sending a conversationUpdate activity to the bot.
+    /// </summary>
     [DebuggerDisplay("UserConversationUpdate")]
     public class UserConversationUpdate : TestAction
     {
+        /// <summary>
+        /// Kind for serialization.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.UserConversationUpdate";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserConversationUpdate"/> class.
+        /// </summary>
+        /// <param name="path">path for source.</param>
+        /// <param name="line">line number in source.</param>
         [JsonConstructor]
         public UserConversationUpdate([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserDelay.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserDelay.cs
@@ -10,12 +10,23 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
+    /// <summary>
+    /// Script action to delay test script for specified timespan.
+    /// </summary>
     [DebuggerDisplay("UserDelay:{Timespan}")]
     public class UserDelay : TestAction
     {
+        /// <summary>
+        /// serialization of kind.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.UserDelay";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserDelay"/> class.
+        /// </summary>
+        /// <param name="path">path for source.</param>
+        /// <param name="line">line number in source.</param>
         [JsonConstructor]
         public UserDelay([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserSays.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserSays.cs
@@ -15,14 +15,22 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
     /// <summary>
-    /// Send an text to the bot.
+    /// Action to script sending text to the bot.
     /// </summary>
     [DebuggerDisplay("UserSays:{Text}")]
     public class UserSays : TestAction
     {
+        /// <summary>
+        /// Seralization of kind.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.UserSays";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserSays"/> class.
+        /// </summary>
+        /// <param name="path">path for source.</param>
+        /// <param name="line">line number in source.</param>
         [JsonConstructor]
         public UserSays([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserTyping.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserTyping.cs
@@ -11,12 +11,23 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
+    /// <summary>
+    /// Action to script sending typing activity to bot.
+    /// </summary>
     [DebuggerDisplay("UserTyping")]
     public class UserTyping : TestAction
     {
+        /// <summary>
+        /// Kind to serialize.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.UserTyping";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserTyping"/> class.
+        /// </summary>
+        /// <param name="path">path for source.</param>
+        /// <param name="line">line number in source.</param>
         [JsonConstructor]
         public UserTyping([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/UserTokenMocks/UserTokenBasicMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/UserTokenMocks/UserTokenBasicMock.cs
@@ -7,11 +7,19 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.UserTokenMocks
 {
+    /// <summary>
+    /// Mock UserToken with juse user id and token.
+    /// </summary>
     public class UserTokenBasicMock : UserTokenMock
     {
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.Test.UserTokenBasicMock";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserTokenBasicMock"/> class.
+        /// </summary>
+        /// <param name="path">optional path.</param>
+        /// <param name="line">optional line.</param>
         [JsonConstructor]
         public UserTokenBasicMock([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/UserTokenMocks/UserTokenMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/UserTokenMocks/UserTokenMock.cs
@@ -6,8 +6,15 @@ using Microsoft.Bot.Builder.Dialogs.Debugging;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.UserTokenMocks
 {
+    /// <summary>
+    /// Abstract class for mocking user token flows.
+    /// </summary>
     public abstract class UserTokenMock
     {
+        /// <summary>
+        /// Method to setup this mock for an adapter.
+        /// </summary>
+        /// <param name="adapter">adapter to register the mock with.</param>
         public abstract void Setup(TestAdapter adapter);
 
         protected void RegisterSourcePath(string path, int line)


### PR DESCRIPTION

## Description
Some classes were missing ctor doc comments and class doc comments.

## Specific Changes
Added missing doc comments.

## Testing
none, it's just comments.