### PR TITLE
keep resource consistent across lg resources

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/LanguageGeneratorManager.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
                 else
                 {
                     var content = resource.ReadTextAsync().GetAwaiter().GetResult();
-                    return (content, resource.Id);
+                    return new LGResource(resource.Id, resource.FullName, content);
                 }
             };
         }
@@ -86,15 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
         private TemplateEngineLanguageGenerator GetTemplateEngineLanguageGenerator(Resource resource)
         {
-            var fileResource = resource as FileResource;
-            if (fileResource == null)
-            {
-                return new TemplateEngineLanguageGenerator(resource.ReadTextAsync().GetAwaiter().GetResult(), resource.Id, multilanguageResources);
-            }
-            else
-            {
-                return new TemplateEngineLanguageGenerator(fileResource.FullName, multilanguageResources);
-            }
+            return new TemplateEngineLanguageGenerator(resource, multilanguageResources);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -47,12 +47,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// <param name="lgText">lg template text.</param>
         /// <param name="id">optional label for the source of the templates (used for labeling source of template errors).</param>
         /// <param name="resourceMapping">template resource loader delegate (locale) -> <see cref="ImportResolverDelegate"/>.</param>
+        [Obsolete("This method will soon be deprecated. Use Resource as the first parameter instead.")]
         public TemplateEngineLanguageGenerator(string lgText, string id, Dictionary<string, IList<Resource>> resourceMapping)
         {
             this.Id = id ?? DEFAULTLABEL;
             var (_, locale) = LGResourceLoader.ParseLGFileName(id);
             var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
-            this.lg = LanguageGeneration.Templates.ParseText(lgText ?? string.Empty, Id, importResolver);
+            var lgResource = new LGResource(Id, Id, lgText ?? string.Empty);
+            this.lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
         }
 
         /// <summary>
@@ -60,6 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// </summary>
         /// <param name="filePath">lg template file absolute path.</param>
         /// <param name="resourceMapping">template resource loader delegate (locale) -> <see cref="ImportResolverDelegate"/>.</param>
+        [Obsolete("This method will soon be deprecated. Use Resource as the first parameter instead.")]
         public TemplateEngineLanguageGenerator(string filePath, Dictionary<string, IList<Resource>> resourceMapping)
         {
             filePath = PathUtils.NormalizePath(filePath);
@@ -67,7 +70,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
             var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
             var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
-            this.lg = LanguageGeneration.Templates.ParseFile(filePath, importResolver);
+            var resource = new LGResource(Id, filePath, File.ReadAllText(filePath));
+            this.lg = LanguageGeneration.Templates.ParseResource(resource, importResolver);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateEngineLanguageGenerator"/> class.
+        /// </summary>
+        /// <param name="resource">Resource.</param>
+        /// <param name="resourceMapping">template resource loader delegate (locale) -> <see cref="ImportResolverDelegate"/>.</param>
+        public TemplateEngineLanguageGenerator(Resource resource, Dictionary<string, IList<Resource>> resourceMapping)
+        {
+            this.Id = resource.Id;
+
+            var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
+            var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
+            var content = resource.ReadTextAsync().GetAwaiter().GetResult();
+            var lgResource = new LGResource(Id, resource.FullName, content);
+            this.lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FileResource.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FileResource.cs
@@ -25,14 +25,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         }
 
         /// <summary>
-        /// Gets the resource path.
-        /// </summary>
-        /// <value>
-        /// The full path to the resource on disk.
-        /// </value>
-        public string FullName { get; }
-
-        /// <summary>
         /// Open a stream to the resource.
         /// </summary>
         /// <returns>Stream for accesssing the content of the resource.</returns>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/Resource.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/Resource.cs
@@ -20,6 +20,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         public string Id { get; protected set; }
 
         /// <summary>
+        /// Gets or sets the resource path.
+        /// </summary>
+        /// <value>
+        /// The full path to the resource on disk.
+        /// </value>
+        public string FullName { get; protected set; }
+
+        /// <summary>
         /// Get readonly stream. 
         /// </summary>
         /// <returns>The resource as a stream.</returns>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGResource.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/LGResource.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.LanguageGeneration
+{
+    /// <summary>
+    /// LG resource entity, contains some core data structure.
+    /// </summary>
+    public class LGResource
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LGResource"/> class.
+        /// </summary>
+        /// <param name="id">Resource id.</param>
+        /// <param name="fullName">The full path to the resource on disk.</param>
+        /// <param name="content">Resource content.</param>
+        public LGResource(string id, string fullName, string content)
+        {
+            Id = id ?? string.Empty;
+            FullName = fullName ?? id ?? string.Empty;
+            Content = content;
+        }
+
+        /// <summary>
+        /// Gets or sets resource id.
+        /// </summary>
+        /// <value>
+        /// Resource id.
+        /// </value>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full path to the resource on disk.
+        /// </summary>
+        /// <value>
+        /// The full path to the resource on disk.
+        /// </value>
+        public string FullName { get; set; }
+
+        /// <summary>
+        /// Gets or sets resource content.
+        /// </summary>
+        /// <value>
+        /// Resource content.
+        /// </value>
+        public string Content { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/StaticChecker.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (templates.AllTemplates.Count == 0)
             {
-                var diagnostic = new Diagnostic(Range.DefaultRange, TemplateErrors.NoTemplate, DiagnosticSeverity.Warning, templates.Id);
+                var diagnostic = new Diagnostic(Range.DefaultRange, TemplateErrors.NoTemplate, DiagnosticSeverity.Warning, templates.Source);
                 result.Add(diagnostic);
                 return result;
             }
@@ -75,7 +75,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     {
                         var startLine = template.SourceRange.Range.Start.Line;
                         var range = new Range(startLine, 0, startLine, template.Name.Length + 1);
-                        var diagnostic = new Diagnostic(range, TemplateErrors.DuplicatedTemplateInDiffTemplate(sameTemplate.Name, sameTemplate.SourceRange.Source), source: templates.Id);
+                        var diagnostic = new Diagnostic(range, TemplateErrors.DuplicatedTemplateInDiffTemplate(sameTemplate.Name, sameTemplate.SourceRange.Source), source: templates.Source);
                         templateDiagnostics.Add(diagnostic);
                     }
                 }
@@ -397,7 +397,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             var range = context == null ? new Range(1 + lineOffset, 0, 1 + lineOffset, 0) : context.ConvertToRange(lineOffset);
-            return new Diagnostic(range, templateNameInfo + message, severity, templates.Id);
+            return new Diagnostic(range, templateNameInfo + message, severity, templates.Source);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
     /// </summary>
     /// <param name="sourceId">The id or path of source file.</param>
     /// <param name="resourceId">Resource id to resolve.</param>
-    /// <returns>Resolved resource content and unique id.</returns>
-    public delegate (string content, string id) ImportResolverDelegate(string sourceId, string resourceId);
+    /// <returns>Resolved resource.</returns>
+    public delegate LGResource ImportResolverDelegate(string sourceId, string resourceId);
 
     /// <summary>
     /// Parser to turn lg content into a <see cref="Templates"/>.
@@ -58,7 +58,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var fullPath = Path.GetFullPath(filePath.NormalizePath());
             var content = File.ReadAllText(fullPath);
 
-            return InnerParseText(content, fullPath, importResolver, expressionParser);
+            var resource = new LGResource(fullPath, fullPath, content);
+            return ParseResource(resource, importResolver, expressionParser);
         }
 
         /// <summary>
@@ -69,13 +70,15 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="importResolver">Resolver to resolve LG import id to template text.</param>
         /// <param name="expressionParser">Expression parser for parsing expressions.</param>
         /// <returns>New <see cref="Templates"/> entity.</returns>
+        [Obsolete("This method will soon be deprecated. Use ParseResource instead.")]
         public static Templates ParseText(
             string content,
             string id = "",
             ImportResolverDelegate importResolver = null,
             ExpressionParser expressionParser = null)
         {
-            return InnerParseText(content, id, importResolver, expressionParser);
+            var resource = new LGResource(id, id, content);
+            return ParseResource(resource, importResolver, expressionParser);
         }
 
         /// <summary>
@@ -91,10 +94,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 throw new ArgumentNullException(nameof(lg));
             }
 
-            var newLG = new Templates(content: content, id: InlineContentId, importResolver: lg.ImportResolver, options: lg.Options);
+            var newLG = new Templates(content: content, id: InlineContentId, source: InlineContentId, importResolver: lg.ImportResolver, options: lg.Options);
             try
             {
-                newLG = new TemplatesTransformer(newLG).Transform(AntlrParseTemplates(content, InlineContentId));
+                var resource = new LGResource(InlineContentId, InlineContentId, content);
+                newLG = new TemplatesTransformer(newLG).Transform(AntlrParseTemplates(resource));
                 newLG.References = GetReferences(newLG)
                         .Union(lg.References)
                         .Union(new List<Templates> { lg })
@@ -113,24 +117,23 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <summary>
         /// Parse LG content and achieve the AST.
         /// </summary>
-        /// <param name="text">LG content.</param>
-        /// <param name="id">Source id.</param>
+        /// <param name="resource">LG resource.</param>
         /// <returns>The abstract syntax tree of lg file.</returns>
-        public static IParseTree AntlrParseTemplates(string text, string id)
+        public static IParseTree AntlrParseTemplates(LGResource resource)
         {
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(resource.Content))
             {
                 return null;
             }
 
-            var input = new AntlrInputStream(text);
+            var input = new AntlrInputStream(resource.Content);
             var lexer = new LGFileLexer(input);
             lexer.RemoveErrorListeners();
 
             var tokens = new CommonTokenStream(lexer);
             var parser = new LGFileParser(tokens);
             parser.RemoveErrorListeners();
-            var listener = new ErrorListener(id);
+            var listener = new ErrorListener(resource.FullName);
 
             parser.AddErrorListener(listener);
             parser.BuildParseTree = true;
@@ -141,31 +144,34 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <summary>
         /// Parser to turn lg content into a <see cref="Templates"/>.
         /// </summary>
-        /// <param name="content">Text content contains lg templates.</param>
-        /// <param name="id">Id is the identifier of content. If importResolver is null, id must be a full path string. </param>
+        /// <param name="resource">LG resource.</param>
         /// <param name="importResolver">Resolver to resolve LG import id to template text.</param>
         /// <param name="expressionParser">Expression parser for parsing expressions.</param>
         /// <param name="cachedTemplates">Give the file path and templates to avoid parsing and to improve performance.</param>
         /// <returns>new <see cref="Templates"/> entity.</returns>
-        private static Templates InnerParseText(
-            string content,
-            string id = "",
+        public static Templates ParseResource(
+            LGResource resource,
             ImportResolverDelegate importResolver = null,
             ExpressionParser expressionParser = null,
             Dictionary<string, Templates> cachedTemplates = null)
         {
-            cachedTemplates = cachedTemplates ?? new Dictionary<string, Templates>();
-            if (cachedTemplates.ContainsKey(id))
+            if (resource == null)
             {
-                return cachedTemplates[id];
+                throw new ArgumentNullException(nameof(resource));
+            }
+
+            cachedTemplates = cachedTemplates ?? new Dictionary<string, Templates>();
+            if (cachedTemplates.ContainsKey(resource.Id))
+            {
+                return cachedTemplates[resource.Id];
             }
 
             importResolver = importResolver ?? DefaultFileResolver;
-            var lg = new Templates(content: content, id: id, importResolver: importResolver, expressionParser: expressionParser);
+            var lg = new Templates(content: resource.Content, id: resource.Id, source: resource.FullName, importResolver: importResolver, expressionParser: expressionParser);
 
             try
             {
-                lg = new TemplatesTransformer(lg).Transform(AntlrParseTemplates(content, id));
+                lg = new TemplatesTransformer(lg).Transform(AntlrParseTemplates(resource));
                 lg.References = GetReferences(lg, cachedTemplates);
                 new StaticChecker(lg).Check().ForEach(u => lg.Diagnostics.Add(u));
             }
@@ -183,7 +189,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="sourceId">Default is file path.</param>
         /// <param name="resourceId">Import path.</param>
         /// <returns>Target content id.</returns>
-        private static (string content, string id) DefaultFileResolver(string sourceId, string resourceId)
+        private static LGResource DefaultFileResolver(string sourceId, string resourceId)
         {
             // import paths are in resource files which can be executed on multiple OS environments
             // normalize to map / & \ in importPath -> OSPath
@@ -195,7 +201,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 importPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(sourceId), resourceId));
             }
 
-            return (File.ReadAllText(importPath), importPath);
+            return new LGResource(importPath, importPath, File.ReadAllText(importPath));
         }
 
         private static IList<Templates> GetReferences(Templates file, Dictionary<string, Templates> cachedTemplates = null)
@@ -213,29 +219,28 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             foreach (var import in start.Imports)
             {
-                string content;
-                string path;
+                LGResource resource;
                 try
                 {
-                    (content, path) = start.ImportResolver(start.Id, import.Id);
+                    resource = start.ImportResolver(start.Id, import.Id);
                 }
                 catch (Exception e)
                 {
-                    var diagnostic = new Diagnostic(import.SourceRange.Range, e.Message, DiagnosticSeverity.Error, start.Id);
+                    var diagnostic = new Diagnostic(import.SourceRange.Range, e.Message, DiagnosticSeverity.Error, start.Source);
                     throw new TemplateException(e.Message, new List<Diagnostic>() { diagnostic });
                 }
 
-                if (resourcesFound.All(u => u.Id != path))
+                if (resourcesFound.All(u => u.Id != resource.Id))
                 {
                     Templates childResource;
-                    if (cachedTemplates.ContainsKey(path))
+                    if (cachedTemplates.ContainsKey(resource.Id))
                     {
-                        childResource = cachedTemplates[path];
+                        childResource = cachedTemplates[resource.Id];
                     }
                     else
                     {
-                        childResource = InnerParseText(content, path, start.ImportResolver, start.ExpressionParser, cachedTemplates);
-                        cachedTemplates.Add(path, childResource);
+                        childResource = ParseResource(resource, start.ImportResolver, start.ExpressionParser, cachedTemplates);
+                        cachedTemplates.Add(resource.Id, childResource);
                     }
 
                     ResolveImportResources(childResource, resourcesFound, cachedTemplates);
@@ -300,7 +305,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                     var description = matchResult.Groups[1].Value?.Trim();
                     var id = matchResult.Groups[2].Value?.Trim();
 
-                    var sourceRange = new SourceRange(context, this.templates.Id);
+                    var sourceRange = new SourceRange(context, this.templates.Source);
                     var import = new TemplateImport(description, id, sourceRange);
                     this.templates.Imports.Add(import);
                 }
@@ -346,7 +351,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     var templateBody = context.templateBody().GetText();
 
-                    var sourceRange = new SourceRange(context, this.templates.Id);
+                    var sourceRange = new SourceRange(context, this.templates.Source);
                     var template = new Template(templateName, parameters, templateBody, sourceRange);
 
                     CheckTemplateName(templateName, context.templateNameLine());
@@ -455,7 +460,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var tokens = new CommonTokenStream(lexer);
                 var parser = new LGTemplateParser(tokens);
                 parser.RemoveErrorListeners();
-                var listener = new ErrorListener(this.templates.Id, lineOffset);
+                var listener = new ErrorListener(this.templates.Source, lineOffset);
 
                 parser.AddErrorListener(listener);
                 parser.BuildParseTree = true;
@@ -465,7 +470,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             private Diagnostic BuildTemplatesDiagnostic(string errorMessage, ParserRuleContext context, DiagnosticSeverity severity = DiagnosticSeverity.Error)
             {
-                return new Diagnostic(context.ConvertToRange(), errorMessage, severity, this.templates.Id);
+                return new Diagnostic(context.ConvertToRange(), errorMessage, severity, this.templates.Source);
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var lgResourceGroup = LGResourceLoader.GroupByLocale(resourceExplorer);
 
             var resource = resourceExplorer.GetResource("a.en-US.lg") as FileResource;
-            var generator = new TemplateEngineLanguageGenerator(resource.FullName, lgResourceGroup);
+            var generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);
             var result = await generator.GenerateAsync(GetDialogContext(), "${templatea()}", null);
             Assert.Equal("from a.en-us.lg", result);
 
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.True(ex.Message.Contains("greeting does not have an evaluator"));
 
             resource = resourceExplorer.GetResource("a.lg") as FileResource;
-            generator = new TemplateEngineLanguageGenerator(resource.FullName, lgResourceGroup);
+            generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);
 
             result = await generator.GenerateAsync(GetDialogContext(), "${templatea()}", null);
             Assert.Equal("from a.lg", result);
@@ -197,12 +197,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             var lg = new MultiLanguageGenerator();
             var multilanguageresources = LGResourceLoader.GroupByLocale(resourceExplorer);
-            lg.LanguageGenerators[string.Empty] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.lg").ReadTextAsync().Result, "test.lg", multilanguageresources);
-            lg.LanguageGenerators["de"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.de.lg").ReadTextAsync().Result, "test.de.lg", multilanguageresources);
-            lg.LanguageGenerators["en"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.en.lg").ReadTextAsync().Result, "test.en.lg", multilanguageresources);
-            lg.LanguageGenerators["en-US"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.en-US.lg").ReadTextAsync().Result, "test.en-US.lg", multilanguageresources);
-            lg.LanguageGenerators["en-GB"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.en-GB.lg").ReadTextAsync().Result, "test.en-GB.lg", multilanguageresources);
-            lg.LanguageGenerators["fr"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.fr.lg").ReadTextAsync().Result, "test.fr.lg", multilanguageresources);
+            lg.LanguageGenerators[string.Empty] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.lg"), multilanguageresources);
+            lg.LanguageGenerators["de"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.de.lg"), multilanguageresources);
+            lg.LanguageGenerators["en"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.en.lg"), multilanguageresources);
+            lg.LanguageGenerators["en-US"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.en-US.lg"), multilanguageresources);
+            lg.LanguageGenerators["en-GB"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.en-GB.lg"), multilanguageresources);
+            lg.LanguageGenerators["fr"] = new TemplateEngineLanguageGenerator(resourceExplorer.GetResource("test.fr.lg"),  multilanguageresources);
 
             // test targeted in each language
             Assert.Equal("english-us", await lg.GenerateAsync(GetDialogContext(locale: "en-us"), "${test()}", null));

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/MultilanguageLGTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
         [Fact]
         public void TemplatesInputs()
         {
-            var enTemplates = Templates.ParseText("[import](1.lg)\r\n # template\r\n - hi", "abc", ConstantResolver);
+            var enTemplates = Templates.ParseResource(new LGResource("abc", "abc", "[import](1.lg)\r\n # template\r\n - hi"), ConstantResolver);
             var templatesDict = new Dictionary<string, Templates>
             {
                 { "en", enTemplates },
@@ -90,9 +90,11 @@ namespace Microsoft.Bot.Builder.LanguageGeneration.Tests
             Assert.Equal("content with id: 1.lg from source: abc", result);
         }
 
-        private static (string content, string id) ConstantResolver(string sourceId, string resourceId)
+        private static LGResource ConstantResolver(string sourceId, string resourceId)
         {
-            return ($"# myTemplate\r\n - content with id: {resourceId} from source: {sourceId}", sourceId + resourceId);
+            var id = sourceId + resourceId;
+            var content = $"# myTemplate\r\n - content with id: {resourceId} from source: {sourceId}";
+            return new LGResource(id, id, content);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -127,12 +127,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
 
-            diagnostics = Templates.ParseText("#Demo2\r\n- ${createArray(1,\r\n, 2,3)").Diagnostics;
+            diagnostics = Templates.ParseResource(new LGResource(string.Empty, string.Empty, "#Demo2\r\n- ${createArray(1,\r\n, 2,3)")).Diagnostics;
             Assert.Equal(1, diagnostics.Count);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
 
-            diagnostics = Templates.ParseText("#Demo4\r\n- ${createArray(1,\r\n2,3)\r\n> this is a comment").Diagnostics;
+            diagnostics = Templates.ParseResource(new LGResource(string.Empty, string.Empty, "#Demo4\r\n- ${createArray(1,\r\n2,3)\r\n> this is a comment")).Diagnostics;
             Assert.Equal(1, diagnostics.Count);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
@@ -280,7 +280,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         [Fact]
         public void AddTextWithWrongId()
         {
-            var diagnostics = Templates.ParseText("[import](xx.lg) \r\n # t \n - hi", "a.lg").Diagnostics;
+            var diagnostics = Templates.ParseResource(new LGResource("a.lg", "a.lg", "[import](xx.lg) \r\n # t \n - hi")).Diagnostics;
             Assert.Equal(1, diagnostics.Count);
             Assert.True(diagnostics[0].Message.Contains("Could not find file"));
         }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.True(evaled == "Hi 2" || evaled == "Hello 2");
 
             // Assert 6.lg of relative path is imported from text.
-            templates = Templates.ParseResource(new LGResource("xx.lg", GetExampleFilePath("xx.lg"), "[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n"));
+            templates = Templates.ParseResource(new LGResource(GetExampleFilePath("xx.lg"), GetExampleFilePath("xx.lg"), "[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n"));
 
             Assert.Equal(8, templates.AllTemplates.Count());
             evaled = templates.Evaluate("basicTemplate", null).ToString();

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var templates = Templates.ParseFile(GetExampleFilePath("Multiline.lg"));
             string evaled = templates.Evaluate("template1").ToString();
-            var generatedTemplates = Templates.ParseText(evaled);
+            var generatedTemplates = Templates.ParseResource(new LGResource(string.Empty, string.Empty, evaled));
             var result = generatedTemplates.Evaluate("generated1");
             Assert.Equal("hi", result);
 
             evaled = templates.Evaluate("template2", new { evaluateNow = "please input" }).ToString();
-            generatedTemplates = Templates.ParseText(evaled);
+            generatedTemplates = Templates.ParseResource(new LGResource(string.Empty, string.Empty, evaled));
             result = generatedTemplates.Evaluate("generated2", new { name = "jack" });
             Assert.Equal("please input jack", result.ToString().Trim());
         }
@@ -461,7 +461,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.True(evaled == "Hi 2" || evaled == "Hello 2");
 
             // Assert 6.lg of relative path is imported from text.
-            templates = Templates.ParseText("[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n", GetExampleFilePath("xx.lg"));
+            templates = Templates.ParseResource(new LGResource("xx.lg", GetExampleFilePath("xx.lg"), "[import](./6.lg)\r\n# basicTemplate\r\n- Hi\r\n- Hello\r\n"));
 
             Assert.Equal(8, templates.AllTemplates.Count());
             evaled = templates.Evaluate("basicTemplate", null).ToString();


### PR DESCRIPTION
Fixes #4152

## Description
Change Import Resolver structure to support richer LG content output.

## Specific Changes
1. change `ImportResolverDelegate` from 
`(string sourceId, string resourceId) => (string content, string id)` to `(string sourceId, string resourceId) => LGResource` and `LGResource` contains Id, Content and FullName properties.

2. Add `ParseResource` function to parse a LG resource. 
`ParseText` would be deprecated and marked as [Obsolete].

3. Add `TemplateEngineLanguageGenerator(Resource resource,  resourceMapping)` constructor,
`filePath` and `lg text` format constructor would be deprecated in the next version. Mark them with [Obsolete]

4. Move `FullName` property from `FileResource` to abstract class `Resource`

5. Use `lgResource.Id` as the id of the unified templates to call

6. Add `Source` property in `Templates` which means the source of current lg file. (which would be absolute file path for file resource.)

7. Adjust corresponding tests.