### PR TITLE
[Declarative] Resource IDs: Update resource ID best-effort assignment to be consistent for debugging experience

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+// Allows us to access some internal methods from the Microsoft.Bot.Builder.Tests unit tests so we don't have to use reflection and we get compile checks.
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Declarative.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Declarative.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Bot.Builder.Dialogs.Choices;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Observers;
@@ -98,9 +99,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
                         }
                     }
 
-                    T result = this.resourceExplorer.BuildType<T>(kind, jToken, serializer);
+                    var tokenToBuild = TryAssignId(jToken, sourceContext);
 
-                    // associate the most specific source context information with this item
+                    T result = this.resourceExplorer.BuildType<T>(kind, tokenToBuild, serializer);
+
+                    // Associate the most specific source context information with this item
                     if (sourceContext.CallStack.Count > 0)
                     {
                         range = sourceContext.CallStack.Peek().DeepClone();
@@ -170,6 +173,29 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
             }
 
             this.observers.Add(observer);
+        }
+
+        private static JToken TryAssignId(JToken jToken, SourceContext sourceContext)
+        {
+            // This is the jToken we'll use to build the concrete type.
+            var tokenToBuild = jToken;
+
+            // If our JToken does not have an id, try to get an id from the resource explorer
+            // in a best-effort manner.
+            if (jToken is JObject jObj && !jObj.ContainsKey("id"))
+            {
+                // Check if we have an id registered for this token
+                if (sourceContext is ResourceSourceContext rsc && rsc.ResourceIdMap.ContainsKey(jToken))
+                {
+                    // Clone the token since we'll alter it from the file version.
+                    // If we don't clone, future ranges will be calculated based on the altered token.
+                    // which will end in a wrong source range.
+                    tokenToBuild = jToken.DeepClone();
+                    tokenToBuild["id"] = rsc.ResourceIdMap[jToken];
+                }
+            }
+
+            return tokenToBuild;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -185,13 +185,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
             if (jToken is JObject jObj && !jObj.ContainsKey("id"))
             {
                 // Check if we have an id registered for this token
-                if (sourceContext is ResourceSourceContext rsc && rsc.ResourceIdMap.ContainsKey(jToken))
+                if (sourceContext is ResourceSourceContext rsc && rsc.DefaultIdMap.ContainsKey(jToken))
                 {
                     // Clone the token since we'll alter it from the file version.
                     // If we don't clone, future ranges will be calculated based on the altered token.
                     // which will end in a wrong source range.
                     tokenToBuild = jToken.DeepClone();
-                    tokenToBuild["id"] = rsc.ResourceIdMap[jToken];
+                    tokenToBuild["id"] = rsc.DefaultIdMap[jToken];
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Debugging/ResourceSourceContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Debugging/ResourceSourceContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Bot.Builder.Dialogs.Debugging;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Debugging/ResourceSourceContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Debugging/ResourceSourceContext.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs.Declarative.Debugging
+{
+    /// <summary>
+    /// Resource-aware specialization of <see cref="SourceContext"/>.
+    /// </summary>
+    internal class ResourceSourceContext : SourceContext
+    {
+        /// <summary>
+        /// Gets a mapping between <see cref="JToken" /> and their respective resource ids. 
+        /// </summary>
+        /// <value>
+        /// A mapping between <see cref="JToken" /> and their respective resource ids.
+        /// </value>
+        internal Dictionary<JToken, string> ResourceIdMap { get; } = new Dictionary<JToken, string>(new JTokenEqualityComparer());
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Debugging/ResourceSourceContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Debugging/ResourceSourceContext.cs
@@ -17,6 +17,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Debugging
         /// <value>
         /// A mapping between <see cref="JToken" /> and their respective resource ids.
         /// </value>
-        internal Dictionary<JToken, string> ResourceIdMap { get; } = new Dictionary<JToken, string>(new JTokenEqualityComparer());
+        internal Dictionary<JToken, string> DefaultIdMap { get; } = new Dictionary<JToken, string>(new JTokenEqualityComparer());
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
@@ -46,14 +46,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Observers
             var hashCode = Hash<T>(range);
 
             // Now analyze the stack to find cycles.
-            var visited = context.CallStack.AsQueryable();
-            
-            // The stack always has a duplicate entry for the root 
-            // because of the source scope being created in ResourceExplorer.LoadTypeAsync().
-            visited = visited.Reverse().Skip(1);
-
             // If the same source range appears twice in the stack, we have a cycle.
-            var isCycle = visited.Count(s => s.Equals(range)) > 1;
+            var isCycle = context.CallStack.Count(s => s.Equals(range)) > 1;
 
             if (isCycle && CycleDetectionPass == CycleDetectionPasses.PassOne)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Observers/CycleDetectionObserver.cs
@@ -45,9 +45,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Observers
             // The token is characterized for the source range and the type expected for that source range.
             var hashCode = Hash<T>(range);
 
+            // Now analyze the stack to find cycles.
+            var visited = context.CallStack.AsQueryable();
+            
+            // The stack always has a duplicate entry for the root 
+            // because of the source scope being created in ResourceExplorer.LoadTypeAsync().
+            visited = visited.Reverse().Skip(1);
+
             // If the same source range appears twice in the stack, we have a cycle.
-            var isCycle = context.CallStack.ToList().Count(s =>
-                s.Equals(range)) > 1;
+            var isCycle = visited.Count(s => s.Equals(range)) > 1;
 
             if (isCycle && CycleDetectionPass == CycleDetectionPasses.PassOne)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -649,7 +649,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             {
                 if (jToken is JObject jObj && !jObj.ContainsKey("id") && !resourceSourceContext.DefaultIdMap.ContainsKey(jToken))
                 {
-                    resourceSourceContext.DefaultIdMap.TryAdd(jToken, resource.Id);
+                    resourceSourceContext.DefaultIdMap.Add(jToken, resource.Id);
                 }
             }
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -48,8 +48,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         }
 
         [TestMethod]
-        [Ignore]
-        [TestCategory("IgnoreInAutomatedBuild")]
         public async Task JsonDialogLoad_CycleDetection()
         {
             await BuildTestFlow(@"Root.dialog")

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -214,6 +216,39 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 await Task.WhenAny(changeFired.Task, Task.Delay(5000)).ConfigureAwait(false);
 
                 AssertResourceNull(explorer, testId);
+            }
+        }
+
+        [TestMethod]
+        public async Task ResourceExplorer_ReadTokenRange_AssignId()
+        {
+            var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
+            var sourceContext = new ResourceSourceContext();
+            var resourcesFolder = "resources";
+            var resourceId = "test.dialog";
+
+            using (var explorer = new ResourceExplorer())
+            {
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
+
+                // Load file using resource explorer
+                var resource = explorer.GetResource("test.dialog");
+
+                // Read token range using resource explorer
+                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext).ConfigureAwait(false);
+
+                // Verify correct range
+                var expectedRange = new SourceRange()
+                {
+                    StartPoint = new SourcePoint(0, 0),
+                    EndPoint = new SourcePoint(13, 1),
+                    Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
+                };
+
+                Assert.AreEqual(expectedRange, range);
+
+                // Verify ID was added
+                Assert.AreEqual(resourceId, sourceContext.DefaultIdMap[jToken]);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 var resources = explorer.GetResources(".dialog").ToArray();
 
-                Assert.AreEqual(3, resources.Length);
+                Assert.AreEqual(4, resources.Length);
                 Assert.AreEqual($".dialog", Path.GetExtension(resources[0].Id));
 
                 resources = explorer.GetResources("foo").ToArray();
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
 
                 // Load file using resource explorer
-                var resource = explorer.GetResource("test.dialog");
+                var resource = explorer.GetResource(resourceId);
 
                 // Read token range using resource explorer
                 var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext).ConfigureAwait(false);
@@ -249,6 +249,99 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 // Verify ID was added
                 Assert.AreEqual(resourceId, sourceContext.DefaultIdMap[jToken]);
+            }
+        }
+
+        [TestMethod]
+        public async Task ResourceExplorer_ReadTokenRangeAdvance_AssignId()
+        {
+            var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
+            var sourceContext = new ResourceSourceContext();
+            var resourcesFolder = "resources";
+            var resourceId = "test.dialog";
+
+            using (var explorer = new ResourceExplorer())
+            {
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
+
+                // Load file using resource explorer
+                var resource = explorer.GetResource(resourceId);
+
+                // Read token range using resource explorer
+                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext, advanceJsonReader: true).ConfigureAwait(false);
+
+                // Verify correct range
+                var expectedRange = new SourceRange()
+                {
+                    StartPoint = new SourcePoint(1, 1),
+                    EndPoint = new SourcePoint(13, 1),
+                    Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
+                };
+
+                Assert.AreEqual(expectedRange, range);
+
+                // Verify ID was added
+                Assert.AreEqual(resourceId, sourceContext.DefaultIdMap[jToken]);
+            }
+        }
+
+        [TestMethod]
+        public async Task ResourceExplorer_LoadType_VerifyTokenRangeAndIdAssigned()
+        {
+            var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
+            var resourcesFolder = "resources";
+            var resourceId = "test.dialog";
+
+            using (var explorer = new ResourceExplorer())
+            {
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
+
+                // Load file using resource explorer
+                var resource = explorer.GetResource(resourceId);
+                var dialog = await explorer.LoadTypeAsync<Dialog>(resource).ConfigureAwait(false);
+
+                // Verify correct range
+                var expectedRange = new SourceRange()
+                {
+                    StartPoint = new SourcePoint(1, 1),
+                    EndPoint = new SourcePoint(13, 1),
+                    Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
+                };
+
+                Assert.AreEqual(expectedRange, dialog.Source);
+
+                // Verify that the correct id was assigned
+                Assert.AreEqual(resourceId, dialog.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task ResourceExplorer_LoadType_VerifyTokenRangeAndIdHonored()
+        {
+            var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
+            var resourcesFolder = "resources";
+            var resourceId = "testWithId.dialog";
+
+            using (var explorer = new ResourceExplorer())
+            {
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
+
+                // Load file using resource explorer
+                var resource = explorer.GetResource(resourceId);
+                var dialog = await explorer.LoadTypeAsync<Dialog>(resource).ConfigureAwait(false);
+
+                // Verify correct range
+                var expectedRange = new SourceRange()
+                {
+                    StartPoint = new SourcePoint(1, 1),
+                    EndPoint = new SourcePoint(14, 1),
+                    Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
+                };
+
+                Assert.AreEqual(expectedRange, dialog.Source);
+
+                // Verify that the correct id was set
+                Assert.AreEqual("explicit-id", dialog.Id);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/resources/testWithId.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/resources/testWithId.dialog
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../tests.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "explicit-id",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnIntent",
+            "actions": [
+                "test2.dialog",
+                "test3.dialog"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
The AutoAssignId function was adding an entry with `'id': '<id>'`, but since it was adding a line, the token ranges computed by `SourceRange` were off. 

Here we 

- Recompute the range after assigning id
- Remove double assignment that was happening before
- Improve stack manipulation logic for corner cases (remove bottom of the call stack since it is a duplicate entry always)
- Re-enable cycle detection test