### PR TITLE
OAuthPrompt timeout applies to all auth related events and invokes.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -613,7 +613,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         {
             switch (channelId)
             {
-                case Channels.Msteams:
                 case Channels.Cortana:
                 case Channels.Skype:
                 case Channels.Skypeforbusiness:

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -307,7 +307,6 @@ namespace Microsoft.Bot.Builder.Dialogs
                 case Channels.Cortana:
                 case Channels.Skype:
                 case Channels.Skypeforbusiness:
-                case Channels.Msteams:
                     return false;
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 { Prompt<int>.AttemptCountKey, 0 },
             };
 
-            state[PersistedExpires] = DateTime.Now.AddMilliseconds(timeout);
+            state[PersistedExpires] = DateTime.UtcNow.AddMilliseconds(timeout);
             state[PersistedCaller] = CreateCallerInfo(dc.Context);
 
             // Attempt to get the users token
@@ -190,7 +190,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                             || IsTokenResponseEvent(dc.Context)
                             || IsTeamsVerificationInvoke(dc.Context)
                             || IsTokenExchangeRequestInvoke(dc.Context);
-            var hasTimedOut = isTimeoutActivityType && DateTime.Compare(DateTime.Now, expires) > 0;
+            var hasTimedOut = isTimeoutActivityType && DateTime.Compare(DateTime.UtcNow, expires) > 0;
 
             if (hasTimedOut)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -183,6 +183,9 @@ namespace Microsoft.Bot.Builder.Dialogs
             var state = dc.ActiveDialog.State;
             var expires = (DateTime)state[PersistedExpires];
             var isMessage = dc.Context.Activity.Type == ActivityTypes.Message;
+
+            // If the incoming Activity is a message, or an Activity Type normally handled by OAuthPrompt,
+            // check to see if this OAuthPrompt Expiration has elapsed, and end the dialog if so.
             var isTimeoutActivityType = isMessage
                             || IsTokenResponseEvent(dc.Context)
                             || IsTeamsVerificationInvoke(dc.Context)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -179,20 +179,24 @@ namespace Microsoft.Bot.Builder.Dialogs
                 throw new ArgumentNullException(nameof(dc));
             }
 
-            // Recognize token
-            var recognized = await RecognizeTokenAsync(dc, cancellationToken).ConfigureAwait(false);
-
             // Check for timeout
             var state = dc.ActiveDialog.State;
             var expires = (DateTime)state[PersistedExpires];
             var isMessage = dc.Context.Activity.Type == ActivityTypes.Message;
-            var hasTimedOut = isMessage && DateTime.Compare(DateTime.Now, expires) > 0;
+            var isTimeoutActivityType = isMessage
+                            || IsTokenResponseEvent(dc.Context)
+                            || IsTeamsVerificationInvoke(dc.Context)
+                            || IsTokenExchangeRequestInvoke(dc.Context);
+            var hasTimedOut = isTimeoutActivityType && DateTime.Compare(DateTime.Now, expires) > 0;
 
             if (hasTimedOut)
             {
                 // if the token fetch request times out, complete the prompt with no result.
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
+
+            // Recognize token
+            var recognized = await RecognizeTokenAsync(dc, cancellationToken).ConfigureAwait(false);
 
             var promptState = state[PersistedState].CastTo<IDictionary<string, object>>();
             var promptOptions = state[PersistedOptions].CastTo<PromptOptions>();
@@ -303,6 +307,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 case Channels.Cortana:
                 case Channels.Skype:
                 case Channels.Skypeforbusiness:
+                case Channels.Msteams:
                     return false;
             }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -127,6 +128,47 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .Send(magicCode)
             .AssertReply("Logged in.")
             .StartTestAsync();
+        }
+
+        [TestMethod]
+        public async Task OAuthPromptTimesOut_Message()
+        {
+            await PromptTimeoutEndsDialogTest(MessageFactory.Text("hi"));
+        }
+
+        [TestMethod]
+        public async Task OAuthPromptTimesOut_TokenResponseEvent()
+        {
+            var activity = new Activity() { Type = ActivityTypes.Event, Name = SignInConstants.TokenResponseEventName };
+            activity.Value = JObject.FromObject(new TokenResponse(Channels.Msteams, "connectionName", "token", null));
+            await PromptTimeoutEndsDialogTest(activity);
+        }
+
+        [TestMethod]
+        public async Task OAuthPromptTimesOut_VerifyStateOperation()
+        {
+            var activity = new Activity() { Type = ActivityTypes.Invoke, Name = SignInConstants.VerifyStateOperationName };
+            activity.Value = JObject.FromObject(new { state = "888999" });
+
+            await PromptTimeoutEndsDialogTest(activity);
+        }
+        
+        [TestMethod]
+        public async Task OAuthPromptTimesOut_TokenExchangeOperation()
+        {
+            var activity = new Activity() { Type = ActivityTypes.Invoke, Name = SignInConstants.TokenExchangeOperationName };
+
+            var connectionName = "myConnection";
+            var exchangeToken = "exch123";
+            var token = "abc123";
+
+            activity.Value = JObject.FromObject(new TokenExchangeInvokeRequest()
+            {
+                ConnectionName = connectionName,
+                Token = exchangeToken
+            });
+
+            await PromptTimeoutEndsDialogTest(activity);
         }
 
         [TestMethod]
@@ -557,6 +599,66 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 botCallbackHandler(ctx, CancellationToken.None);
             })
             .AssertReply("Logged in.")
+            .StartTestAsync();
+        }
+
+        private async Task PromptTimeoutEndsDialogTest(IActivity oauthPromptActivity)
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var connectionName = "myConnection";
+            var exchangeToken = "exch123";
+            var magicCode = "888999";
+            var token = "abc123";
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+            
+            // Set timeout to zero, so the prompt will end immediately.
+            dialogs.Add(new OAuthPrompt("OAuthPrompt", new OAuthPromptSettings() { Text = "Please sign in", ConnectionName = connectionName, Title = "Sign in", Timeout = 0 }));
+
+            BotCallbackHandler botCallbackHandler = async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("OAuthPrompt", new PromptOptions(), cancellationToken: cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    // If the TokenResponse comes back, the timeout did not occur.
+                    if (results.Result is TokenResponse)
+                    {
+                        await turnContext.SendActivityAsync("failed", cancellationToken: cancellationToken);
+                    }
+                    else
+                    {
+                        await turnContext.SendActivityAsync("ended", cancellationToken: cancellationToken);
+                    }
+                }
+            };
+
+            await new TestFlow(adapter, botCallbackHandler)
+            .Send("hello")
+            .AssertReply(activity =>
+            {
+                Assert.AreEqual(1, ((Activity)activity).Attachments.Count);
+                Assert.AreEqual(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+
+                // Add a magic code to the adapter
+                adapter.AddUserToken(connectionName, activity.ChannelId, activity.Recipient.Id, token, magicCode);
+
+                // Add an exchangable token to the adapter
+                adapter.AddExchangeableToken(connectionName, activity.ChannelId, activity.Recipient.Id, exchangeToken, token);
+            })
+            .Send(oauthPromptActivity)
+            .AssertReply("ended")
             .StartTestAsync();
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/3627

This PR also prioritizes the timeout check before RecognizeTokenAsync, since RecognizeTokenAsync has side affects.