### PR TITLE
Add EndOnInvalidMessage to OAuthPromptSettings

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -218,6 +218,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 return await dc.EndDialogAsync(recognized.Value, cancellationToken).ConfigureAwait(false);
             }
+            else if (isMessage && _settings.EndOnInvalidMessage)
+            {
+                // If EndOnInvalidMessage is set, complete the prompt with no result.
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
 
             if (!dc.Context.Responded && isMessage && promptOptions?.RetryPrompt != null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPromptSettings.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPromptSettings.cs
@@ -43,7 +43,11 @@ namespace Microsoft.Bot.Builder.Dialogs
 
         /// <summary>
         /// Gets or sets a value indicating whether the <see cref="OAuthPrompt"/> should end upon
-        /// receiving an invalid message.
+        /// receiving an invalid message.  Generally the <see cref="OAuthPrompt"/> will ignore
+        /// incoming messages from the user during the auth flow, if they are not related to the
+        /// auth flow.  This flag enables ending the <see cref="OAuthPrompt"/> rather than
+        /// ignoring the user's message.  Typically, this flag will be set to 'true', but is 'false'
+        /// by default for backwards compatibility.
         /// </summary>
         /// <value>True if the <see cref="OAuthPrompt"/> should automatically end upon receiving
         /// an invalid message.</value>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPromptSettings.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPromptSettings.cs
@@ -40,5 +40,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <value>The number of milliseconds the prompt waits for the user to authenticate.</value>
         public int? Timeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="OAuthPrompt"/> should end upon
+        /// receiving an invalid message.
+        /// </summary>
+        /// <value>True if the <see cref="OAuthPrompt"/> should automatically end upon receiving
+        /// an invalid message.</value>
+        public bool EndOnInvalidMessage { get; set; }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -130,6 +130,59 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [TestMethod]
+        public async Task OAuthPromptEndOnInvalidMessageSetting()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
+
+            var adapter = new TestAdapter()
+                .Use(new AutoSaveStateMiddleware(convoState));
+
+            var connectionName = "myConnection";
+
+            // Create new DialogSet.
+            var dialogs = new DialogSet(dialogState);
+            dialogs.Add(new OAuthPrompt("OAuthPrompt", new OAuthPromptSettings() { Text = "Please sign in", ConnectionName = connectionName, Title = "Sign in", EndOnInvalidMessage = true }));
+
+            BotCallbackHandler botCallbackHandler = async (turnContext, cancellationToken) =>
+            {
+                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                var results = await dc.ContinueDialogAsync(cancellationToken);
+                if (results.Status == DialogTurnStatus.Empty)
+                {
+                    await dc.PromptAsync("OAuthPrompt", new PromptOptions(), cancellationToken: cancellationToken);
+                }
+                else if (results.Status == DialogTurnStatus.Waiting)
+                {
+                    throw new InvalidOperationException("Test OAuthPromptEndOnInvalidMessageSetting expected DialogTurnStatus.Complete");
+                }
+                else if (results.Status == DialogTurnStatus.Complete)
+                {
+                    if (results.Result is TokenResponse)
+                    {
+                        await turnContext.SendActivityAsync(MessageFactory.Text("Logged in."), cancellationToken);
+                    }
+                    else
+                    {
+                        await turnContext.SendActivityAsync(MessageFactory.Text("Ended."), cancellationToken);
+                    }
+                }
+            };
+
+            await new TestFlow(adapter, botCallbackHandler)
+            .Send("hello")
+            .AssertReply(activity =>
+            {
+                Assert.AreEqual(1, ((Activity)activity).Attachments.Count);
+                Assert.AreEqual(OAuthCard.ContentType, ((Activity)activity).Attachments[0].ContentType);
+            })
+            .Send("blah")
+            .AssertReply("Ended.")
+            .StartTestAsync();
+        }
+
+        [TestMethod]
         public async Task OAuthPromptDoesNotDetectCodeInBeginDialog()
         {
             var convoState = new ConversationState(new MemoryStorage());


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4395
