### PR TITLE
change the error message of Json pre-built function to provide more context infomation.

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
@@ -24,16 +24,27 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static EvaluateExpressionDelegate Evaluator()
         {
-            return FunctionUtils.Apply(
+            return FunctionUtils.ApplyWithError(
                         args =>
                         {
+                            object result = null;
+                            string error = null;
                             using (var textReader = new StringReader(args[0].ToString()))
                             {
                                 using (var jsonReader = new JsonTextReader(textReader) { DateParseHandling = DateParseHandling.None })
                                 {
-                                    return JToken.ReadFrom(jsonReader);
+                                    try
+                                    {
+                                        result = JToken.ReadFrom(jsonReader);
+                                    }
+                                    catch (JsonReaderException err)
+                                    {
+                                        error = $"While parsing the value {args[0]}, an unexpected character was encountered. Path {err.Path}, line {err.LineNumber}, position {err.LinePosition}.";
+                                    }
                                 }
                             }
+
+                            return (result, error);
                         });
         }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
@@ -39,7 +39,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                     }
                                     catch (JsonReaderException err)
                                     {
-                                        error = $"While parsing the value {args[0]}, an unexpected character was encountered. Path {err.Path}, line {err.LineNumber}, position {err.LinePosition}.";
+                                        error = $"Unexpected character at Path {err.Path}, line {err.LineNumber}, position {err.LinePosition} when parsing {args[0]}.";
                                     }
                                 }
                             }


### PR DESCRIPTION
closes: #4397 
Now the error message of json pre-built function is:
$"Unexpected character at Path {err.Path}, line {err.LineNumber}, position {err.LinePosition} when parsing {originalContent}."
which can provide more details of where the error occured in LG or Expressions.