### PR TITLE
Debugging: Add missing documentation to all visible classes, methods,…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Debugging.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Debugging.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
@@ -2,15 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Runtime.CompilerServices;
 using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
 using Microsoft.Extensions.Logging;
-
-#if SIGNASSEMBLY
-[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Debugging.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
-#else
-[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Debugging.Tests")]
-#endif
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
@@ -2,11 +2,21 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
 using Microsoft.Extensions.Logging;
 
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Debugging.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Dialogs.Debugging.Tests")]
+#endif
+
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
+    /// <summary>
+    /// Defines debugging extension methods for the <see cref="BotAdapter"/> class.
+    /// </summary>
     public static class DebuggingBotAdapterExtensions
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/Identifier.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Identifiers/Identifier.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Identifiers
 {
-    public static class Identifier
+    internal static class Identifier
     {
         private const ulong More = 0x80;
         private const ulong Data = 0x7F;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
@@ -25,7 +25,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
     <!-- CA1812: Internal class that is apparently never instantiated. A lot of internal classes are just used for serialization and not instantiated explicitly, excliding from this project only -->
     <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Microsoft.Bot.Builder.Dialogs.Debugging.csproj
@@ -27,7 +27,7 @@
   <PropertyGroup>
     <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
     <!-- CA1812: Internal class that is apparently never instantiated. A lot of internal classes are just used for serialization and not instantiated explicitly, excliding from this project only -->
-    <NoWarn>$(NoWarn);CS1591;CA1812</NoWarn>
+    <NoWarn>$(NoWarn);CA1812</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/FunctionBreakpoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/FunctionBreakpoint.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Protocol
 {
-    public sealed class FunctionBreakpoint
+    internal sealed class FunctionBreakpoint
     {
         public string Name { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/Reference.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/Reference.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
-    public abstract class Reference
+    internal abstract class Reference
     {
         public ulong Id { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/Source.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/Source.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Protocol
 {
-    public sealed class Source
+    internal sealed class Source
     {
         public Source(string path)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/SourceBreakpoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/SourceBreakpoint.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Protocol
 {
-    public sealed class SourceBreakpoint
+    internal sealed class SourceBreakpoint
     {
         public int Line { get; set; }
     }


### PR DESCRIPTION
… properties and parameters

Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4353

## Description
Enables xmldoc for debugging project.

## Specific Changes
- Removes disabling the "missing xmldoc" warning
- makes some more classes internal
- uses InternalsVisibleTo for tests
- add one missing xmldoc.

## Testing
None