### PR TITLE
BeginSkill fixes for ContinueDialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.BeginSkill";
 
-        // Used to cached DialogOptions for multi-turn calls across servers
+        // Used to cache DialogOptions for multi-turn calls across servers
         private readonly string _dialogOptionsStateKey = $"{typeof(BeginSkill).FullName}.DialogOptionsData";
 
         [JsonConstructor]

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -138,7 +138,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             DialogOptions.Skill.Id = DialogOptions.Skill.AppId = SkillAppId.GetValue(dc.State);
             DialogOptions.Skill.SkillEndpoint = new Uri(SkillEndpoint.GetValue(dc.State));
 
-            SaveDialogOptionsToState(dc.ActiveDialog);
+            // Store the initialized DialogOptions in state so we can restore these values when the dialog is resumed.
+            dc.ActiveDialog.State[_dialogOptionsStateKey] = DialogOptions;
 
             // Get the activity to send to the skill.
             Activity activity;
@@ -205,14 +206,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
 
             return $"{GetType().Name}['{appId}','{activity}']";
-        }
-
-        /// <summary>
-        /// Stores the DialogOptions initialized during BeginDialog so they can be restored when the dialog is resumed.
-        /// </summary>
-        private void SaveDialogOptionsToState(DialogInstance instance)
-        {
-            instance.State[_dialogOptionsStateKey] = DialogOptions;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.BeginSkill";
 
+        // Used to cached DialogOptions for multi-turn calls across servers
+        private readonly string _dialogOptionsStateKey = $"{typeof(BeginSkill).FullName}.DialogOptionsData";
+
         [JsonConstructor]
         public BeginSkill([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(new SkillDialogOptions())
@@ -135,12 +138,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             DialogOptions.Skill.Id = DialogOptions.Skill.AppId = SkillAppId.GetValue(dc.State);
             DialogOptions.Skill.SkillEndpoint = new Uri(SkillEndpoint.GetValue(dc.State));
 
+            SaveDialogOptionsToState(dc.ActiveDialog);
+
             // Get the activity to send to the skill.
             Activity activity;
             if (ActivityProcessed.GetValue(dc.State))
             {
                 // The parent consumed the activity in context, use the Activity property to start the skill.
-                activity = await Activity.BindAsync(dc).ConfigureAwait(false);
+                activity = await Activity.BindAsync(dc, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -154,6 +159,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
         public override Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
+            LoadDialogOptions(dc.Context, dc.ActiveDialog);
             if (dc.Context.Activity.Type == ActivityTypes.EndOfConversation)
             {
                 // Capture the result of the dialog if the property is set
@@ -164,6 +170,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             }
 
             return base.ContinueDialogAsync(dc, cancellationToken);
+        }
+
+        public override Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default)
+        {
+            LoadDialogOptions(turnContext, instance);
+            return base.RepromptDialogAsync(turnContext, instance, cancellationToken);
+        }
+
+        public override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
+        {
+            LoadDialogOptions(dc.Context, dc.ActiveDialog);
+            return base.ResumeDialogAsync(dc, reason, result, cancellationToken);
+        }
+
+        public override Task EndDialogAsync(ITurnContext turnContext, DialogInstance instance, DialogReason reason, CancellationToken cancellationToken = default)
+        {
+            LoadDialogOptions(turnContext, instance);
+            return base.EndDialogAsync(turnContext, instance, reason, cancellationToken);
         }
 
         protected override string OnComputeId()
@@ -180,7 +204,39 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 activity = StringUtils.Ellipsis(Activity?.ToString().Trim(), 30);
             }
 
-            return $"{this.GetType().Name}['{appId}','{activity}']";
+            return $"{GetType().Name}['{appId}','{activity}']";
+        }
+
+        /// <summary>
+        /// Stores the DialogOptions initialized during BeginDialog so they can be restored when the dialog is resumed.
+        /// </summary>
+        private void SaveDialogOptionsToState(DialogInstance instance)
+        {
+            instance.State[_dialogOptionsStateKey] = DialogOptions;
+        }
+
+        /// <summary>
+        /// Regenerates the <see cref="SkillDialog.DialogOptions"/> based on the values used during the BeingDialog call.
+        /// </summary>
+        /// <remarks>
+        /// The dialog can be resumed in another server or after redeploying the bot, this code ensure that the options used are the ones
+        /// used to call BeginDialog.
+        /// Also, if ContinueConversation or other methods are called on a server different than the one where BeginDialog was called,
+        /// DialogOptions will be empty and this code will make sure it has the right value.
+        /// </remarks>
+        private void LoadDialogOptions(ITurnContext context, DialogInstance instance)
+        {
+            var dialogOptions = (SkillDialogOptions)instance.State[_dialogOptionsStateKey];
+
+            DialogOptions.BotId = dialogOptions.BotId;
+            DialogOptions.SkillHostEndpoint = dialogOptions.SkillHostEndpoint;
+            DialogOptions.ConversationIdFactory = context.TurnState.Get<SkillConversationIdFactoryBase>() ?? throw new NullReferenceException("Unable to locate SkillConversationIdFactoryBase in HostContext");
+            DialogOptions.SkillClient = context.TurnState.Get<BotFrameworkClient>() ?? throw new NullReferenceException("Unable to locate BotFrameworkClient in HostContext");
+            DialogOptions.ConversationState = context.TurnState.Get<ConversationState>() ?? throw new NullReferenceException($"Unable to get an instance of {nameof(ConversationState)} from TurnState.");
+            DialogOptions.ConnectionName = dialogOptions.ConnectionName;
+
+            // Set the skill to call
+            DialogOptions.Skill = dialogOptions.Skill;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialogOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialogOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Bot.Builder.Skills;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
@@ -17,6 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The the Microsoft app ID of the bot calling the skill.
         /// </value>
+        [JsonProperty("botId")]
         public string BotId { get; set; }
 
         /// <summary>
@@ -25,6 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The <see cref="BotFrameworkClient"/> used to call the remote skill.
         /// </value>
+        [JsonIgnore]
         public BotFrameworkClient SkillClient { get; set; }
 
         /// <summary>
@@ -33,6 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The callback Url for the skill host.
         /// </value>
+        [JsonProperty("skillHostEndpoint")]
         public Uri SkillHostEndpoint { get; set; }
 
         /// <summary>
@@ -41,6 +45,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The <see cref="BotFrameworkSkill"/> that the dialog will call.
         /// </value>
+        [JsonProperty("skill")]
         public BotFrameworkSkill Skill { get; set; }
 
         /// <summary>
@@ -49,6 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// An instance of a <see cref="SkillConversationIdFactoryBase"/> used to generate conversation IDs for interacting with the skill.
         /// </value>
+        [JsonIgnore]
         public SkillConversationIdFactoryBase ConversationIdFactory { get; set; }
 
         /// <summary>
@@ -57,6 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The <see cref="ConversationState"/> to be used by the dialog.
         /// </value>
+        [JsonIgnore]
         public ConversationState ConversationState { get; set; }
 
         /// <summary>
@@ -65,6 +72,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The OAuth Connection Name for the Parent Bot.
         /// </value>
+        [JsonProperty("connectionName")]
         public string ConnectionName { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/Skills/BotFrameworkSkill.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/BotFrameworkSkill.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Skills
 {
@@ -16,6 +17,7 @@ namespace Microsoft.Bot.Builder.Skills
         /// <value>
         /// Id of the skill.
         /// </value>
+        [JsonProperty("id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -24,6 +26,7 @@ namespace Microsoft.Bot.Builder.Skills
         /// <value>
         /// AppId of the skill.
         /// </value>
+        [JsonProperty("appId")]
         public string AppId { get; set; }
 
         /// <summary>
@@ -32,6 +35,7 @@ namespace Microsoft.Bot.Builder.Skills
         /// <value>
         /// /api/messages endpoint for the skill.
         /// </value>
+        [JsonProperty("skillEndpoint")]
         public Uri SkillEndpoint { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #4372

- Added code to `BeginSkill.BeginDialog()` that stores `DialogOptions` in state.
- Added overrides for `ContinueDialogAsync`, `RepromptDialogAsync`, `ResumeDialogAsync` and `EndDialogAsync` that pull the stored DialogOptions from the dialog state and regenerate the property .
- Added json serialization attributes to `SkillDialogOptions` and `BotFrameworkSkill` classes.

Notes:

- Unit tests will be added as part of #3879, I am just trying to fix the P0 issue for R10 right now. 
- This PR requires parity on JS and Python
