### PR TITLE
[CI-PR Pipelines] Skip tests in Debug builds

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -82,27 +82,16 @@ stages:
     steps:
     - powershell: |
        $multiconfig = '{';
-       if ("$(Build.Reason)" -eq 'Schedule') {
+       if ("$(Build.Reason)" -in ('Schedule', 'Manual')) {
          $env:BotBuilderDll.Split(",") | ForEach {
            $library = $_.Trim()
-           $threadName = $library.Split(".")[-1];
+           $threadName = $library -replace "Microsoft.", "";
            $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $library + "'}, ";
          }
        }
        else {
-         if ("$(Build.Reason)" -eq 'Manual') {
-           git checkout master
-           $branchSource = "$(Build.SourceBranch)"
-           echo $branchSource
-           $branchSourcePath = $branchSource -replace "refs/heads/", ""
-           git checkout $branchSourcePath
-           $commits = $(git rev-list --count HEAD ^master)
-           echo "Commits: $commits"
-           $updatedFiles = $(git diff HEAD HEAD~$commits --name-only)
-         }
-         else {
-           $updatedFiles = $(git diff HEAD HEAD~ --name-only)
-         }
+         $updatedFiles = $(git diff HEAD HEAD~ --name-only)
+
          $updatedFiles | ForEach-Object {
            $changedLibrary = ''
            Switch -Wildcard ($_) {
@@ -127,7 +116,7 @@ stages:
              $multiconfig += "'" + $threadName + "':{'BotBuilderDll':'" + $changedLibrary + "'}, ";
            }
           }
-        }
+       }
        $multiconfig = $multiconfig.TrimEnd(' ').TrimEnd(',') + "}";
        echo $multiconfig
        "##vso[task.setVariable variable=MULTICONFIG;isOutput=true]$multiconfig"

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -29,20 +29,9 @@ steps:
     projects: |
      Tests/**/*Tests.csproj
      !Tests/**/Microsoft.Bot.Builder.TestBot.Tests.csproj
-     
+
     arguments: '-v n  -f netcoreapp2.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp21'))
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test (debug) 2.1'
-  inputs:
-    command: test
-    projects: |
-     Tests/**/*Tests.csproj
-     !Tests/**/Microsoft.Bot.Builder.TestBot.Tests.csproj
-     
-    arguments: '-v n  -f netcoreapp2.1 --configuration debug --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
-  condition: and(eq(variables['BuildConfiguration'],'Debug-Windows'), eq(variables['BuildTarget'],'netcoreapp21'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test (release) 3.1'
@@ -51,20 +40,9 @@ steps:
     projects: |
      Tests/**/*Tests.csproj
      !Tests/**/*21.Tests.csproj
-     
+
     arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet test (debug) 3.1'
-  inputs:
-    command: test
-    projects: |
-     Tests/**/*Tests.csproj
-     !Tests/**/*21.Tests.csproj
-     
-    arguments: '-v n  -f netcoreapp3.1 --configuration debug --no-build --no-restore --filter TestCategory!=IgnoreInAutomatedBuild --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
-  condition: and(eq(variables['BuildConfiguration'],'Debug-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
 
 - powershell: |
    # This task copies the code coverage file created by dotnet test into a well known location. In all
@@ -74,11 +52,12 @@ steps:
    
    Get-ChildItem -Path "D:\a\_temp" -Include "*.coverage" -Recurse | Copy-Item -Destination CodeCoverage
   displayName: 'Copy .coverage Files to CodeCoverage folder'
+  condition: eq(variables['BuildConfiguration'],'Release-Windows')
 
 - powershell: 'echo ''##vso[task.setvariable variable=CoverallsToken]$(DotNetCoverallsToken)'''
   displayName: 'Set CoverallsToken for PublishToCoveralls.ps1 if token exists'
   continueOnError: true
-  condition: and(succeeded(), ne(variables['NoCoverageUpload'], 'true'))
+  condition: and(succeeded(), ne(variables['NoCoverageUpload'], 'true'), eq(variables['BuildConfiguration'],'Release-Windows'))
 
 - task: PowerShell@2
   displayName: 'Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
@@ -87,7 +66,7 @@ steps:
     filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
     arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "master CI-PR"'
   continueOnError: true
-  condition: and(succeeded(), ne(variables['CoverallsToken'], ''), ne(variables['NoCoverageUpload'], 'true'))
+  condition: and(succeeded(), ne(variables['CoverallsToken'], ''), ne(variables['NoCoverageUpload'], 'true'), eq(variables['BuildConfiguration'],'Release-Windows'))
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish build artifact CodeCoverage'


### PR DESCRIPTION
## Description
This PR updates the [ci-test-steps](https://github.com/microsoft/botbuilder-dotnet/blob/master/build/yaml/ci-test-steps.yml) yaml file to skip the test and coverage steps in the Debug builds.
Also, it fixes an issue found on the API Compat job matrix that caused that the _Microsoft.Bot.Builder.Integration.ApplicationInsights.Core_ library wasn't getting compared.

## Specific Changes
  - **ci-test-steps yaml**:
    - Removed the test steps for Debug 2.1 and Debug 3.1 jobs
    - Added a condition to execute the coverage steps only for Release builds.

 - **botbuilder-dotnet-ci.yml**:
   - Updated the PowerShell script to create the matrix for the API Compat job including all the libraries. 
   - Updated the Powershell script to run all API Compat validation on Manual builds fixing an error.

## Testing
The following image shows the test and coverage steps being skipped on the Debug build, releasing the agent that executes the Debug job about 4 minutes earlier.

![image](https://user-images.githubusercontent.com/44245136/89675777-e4131e00-d8c0-11ea-9776-d6dd01c1dfba.png)