### PR TITLE
Fix schema bugs in Microsoft.Ask.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.schema
@@ -9,6 +9,11 @@
             "$ref": "schema:#/definitions/arrayExpression",
             "title": "Expected Properties",
             "description": "Properties expected from the user.",
+            "items": {
+                "type": "string",
+                "title": "Name",
+                "description": "Name of the property"
+            },
             "examples": [
                 [
                     "age",
@@ -17,11 +22,12 @@
             ]
         },
         "defaultOperation": {
-            "$ref": "schema:#/definitions/objectExpression",
+            "$ref": "schema:#/definitions/stringExpression",
             "title": "Default Operation",
-            "description": "Sets the default operation for each property and entity that will be used when no operation is recognized in the response to this Ask.",
+            "description": "Sets the default operation that will be used when no operation is recognized in the response to this Ask.",
             "examples": [
-                { "number": "add" }
+                "Add()",
+                "Remove()"
             ]
         }
     }

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -242,6 +242,9 @@
       "$ref": "#/definitions/Microsoft.OnUnknownIntent"
     },
     {
+      "$ref": "#/definitions/Microsoft.OrchestratorRecognizer"
+    },
+    {
       "$ref": "#/definitions/Microsoft.OrdinalEntityRecognizer"
     },
     {
@@ -1032,16 +1035,20 @@
               "age",
               "name"
             ]
-          ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the property"
+          }
         },
         "defaultOperation": {
-          "$ref": "#/definitions/objectExpression",
+          "$ref": "#/definitions/stringExpression",
           "title": "Default Operation",
-          "description": "Sets the default operation for each property and entity that will be used when no operation is recognized in the response to this Ask.",
+          "description": "Sets the default operation that will be used when no operation is recognized in the response to this Ask.",
           "examples": [
-            {
-              "number": "add"
-            }
+            "Add()",
+            "Remove()"
           ]
         },
         "id": {
@@ -4559,6 +4566,9 @@
           "$ref": "#/definitions/Microsoft.LuisRecognizer"
         },
         {
+          "$ref": "#/definitions/Microsoft.OrchestratorRecognizer"
+        },
+        {
           "$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
         },
         {
@@ -7492,6 +7502,86 @@
           "type": "string",
           "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
           "const": "Microsoft.OnUnknownIntent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OrchestratorRecognizer": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "Orchestrator Recognizer",
+      "description": "Orchestrator recognizer.",
+      "type": "object",
+      "required": [
+        "model",
+        "shapShot",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet."
+        },
+        "modelPath": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Model",
+          "description": "NLR model file path.",
+          "default": "=settings.orchestrator.modelpath"
+        },
+        "snapshotPath": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Endpoint Key",
+          "description": "SnapShot file path.",
+          "default": "=settings.orchestrator.shapshotpath"
+        },
+        "entityRecognizers": {
+          "type": "array",
+          "title": "Entity recognizers",
+          "description": "Collection of entity recognizers to use.",
+          "items": {
+            "$kind": "Microsoft.IEntityRecognizer",
+            "$ref": "#/definitions/Microsoft.IEntityRecognizer"
+          }
+        },
+        "disambiguationScoreThreshold": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Threshold",
+          "description": "Recognizer returns ChooseIntent (disambiguation) if other intents are classified within this score of the top scoring intent.",
+          "default": 0.05,
+          "examples": [
+            "=true",
+            "=turn.scoreThreshold",
+            "=settings.orchestrator.disambigScoreThreshold"
+          ]
+        },
+        "detectAmbiguousIntents": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Detect ambiguous intents",
+          "description": "If true, recognizer will look for ambiguous intents (intents with close recognition scores from top scoring intent).",
+          "default": false,
+          "examples": [
+            "=true",
+            "=turn.detectAmbiguousIntents",
+            "=settings.orchestrator.detectAmbiguousIntents"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OrchestratorRecognizer"
         },
         "$designer": {
           "title": "Designer information",


### PR DESCRIPTION
The Microsoft.Ask schema had two errors that did not match the Microsoft.Ask implementation.
1) expectedProperties was missing the items specification.
2) defaultOperation was an objectExpression rather than a stringExpression.

