### PR TITLE
Change versioning of Microsoft.Bot.Builder.AI.Orchestrator package to use var ReleasePackageVersion

### DIFF
--- a/FunctionalTests/ExportedTemplate/template.json
+++ b/FunctionalTests/ExportedTemplate/template.json
@@ -1,183 +1,184 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "groupLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "Specifies the location of the Resource Group."
-            }
-        },
-        "groupName": {
-            "type": "string",
-            "metadata": {
-                "description": "Specifies the name of the Resource Group."
-            }
-        },
-        "appId": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
-            }
-        },
-        "appSecret": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
-            }
-        },
-        "botId": {
-            "type": "string",
-            "metadata": {
-                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
-            }
-        },
-        "botSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
-            }
-        },
-        "newAppServicePlanName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the App Service Plan."
-            }
-        },
-        "newAppServicePlanSku": {
-            "type": "object",
-            "defaultValue": {
-                "name": "S1",
-                "tier": "Standard",
-                "size": "S1",
-                "family": "S",
-                "capacity": 1
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "groupLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location of the Resource Group."
+      }
+    },
+    "groupName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Resource Group."
+      }
+    },
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
+    },
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+      }
+    },
+    "botId": {
+      "type": "string",
+      "metadata": {
+        "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+      }
+    },
+    "botSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    },
+    "newAppServicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Service Plan."
+      }
+    },
+    "newAppServicePlanSku": {
+      "type": "object",
+      "defaultValue": {
+        "name": "S1",
+        "tier": "Standard",
+        "size": "S1",
+        "family": "S",
+        "capacity": 1
+      },
+      "metadata": {
+        "description": "The SKU of the App Service Plan. Defaults to Standard values."
+      }
+    },
+    "newAppServicePlanLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The location of the App Service Plan. Defaults to \"westus\"."
+      }
+    },
+    "newWebAppName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+      }
+    }
+  },
+  "variables": {
+    "appServicePlanName": "[parameters('newAppServicePlanName')]",
+    "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+    "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+    "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/mybot')]",
+    "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('groupName')]",
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2018-05-01",
+      "location": "[parameters('groupLocation')]",
+      "properties": {
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2018-05-01",
+      "name": "storageDeployment",
+      "resourceGroup": "[parameters('groupName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {},
+          "variables": {},
+          "resources": [
+            {
+              "comments": "Create a new App Service Plan",
+              "type": "Microsoft.Web/serverfarms",
+              "name": "[variables('appServicePlanName')]",
+              "apiVersion": "2018-02-01",
+              "location": "[variables('resourcesLocation')]",
+              "sku": "[parameters('newAppServicePlanSku')]",
+              "properties": {
+                "name": "[variables('appServicePlanName')]"
+              }
             },
-            "metadata": {
-                "description": "The SKU of the App Service Plan. Defaults to Standard values."
-            }
-        },
-        "newAppServicePlanLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the App Service Plan. Defaults to \"westus\"."
-            }
-        },
-        "newWebAppName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
-            }
-        }
-    },
-    "variables": {
-        "appServicePlanName": "[parameters('newAppServicePlanName')]",
-        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
-        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
-        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/mybot')]"
-    },
-    "resources": [
-        {
-            "name": "[parameters('groupName')]",
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2018-05-01",
-            "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
-        },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2018-05-01",
-            "name": "storageDeployment",
-            "resourceGroup": "[parameters('groupName')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "comments": "Create a new App Service Plan",
-                            "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
-                            "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
-                            "properties": {
-                                "name": "[variables('appServicePlanName')]"
-                            }
-                        },
-                        {
-                            "comments": "Create a Web App using the new App Service Plan",
-                            "type": "Microsoft.Web/sites",
-                            "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "kind": "app",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
-                            ],
-                            "name": "[variables('webAppName')]",
-                            "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
-                                "siteConfig": {
-                                    "appSettings": [
-                                        {
-                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
-                                        },
-                                        {
-                                            "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
-                                        },
-                                        {
-                                            "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
-                                        }
-                                    ],
-                                    "cors": {
-                                        "allowedOrigins": [
-                                            "https://botservice.hosting.portal.azure.net",
-                                            "https://hosting.onecloud.azure-test.net/"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "apiVersion": "2017-12-01",
-                            "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
-                            "location": "global",
-                            "kind": "bot",
-                            "sku": {
-                                "name": "[parameters('botSku')]"
-                            },
-                            "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-                            ]
-                        }
-                    ],
-                    "outputs": {}
+            {
+              "comments": "Create a Web App using the new App Service Plan",
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2015-08-01",
+              "location": "[variables('resourcesLocation')]",
+              "kind": "app",
+              "dependsOn": [
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlanName'))]"
+              ],
+              "name": "[variables('webAppName')]",
+              "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[variables('appServicePlanName')]",
+                "siteConfig": {
+                  "appSettings": [
+                    {
+                      "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                      "value": "10.14.1"
+                    },
+                    {
+                      "name": "MicrosoftAppId",
+                      "value": "[parameters('appId')]"
+                    },
+                    {
+                      "name": "MicrosoftAppPassword",
+                      "value": "[parameters('appSecret')]"
+                    }
+                  ],
+                  "cors": {
+                    "allowedOrigins": [
+                      "https://botservice.hosting.portal.azure.net",
+                      "https://hosting.onecloud.azure-test.net/"
+                    ]
+                  }
                 }
+              }
+            },
+            {
+              "apiVersion": "2017-12-01",
+              "type": "Microsoft.BotService/botServices",
+              "name": "[parameters('botId')]",
+              "location": "global",
+              "kind": "bot",
+              "sku": {
+                "name": "[parameters('botSku')]"
+              },
+              "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "developerAppInsightsApplicationId": null,
+                "developerAppInsightKey": null,
+                "publishingCredentials": null,
+                "storageResourceId": null
+              },
+              "dependsOn": [
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+              ]
             }
+          ],
+          "outputs": {}
         }
-    ]
+      }
+    }
+  ]
 }

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -35,8 +35,8 @@ variables:
   IsBuildServer: true # Consumed by projects in Microsoft.Bot.Builder.sln.
   MSBuildArguments: -p:PublishRepositoryUrl=true -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
   Parameters.solution: Microsoft.Bot.Builder.sln
-#  PreviewPackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
-#  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
+#  PreviewPackageVersion: Define this in Azure to be settable at queue time. Consumed by projects in Microsoft.Bot.Builder.sln.
+#  ReleasePackageVersion: Define this in Azure to be settable at queue time. Consumed by projects in Microsoft.Bot.Builder.sln.
 
 jobs:
 - job: Build_and_Sign

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -7,7 +7,9 @@ steps:
 - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
   displayName: 'Tag build with package version'
   inputs:
-    tags: 'Version=$(ReleasePackageVersion)'
+    tags: 
+     ReleasePackageVersion=$(ReleasePackageVersion)
+     PreviewPackageVersion=$(PreviewPackageVersion)
   continueOnError: true
 
 - task: NuGetToolInstaller@0

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <Version Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</Version>
-    <Version Condition=" '$(IsBuildServer)' != '' ">$(PreviewPackageVersion)</Version>
+    <Version Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</Version>
     <PackageVersion Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</PackageVersion>
-    <PackageVersion Condition=" '$(IsBuildServer)' != '' ">$(PreviewPackageVersion)</PackageVersion>
+    <PackageVersion Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</PackageVersion>
     <Configurations>Debug;Release</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.Bot.Builder.AI.Orchestrator.xml</DocumentationFile>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "groupLocation": {
@@ -97,7 +97,8 @@
     "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
     "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
     "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+    "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
   },
   "resources": [
     {
@@ -142,7 +143,7 @@
               "location": "[variables('resourcesLocation')]",
               "kind": "app",
               "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlanName'))]"
               ],
               "name": "[variables('webAppName')]",
               "properties": {
@@ -204,7 +205,7 @@
                 "storageResourceId": null
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
               ]
             }
           ],

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/DeploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "groupLocation": {
@@ -76,7 +76,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -117,11 +118,11 @@
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
-                            "apiVersion": "2015-08-01",
+                            "apiVersion": "2018-11-01",
                             "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                            "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
                             "properties": {
@@ -171,7 +172,7 @@
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                            "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/DeploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "groupLocation": {
@@ -97,7 +97,8 @@
     "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
     "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
     "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+    "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
   },
   "resources": [
     {
@@ -138,11 +139,11 @@
             {
               "comments": "Create a Web App using the new App Service Plan",
               "type": "Microsoft.Web/sites",
-              "apiVersion": "2015-08-01",
+              "apiVersion": "2018-11-01",
               "location": "[variables('resourcesLocation')]",
               "kind": "app",
               "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlanName'))]"
               ],
               "name": "[variables('webAppName')]",
               "properties": {
@@ -204,7 +205,7 @@
                 "storageResourceId": null
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
               ]
             }
           ],

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/DeploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "groupLocation": {
@@ -94,7 +94,8 @@
     "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
     "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
     "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+    "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
   },
   "resources": [
     {
@@ -135,11 +136,11 @@
             {
               "comments": "Create a Web App using the new App Service Plan",
               "type": "Microsoft.Web/sites",
-              "apiVersion": "2015-08-01",
+              "apiVersion": "2018-11-01",
               "location": "[variables('resourcesLocation')]",
               "kind": "app",
               "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlanName'))]"
               ],
               "name": "[variables('webAppName')]",
               "properties": {
@@ -205,7 +206,7 @@
                 "storageResourceId": null
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
               ]
             }
           ],

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/DeploymentTemplates/template-with-new-rg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
   "parameters": {
     "groupLocation": {
@@ -104,7 +104,8 @@
         "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
         "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
         "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
+        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+        "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
     },
     "resources": [
         {
@@ -145,11 +146,11 @@
                         {
                             "comments": "Create a Web App using the new App Service Plan",
                             "type": "Microsoft.Web/sites",
-                            "apiVersion": "2015-08-01",
+                            "apiVersion": "2018-11-01",
                             "location": "[variables('resourcesLocation')]",
                             "kind": "app",
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlanName'))]"
                             ],
                             "name": "[variables('webAppName')]",
                             "properties": {
@@ -215,7 +216,7 @@
                                 "storageResourceId": null
                             },
                             "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
+                              "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
                             ]
                         }
                     ],


### PR DESCRIPTION
Versioning for this package is controlled by build var PreviewPackageVersion, settable at queue time.
This PR would change it to be controlled by build var ReleasePackageVersion, also settable at queue time.

Other packages currently versioned by PreviewPackageVersion are:

Microsoft.Bot.Builder.Azure.Queues
Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
Microsoft.Bot.Builder.Dialogs.Debugging