### PR TITLE
Change versioning of Microsoft.Bot.Builder.AI.Orchestrator package to use var ReleasePackageVersion

### DIFF
--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -35,8 +35,8 @@ variables:
   IsBuildServer: true # Consumed by projects in Microsoft.Bot.Builder.sln.
   MSBuildArguments: -p:PublishRepositoryUrl=true -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
   Parameters.solution: Microsoft.Bot.Builder.sln
-#  PreviewPackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
-#  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
+#  PreviewPackageVersion: Define this in Azure to be settable at queue time. Consumed by projects in Microsoft.Bot.Builder.sln.
+#  ReleasePackageVersion: Define this in Azure to be settable at queue time. Consumed by projects in Microsoft.Bot.Builder.sln.
 
 jobs:
 - job: Build_and_Sign

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -7,7 +7,9 @@ steps:
 - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
   displayName: 'Tag build with package version'
   inputs:
-    tags: 'Version=$(ReleasePackageVersion)'
+    tags: 
+     ReleasePackageVersion=$(ReleasePackageVersion)
+     PreviewPackageVersion=$(PreviewPackageVersion)
   continueOnError: true
 
 - task: NuGetToolInstaller@0

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <Version Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</Version>
-    <Version Condition=" '$(IsBuildServer)' != '' ">$(PreviewPackageVersion)</Version>
+    <Version Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</Version>
     <PackageVersion Condition=" '$(IsBuildServer)' == '' ">$(LocalPackageVersion)</PackageVersion>
-    <PackageVersion Condition=" '$(IsBuildServer)' != '' ">$(PreviewPackageVersion)</PackageVersion>
+    <PackageVersion Condition=" '$(IsBuildServer)' != '' ">$(ReleasePackageVersion)</PackageVersion>
     <Configurations>Debug;Release</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.Bot.Builder.AI.Orchestrator.xml</DocumentationFile>


### PR DESCRIPTION
Versioning for this package is controlled by build var PreviewPackageVersion, settable at queue time.
This PR would change it to be controlled by build var ReleasePackageVersion, also settable at queue time.

Other packages versioned by PreviewPackageVersion are:

Microsoft.Bot.Builder.Azure.Queues
Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
Microsoft.Bot.Builder.Dialogs.Debugging
