### PR TITLE
QnAMaker GenerateAnswer StrictFiltersCompoundOperationType  for Metadata Join Operation

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/JoinOperator.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/JoinOperator.cs
@@ -1,23 +1,20 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using Newtonsoft.Json;
-
 namespace Microsoft.Bot.Builder.AI.QnA
 {
     /// <summary>
-    /// Compound Filter for Metadata Join Expression.
+    /// Join Operator for Strict Filters.
     /// </summary>
-    public enum StrictFiltersCompoundOperationType
+    public enum JoinOperator
     {
         /// <summary>
-        /// Default Search Filter Operation Type, AND.
+        /// Default Join Operator, AND.
         /// </summary>
         AND,
 
         /// <summary>
-        /// Search Filter Operation Type OR.
+        /// Join Operator, OR.
         /// </summary>
         OR
     }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public string RankerType { get; set; }
 
         /// <summary>
-        /// Gets or Sets a value Compound Filter for Metadata Join Expression, for Search.
+        /// Gets or Sets a value of Compound Filter for Metadata Join Expression.
         /// </summary>
         /// [JsonProperty("strictFiltersCompoundOperationType")]
         /// <value>

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
@@ -111,5 +111,14 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <seealso cref="RankerTypes"/>
         [JsonProperty("rankerType")]
         public string RankerType { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a value Compound Filter for Metadata Join Expression, for Search.
+        /// </summary>
+        /// [JsonProperty("strictFiltersCompoundOperationType")]
+        /// <value>
+        /// A value used for join operation of Metadata <see cref="Metadata"/>.
+        /// </value>
+        public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
@@ -113,13 +113,12 @@ namespace Microsoft.Bot.Builder.AI.QnA
         public string RankerType { get; set; }
 
         /// <summary>
-        /// Gets or Sets a value of Compound Filter for Metadata Join Expression.
+        /// Gets or sets <see cref="StrictFilters"/> join operator.
         /// </summary>
-        /// [JsonProperty("strictFiltersCompoundOperationType")]
         /// <value>
-        /// A value used for join operation of Metadata <see cref="Metadata"/>.
+        /// A value used for join operation of StrictFilters <see cref="StrictFilters"/>.
         /// </value>
-        [JsonProperty("strictFiltersCompoundOperationType")]
-        public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
+        [JsonProperty("strictFiltersJoinOperator")]
+        public JoinOperator StrictFiltersJoinOperator { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerOptions.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <value>
         /// A value used for join operation of Metadata <see cref="Metadata"/>.
         /// </value>
+        [JsonProperty("strictFiltersCompoundOperationType")]
         public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
@@ -108,14 +108,13 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
         public StringExpression RankerType { get; set; } = RankerTypes.DefaultRankerType;
 
         /// <summary>
-        /// Gets or Sets a value of Compound Filter for Metadata Join Expression.
+        /// Gets or sets <see cref="Metadata"/> join operator.
         /// </summary>
-        /// [JsonProperty("strictFiltersCompoundOperationType")]
         /// <value>
-        /// A value used for join operation of Metadata <see cref="Metadata"/>.
+        /// A value used for Join operation of Metadata <see cref="Metadata"/>.
         /// </value>
-        [JsonProperty("strictFiltersCompoundOperationType")]
-        public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
+        [JsonProperty("strictFiltersJoinOperator")]
+        public JoinOperator StrictFiltersJoinOperator { get; set; }
 
         /// <summary>
         /// Gets or sets the whether to include the dialog name metadata for QnA context.
@@ -220,7 +219,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
                     QnAId = QnAId.GetValue(dialogContext.State),
                     RankerType = RankerType.GetValue(dialogContext.State),
                     IsTest = IsTest,
-                    StrictFiltersCompoundOperationType = StrictFiltersCompoundOperationType
+                    StrictFiltersJoinOperator = StrictFiltersJoinOperator
                 },
                 null).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
@@ -108,6 +108,16 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
         public StringExpression RankerType { get; set; } = RankerTypes.DefaultRankerType;
 
         /// <summary>
+        /// Gets or Sets a value of Compound Filter for Metadata Join Expression.
+        /// </summary>
+        /// [JsonProperty("strictFiltersCompoundOperationType")]
+        /// <value>
+        /// A value used for join operation of Metadata <see cref="Metadata"/>.
+        /// </value>
+        [JsonProperty("strictFiltersCompoundOperationType")]
+        public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
+
+        /// <summary>
         /// Gets or sets the whether to include the dialog name metadata for QnA context.
         /// </summary>
         /// <value>
@@ -209,7 +219,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
                     Top = Top.GetValue(dialogContext.State),
                     QnAId = QnAId.GetValue(dialogContext.State),
                     RankerType = RankerType.GetValue(dialogContext.State),
-                    IsTest = IsTest
+                    IsTest = IsTest,
+                    StrictFiltersCompoundOperationType = StrictFiltersCompoundOperationType
                 },
                 null).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.schema
@@ -113,14 +113,14 @@
                 }
             ]
         },
-        "strictFiltersCompoundOperationType": {
+        "strictFiltersJoinOperator": {
             "$ref": "schema:#/definitions/stringExpression",
-            "title": "StrictFilters Compound Operation Type",
-            "description": "Type of Operation for Strict Filters.",
+            "title": "StrictFiltersJoinOperator",
+            "description": "Join operator for Strict Filters.",
             "oneOf": [
                 {
-                    "title": "StrictFiltersCompoundOperationType",
-                    "description": "StrictFiltersCompoundOperationType.",
+                    "title": "Join Operator",
+                    "description": "Value of Join Operator to be used as conjunction with Strict Filter values.",
                     "enum": [
                         "AND",
                         "OR"

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.schema
@@ -122,8 +122,8 @@
                     "title": "StrictFiltersCompoundOperationType",
                     "description": "StrictFiltersCompoundOperationType.",
                     "enum": [
-                        "OR",
-                        "AND"
+                        "AND",
+                        "OR"
                     ],
                     "default": "AND"
                 },

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.schema
@@ -112,6 +112,25 @@
                     "$ref": "schema:#/definitions/equalsExpression"
                 }
             ]
+        },
+        "strictFiltersCompoundOperationType": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "StrictFilters Compound Operation Type",
+            "description": "Type of Operation for Strict Filters.",
+            "oneOf": [
+                {
+                    "title": "StrictFiltersCompoundOperationType",
+                    "description": "StrictFiltersCompoundOperationType.",
+                    "enum": [
+                        "OR",
+                        "AND"
+                    ],
+                    "default": "AND"
+                },
+                {
+                    "$ref": "schema:#/definitions/equalsExpression"
+                }
+            ]
         }
     },
     "required": [

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerRecognizer.schema
@@ -114,51 +114,50 @@
                     "$ref": "schema:#/definitions/equalsExpression"
                 }
             ]
-        }
-    },
-    "includeDialogNameInMetadata": {
-        "$ref": "schema:#/definitions/booleanExpression",
-        "title": "Include Dialog Name",
-        "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
-        "default": true,
-        "examples": [
-            true,
-            "=f(x)"
-        ]
-    },
-    "metadata": {
-        "$ref": "schema:#/definitions/arrayExpression",
-        "title": "Metadata filters",
-        "description": "Metadata filters to use when calling the QnA Maker KB.",
-        "items": {
-            "type": "object",
-            "title": "Metadata filter",
-            "description": "Metadata filter to use when calling the QnA Maker KB.",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "Name of value to test."
-                },
-                "value": {
-                    "type": "string",
-                    "title": "Value",
-                    "description": "Value to filter against."
+        },
+        "includeDialogNameInMetadata": {
+            "$ref": "schema:#/definitions/booleanExpression",
+            "title": "Include Dialog Name",
+            "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+            "default": true,
+            "examples": [
+                true,
+                "=f(x)"
+            ]
+        },
+        "metadata": {
+            "$ref": "schema:#/definitions/arrayExpression",
+            "title": "Metadata filters",
+            "description": "Metadata filters to use when calling the QnA Maker KB.",
+            "items": {
+                "type": "object",
+                "title": "Metadata filter",
+                "description": "Metadata filter to use when calling the QnA Maker KB.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "Name of value to test."
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value",
+                        "description": "Value to filter against."
+                    }
                 }
             }
+        },
+        "context": {
+            "$ref": "schema:#/definitions/objectExpression",
+            "title": "QnARequestContext",
+            "description": "Context to use for ranking."
+        },
+        "qnaId": {
+            "$ref": "schema:#/definitions/integerExpression",
+            "title": "QnAId",
+            "description": "A number or expression which is the QnAId to paass to QnAMaker API."
         }
     },
-    "context": {
-        "$ref": "schema:#/definitions/objectExpression",
-        "title": "QnARequestContext",
-        "description": "Context to use for ranking."
-    },
-    "qnaId": {
-        "$ref": "schema:#/definitions/integerExpression",
-        "title": "QnAId",
-        "description": "A number or expression which is the QnAId to paass to QnAMaker API."
-    }
-},
     "required": [
         "knowledgeBaseId",
         "endpointKey",

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerRecognizer.schema
@@ -96,49 +96,69 @@
                 }
             ]
         },
-        "includeDialogNameInMetadata": {
-            "$ref": "schema:#/definitions/booleanExpression",
-            "title": "Include Dialog Name",
-            "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
-            "default": true,
-            "examples": [
-                true,
-                "=f(x)"
-            ]
-        },
-        "metadata": {
-            "$ref": "schema:#/definitions/arrayExpression",
-            "title": "Metadata filters",
-            "description": "Metadata filters to use when calling the QnA Maker KB.",
-            "items": {
-                "type": "object",
-                "title": "Metadata filter",
-                "description": "Metadata filter to use when calling the QnA Maker KB.",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "description": "Name of value to test."
-                    },
-                    "value": {
-                        "type": "string",
-                        "title": "Value",
-                        "description": "Value to filter against."
-                    }
+        "strictFiltersJoinOperator": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "StrictFiltersJoinOperator",
+            "description": "Join operator for Strict Filters.",
+            "oneOf": [
+                {
+                    "title": "Join Operator",
+                    "description": "Value of Join Operator to be used as onjuction with Strict Filter values.",
+                    "enum": [
+                        "AND",
+                        "OR"
+                    ],
+                    "default": "AND"
+                },
+                {
+                    "$ref": "schema:#/definitions/equalsExpression"
                 }
-            }
-        },
-        "context": {
-            "$ref": "schema:#/definitions/objectExpression",
-            "title": "QnARequestContext",
-            "description": "Context to use for ranking."
-        },
-        "qnaId": {
-            "$ref": "schema:#/definitions/integerExpression",
-            "title": "QnAId",
-            "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+            ]
         }
     },
+    "includeDialogNameInMetadata": {
+        "$ref": "schema:#/definitions/booleanExpression",
+        "title": "Include Dialog Name",
+        "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+        "default": true,
+        "examples": [
+            true,
+            "=f(x)"
+        ]
+    },
+    "metadata": {
+        "$ref": "schema:#/definitions/arrayExpression",
+        "title": "Metadata filters",
+        "description": "Metadata filters to use when calling the QnA Maker KB.",
+        "items": {
+            "type": "object",
+            "title": "Metadata filter",
+            "description": "Metadata filter to use when calling the QnA Maker KB.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "Name of value to test."
+                },
+                "value": {
+                    "type": "string",
+                    "title": "Value",
+                    "description": "Value to filter against."
+                }
+            }
+        }
+    },
+    "context": {
+        "$ref": "schema:#/definitions/objectExpression",
+        "title": "QnARequestContext",
+        "description": "Context to use for ranking."
+    },
+    "qnaId": {
+        "$ref": "schema:#/definitions/integerExpression",
+        "title": "QnAId",
+        "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+    }
+},
     "required": [
         "knowledgeBaseId",
         "endpointKey",

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/StrictFiltersCompoundOperationType.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/StrictFiltersCompoundOperationType.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.AI.QnA
 {
     /// <summary>
-    /// Operation types for Search Filter.
+    /// Compound Filter for Metadata Join Expression.
     /// </summary>
     public enum StrictFiltersCompoundOperationType
     {

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/StrictFiltersCompoundOperationType.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/StrictFiltersCompoundOperationType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.AI.QnA
+{
+    /// <summary>
+    /// Operation types for Search Filter.
+    /// </summary>
+    public enum StrictFiltersCompoundOperationType
+    {
+        /// <summary>
+        /// Default Search Filter Operation Type, AND.
+        /// </summary>
+        AND,
+
+        /// <summary>
+        /// Search Filter Operation Type OR.
+        /// </summary>
+        OR
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 hydratedOptions.QnAId = queryOptions.QnAId;
                 hydratedOptions.IsTest = queryOptions.IsTest;
                 hydratedOptions.RankerType = queryOptions.RankerType != null ? queryOptions.RankerType : RankerTypes.DefaultRankerType;
-                hydratedOptions.StrictFiltersCompoundOperationType = queryOptions.StrictFiltersCompoundOperationType;
+                hydratedOptions.StrictFiltersJoinOperator = queryOptions.StrictFiltersJoinOperator;
             }
 
             return hydratedOptions;
@@ -195,7 +195,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     qnaId = options.QnAId,
                     isTest = options.IsTest,
                     rankerType = options.RankerType,
-                    StrictFiltersCompoundOperationType = options.StrictFiltersCompoundOperationType,
+                    StrictFiltersCompoundOperationType = options.StrictFiltersJoinOperator,
                 }, Formatting.None);
 
             var httpRequestHelper = new HttpRequestUtils(_httpClient);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/GenerateAnswerUtils.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 hydratedOptions.QnAId = queryOptions.QnAId;
                 hydratedOptions.IsTest = queryOptions.IsTest;
                 hydratedOptions.RankerType = queryOptions.RankerType != null ? queryOptions.RankerType : RankerTypes.DefaultRankerType;
+                hydratedOptions.StrictFiltersCompoundOperationType = queryOptions.StrictFiltersCompoundOperationType;
             }
 
             return hydratedOptions;
@@ -193,7 +194,8 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     context = options.Context,
                     qnaId = options.QnAId,
                     isTest = options.IsTest,
-                    rankerType = options.RankerType
+                    rankerType = options.RankerType,
+                    StrictFiltersCompoundOperationType = options.StrictFiltersCompoundOperationType,
                 }, Formatting.None);
 
             var httpRequestHelper = new HttpRequestUtils(_httpClient);

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerRecognizerTests.cs
@@ -59,16 +59,16 @@ namespace Microsoft.Bot.Builder.AI.Tests
         {
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
-                .WithContent("{\"question\":\"QnaMaker_ReturnsAnswer\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+                .WithContent("{\"question\":\"QnaMaker_ReturnsAnswer\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer.json"));
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
-                .WithContent("{\"question\":\"QnaMaker_ReturnsNoAnswer\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+                .WithContent("{\"question\":\"QnaMaker_ReturnsNoAnswer\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_ReturnsNoAnswer.json"));
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
-                .WithContent("{\"question\":\"QnaMaker_TopNAnswer\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+                .WithContent("{\"question\":\"QnaMaker_TopNAnswer\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_TopNAnswer.json"));
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
-                .WithContent("{\"question\":\"QnaMaker_ReturnsAnswerWithIntent\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+                .WithContent("{\"question\":\"QnaMaker_ReturnsAnswerWithIntent\",\"top\":3,\"strictFilters\":[{\"name\":\"dialogName\",\"value\":\"outer\"}],\"scoreThreshold\":0.3,\"context\":null,\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswerWithIntent.json"));
 
             return CreateQnAMakerActionDialog(mockHttp);

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -1179,8 +1179,8 @@ namespace Microsoft.Bot.Builder.AI.Tests
             var context = GetContext("up");
             var noFilterResults1 = await qna.GetAnswersAsync(context, oneFilteredOption);
             var requestContent1 = JsonConvert.DeserializeObject<CapturedRequest>(interceptHttp.Content);
-
-            Assert.AreEqual(1, noFilterResults1.Length);
+            Assert.AreEqual(2, oneFilteredOption.StrictFilters.Length);
+            Assert.AreEqual(StrictFiltersCompoundOperationType.OR, oneFilteredOption.StrictFiltersCompoundOperationType);
         }
 
         [TestMethod]

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -40,11 +40,11 @@ namespace Microsoft.Bot.Builder.AI.Tests
         public AdaptiveDialog QnAMakerAction_ActiveLearningDialogBase()
         {
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Q11\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Q11\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_TopNAnswer.json"));
             mockHttp.When(HttpMethod.Post, GetTrainRequestUrl())
                 .Respond(HttpStatusCode.NoContent, "application/json", "{ }");
-            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Q12\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Q12\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer_WhenNoAnswerFoundInKb.json"));
 
             return CreateQnAMakerActionDialog(mockHttp);
@@ -106,9 +106,9 @@ namespace Microsoft.Bot.Builder.AI.Tests
         public AdaptiveDialog QnAMakerAction_MultiTurnDialogBase()
         {
             var mockHttp = new MockHttpMessageHandler();
-            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"I have issues related to KB\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\"}")
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"I have issues related to KB\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_ReturnAnswer_withPrompts.json"));
-            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Accidently deleted KB\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":27,\"previousUserQuery\":\"\"},\"qnaId\":1,\"isTest\":false,\"rankerType\":\"Default\"}")
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Accidently deleted KB\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":0.3,\"context\":{\"previousQnAId\":27,\"previousUserQuery\":\"\"},\"qnaId\":1,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
                 .Respond("application/json", GetResponse("QnaMaker_ReturnAnswer_MultiTurnLevel1.json"));
 
             return CreateQnAMakerActionDialog(mockHttp);

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -1141,6 +1141,51 @@ namespace Microsoft.Bot.Builder.AI.Tests
         [TestMethod]
         [TestCategory("AI")]
         [TestCategory("QnAMaker")]
+        public async Task QnaMaker_StrictFilters_Compound_OperationType()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetRequestUrl())
+                .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer.json"));
+
+            var interceptHttp = new InterceptRequestHandler(mockHttp);
+            var oneFilteredOption = new QnAMakerOptions()
+            {
+                Top = 30,
+                StrictFilters = new Metadata[]
+                {
+                    new Metadata()
+                    {
+                        Name = "movie",
+                        Value = "disney",
+                    },
+                    new Metadata()
+                    {
+                        Name = "production",
+                        Value = "Walden",
+                    },
+                },
+                StrictFiltersCompoundOperationType = StrictFiltersCompoundOperationType.OR
+            };
+            var qna = GetQnAMaker(
+                            interceptHttp,
+                            new QnAMakerEndpoint
+                            {
+                                KnowledgeBaseId = _knowledgeBaseId,
+                                EndpointKey = _endpointKey,
+
+                                Host = _hostname,
+                            }, oneFilteredOption);
+            
+            var context = GetContext("up");
+            var noFilterResults1 = await qna.GetAnswersAsync(context, oneFilteredOption);
+            var requestContent1 = JsonConvert.DeserializeObject<CapturedRequest>(interceptHttp.Content);
+
+            Assert.AreEqual(1, noFilterResults1.Length);
+        }
+
+        [TestMethod]
+        [TestCategory("AI")]
+        [TestCategory("QnAMaker")]
         [TestCategory("Telemetry")]
         public async Task Telemetry_NullTelemetryClient()
         {
@@ -1833,6 +1878,8 @@ namespace Microsoft.Bot.Builder.AI.Tests
             public Metadata[] MetadataBoost { get; set; }
 
             public float ScoreThreshold { get; set; }
-        }
+
+            public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
+           }
     }
 }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -1164,7 +1164,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
                         Value = "Walden",
                     },
                 },
-                StrictFiltersCompoundOperationType = StrictFiltersCompoundOperationType.OR
+                StrictFiltersJoinOperator = JoinOperator.OR
             };
             var qna = GetQnAMaker(
                             interceptHttp,
@@ -1180,7 +1180,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             var noFilterResults1 = await qna.GetAnswersAsync(context, oneFilteredOption);
             var requestContent1 = JsonConvert.DeserializeObject<CapturedRequest>(interceptHttp.Content);
             Assert.AreEqual(2, oneFilteredOption.StrictFilters.Length);
-            Assert.AreEqual(StrictFiltersCompoundOperationType.OR, oneFilteredOption.StrictFiltersCompoundOperationType);
+            Assert.AreEqual(JoinOperator.OR, oneFilteredOption.StrictFiltersJoinOperator);
         }
 
         [TestMethod]
@@ -1878,8 +1878,6 @@ namespace Microsoft.Bot.Builder.AI.Tests
             public Metadata[] MetadataBoost { get; set; }
 
             public float ScoreThreshold { get; set; }
-
-            public StrictFiltersCompoundOperationType StrictFiltersCompoundOperationType { get; set; }
            }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7361,25 +7361,6 @@
 						}
 					]
 				},
-				"strictFiltersCompoundOperationType": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "StrictFilters Compound Operation Type",
-					"description": "Type of Operation for Strict Filters.",
-					"oneOf": [
-						{
-							"title": "StrictFilters Compound Operation Type",
-							"description": "StrictFilters Compound Operation Type",
-							"enum": [
-								"AND",
-								"OR"
-							],
-							"default": "AND"
-						},
-						{
-							"$ref": "#/definitions/equalsExpression"
-						}
-					]
-				},
 				"$kind": {
 					"title": "Kind of dialog object",
 					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7251,148 +7251,148 @@
 					"description": "Open ended property for tooling."
 				}
 			},
-			"properties": {
-				"knowledgeBaseId": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "KnowledgeBase Id",
-					"description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-					"default": "=settings.qna.knowledgebaseid"
-				},
-				"endpointKey": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Endpoint Key",
-					"description": "Endpoint key for the QnA Maker KB.",
-					"default": "=settings.qna.endpointkey"
-				},
-				"hostname": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Hostname",
-					"description": "Hostname for your QnA Maker service.",
-					"default": "=settings.qna.hostname",
-					"examples": [
-						"https://yourserver.azurewebsites.net/qnamaker"
-					]
-				},
-				"noAnswer": {
-					"$kind": "Microsoft.IActivityTemplate",
-					"title": "Fallback answer",
-					"description": "Default answer to return when none found in KB.",
-					"default": "Sorry, I did not find an answer.",
-					"$ref": "#/definitions/Microsoft.IActivityTemplate"
-				},
-				"threshold": {
-					"$ref": "#/definitions/numberExpression",
-					"title": "Threshold",
-					"description": "Threshold score to filter results.",
-					"default": 0.3
-				},
-				"activeLearningCardTitle": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Active learning card title",
-					"description": "Title for active learning suggestions card.",
-					"default": "Did you mean:"
-				},
-				"cardNoMatchText": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Card no match text",
-					"description": "Text for no match option.",
-					"default": "None of the above."
-				},
-				"cardNoMatchResponse": {
-					"$kind": "Microsoft.IActivityTemplate",
-					"title": "Card no match response",
-					"description": "Custom response when no match option was selected.",
-					"default": "Thanks for the feedback.",
-					"$ref": "#/definitions/Microsoft.IActivityTemplate"
-				},
-				"strictFilters": {
-					"$ref": "#/definitions/arrayExpression",
-					"title": "Strict Filters",
-					"description": "Metadata filters to use when calling the QnA Maker KB.",
-					"items": {
-						"type": "object",
-						"title": "Metadata filter",
-						"description": "Metadata filter.",
-						"properties": {
-							"name": {
-								"type": "string",
-								"title": "Name",
-								"description": "Name of filter property.",
-								"maximum": 100
-							},
-							"value": {
-								"type": "string",
-								"title": "Value",
-								"description": "Value to filter on.",
-								"maximum": 100
-							}
-						}
-					}
-				},
-				"top": {
-					"$ref": "#/definitions/numberExpression",
-					"title": "Top",
-					"description": "The number of answers you want to retrieve.",
-					"default": 3
-				},
-				"isTest": {
-					"type": "boolean",
-					"title": "IsTest",
-					"description": "True, if pointing to Test environment, else false.",
-					"default": false
-				},
-				"rankerType": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Ranker Type",
-					"description": "Type of Ranker.",
-					"oneOf": [
-						{
-							"title": "Standard ranker",
-							"description": "Standard ranker types.",
-							"enum": [
-								"default",
-								"questionOnly",
-								"autoSuggestQuestion"
-							],
-							"default": "default"
-						},
-						{
-							"$ref": "#/definitions/equalsExpression"
-						}
-					]
-				},
-				"strictFiltersCompoundOperationType": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "StrictFilters Compound Operation Type",
-					"description": "Type of Operation for Strict Filters.",
-					"oneOf": [
-						{
-							"title": "StrictFiltersCompoundOperationType",
-							"description": "StrictFilters Compound Operation Type.",
-							"enum": [
-								"AND",
-								"OR"
-							],
-							"default": "AND"
-						},
-						{
-							"$ref": "#/definitions/equalsExpression"
-						}
-					]
-				},
-				"$kind": {
-					"title": "Kind of dialog object",
-					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-					"type": "string",
-					"pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-					"const": "Microsoft.QnAMakerDialog"
-				},
-				"$designer": {
-					"title": "Designer information",
-					"type": "object",
-					"description": "Extra information for the Bot Framework Composer."
-				}
-			}
+            "properties": {
+                "knowledgeBaseId": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "KnowledgeBase Id",
+                    "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+                    "default": "=settings.qna.knowledgebaseid"
+                },
+                "endpointKey": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Endpoint Key",
+                    "description": "Endpoint key for the QnA Maker KB.",
+                    "default": "=settings.qna.endpointkey"
+                },
+                "hostname": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Hostname",
+                    "description": "Hostname for your QnA Maker service.",
+                    "default": "=settings.qna.hostname",
+                    "examples": [
+                        "https://yourserver.azurewebsites.net/qnamaker"
+                    ]
+                },
+                "noAnswer": {
+                    "$kind": "Microsoft.IActivityTemplate",
+                    "title": "Fallback answer",
+                    "description": "Default answer to return when none found in KB.",
+                    "default": "Sorry, I did not find an answer.",
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "threshold": {
+                    "$ref": "#/definitions/numberExpression",
+                    "title": "Threshold",
+                    "description": "Threshold score to filter results.",
+                    "default": 0.3
+                },
+                "activeLearningCardTitle": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Active learning card title",
+                    "description": "Title for active learning suggestions card.",
+                    "default": "Did you mean:"
+                },
+                "cardNoMatchText": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Card no match text",
+                    "description": "Text for no match option.",
+                    "default": "None of the above."
+                },
+                "cardNoMatchResponse": {
+                    "$kind": "Microsoft.IActivityTemplate",
+                    "title": "Card no match response",
+                    "description": "Custom response when no match option was selected.",
+                    "default": "Thanks for the feedback.",
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "strictFilters": {
+                    "$ref": "#/definitions/arrayExpression",
+                    "title": "Strict Filters",
+                    "description": "Metadata filters to use when calling the QnA Maker KB.",
+                    "items": {
+                        "type": "object",
+                        "title": "Metadata filter",
+                        "description": "Metadata filter.",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "Name",
+                                "description": "Name of filter property.",
+                                "maximum": 100
+                            },
+                            "value": {
+                                "type": "string",
+                                "title": "Value",
+                                "description": "Value to filter on.",
+                                "maximum": 100
+                            }
+                        }
+                    }
+                },
+                "top": {
+                    "$ref": "#/definitions/numberExpression",
+                    "title": "Top",
+                    "description": "The number of answers you want to retrieve.",
+                    "default": 3
+                },
+                "isTest": {
+                    "type": "boolean",
+                    "title": "IsTest",
+                    "description": "True, if pointing to Test environment, else false.",
+                    "default": false
+                },
+                "rankerType": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Ranker Type",
+                    "description": "Type of Ranker.",
+                    "oneOf": [
+                        {
+                            "title": "Standard ranker",
+                            "description": "Standard ranker types.",
+                            "enum": [
+                                "default",
+                                "questionOnly",
+                                "autoSuggestQuestion"
+                            ],
+                            "default": "default"
+                        },
+                        {
+                            "$ref": "#/definitions/equalsExpression"
+                        }
+                    ]
+                },
+                "strictFiltersCompoundOperationType": {
+                    "$ref": "schema:#/definitions/stringExpression",
+                    "title": "StrictFilters Compound Operation Type",
+                    "description": "Type of Operation for Strict Filters.",
+                    "oneOf": [
+                        {
+                            "title": "StrictFiltersCompoundOperationType",
+                            "description": "StrictFiltersCompoundOperationType.",
+                            "enum": [
+                                "OR",
+                                "AND"
+                            ],
+                            "default": "AND"
+                        },
+                        {
+                            "$ref": "schema:#/definitions/equalsExpression"
+                        }
+                    ]
+                },
+                "$kind": {
+                    "title": "Kind of dialog object",
+                    "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+                    "const": "Microsoft.QnAMakerDialog"
+                },
+                "$designer": {
+                    "title": "Designer information",
+                    "type": "object",
+                    "description": "Extra information for the Bot Framework Composer."
+                }
+            }
 		},
 		"Microsoft.QnAMakerRecognizer": {
 			"$role": "implements(Microsoft.IRecognizer)",
@@ -7535,6 +7535,24 @@
 							}
 						}
 					}
+				},
+				"strictFiltersCompoundOperationType": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "StrictFilters Compound Operation Type",
+					"description": "Type of Operation for Strict Filters.",
+					"oneOf": [
+						"title": "StrictFiltersCompoundOperationType",
+						"description": "Metadata filter to use when calling the QnA Maker KB.",
+						"enum": [
+								"AND",
+								"OR"
+							],
+							"default": "AND"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
 				},
 				"context": {
 					"$ref": "#/definitions/objectExpression",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7536,6 +7536,24 @@
 						}
 					}
 				},
+				"strictFiltersCompoundOperationType": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "StrictFilters Compound Operation Type",
+					"description": "Type of Operation for Strict Filters.",
+					"oneOf": [
+						"title": "StrictFiltersCompoundOperationType",
+						"description": "Metadata filter to use when calling the QnA Maker KB.",
+						"enum": [
+								"AND",
+								"OR"
+							],
+							"default": "AND"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
+				},
 				"context": {
 					"$ref": "#/definitions/objectExpression",
 					"title": "QnARequestContext",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7251,129 +7251,148 @@
 					"description": "Open ended property for tooling."
 				}
 			},
-			"properties": {
-				"knowledgeBaseId": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "KnowledgeBase Id",
-					"description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-					"default": "=settings.qna.knowledgebaseid"
-				},
-				"endpointKey": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Endpoint Key",
-					"description": "Endpoint key for the QnA Maker KB.",
-					"default": "=settings.qna.endpointkey"
-				},
-				"hostname": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Hostname",
-					"description": "Hostname for your QnA Maker service.",
-					"default": "=settings.qna.hostname",
-					"examples": [
-						"https://yourserver.azurewebsites.net/qnamaker"
-					]
-				},
-				"noAnswer": {
-					"$kind": "Microsoft.IActivityTemplate",
-					"title": "Fallback answer",
-					"description": "Default answer to return when none found in KB.",
-					"default": "Sorry, I did not find an answer.",
-					"$ref": "#/definitions/Microsoft.IActivityTemplate"
-				},
-				"threshold": {
-					"$ref": "#/definitions/numberExpression",
-					"title": "Threshold",
-					"description": "Threshold score to filter results.",
-					"default": 0.3
-				},
-				"activeLearningCardTitle": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Active learning card title",
-					"description": "Title for active learning suggestions card.",
-					"default": "Did you mean:"
-				},
-				"cardNoMatchText": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Card no match text",
-					"description": "Text for no match option.",
-					"default": "None of the above."
-				},
-				"cardNoMatchResponse": {
-					"$kind": "Microsoft.IActivityTemplate",
-					"title": "Card no match response",
-					"description": "Custom response when no match option was selected.",
-					"default": "Thanks for the feedback.",
-					"$ref": "#/definitions/Microsoft.IActivityTemplate"
-				},
-				"strictFilters": {
-					"$ref": "#/definitions/arrayExpression",
-					"title": "Strict Filters",
-					"description": "Metadata filters to use when calling the QnA Maker KB.",
-					"items": {
-						"type": "object",
-						"title": "Metadata filter",
-						"description": "Metadata filter.",
-						"properties": {
-							"name": {
-								"type": "string",
-								"title": "Name",
-								"description": "Name of filter property.",
-								"maximum": 100
-							},
-							"value": {
-								"type": "string",
-								"title": "Value",
-								"description": "Value to filter on.",
-								"maximum": 100
-							}
-						}
-					}
-				},
-				"top": {
-					"$ref": "#/definitions/numberExpression",
-					"title": "Top",
-					"description": "The number of answers you want to retrieve.",
-					"default": 3
-				},
-				"isTest": {
-					"type": "boolean",
-					"title": "IsTest",
-					"description": "True, if pointing to Test environment, else false.",
-					"default": false
-				},
-				"rankerType": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "Ranker Type",
-					"description": "Type of Ranker.",
-					"oneOf": [
-						{
-							"title": "Standard ranker",
-							"description": "Standard ranker types.",
-							"enum": [
-								"default",
-								"questionOnly",
-								"autoSuggestQuestion"
-							],
-							"default": "default"
-						},
-						{
-							"$ref": "#/definitions/equalsExpression"
-						}
-					]
-				},
-				"$kind": {
-					"title": "Kind of dialog object",
-					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-					"type": "string",
-					"pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-					"const": "Microsoft.QnAMakerDialog"
-				},
-				"$designer": {
-					"title": "Designer information",
-					"type": "object",
-					"description": "Extra information for the Bot Framework Composer."
-				}
-			}
+            "properties": {
+                "knowledgeBaseId": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "KnowledgeBase Id",
+                    "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+                    "default": "=settings.qna.knowledgebaseid"
+                },
+                "endpointKey": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Endpoint Key",
+                    "description": "Endpoint key for the QnA Maker KB.",
+                    "default": "=settings.qna.endpointkey"
+                },
+                "hostname": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Hostname",
+                    "description": "Hostname for your QnA Maker service.",
+                    "default": "=settings.qna.hostname",
+                    "examples": [
+                        "https://yourserver.azurewebsites.net/qnamaker"
+                    ]
+                },
+                "noAnswer": {
+                    "$kind": "Microsoft.IActivityTemplate",
+                    "title": "Fallback answer",
+                    "description": "Default answer to return when none found in KB.",
+                    "default": "Sorry, I did not find an answer.",
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "threshold": {
+                    "$ref": "#/definitions/numberExpression",
+                    "title": "Threshold",
+                    "description": "Threshold score to filter results.",
+                    "default": 0.3
+                },
+                "activeLearningCardTitle": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Active learning card title",
+                    "description": "Title for active learning suggestions card.",
+                    "default": "Did you mean:"
+                },
+                "cardNoMatchText": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Card no match text",
+                    "description": "Text for no match option.",
+                    "default": "None of the above."
+                },
+                "cardNoMatchResponse": {
+                    "$kind": "Microsoft.IActivityTemplate",
+                    "title": "Card no match response",
+                    "description": "Custom response when no match option was selected.",
+                    "default": "Thanks for the feedback.",
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
+                },
+                "strictFilters": {
+                    "$ref": "#/definitions/arrayExpression",
+                    "title": "Strict Filters",
+                    "description": "Metadata filters to use when calling the QnA Maker KB.",
+                    "items": {
+                        "type": "object",
+                        "title": "Metadata filter",
+                        "description": "Metadata filter.",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "title": "Name",
+                                "description": "Name of filter property.",
+                                "maximum": 100
+                            },
+                            "value": {
+                                "type": "string",
+                                "title": "Value",
+                                "description": "Value to filter on.",
+                                "maximum": 100
+                            }
+                        }
+                    }
+                },
+                "top": {
+                    "$ref": "#/definitions/numberExpression",
+                    "title": "Top",
+                    "description": "The number of answers you want to retrieve.",
+                    "default": 3
+                },
+                "isTest": {
+                    "type": "boolean",
+                    "title": "IsTest",
+                    "description": "True, if pointing to Test environment, else false.",
+                    "default": false
+                },
+                "rankerType": {
+                    "$ref": "#/definitions/stringExpression",
+                    "title": "Ranker Type",
+                    "description": "Type of Ranker.",
+                    "oneOf": [
+                        {
+                            "title": "Standard ranker",
+                            "description": "Standard ranker types.",
+                            "enum": [
+                                "default",
+                                "questionOnly",
+                                "autoSuggestQuestion"
+                            ],
+                            "default": "default"
+                        },
+                        {
+                            "$ref": "#/definitions/equalsExpression"
+                        }
+                    ]
+                },
+                "strictFiltersCompoundOperationType": {
+                    "$ref": "schema:#/definitions/stringExpression",
+                    "title": "StrictFilters Compound Operation Type",
+                    "description": "Type of Operation for Strict Filters.",
+                    "oneOf": [
+                        {
+                            "title": "StrictFiltersCompoundOperationType",
+                            "description": "StrictFiltersCompoundOperationType.",
+                            "enum": [
+                                "OR",
+                                "AND"
+                            ],
+                            "default": "AND"
+                        },
+                        {
+                            "$ref": "schema:#/definitions/equalsExpression"
+                        }
+                    ]
+                },
+                "$kind": {
+                    "title": "Kind of dialog object",
+                    "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+                    "type": "string",
+                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+                    "const": "Microsoft.QnAMakerDialog"
+                },
+                "$designer": {
+                    "title": "Designer information",
+                    "type": "object",
+                    "description": "Extra information for the Bot Framework Composer."
+                }
+            }
 		},
 		"Microsoft.QnAMakerRecognizer": {
 			"$role": "implements(Microsoft.IRecognizer)",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7485,6 +7485,25 @@
 						}
 					]
 				},
+				"strictFiltersCompoundOperationType": {
+					"title": "Strict Filters Compound OperationType",
+					"description": "Strict Filters Compound OperationType.",
+					"oneOf": [
+						{
+							"type": "string",
+							"title": "Strict Filters Compound OperationType",
+							"description": "Strict Filters Compound OperationType.",
+							"enum": [
+								"AND",
+								"OR"
+							],
+							"default": "AND"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
+				},
 				"includeDialogNameInMetadata": {
 					"$ref": "#/definitions/booleanExpression",
 					"title": "Include Dialog Name",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7251,148 +7251,129 @@
 					"description": "Open ended property for tooling."
 				}
 			},
-            "properties": {
-                "knowledgeBaseId": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "KnowledgeBase Id",
-                    "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-                    "default": "=settings.qna.knowledgebaseid"
-                },
-                "endpointKey": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Endpoint Key",
-                    "description": "Endpoint key for the QnA Maker KB.",
-                    "default": "=settings.qna.endpointkey"
-                },
-                "hostname": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Hostname",
-                    "description": "Hostname for your QnA Maker service.",
-                    "default": "=settings.qna.hostname",
-                    "examples": [
-                        "https://yourserver.azurewebsites.net/qnamaker"
-                    ]
-                },
-                "noAnswer": {
-                    "$kind": "Microsoft.IActivityTemplate",
-                    "title": "Fallback answer",
-                    "description": "Default answer to return when none found in KB.",
-                    "default": "Sorry, I did not find an answer.",
-                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
-                },
-                "threshold": {
-                    "$ref": "#/definitions/numberExpression",
-                    "title": "Threshold",
-                    "description": "Threshold score to filter results.",
-                    "default": 0.3
-                },
-                "activeLearningCardTitle": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Active learning card title",
-                    "description": "Title for active learning suggestions card.",
-                    "default": "Did you mean:"
-                },
-                "cardNoMatchText": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Card no match text",
-                    "description": "Text for no match option.",
-                    "default": "None of the above."
-                },
-                "cardNoMatchResponse": {
-                    "$kind": "Microsoft.IActivityTemplate",
-                    "title": "Card no match response",
-                    "description": "Custom response when no match option was selected.",
-                    "default": "Thanks for the feedback.",
-                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
-                },
-                "strictFilters": {
-                    "$ref": "#/definitions/arrayExpression",
-                    "title": "Strict Filters",
-                    "description": "Metadata filters to use when calling the QnA Maker KB.",
-                    "items": {
-                        "type": "object",
-                        "title": "Metadata filter",
-                        "description": "Metadata filter.",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "title": "Name",
-                                "description": "Name of filter property.",
-                                "maximum": 100
-                            },
-                            "value": {
-                                "type": "string",
-                                "title": "Value",
-                                "description": "Value to filter on.",
-                                "maximum": 100
-                            }
-                        }
-                    }
-                },
-                "top": {
-                    "$ref": "#/definitions/numberExpression",
-                    "title": "Top",
-                    "description": "The number of answers you want to retrieve.",
-                    "default": 3
-                },
-                "isTest": {
-                    "type": "boolean",
-                    "title": "IsTest",
-                    "description": "True, if pointing to Test environment, else false.",
-                    "default": false
-                },
-                "rankerType": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Ranker Type",
-                    "description": "Type of Ranker.",
-                    "oneOf": [
-                        {
-                            "title": "Standard ranker",
-                            "description": "Standard ranker types.",
-                            "enum": [
-                                "default",
-                                "questionOnly",
-                                "autoSuggestQuestion"
-                            ],
-                            "default": "default"
-                        },
-                        {
-                            "$ref": "#/definitions/equalsExpression"
-                        }
-                    ]
-                },
-                "strictFiltersCompoundOperationType": {
-                    "$ref": "schema:#/definitions/stringExpression",
-                    "title": "StrictFilters Compound Operation Type",
-                    "description": "Type of Operation for Strict Filters.",
-                    "oneOf": [
-                        {
-                            "title": "StrictFiltersCompoundOperationType",
-                            "description": "StrictFiltersCompoundOperationType.",
-                            "enum": [
-                                "OR",
-                                "AND"
-                            ],
-                            "default": "AND"
-                        },
-                        {
-                            "$ref": "schema:#/definitions/equalsExpression"
-                        }
-                    ]
-                },
-                "$kind": {
-                    "title": "Kind of dialog object",
-                    "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-                    "const": "Microsoft.QnAMakerDialog"
-                },
-                "$designer": {
-                    "title": "Designer information",
-                    "type": "object",
-                    "description": "Extra information for the Bot Framework Composer."
-                }
-            }
+			"properties": {
+				"knowledgeBaseId": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "KnowledgeBase Id",
+					"description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+					"default": "=settings.qna.knowledgebaseid"
+				},
+				"endpointKey": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Endpoint Key",
+					"description": "Endpoint key for the QnA Maker KB.",
+					"default": "=settings.qna.endpointkey"
+				},
+				"hostname": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Hostname",
+					"description": "Hostname for your QnA Maker service.",
+					"default": "=settings.qna.hostname",
+					"examples": [
+						"https://yourserver.azurewebsites.net/qnamaker"
+					]
+				},
+				"noAnswer": {
+					"$kind": "Microsoft.IActivityTemplate",
+					"title": "Fallback answer",
+					"description": "Default answer to return when none found in KB.",
+					"default": "Sorry, I did not find an answer.",
+					"$ref": "#/definitions/Microsoft.IActivityTemplate"
+				},
+				"threshold": {
+					"$ref": "#/definitions/numberExpression",
+					"title": "Threshold",
+					"description": "Threshold score to filter results.",
+					"default": 0.3
+				},
+				"activeLearningCardTitle": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Active learning card title",
+					"description": "Title for active learning suggestions card.",
+					"default": "Did you mean:"
+				},
+				"cardNoMatchText": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Card no match text",
+					"description": "Text for no match option.",
+					"default": "None of the above."
+				},
+				"cardNoMatchResponse": {
+					"$kind": "Microsoft.IActivityTemplate",
+					"title": "Card no match response",
+					"description": "Custom response when no match option was selected.",
+					"default": "Thanks for the feedback.",
+					"$ref": "#/definitions/Microsoft.IActivityTemplate"
+				},
+				"strictFilters": {
+					"$ref": "#/definitions/arrayExpression",
+					"title": "Strict Filters",
+					"description": "Metadata filters to use when calling the QnA Maker KB.",
+					"items": {
+						"type": "object",
+						"title": "Metadata filter",
+						"description": "Metadata filter.",
+						"properties": {
+							"name": {
+								"type": "string",
+								"title": "Name",
+								"description": "Name of filter property.",
+								"maximum": 100
+							},
+							"value": {
+								"type": "string",
+								"title": "Value",
+								"description": "Value to filter on.",
+								"maximum": 100
+							}
+						}
+					}
+				},
+				"top": {
+					"$ref": "#/definitions/numberExpression",
+					"title": "Top",
+					"description": "The number of answers you want to retrieve.",
+					"default": 3
+				},
+				"isTest": {
+					"type": "boolean",
+					"title": "IsTest",
+					"description": "True, if pointing to Test environment, else false.",
+					"default": false
+				},
+				"rankerType": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Ranker Type",
+					"description": "Type of Ranker.",
+					"oneOf": [
+						{
+							"title": "Standard ranker",
+							"description": "Standard ranker types.",
+							"enum": [
+								"default",
+								"questionOnly",
+								"autoSuggestQuestion"
+							],
+							"default": "default"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
+				},
+				"$kind": {
+					"title": "Kind of dialog object",
+					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+					"type": "string",
+					"pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+					"const": "Microsoft.QnAMakerDialog"
+				},
+				"$designer": {
+					"title": "Designer information",
+					"type": "object",
+					"description": "Extra information for the Bot Framework Composer."
+				}
+			}
 		},
 		"Microsoft.QnAMakerRecognizer": {
 			"$role": "implements(Microsoft.IRecognizer)",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7485,25 +7485,25 @@
 						}
 					]
 				},
-				"strictFiltersCompoundOperationType": {
-					"title": "Strict Filters Compound OperationType",
-					"description": "Strict Filters Compound OperationType.",
-					"oneOf": [
-						{
-							"type": "string",
-							"title": "Strict Filters Compound OperationType",
-							"description": "Strict Filters Compound OperationType.",
-							"enum": [
-								"AND",
-								"OR"
-							],
-							"default": "AND"
-						},
-						{
-							"$ref": "#/definitions/equalsExpression"
-						}
-					]
-				},
+                "strictFiltersCompoundOperationType": {
+                    "title": "Strict Filters Compound OperationType",
+                    "description": "Join operator for Strict Filters.",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "title": "Strict Filters Compound OperationType",
+                            "description": "Value of Join Operator to be used as Conjunction with Strict Filter Values",
+                            "enum": [
+                                "AND",
+                                "OR"
+                            ],
+                            "default": "AND"
+                        },
+                        {
+                            "$ref": "#/definitions/equalsExpression"
+                        }
+                    ]
+                },
 				"includeDialogNameInMetadata": {
 					"$ref": "#/definitions/booleanExpression",
 					"title": "Include Dialog Name",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7251,7 +7251,7 @@
 					"description": "Open ended property for tooling."
 				}
 			},
-            "properties": {
+			"properties": {
                 "knowledgeBaseId": {
                     "$ref": "#/definitions/stringExpression",
                     "title": "KnowledgeBase Id",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7251,148 +7251,148 @@
 					"description": "Open ended property for tooling."
 				}
 			},
-            "properties": {
-                "knowledgeBaseId": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "KnowledgeBase Id",
-                    "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-                    "default": "=settings.qna.knowledgebaseid"
-                },
-                "endpointKey": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Endpoint Key",
-                    "description": "Endpoint key for the QnA Maker KB.",
-                    "default": "=settings.qna.endpointkey"
-                },
-                "hostname": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Hostname",
-                    "description": "Hostname for your QnA Maker service.",
-                    "default": "=settings.qna.hostname",
-                    "examples": [
-                        "https://yourserver.azurewebsites.net/qnamaker"
-                    ]
-                },
-                "noAnswer": {
-                    "$kind": "Microsoft.IActivityTemplate",
-                    "title": "Fallback answer",
-                    "description": "Default answer to return when none found in KB.",
-                    "default": "Sorry, I did not find an answer.",
-                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
-                },
-                "threshold": {
-                    "$ref": "#/definitions/numberExpression",
-                    "title": "Threshold",
-                    "description": "Threshold score to filter results.",
-                    "default": 0.3
-                },
-                "activeLearningCardTitle": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Active learning card title",
-                    "description": "Title for active learning suggestions card.",
-                    "default": "Did you mean:"
-                },
-                "cardNoMatchText": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Card no match text",
-                    "description": "Text for no match option.",
-                    "default": "None of the above."
-                },
-                "cardNoMatchResponse": {
-                    "$kind": "Microsoft.IActivityTemplate",
-                    "title": "Card no match response",
-                    "description": "Custom response when no match option was selected.",
-                    "default": "Thanks for the feedback.",
-                    "$ref": "#/definitions/Microsoft.IActivityTemplate"
-                },
-                "strictFilters": {
-                    "$ref": "#/definitions/arrayExpression",
-                    "title": "Strict Filters",
-                    "description": "Metadata filters to use when calling the QnA Maker KB.",
-                    "items": {
-                        "type": "object",
-                        "title": "Metadata filter",
-                        "description": "Metadata filter.",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "title": "Name",
-                                "description": "Name of filter property.",
-                                "maximum": 100
-                            },
-                            "value": {
-                                "type": "string",
-                                "title": "Value",
-                                "description": "Value to filter on.",
-                                "maximum": 100
-                            }
-                        }
-                    }
-                },
-                "top": {
-                    "$ref": "#/definitions/numberExpression",
-                    "title": "Top",
-                    "description": "The number of answers you want to retrieve.",
-                    "default": 3
-                },
-                "isTest": {
-                    "type": "boolean",
-                    "title": "IsTest",
-                    "description": "True, if pointing to Test environment, else false.",
-                    "default": false
-                },
-                "rankerType": {
-                    "$ref": "#/definitions/stringExpression",
-                    "title": "Ranker Type",
-                    "description": "Type of Ranker.",
-                    "oneOf": [
-                        {
-                            "title": "Standard ranker",
-                            "description": "Standard ranker types.",
-                            "enum": [
-                                "default",
-                                "questionOnly",
-                                "autoSuggestQuestion"
-                            ],
-                            "default": "default"
-                        },
-                        {
-                            "$ref": "#/definitions/equalsExpression"
-                        }
-                    ]
-                },
-                "strictFiltersCompoundOperationType": {
-                    "$ref": "schema:#/definitions/stringExpression",
-                    "title": "StrictFilters Compound Operation Type",
-                    "description": "Type of Operation for Strict Filters.",
-                    "oneOf": [
-                        {
-                            "title": "StrictFiltersCompoundOperationType",
-                            "description": "StrictFiltersCompoundOperationType.",
-                            "enum": [
-                                "OR",
-                                "AND"
-                            ],
-                            "default": "AND"
-                        },
-                        {
-                            "$ref": "schema:#/definitions/equalsExpression"
-                        }
-                    ]
-                },
-                "$kind": {
-                    "title": "Kind of dialog object",
-                    "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-                    "const": "Microsoft.QnAMakerDialog"
-                },
-                "$designer": {
-                    "title": "Designer information",
-                    "type": "object",
-                    "description": "Extra information for the Bot Framework Composer."
-                }
-            }
+			"properties": {
+				"knowledgeBaseId": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "KnowledgeBase Id",
+					"description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+					"default": "=settings.qna.knowledgebaseid"
+				},
+				"endpointKey": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Endpoint Key",
+					"description": "Endpoint key for the QnA Maker KB.",
+					"default": "=settings.qna.endpointkey"
+				},
+				"hostname": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Hostname",
+					"description": "Hostname for your QnA Maker service.",
+					"default": "=settings.qna.hostname",
+					"examples": [
+						"https://yourserver.azurewebsites.net/qnamaker"
+					]
+				},
+				"noAnswer": {
+					"$kind": "Microsoft.IActivityTemplate",
+					"title": "Fallback answer",
+					"description": "Default answer to return when none found in KB.",
+					"default": "Sorry, I did not find an answer.",
+					"$ref": "#/definitions/Microsoft.IActivityTemplate"
+				},
+				"threshold": {
+					"$ref": "#/definitions/numberExpression",
+					"title": "Threshold",
+					"description": "Threshold score to filter results.",
+					"default": 0.3
+				},
+				"activeLearningCardTitle": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Active learning card title",
+					"description": "Title for active learning suggestions card.",
+					"default": "Did you mean:"
+				},
+				"cardNoMatchText": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Card no match text",
+					"description": "Text for no match option.",
+					"default": "None of the above."
+				},
+				"cardNoMatchResponse": {
+					"$kind": "Microsoft.IActivityTemplate",
+					"title": "Card no match response",
+					"description": "Custom response when no match option was selected.",
+					"default": "Thanks for the feedback.",
+					"$ref": "#/definitions/Microsoft.IActivityTemplate"
+				},
+				"strictFilters": {
+					"$ref": "#/definitions/arrayExpression",
+					"title": "Strict Filters",
+					"description": "Metadata filters to use when calling the QnA Maker KB.",
+					"items": {
+						"type": "object",
+						"title": "Metadata filter",
+						"description": "Metadata filter.",
+						"properties": {
+							"name": {
+								"type": "string",
+								"title": "Name",
+								"description": "Name of filter property.",
+								"maximum": 100
+							},
+							"value": {
+								"type": "string",
+								"title": "Value",
+								"description": "Value to filter on.",
+								"maximum": 100
+							}
+						}
+					}
+				},
+				"top": {
+					"$ref": "#/definitions/numberExpression",
+					"title": "Top",
+					"description": "The number of answers you want to retrieve.",
+					"default": 3
+				},
+				"isTest": {
+					"type": "boolean",
+					"title": "IsTest",
+					"description": "True, if pointing to Test environment, else false.",
+					"default": false
+				},
+				"rankerType": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "Ranker Type",
+					"description": "Type of Ranker.",
+					"oneOf": [
+						{
+							"title": "Standard ranker",
+							"description": "Standard ranker types.",
+							"enum": [
+								"default",
+								"questionOnly",
+								"autoSuggestQuestion"
+							],
+							"default": "default"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
+				},
+				"strictFiltersCompoundOperationType": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "StrictFilters Compound Operation Type",
+					"description": "Type of Operation for Strict Filters.",
+					"oneOf": [
+						{
+							"title": "StrictFiltersCompoundOperationType",
+							"description": "StrictFilters Compound Operation Type.",
+							"enum": [
+								"AND",
+								"OR"
+							],
+							"default": "AND"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
+				},
+				"$kind": {
+					"title": "Kind of dialog object",
+					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+					"type": "string",
+					"pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+					"const": "Microsoft.QnAMakerDialog"
+				},
+				"$designer": {
+					"title": "Designer information",
+					"type": "object",
+					"description": "Extra information for the Bot Framework Composer."
+				}
+			}
 		},
 		"Microsoft.QnAMakerRecognizer": {
 			"$role": "implements(Microsoft.IRecognizer)",
@@ -7535,24 +7535,6 @@
 							}
 						}
 					}
-				},
-				"strictFiltersCompoundOperationType": {
-					"$ref": "#/definitions/stringExpression",
-					"title": "StrictFilters Compound Operation Type",
-					"description": "Type of Operation for Strict Filters.",
-					"oneOf": [
-						"title": "StrictFiltersCompoundOperationType",
-						"description": "Metadata filter to use when calling the QnA Maker KB.",
-						"enum": [
-								"AND",
-								"OR"
-							],
-							"default": "AND"
-						},
-						{
-							"$ref": "#/definitions/equalsExpression"
-						}
-					]
 				},
 				"context": {
 					"$ref": "#/definitions/objectExpression",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7361,6 +7361,25 @@
 						}
 					]
 				},
+				"strictFiltersCompoundOperationType": {
+					"$ref": "#/definitions/stringExpression",
+					"title": "StrictFilters Compound Operation Type",
+					"description": "Type of Operation for Strict Filters.",
+					"oneOf": [
+						{
+							"title": "StrictFilters Compound Operation Type",
+							"description": "StrictFilters Compound Operation Type",
+							"enum": [
+								"AND",
+								"OR"
+							],
+							"default": "AND"
+						},
+						{
+							"$ref": "#/definitions/equalsExpression"
+						}
+					]
+				},
 				"$kind": {
 					"title": "Kind of dialog object",
 					"description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -7251,7 +7251,7 @@
 					"description": "Open ended property for tooling."
 				}
 			},
-			"properties": {
+            "properties": {
                 "knowledgeBaseId": {
                     "$ref": "#/definitions/stringExpression",
                     "title": "KnowledgeBase Id",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7811,11 +7811,11 @@
         "strictFiltersCompoundOperationType": {
             "$ref": "#/definitions/stringExpression",
             "title": "StrictFiltersCompoundOperationType",
-            "description": "Strict Filters Compound Operation Type.",
+            "description": "Join operator for Strict Filters.",
             "oneOf": [
                 {
                     "title": "StrictFilters CompoundOperation Type",
-                    "description": "Strict Filters Compound Operation Type.",
+                    "description": "Value of Join Operator to be used as Conjunction with Strict Filter Value.",
                     "enum": [
                         "AND",
                         "OR"

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7840,172 +7840,153 @@
           "description": "Open ended property for tooling."
         }
       },
-        "properties": {
-            "id": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet."
+        },
+        "knowledgeBaseId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "KnowledgeBase Id",
+          "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+          "default": "settings.qna.knowledgebaseid"
+        },
+        "endpointKey": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Endpoint Key",
+          "description": "Endpoint key for the QnA Maker KB.",
+          "default": "settings.qna.endpointkey"
+        },
+        "hostname": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Hostname",
+          "description": "Hostname for your QnA Maker service.",
+          "default": "settings.qna.hostname",
+          "examples": [
+            "https://yourserver.azurewebsites.net/qnamaker"
+          ]
+        },
+        "threshold": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Threshold",
+          "description": "Threshold score to filter results.",
+          "default": 0.3
+        },
+        "strictFilters": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Strict Filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filters",
+            "description": "Metadata filters to use when querying QnA Maker KB.",
+            "properties": {
+              "name": {
                 "type": "string",
-                "title": "Id",
-                "description": "Optional unique id using with RecognizerSet."
-            },
-            "knowledgeBaseId": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "KnowledgeBase Id",
-                "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-                "default": "settings.qna.knowledgebaseid"
-            },
-            "endpointKey": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "Endpoint Key",
-                "description": "Endpoint key for the QnA Maker KB.",
-                "default": "settings.qna.endpointkey"
-            },
-            "hostname": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "Hostname",
-                "description": "Hostname for your QnA Maker service.",
-                "default": "settings.qna.hostname",
-                "examples": [
-                    "https://yourserver.azurewebsites.net/qnamaker"
-                ]
-            },
-            "threshold": {
-                "$ref": "#/definitions/numberExpression",
-                "title": "Threshold",
-                "description": "Threshold score to filter results.",
-                "default": 0.3
-            },
-            "strictFilters": {
-                "$ref": "#/definitions/arrayExpression",
-                "title": "Strict Filters",
-                "description": "Metadata filters to use when calling the QnA Maker KB.",
-                "items": {
-                    "type": "object",
-                    "title": "Metadata filters",
-                    "description": "Metadata filters to use when querying QnA Maker KB.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "title": "Name",
-                            "description": "Name to filter on.",
-                            "maximum": 100
-                        },
-                        "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "Value to restrict filter.",
-                            "maximum": 100
-                        }
-                    }
-                }
-            },
-            "top": {
-                "$ref": "#/definitions/numberExpression",
-                "title": "Top",
-                "description": "The number of answers you want to retrieve.",
-                "default": 3
-            },
-            "isTest": {
-                "$ref": "#/definitions/booleanExpression",
-                "title": "IsTest",
-                "description": "True, if pointing to Test environment, else false.",
-                "examples": [
-                    true,
-                    "=f(x)"
-                ]
-            },
-            "rankerType": {
-                "title": "Ranker Type",
-                "description": "Type of Ranker.",
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "title": "Ranker type",
-                        "description": "Type of Ranker.",
-                        "enum": [
-                            "default",
-                            "questionOnly",
-                            "autoSuggestQuestion"
-                        ],
-                        "default": "default"
-                    },
-                    {
-                        "$ref": "#/definitions/equalsExpression"
-                    }
-                ]
-            },
-            "strictFiltersCompoundOperationType": {
-                "$ref": "schema:#/definitions/stringExpression",
-                "title": "StrictFilters Compound Operation Type",
-                "description": "Type of Operation for Strict Filters.",
-                "oneOf": [
-                    {
-                        "title": "StrictFiltersCompoundOperationType",
-                        "description": "StrictFiltersCompoundOperationType.",
-                        "enum": [
-                            "AND",
-                            "OR"
-                        ],
-                        "default": "AND"
-                    },
-                    {
-                        "$ref": "schema:#/definitions/equalsExpression"
-                    }
-                ]
-            },
-            "includeDialogNameInMetadata": {
-                "$ref": "#/definitions/booleanExpression",
-                "title": "Include Dialog Name",
-                "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
-                "default": true,
-                "examples": [
-                    true,
-                    "=f(x)"
-                ]
-            },
-            "metadata": {
-                "$ref": "#/definitions/arrayExpression",
-                "title": "Metadata filters",
-                "description": "Metadata filters to use when calling the QnA Maker KB.",
-                "items": {
-                    "type": "object",
-                    "title": "Metadata filter",
-                    "description": "Metadata filter to use when calling the QnA Maker KB.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "title": "Name",
-                            "description": "Name of value to test."
-                        },
-                        "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "Value to filter against."
-                        }
-                    }
-                }
-            },
-            "context": {
-                "$ref": "#/definitions/objectExpression",
-                "title": "QnARequestContext",
-                "description": "Context to use for ranking."
-            },
-            "qnaId": {
-                "$ref": "#/definitions/integerExpression",
-                "title": "QnAId",
-                "description": "A number or expression which is the QnAId to paass to QnAMaker API."
-            },
-            "$kind": {
-                "title": "Kind of dialog object",
-                "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+                "title": "Name",
+                "description": "Name to filter on.",
+                "maximum": 100
+              },
+              "value": {
                 "type": "string",
-                "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-                "const": "Microsoft.QnAMakerRecognizer"
-            },
-            "$designer": {
-                "title": "Designer information",
-                "type": "object",
-                "description": "Extra information for the Bot Framework Composer."
+                "title": "Value",
+                "description": "Value to restrict filter.",
+                "maximum": 100
+              }
             }
+          }
+        },
+        "top": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Top",
+          "description": "The number of answers you want to retrieve.",
+          "default": 3
+        },
+        "isTest": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "IsTest",
+          "description": "True, if pointing to Test environment, else false.",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "rankerType": {
+          "title": "Ranker Type",
+          "description": "Type of Ranker.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Ranker type",
+              "description": "Type of Ranker.",
+              "enum": [
+                "default",
+                "questionOnly",
+                "autoSuggestQuestion"
+              ],
+              "default": "default"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "includeDialogNameInMetadata": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Include Dialog Name",
+          "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+          "default": true,
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Metadata filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filter",
+            "description": "Metadata filter to use when calling the QnA Maker KB.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Name of value to test."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Value to filter against."
+              }
+            }
+          }
+        },
+        "context": {
+          "$ref": "#/definitions/objectExpression",
+          "title": "QnARequestContext",
+          "description": "Context to use for ranking."
+        },
+        "qnaId": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "QnAId",
+          "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.QnAMakerRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
         }
+      }
     },
     "Microsoft.RandomSelector": {
       "$role": "implements(Microsoft.ITriggerSelector)",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7840,172 +7840,153 @@
           "description": "Open ended property for tooling."
         }
       },
-        "properties": {
-            "id": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet."
+        },
+        "knowledgeBaseId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "KnowledgeBase Id",
+          "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+          "default": "settings.qna.knowledgebaseid"
+        },
+        "endpointKey": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Endpoint Key",
+          "description": "Endpoint key for the QnA Maker KB.",
+          "default": "settings.qna.endpointkey"
+        },
+        "hostname": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Hostname",
+          "description": "Hostname for your QnA Maker service.",
+          "default": "settings.qna.hostname",
+          "examples": [
+            "https://yourserver.azurewebsites.net/qnamaker"
+          ]
+        },
+        "threshold": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Threshold",
+          "description": "Threshold score to filter results.",
+          "default": 0.3
+        },
+        "strictFilters": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Strict Filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filters",
+            "description": "Metadata filters to use when querying QnA Maker KB.",
+            "properties": {
+              "name": {
                 "type": "string",
-                "title": "Id",
-                "description": "Optional unique id using with RecognizerSet."
-            },
-            "knowledgeBaseId": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "KnowledgeBase Id",
-                "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-                "default": "settings.qna.knowledgebaseid"
-            },
-            "endpointKey": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "Endpoint Key",
-                "description": "Endpoint key for the QnA Maker KB.",
-                "default": "settings.qna.endpointkey"
-            },
-            "hostname": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "Hostname",
-                "description": "Hostname for your QnA Maker service.",
-                "default": "settings.qna.hostname",
-                "examples": [
-                    "https://yourserver.azurewebsites.net/qnamaker"
-                ]
-            },
-            "threshold": {
-                "$ref": "#/definitions/numberExpression",
-                "title": "Threshold",
-                "description": "Threshold score to filter results.",
-                "default": 0.3
-            },
-            "strictFilters": {
-                "$ref": "#/definitions/arrayExpression",
-                "title": "Strict Filters",
-                "description": "Metadata filters to use when calling the QnA Maker KB.",
-                "items": {
-                    "type": "object",
-                    "title": "Metadata filters",
-                    "description": "Metadata filters to use when querying QnA Maker KB.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "title": "Name",
-                            "description": "Name to filter on.",
-                            "maximum": 100
-                        },
-                        "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "Value to restrict filter.",
-                            "maximum": 100
-                        }
-                    }
-                }
-            },
-            "top": {
-                "$ref": "#/definitions/numberExpression",
-                "title": "Top",
-                "description": "The number of answers you want to retrieve.",
-                "default": 3
-            },
-            "isTest": {
-                "$ref": "#/definitions/booleanExpression",
-                "title": "IsTest",
-                "description": "True, if pointing to Test environment, else false.",
-                "examples": [
-                    true,
-                    "=f(x)"
-                ]
-            },
-            "rankerType": {
-                "title": "Ranker Type",
-                "description": "Type of Ranker.",
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "title": "Ranker type",
-                        "description": "Type of Ranker.",
-                        "enum": [
-                            "default",
-                            "questionOnly",
-                            "autoSuggestQuestion"
-                        ],
-                        "default": "default"
-                    },
-                    {
-                        "$ref": "#/definitions/equalsExpression"
-                    }
-                ]
-            },
-            "strictFiltersCompoundOperationType": {
-                "$ref": "#/definitions/stringExpression",
-                "title": "StrictFilters Compound Operation Type",
-                "description": "Type of Operation for Strict Filters.",
-                "oneOf": [
-                    {
-                        "title": "StrictFilters Compound Operation Type",
-                        "description": "StrictFilters Compound Operation Type",
-                        "enum": [
-                            "AND",
-                            "OR"
-                        ],
-                        "default": "AND"
-                    },
-                    {
-                        "$ref": "#/definitions/equalsExpression"
-                    }
-                ]
-            },
-            "includeDialogNameInMetadata": {
-                "$ref": "#/definitions/booleanExpression",
-                "title": "Include Dialog Name",
-                "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
-                "default": true,
-                "examples": [
-                    true,
-                    "=f(x)"
-                ]
-            },
-            "metadata": {
-                "$ref": "#/definitions/arrayExpression",
-                "title": "Metadata filters",
-                "description": "Metadata filters to use when calling the QnA Maker KB.",
-                "items": {
-                    "type": "object",
-                    "title": "Metadata filter",
-                    "description": "Metadata filter to use when calling the QnA Maker KB.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "title": "Name",
-                            "description": "Name of value to test."
-                        },
-                        "value": {
-                            "type": "string",
-                            "title": "Value",
-                            "description": "Value to filter against."
-                        }
-                    }
-                }
-            },
-            "context": {
-                "$ref": "#/definitions/objectExpression",
-                "title": "QnARequestContext",
-                "description": "Context to use for ranking."
-            },
-            "qnaId": {
-                "$ref": "#/definitions/integerExpression",
-                "title": "QnAId",
-                "description": "A number or expression which is the QnAId to paass to QnAMaker API."
-            },
-            "$kind": {
-                "title": "Kind of dialog object",
-                "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+                "title": "Name",
+                "description": "Name to filter on.",
+                "maximum": 100
+              },
+              "value": {
                 "type": "string",
-                "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-                "const": "Microsoft.QnAMakerRecognizer"
-            },
-            "$designer": {
-                "title": "Designer information",
-                "type": "object",
-                "description": "Extra information for the Bot Framework Composer."
+                "title": "Value",
+                "description": "Value to restrict filter.",
+                "maximum": 100
+              }
             }
+          }
+        },
+        "top": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Top",
+          "description": "The number of answers you want to retrieve.",
+          "default": 3
+        },
+        "isTest": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "IsTest",
+          "description": "True, if pointing to Test environment, else false.",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "rankerType": {
+          "title": "Ranker Type",
+          "description": "Type of Ranker.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Ranker type",
+              "description": "Type of Ranker.",
+              "enum": [
+                "default",
+                "questionOnly",
+                "autoSuggestQuestion"
+              ],
+              "default": "default"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "includeDialogNameInMetadata": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Include Dialog Name",
+          "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+          "default": true,
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Metadata filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filter",
+            "description": "Metadata filter to use when calling the QnA Maker KB.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Name of value to test."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Value to filter against."
+              }
+            }
+          }
+        },
+        "context": {
+          "$ref": "#/definitions/objectExpression",
+          "title": "QnARequestContext",
+          "description": "Context to use for ranking."
+        },
+        "qnaId": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "QnAId",
+          "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.QnAMakerRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
         }
+      }
     },
     "Microsoft.RandomSelector": {
       "$role": "implements(Microsoft.ITriggerSelector)",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7789,24 +7789,43 @@
           "default": false
         },
         "rankerType": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Ranker Type",
-          "description": "Type of Ranker.",
-          "oneOf": [
-            {
-              "title": "Standard ranker",
-              "description": "Standard ranker types.",
-              "enum": [
-                "default",
-                "questionOnly",
-                "autoSuggestQuestion"
-              ],
-              "default": "default"
-            },
-            {
-              "$ref": "#/definitions/equalsExpression"
-            }
-          ]
+            "$ref": "#/definitions/stringExpression",
+            "title": "Ranker Type",
+            "description": "Type of Ranker.",
+            "oneOf": [
+                {
+                    "title": "Standard ranker",
+                    "description": "Standard ranker types.",
+                    "enum": [
+                        "default",
+                        "questionOnly",
+                        "autoSuggestQuestion"
+                    ],
+                    "default": "default"
+                },
+                {
+                    "$ref": "#/definitions/equalsExpression"
+                }
+            ]
+        },
+        "strictFiltersCompoundOperationType": {
+            "$ref": "#/definitions/stringExpression",
+            "title": "StrictFiltersCompoundOperationType",
+            "description": "Strict Filters Compound Operation Type.",
+            "oneOf": [
+                {
+                    "title": "StrictFilters CompoundOperation Type",
+                    "description": "Strict Filters Compound Operation Type.",
+                    "enum": [
+                        "AND",
+                        "OR"
+                    ],
+                    "default": "AND"
+                },
+                {
+                    "$ref": "#/definitions/equalsExpression"
+                }
+            ]
         },
         "$kind": {
           "title": "Kind of dialog object",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7840,153 +7840,172 @@
           "description": "Open ended property for tooling."
         }
       },
-      "properties": {
-        "id": {
-          "type": "string",
-          "title": "Id",
-          "description": "Optional unique id using with RecognizerSet."
-        },
-        "knowledgeBaseId": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "KnowledgeBase Id",
-          "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-          "default": "settings.qna.knowledgebaseid"
-        },
-        "endpointKey": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Endpoint Key",
-          "description": "Endpoint key for the QnA Maker KB.",
-          "default": "settings.qna.endpointkey"
-        },
-        "hostname": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Hostname",
-          "description": "Hostname for your QnA Maker service.",
-          "default": "settings.qna.hostname",
-          "examples": [
-            "https://yourserver.azurewebsites.net/qnamaker"
-          ]
-        },
-        "threshold": {
-          "$ref": "#/definitions/numberExpression",
-          "title": "Threshold",
-          "description": "Threshold score to filter results.",
-          "default": 0.3
-        },
-        "strictFilters": {
-          "$ref": "#/definitions/arrayExpression",
-          "title": "Strict Filters",
-          "description": "Metadata filters to use when calling the QnA Maker KB.",
-          "items": {
-            "type": "object",
-            "title": "Metadata filters",
-            "description": "Metadata filters to use when querying QnA Maker KB.",
-            "properties": {
-              "name": {
+        "properties": {
+            "id": {
                 "type": "string",
-                "title": "Name",
-                "description": "Name to filter on.",
-                "maximum": 100
-              },
-              "value": {
-                "type": "string",
-                "title": "Value",
-                "description": "Value to restrict filter.",
-                "maximum": 100
-              }
-            }
-          }
-        },
-        "top": {
-          "$ref": "#/definitions/numberExpression",
-          "title": "Top",
-          "description": "The number of answers you want to retrieve.",
-          "default": 3
-        },
-        "isTest": {
-          "$ref": "#/definitions/booleanExpression",
-          "title": "IsTest",
-          "description": "True, if pointing to Test environment, else false.",
-          "examples": [
-            true,
-            "=f(x)"
-          ]
-        },
-        "rankerType": {
-          "title": "Ranker Type",
-          "description": "Type of Ranker.",
-          "oneOf": [
-            {
-              "type": "string",
-              "title": "Ranker type",
-              "description": "Type of Ranker.",
-              "enum": [
-                "default",
-                "questionOnly",
-                "autoSuggestQuestion"
-              ],
-              "default": "default"
+                "title": "Id",
+                "description": "Optional unique id using with RecognizerSet."
             },
-            {
-              "$ref": "#/definitions/equalsExpression"
-            }
-          ]
-        },
-        "includeDialogNameInMetadata": {
-          "$ref": "#/definitions/booleanExpression",
-          "title": "Include Dialog Name",
-          "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
-          "default": true,
-          "examples": [
-            true,
-            "=f(x)"
-          ]
-        },
-        "metadata": {
-          "$ref": "#/definitions/arrayExpression",
-          "title": "Metadata filters",
-          "description": "Metadata filters to use when calling the QnA Maker KB.",
-          "items": {
-            "type": "object",
-            "title": "Metadata filter",
-            "description": "Metadata filter to use when calling the QnA Maker KB.",
-            "properties": {
-              "name": {
+            "knowledgeBaseId": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "KnowledgeBase Id",
+                "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+                "default": "settings.qna.knowledgebaseid"
+            },
+            "endpointKey": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "Endpoint Key",
+                "description": "Endpoint key for the QnA Maker KB.",
+                "default": "settings.qna.endpointkey"
+            },
+            "hostname": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "Hostname",
+                "description": "Hostname for your QnA Maker service.",
+                "default": "settings.qna.hostname",
+                "examples": [
+                    "https://yourserver.azurewebsites.net/qnamaker"
+                ]
+            },
+            "threshold": {
+                "$ref": "#/definitions/numberExpression",
+                "title": "Threshold",
+                "description": "Threshold score to filter results.",
+                "default": 0.3
+            },
+            "strictFilters": {
+                "$ref": "#/definitions/arrayExpression",
+                "title": "Strict Filters",
+                "description": "Metadata filters to use when calling the QnA Maker KB.",
+                "items": {
+                    "type": "object",
+                    "title": "Metadata filters",
+                    "description": "Metadata filters to use when querying QnA Maker KB.",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Name to filter on.",
+                            "maximum": 100
+                        },
+                        "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Value to restrict filter.",
+                            "maximum": 100
+                        }
+                    }
+                }
+            },
+            "top": {
+                "$ref": "#/definitions/numberExpression",
+                "title": "Top",
+                "description": "The number of answers you want to retrieve.",
+                "default": 3
+            },
+            "isTest": {
+                "$ref": "#/definitions/booleanExpression",
+                "title": "IsTest",
+                "description": "True, if pointing to Test environment, else false.",
+                "examples": [
+                    true,
+                    "=f(x)"
+                ]
+            },
+            "rankerType": {
+                "title": "Ranker Type",
+                "description": "Type of Ranker.",
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "title": "Ranker type",
+                        "description": "Type of Ranker.",
+                        "enum": [
+                            "default",
+                            "questionOnly",
+                            "autoSuggestQuestion"
+                        ],
+                        "default": "default"
+                    },
+                    {
+                        "$ref": "#/definitions/equalsExpression"
+                    }
+                ]
+            },
+            "strictFiltersCompoundOperationType": {
+                "$ref": "schema:#/definitions/stringExpression",
+                "title": "StrictFilters Compound Operation Type",
+                "description": "Type of Operation for Strict Filters.",
+                "oneOf": [
+                    {
+                        "title": "StrictFiltersCompoundOperationType",
+                        "description": "StrictFiltersCompoundOperationType.",
+                        "enum": [
+                            "OR",
+                            "AND"
+                        ],
+                        "default": "AND"
+                    },
+                    {
+                        "$ref": "schema:#/definitions/equalsExpression"
+                    }
+                ]
+            },
+            "includeDialogNameInMetadata": {
+                "$ref": "#/definitions/booleanExpression",
+                "title": "Include Dialog Name",
+                "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+                "default": true,
+                "examples": [
+                    true,
+                    "=f(x)"
+                ]
+            },
+            "metadata": {
+                "$ref": "#/definitions/arrayExpression",
+                "title": "Metadata filters",
+                "description": "Metadata filters to use when calling the QnA Maker KB.",
+                "items": {
+                    "type": "object",
+                    "title": "Metadata filter",
+                    "description": "Metadata filter to use when calling the QnA Maker KB.",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Name of value to test."
+                        },
+                        "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Value to filter against."
+                        }
+                    }
+                }
+            },
+            "context": {
+                "$ref": "#/definitions/objectExpression",
+                "title": "QnARequestContext",
+                "description": "Context to use for ranking."
+            },
+            "qnaId": {
+                "$ref": "#/definitions/integerExpression",
+                "title": "QnAId",
+                "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+            },
+            "$kind": {
+                "title": "Kind of dialog object",
+                "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
                 "type": "string",
-                "title": "Name",
-                "description": "Name of value to test."
-              },
-              "value": {
-                "type": "string",
-                "title": "Value",
-                "description": "Value to filter against."
-              }
+                "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+                "const": "Microsoft.QnAMakerRecognizer"
+            },
+            "$designer": {
+                "title": "Designer information",
+                "type": "object",
+                "description": "Extra information for the Bot Framework Composer."
             }
-          }
-        },
-        "context": {
-          "$ref": "#/definitions/objectExpression",
-          "title": "QnARequestContext",
-          "description": "Context to use for ranking."
-        },
-        "qnaId": {
-          "$ref": "#/definitions/integerExpression",
-          "title": "QnAId",
-          "description": "A number or expression which is the QnAId to paass to QnAMaker API."
-        },
-        "$kind": {
-          "title": "Kind of dialog object",
-          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-          "type": "string",
-          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-          "const": "Microsoft.QnAMakerRecognizer"
-        },
-        "$designer": {
-          "title": "Designer information",
-          "type": "object",
-          "description": "Extra information for the Bot Framework Composer."
         }
-      }
     },
     "Microsoft.RandomSelector": {
       "$role": "implements(Microsoft.ITriggerSelector)",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7840,153 +7840,172 @@
           "description": "Open ended property for tooling."
         }
       },
-      "properties": {
-        "id": {
-          "type": "string",
-          "title": "Id",
-          "description": "Optional unique id using with RecognizerSet."
-        },
-        "knowledgeBaseId": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "KnowledgeBase Id",
-          "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
-          "default": "settings.qna.knowledgebaseid"
-        },
-        "endpointKey": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Endpoint Key",
-          "description": "Endpoint key for the QnA Maker KB.",
-          "default": "settings.qna.endpointkey"
-        },
-        "hostname": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Hostname",
-          "description": "Hostname for your QnA Maker service.",
-          "default": "settings.qna.hostname",
-          "examples": [
-            "https://yourserver.azurewebsites.net/qnamaker"
-          ]
-        },
-        "threshold": {
-          "$ref": "#/definitions/numberExpression",
-          "title": "Threshold",
-          "description": "Threshold score to filter results.",
-          "default": 0.3
-        },
-        "strictFilters": {
-          "$ref": "#/definitions/arrayExpression",
-          "title": "Strict Filters",
-          "description": "Metadata filters to use when calling the QnA Maker KB.",
-          "items": {
-            "type": "object",
-            "title": "Metadata filters",
-            "description": "Metadata filters to use when querying QnA Maker KB.",
-            "properties": {
-              "name": {
+        "properties": {
+            "id": {
                 "type": "string",
-                "title": "Name",
-                "description": "Name to filter on.",
-                "maximum": 100
-              },
-              "value": {
-                "type": "string",
-                "title": "Value",
-                "description": "Value to restrict filter.",
-                "maximum": 100
-              }
-            }
-          }
-        },
-        "top": {
-          "$ref": "#/definitions/numberExpression",
-          "title": "Top",
-          "description": "The number of answers you want to retrieve.",
-          "default": 3
-        },
-        "isTest": {
-          "$ref": "#/definitions/booleanExpression",
-          "title": "IsTest",
-          "description": "True, if pointing to Test environment, else false.",
-          "examples": [
-            true,
-            "=f(x)"
-          ]
-        },
-        "rankerType": {
-          "title": "Ranker Type",
-          "description": "Type of Ranker.",
-          "oneOf": [
-            {
-              "type": "string",
-              "title": "Ranker type",
-              "description": "Type of Ranker.",
-              "enum": [
-                "default",
-                "questionOnly",
-                "autoSuggestQuestion"
-              ],
-              "default": "default"
+                "title": "Id",
+                "description": "Optional unique id using with RecognizerSet."
             },
-            {
-              "$ref": "#/definitions/equalsExpression"
-            }
-          ]
-        },
-        "includeDialogNameInMetadata": {
-          "$ref": "#/definitions/booleanExpression",
-          "title": "Include Dialog Name",
-          "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
-          "default": true,
-          "examples": [
-            true,
-            "=f(x)"
-          ]
-        },
-        "metadata": {
-          "$ref": "#/definitions/arrayExpression",
-          "title": "Metadata filters",
-          "description": "Metadata filters to use when calling the QnA Maker KB.",
-          "items": {
-            "type": "object",
-            "title": "Metadata filter",
-            "description": "Metadata filter to use when calling the QnA Maker KB.",
-            "properties": {
-              "name": {
+            "knowledgeBaseId": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "KnowledgeBase Id",
+                "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+                "default": "settings.qna.knowledgebaseid"
+            },
+            "endpointKey": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "Endpoint Key",
+                "description": "Endpoint key for the QnA Maker KB.",
+                "default": "settings.qna.endpointkey"
+            },
+            "hostname": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "Hostname",
+                "description": "Hostname for your QnA Maker service.",
+                "default": "settings.qna.hostname",
+                "examples": [
+                    "https://yourserver.azurewebsites.net/qnamaker"
+                ]
+            },
+            "threshold": {
+                "$ref": "#/definitions/numberExpression",
+                "title": "Threshold",
+                "description": "Threshold score to filter results.",
+                "default": 0.3
+            },
+            "strictFilters": {
+                "$ref": "#/definitions/arrayExpression",
+                "title": "Strict Filters",
+                "description": "Metadata filters to use when calling the QnA Maker KB.",
+                "items": {
+                    "type": "object",
+                    "title": "Metadata filters",
+                    "description": "Metadata filters to use when querying QnA Maker KB.",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Name to filter on.",
+                            "maximum": 100
+                        },
+                        "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Value to restrict filter.",
+                            "maximum": 100
+                        }
+                    }
+                }
+            },
+            "top": {
+                "$ref": "#/definitions/numberExpression",
+                "title": "Top",
+                "description": "The number of answers you want to retrieve.",
+                "default": 3
+            },
+            "isTest": {
+                "$ref": "#/definitions/booleanExpression",
+                "title": "IsTest",
+                "description": "True, if pointing to Test environment, else false.",
+                "examples": [
+                    true,
+                    "=f(x)"
+                ]
+            },
+            "rankerType": {
+                "title": "Ranker Type",
+                "description": "Type of Ranker.",
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "title": "Ranker type",
+                        "description": "Type of Ranker.",
+                        "enum": [
+                            "default",
+                            "questionOnly",
+                            "autoSuggestQuestion"
+                        ],
+                        "default": "default"
+                    },
+                    {
+                        "$ref": "#/definitions/equalsExpression"
+                    }
+                ]
+            },
+            "strictFiltersCompoundOperationType": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "StrictFilters Compound Operation Type",
+                "description": "Type of Operation for Strict Filters.",
+                "oneOf": [
+                    {
+                        "title": "StrictFilters Compound Operation Type",
+                        "description": "StrictFilters Compound Operation Type",
+                        "enum": [
+                            "AND",
+                            "OR"
+                        ],
+                        "default": "AND"
+                    },
+                    {
+                        "$ref": "#/definitions/equalsExpression"
+                    }
+                ]
+            },
+            "includeDialogNameInMetadata": {
+                "$ref": "#/definitions/booleanExpression",
+                "title": "Include Dialog Name",
+                "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+                "default": true,
+                "examples": [
+                    true,
+                    "=f(x)"
+                ]
+            },
+            "metadata": {
+                "$ref": "#/definitions/arrayExpression",
+                "title": "Metadata filters",
+                "description": "Metadata filters to use when calling the QnA Maker KB.",
+                "items": {
+                    "type": "object",
+                    "title": "Metadata filter",
+                    "description": "Metadata filter to use when calling the QnA Maker KB.",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "Name of value to test."
+                        },
+                        "value": {
+                            "type": "string",
+                            "title": "Value",
+                            "description": "Value to filter against."
+                        }
+                    }
+                }
+            },
+            "context": {
+                "$ref": "#/definitions/objectExpression",
+                "title": "QnARequestContext",
+                "description": "Context to use for ranking."
+            },
+            "qnaId": {
+                "$ref": "#/definitions/integerExpression",
+                "title": "QnAId",
+                "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+            },
+            "$kind": {
+                "title": "Kind of dialog object",
+                "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
                 "type": "string",
-                "title": "Name",
-                "description": "Name of value to test."
-              },
-              "value": {
-                "type": "string",
-                "title": "Value",
-                "description": "Value to filter against."
-              }
+                "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+                "const": "Microsoft.QnAMakerRecognizer"
+            },
+            "$designer": {
+                "title": "Designer information",
+                "type": "object",
+                "description": "Extra information for the Bot Framework Composer."
             }
-          }
-        },
-        "context": {
-          "$ref": "#/definitions/objectExpression",
-          "title": "QnARequestContext",
-          "description": "Context to use for ranking."
-        },
-        "qnaId": {
-          "$ref": "#/definitions/integerExpression",
-          "title": "QnAId",
-          "description": "A number or expression which is the QnAId to paass to QnAMaker API."
-        },
-        "$kind": {
-          "title": "Kind of dialog object",
-          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-          "type": "string",
-          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-          "const": "Microsoft.QnAMakerRecognizer"
-        },
-        "$designer": {
-          "title": "Designer information",
-          "type": "object",
-          "description": "Extra information for the Bot Framework Composer."
         }
-      }
     },
     "Microsoft.RandomSelector": {
       "$role": "implements(Microsoft.ITriggerSelector)",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7941,8 +7941,8 @@
                         "title": "StrictFiltersCompoundOperationType",
                         "description": "StrictFiltersCompoundOperationType.",
                         "enum": [
-                            "OR",
-                            "AND"
+                            "AND",
+                            "OR"
                         ],
                         "default": "AND"
                     },

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7789,24 +7789,24 @@
           "default": false
         },
         "rankerType": {
-            "$ref": "#/definitions/stringExpression",
-            "title": "Ranker Type",
-            "description": "Type of Ranker.",
-            "oneOf": [
-                {
-                    "title": "Standard ranker",
-                    "description": "Standard ranker types.",
-                    "enum": [
-                        "default",
-                        "questionOnly",
-                        "autoSuggestQuestion"
-                    ],
-                    "default": "default"
-                },
-                {
-                    "$ref": "#/definitions/equalsExpression"
-                }
-            ]
+          "$ref": "#/definitions/stringExpression",
+          "title": "Ranker Type",
+          "description": "Type of Ranker.",
+          "oneOf": [
+            {
+              "title": "Standard ranker",
+              "description": "Standard ranker types.",
+              "enum": [
+                "default",
+                "questionOnly",
+                "autoSuggestQuestion"
+              ],
+              "default": "default"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
         },
         "strictFiltersCompoundOperationType": {
             "$ref": "#/definitions/stringExpression",


### PR DESCRIPTION
Fixes #4454
QnAMaker GenerateAnswer API has been enhanced to provide choice to user for join condition. User can choose the Compound Operation for joining strictfilters a.k.a metadata. The values for the Compound Operation Type are 'AND' and 'OR'. The default behaviour is 'AND', to support  backward compatibility. 

The changes implementation needs change in QnAMakerOptions, QnAMakerDialog.schema, testbot.schema and tests.schema. Changes implemented in QnARecognizer and QnAMakerDialog. Test has been created for testing the functionality.

  -

## Testing
QnaMaker_StrictFilters_Compound_OperationType() added for testing.