### PR TITLE
Support accessing global memories in injecting LG templates as Expressions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             }
 
             var parameters = TemplateMap[templateName].Parameters;
-            var currentScope = _evaluationTargetStack.Count > 0 ? CurrentTarget().Scope : new CustomizedMemory(null);
+            var currentScope = CurrentTarget().Scope;
 
             if (args.Count == 0)
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
@@ -42,7 +42,7 @@
         },
         {
           "$kind": "Microsoft.SendActivity",
-          "activity": "${foo.UserDataConcat()}"
+          "activity": "${foo.UserDataConcat(user.name)}"
         }
       ]
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
@@ -13,6 +13,17 @@
         },
         {
           "$kind": "Microsoft.SetProperty",
+          "property": "user.name",
+          "value": "Jonathan"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.date",
+          "value": "2003-03-20"
+        },
+        
+        {
+          "$kind": "Microsoft.SetProperty",
           "property": "user.tasks",
           "value": [ "car", "washing", "food", "laundry" ]
         },
@@ -28,8 +39,11 @@
         {
           "$kind": "Microsoft.SendActivity",
           "activity": "${user.message}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${foo.UserDataConcat()}"
         }
-
       ]
     }
   ]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
@@ -14,7 +14,7 @@
         {
           "$kind": "Microsoft.SetProperty",
           "property": "user.name",
-          "value": "Jonathan"
+          "value": "jonathan"
         },
         {
           "$kind": "Microsoft.SetProperty",
@@ -42,7 +42,15 @@
         },
         {
           "$kind": "Microsoft.SendActivity",
-          "activity": "${foo.UserDataConcat(user.name)}"
+          "activity": "${foo.WelcomeUser()}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${foo.UserDataConcat(user.date)}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${foo.ShowTasks(foo.GetList(user.tasks))}"
         }
       ]
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -420,6 +420,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             .Send("hello")
                 .AssertReply("[{\"Id\":0,\"Topic\":\"car\"},{\"Id\":1,\"Topic\":\"washing\"},{\"Id\":2,\"Topic\":\"food\"},{\"Id\":3,\"Topic\":\"laundry\"}]")
                 .AssertReply("This is an injected message")
+                .AssertReply("Jonathan : 2003-03-20")
             .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -420,7 +420,9 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             .Send("hello")
                 .AssertReply("[{\"Id\":0,\"Topic\":\"car\"},{\"Id\":1,\"Topic\":\"washing\"},{\"Id\":2,\"Topic\":\"food\"},{\"Id\":3,\"Topic\":\"laundry\"}]")
                 .AssertReply("This is an injected message")
+                .AssertReply("Hi Jonathan")
                 .AssertReply("Jonathan : 2003-03-20")
+                .AssertReply("Jonathan, your tasks: car, washing, food and laundry")
             .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
@@ -15,5 +15,5 @@
 #GetMessage
 - This is an injected message
 
-#UserDataConcat()
-- ${user.name} : ${user.date}
+#UserDataConcat(name)
+- ${name} : ${user.date}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
@@ -1,6 +1,6 @@
 ﻿> !# @strict = false
 > !# @namespace = foo
-> !# @Exports = GetList, Convert, GetProperty, GetMessage, UserDataConcat
+> !# @Exports = GetList, Convert, GetProperty, GetMessage, UserDataConcat, WelcomeUser, ShowTasks
 
 
 # Convert(index, value)
@@ -15,5 +15,13 @@
 #GetMessage
 - This is an injected message
 
-#UserDataConcat(name)
-- ${name} : ${user.date}
+> Use both global and local memory
+#UserDataConcat(date)
+- ${sentenceCase(user.name)} : ${date}
+
+> Use global memory
+#WelcomeUser
+- Hi ${sentenceCase(user.name)}
+
+# ShowTasks(tasks)
+- ${sentenceCase(user.name)}, your tasks: ${join(foreach(tasks, task, task.value), ', ', ' and ')}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
@@ -1,6 +1,6 @@
 ﻿> !# @strict = false
 > !# @namespace = foo
-> !# @Exports = GetList, Convert, GetProperty, GetMessage
+> !# @Exports = GetList, Convert, GetProperty, GetMessage, UserDataConcat
 
 
 # Convert(index, value)
@@ -14,3 +14,6 @@
 
 #GetMessage
 - This is an injected message
+
+#UserDataConcat()
+- ${user.name} : ${user.date}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/inject.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/inject.lg
@@ -1,11 +1,20 @@
 ﻿> !# @strict = false
-> !# @Namespace = foo
-> !# @Exports = bar, cool
+> !# @Namespace = general
+> !# @Exports = sumAll, cool, greeting, addTwoNum, yolo
 
 [import](common.lg)
 
-#bar()
+#sumAll()
 - ${add(1,2)}
 
 #cool(a)
 - ${add(1,a)}
+
+#greeting
+- hi ${name}
+
+#addTwoNum(a,b)
+- ${a + b}
+
+# yolo(a, b)
+- ${name} have ${a + b} cookies!

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1481,12 +1481,21 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestInjectLG()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("./InjectionTest/inject.lg"));
-            
-            var (evaled, error) = Expression.Parse("foo.bar()").TryEvaluate(null);
-            
+
+            var (evaled, error) = Expression.Parse("general.greeting()").TryEvaluate(new { name = "Alice" });
+            Assert.Equal("hi Alice", evaled.ToString());
+
+            (evaled, error) = Expression.Parse("general.yolo(8, 7)").TryEvaluate(new { name = "Alice" });
+            Assert.Equal("Alice have 15 cookies!", evaled.ToString());
+
+            (evaled, error) = Expression.Parse("general.addTwoNum(5,6)").TryEvaluate(new { a = 3, b = 1 });
+            Assert.Equal("11", evaled.ToString());
+
+            (evaled, error) = Expression.Parse("general.sumAll()").TryEvaluate(null);
+
             Assert.Equal("3", evaled.ToString());
 
-            (evaled, error) = Expression.Parse("foo.cool(2)").TryEvaluate(null);
+            (evaled, error) = Expression.Parse("general.cool(2)").TryEvaluate(null);
             Assert.Equal("3", evaled.ToString());
 
             (evaled, error) = Expression.Parse("common.looking()").TryEvaluate(null);

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1487,7 +1487,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             var memory1 = new StackedMemory();
             memory1.Push(new SimpleObjectMemory(new { name = "Alice" }));
-            memory1.Push(new SimpleObjectMemory(new { name = "Bob" }));
+            memory1.Push(new CustomizedMemory(new { name = "Bob" }));
             (evaled, error) = Expression.Parse("general.greeting()").TryEvaluate(memory1);
             Assert.Equal("hi Bob", evaled.ToString());
 
@@ -1496,7 +1496,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             var memory2 = new StackedMemory();
             memory2.Push(new SimpleObjectMemory(new { name = "Alice" }));
-            memory2.Push(new SimpleObjectMemory(new { name = "Bob" }));
+            memory2.Push(new CustomizedMemory(new { name = "Bob" }));
             (evaled, error) = Expression.Parse("general.yolo(12, 12)").TryEvaluate(memory2);
             Assert.Equal("Bob have 24 cookies!", evaled.ToString());
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1485,8 +1485,20 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var (evaled, error) = Expression.Parse("general.greeting()").TryEvaluate(new { name = "Alice" });
             Assert.Equal("hi Alice", evaled.ToString());
 
+            var memory1 = new StackedMemory();
+            memory1.Push(new SimpleObjectMemory(new { name = "Alice" }));
+            memory1.Push(new SimpleObjectMemory(new { name = "Bob" }));
+            (evaled, error) = Expression.Parse("general.greeting()").TryEvaluate(memory1);
+            Assert.Equal("hi Bob", evaled.ToString());
+
             (evaled, error) = Expression.Parse("general.yolo(8, 7)").TryEvaluate(new { name = "Alice" });
             Assert.Equal("Alice have 15 cookies!", evaled.ToString());
+
+            var memory2 = new StackedMemory();
+            memory2.Push(new SimpleObjectMemory(new { name = "Alice" }));
+            memory2.Push(new SimpleObjectMemory(new { name = "Bob" }));
+            (evaled, error) = Expression.Parse("general.yolo(12, 12)").TryEvaluate(memory2);
+            Assert.Equal("Bob have 24 cookies!", evaled.ToString());
 
             (evaled, error) = Expression.Parse("general.addTwoNum(5,6)").TryEvaluate(new { a = 3, b = 1 });
             Assert.Equal("11", evaled.ToString());


### PR DESCRIPTION
Issue reported by @chrimc62 that the injected LG function don't have access to global state (DSM state).

This PR enable injected LG template functions to access global memories. 

Suppose we have a template, with a global variable {user: {name: "user1", date: "2001-01-01"}, }
```
> !# @strict = false
> !# @namespace = Adaptive
> !# @Exports = UserDataConcat

#UserDataConcat()
- ${user.name} : ${user.date}
```

The result of evaluating the expression `Expression.parse("Adaptive.UserDataConcat()")` is `user1 : 2001-01-01`