### PR TITLE
Fixing Issue#3568, bot receives a utterances smaller than the entity indexes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisUtil.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisUtil.cs
@@ -131,32 +131,32 @@ namespace Microsoft.Bot.Builder.AI.Luis
                 case "builtin.number":
                 case "builtin.ordinal": return Number(resolution.value);
                 case "builtin.percentage":
-                {
-                    var svalue = (string)resolution.value;
-                    if (svalue.EndsWith("%", StringComparison.Ordinal))
                     {
-                        svalue = svalue.Substring(0, svalue.Length - 1);
-                    }
+                        var svalue = (string)resolution.value;
+                        if (svalue.EndsWith("%", StringComparison.Ordinal))
+                        {
+                            svalue = svalue.Substring(0, svalue.Length - 1);
+                        }
 
-                    return Number(svalue);
-                }
+                        return Number(svalue);
+                    }
 
                 case "builtin.age":
                 case "builtin.dimension":
                 case "builtin.currency":
                 case "builtin.temperature":
-                {
-                    var units = (string)resolution.unit;
-                    var val = Number(resolution.value);
-                    var obj = new JObject();
-                    if (val != null)
                     {
-                        obj.Add("number", val);
-                    }
+                        var units = (string)resolution.unit;
+                        var val = Number(resolution.value);
+                        var obj = new JObject();
+                        if (val != null)
+                        {
+                            obj.Add("number", val);
+                        }
 
-                    obj.Add("units", units);
-                    return obj;
-                }
+                        obj.Add("units", units);
+                        return obj;
+                    }
 
                 default:
                     return resolution.value ?? (resolution.values != null ? JArray.FromObject(resolution.values) : resolution);
@@ -165,17 +165,17 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
         internal static JObject ExtractEntityMetadata(EntityModel entity, string utterance)
         {
-            var start = (int)entity.StartIndex;
-            var end = (int)entity.EndIndex + 1;
+            var start = entity.StartIndex;
+            var end = entity.EndIndex + 1;
             dynamic obj = JObject.FromObject(new
             {
                 startIndex = start,
                 endIndex = end,
-                text = entity.Entity.Length == end - start ? entity.Entity : utterance.Substring(start, end - start),
+                text = GetText(entity, utterance, start, end),
                 type = entity.Type,
             });
 
-            if (entity.AdditionalProperties != null)
+            if (entity?.AdditionalProperties != null)
             {
                 if (entity.AdditionalProperties.TryGetValue("score", out var score))
                 {
@@ -191,6 +191,27 @@ namespace Microsoft.Bot.Builder.AI.Luis
             }
 
             return obj;
+        }
+
+        internal static string GetText(EntityModel entity, string utterance, int start, int end)
+        {
+            string result;
+            var entitySize = end - start;
+
+            if (entity.Entity.Length == entitySize)
+            {
+                result = entity.Entity;
+            }
+            else if (utterance.Length <= entitySize)
+            {
+                result = utterance;
+            }
+            else
+            {
+                result = utterance.Substring(start, entitySize);
+            }
+
+            return result;
         }
 
         internal static string ExtractNormalizedEntityName(EntityModel entity)


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
I've got the same issue as described on https://github.com/microsoft/botframework-solutions/issues/3568 and as analyzing the bot framework code and my LUIS applications, my team could get to the result that the code is trying to peform a substring on a utterance with bigger entities indexes.

## Specific Changes
The change performed was to verirfy if the utterance length is smaller or equals to the entity size (endIndex - startIndex) and, as a suggestion, return the utterance, if not continues to perform the substring as always.
I putted as suggestion so you guys analyze if it does not impact other parts of the framework. None of the unit test were broken with the change.

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->