### PR TITLE
Change JSON serialization formatting of ConnectorClient

### DIFF
--- a/libraries/Microsoft.Bot.Connector/ConnectorClient.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClient.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Bot.Connector
             BaseUri = new System.Uri("https://api.botframework.com");
             SerializationSettings = new JsonSerializerSettings
             {
-                Formatting = Newtonsoft.Json.Formatting.Indented,
+                Formatting = Newtonsoft.Json.Formatting.None,
                 DateFormatHandling = Newtonsoft.Json.DateFormatHandling.IsoDateFormat,
                 DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Utc,
                 NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,


### PR DESCRIPTION
Fixes #4462

## Description
Change JSON serialization formatting from `Formatting.Indented` to `Formatting.None` .

## Results
Remove the indention from the JSON body to shrink the size of HTTP request.


Local test result: With code:
```
            var serializerSettings = new JsonSerializerSettings
            {
                DateFormatHandling = DateFormatHandling.IsoDateFormat,
                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
                NullValueHandling = NullValueHandling.Ignore,
                ReferenceLoopHandling = ReferenceLoopHandling.Serialize
            };

            var jObj = new JObject
            {
                ["key1"] = "value1",
                ["key2"] = "value2"
            };

            serializerSettings.Formatting = Formatting.None;
            Console.WriteLine("Serialization result with None formatting:");
            Console.WriteLine(JsonConvert.SerializeObject(jObj, serializerSettings));

            serializerSettings.Formatting = Formatting.Indented;
            Console.WriteLine("\r\nSerialization result with Indented formatting:");
            Console.WriteLine(JsonConvert.SerializeObject(jObj, serializerSettings));
```

Result screenshot:
![image](https://user-images.githubusercontent.com/7289268/90371250-43331880-e0a1-11ea-9171-6fbef3323ee0.png)
