### PR TITLE
fix bugs in getNextViableTime, getPreviousViableDate, getPreviousViableTime

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetNextViableTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetNextViableTime.cs
@@ -75,6 +75,11 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                 validHour = hour + 1;
                             }
 
+                            if (validHour >= 24)
+                            {
+                                validHour -= 24;
+                            }
+
                             validMinute = parsed.Minute ?? 0;
                             validSecond = parsed.Second ?? 0;
                             result = TimexProperty.FromTime(new Time(validHour, validMinute, validSecond)).TimexValue;

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetPreviousViableDate.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetPreviousViableDate.cs
@@ -64,7 +64,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         if (error == null)
                         {
                             var (year, month, day) = (convertedDateTime.Year, convertedDateTime.Month, convertedDateTime.Day);
-                            if (parsed.Month <= month || (parsed.Month == month && parsed.DayOfMonth < day))
+                            if (parsed.Month < month || (parsed.Month == month && parsed.DayOfMonth < day))
                             {
                                 validYear = year;
                             }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetPreviousViableTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetPreviousViableTime.cs
@@ -79,10 +79,6 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     validHour += 24;
                 }
-                else if (validHour >= 24)
-                {
-                    validHour -= 24;
-                }
 
                 validMinute = parsed.Minute ?? 0;
                 validSecond = parsed.Second ?? 0;

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetPreviousViableTime.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetPreviousViableTime.cs
@@ -75,6 +75,15 @@ namespace AdaptiveExpressions.BuiltinFunctions
                     validHour = hour - 1;
                 }
 
+                if (validHour < 0)
+                {
+                    validHour += 24;
+                }
+                else if (validHour >= 24)
+                {
+                    validHour -= 24;
+                }
+
                 validMinute = parsed.Minute ?? 0;
                 validSecond = parsed.Second ?? 0;
                 result = TimexProperty.FromTime(new Time(validHour, validMinute, validSecond)).TimexValue;


### PR DESCRIPTION
fixes: #4465
After checking these bugs and tested with freezing DateTime.UtcNow in BotBuilder-JS. 
The bugs in getNextViableTime, getPreviousViableDate, getPreviousViableTime are now fixed.
However we lack of a test framework in C# to mock DateTime.UtcNow so that the tests related to that will be more meaningful.