### PR TITLE
Support AllowInterruptions in BeginSkill

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// Gets or sets interruption policy. 
         /// </summary>
         /// <value>
-        /// Bool or expression which evalutes to bool.
+        /// Bool or expression which evaluates to bool.
         /// </value>
         [JsonProperty("allowInterruptions")]
         public BoolExpression AllowInterruptions { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BeginSkill.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public ITemplate<Activity> Activity { get; set; }
 
         /// <summary>
-        /// Gets or sets intteruption policy. 
+        /// Gets or sets interruption policy. 
         /// </summary>
         /// <value>
         /// Bool or expression which evalutes to bool.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.schema
@@ -75,6 +75,17 @@
             "$kind": "Microsoft.IActivityTemplate",
             "title": "Activity",
             "description": "The activity to send to the skill."
+        },
+        "allowInterruptions": {
+            "$ref": "schema:#/definitions/booleanExpression",
+            "title": "Allow Interruptions",
+            "description": "A boolean expression that determines whether the parent should be allowed to interrupt the skill.",
+            "default": true,
+            "examples": [
+                true,
+                "=user.xyz"
+            ]
         }
+
     }
 }


### PR DESCRIPTION
Similar as InputDialog, Support AllowInterruptions in BeginSkill action. 

Fixes https://github.com/microsoft/BotFramework-Composer/issues/3848
