### PR TITLE
Avoid sending typing activity when bot is invoked as skill

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder
@@ -61,7 +64,7 @@ namespace Microsoft.Bot.Builder
                 try
                 {
                     // If the incoming activity is a MessageActivity, start a timer to periodically send the typing activity.
-                    if (turnContext.Activity.Type == ActivityTypes.Message)
+                    if (IsNotRunningAsSkill(turnContext) && turnContext.Activity.Type == ActivityTypes.Message)
                     {
                         // do not await task - we want this to run in the background and we will cancel it when its done
                         typingTask = SendTypingAsync(turnContext, _delay, _period, cts.Token);
@@ -78,6 +81,12 @@ namespace Microsoft.Bot.Builder
                     }
                 }
             }
+        }
+
+        private static bool IsNotRunningAsSkill(ITurnContext turnContext)
+        {
+            return turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity claimIdentity
+                && SkillValidation.IsSkillClaim(claimIdentity.Claims) == false;
         }
 
         private static async Task SendTypingAsync(ITurnContext turnContext, TimeSpan delay, TimeSpan period, CancellationToken cancellationToken)

--- a/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ShowTyping_MiddlewareTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Xunit;
 
@@ -11,10 +14,27 @@ namespace Microsoft.Bot.Builder.Tests
 {
     public class ShowTyping_MiddlewareTests
     {
+        /// <summary>
+        /// Enum to handle different test cases.
+        /// </summary>
+        public enum FlowTestCase
+        {
+            /// <summary>
+            /// RunAsync is executing on a root bot with no skills (typical standalone bot).
+            /// </summary>
+            RootBot,
+
+            /// <summary>
+            /// RunAsync is executing in a skill.
+            /// </summary>
+            Skill
+        }
+
         [Fact]
         public async Task ShowTyping_TestMiddleware_1_Second_Interval()
         {
             TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation("ShowTyping_TestMiddleware_1_Second_Interval"))
+                .Use(new MockBotIdentityMiddleware(FlowTestCase.RootBot))
                 .Use(new ShowTypingMiddleware(100, 1000));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
@@ -39,6 +59,7 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task ShowTyping_TestMiddleware_Context_Completes_Before_Typing_Interval()
         {
             TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation("ShowTyping_TestMiddleware_Context_Completes_Before_Typing_Interval"))
+                .Use(new MockBotIdentityMiddleware(FlowTestCase.RootBot))
                 .Use(new ShowTypingMiddleware(100, 5000));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
@@ -57,10 +78,33 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task ShowTyping_TestMiddleware_ImmediateResponse_5SecondInterval()
         {
             TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation("ShowTyping_TestMiddleware_ImmediateResponse_5SecondInterval"))
+                .Use(new MockBotIdentityMiddleware(FlowTestCase.RootBot))
                 .Use(new ShowTypingMiddleware(2000, 5000));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {
+                await context.SendActivityAsync("Message sent after delay");
+                await Task.CompletedTask;
+            })
+                .Send("foo")
+                .AssertReply("Message sent after delay")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task ShowTyping_TestMiddleware_ImmediateResponse_When_Running_As_Skill()
+        {
+            TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation("ShowTyping_TestMiddleware_1_Second_Interval"))
+                .Use(new MockBotIdentityMiddleware(FlowTestCase.Skill))
+                .Use(new ShowTypingMiddleware(100, 1000));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(2800));
+
+                // note the ShowTypingMiddleware should not cause the Responded flag to be set
+                Assert.False(context.Responded);
+
                 await context.SendActivityAsync("Message sent after delay");
                 await Task.CompletedTask;
             })
@@ -75,6 +119,7 @@ namespace Microsoft.Bot.Builder.Tests
             try
             {
                 TestAdapter adapter = new TestAdapter(TestAdapter.CreateConversation("ShowTyping_TestMiddleware_NegativeDelay"))
+                    .Use(new MockBotIdentityMiddleware(FlowTestCase.RootBot))
                     .Use(new ShowTypingMiddleware(-100, 1000));
             }
             catch (Exception ex)
@@ -107,6 +152,39 @@ namespace Microsoft.Bot.Builder.Tests
             else
             {
                 throw new Exception("Activity was not of type TypingActivity");
+            }
+        }
+
+        private class MockBotIdentityMiddleware : IMiddleware
+        {
+            private readonly FlowTestCase _flowTestCase;
+
+            // An App ID for a parent bot.
+            private readonly string _parentBotId = Guid.NewGuid().ToString();
+
+            // An App ID for a skill bot.
+            private readonly string _skillBotId = Guid.NewGuid().ToString();
+
+            public MockBotIdentityMiddleware(FlowTestCase flowTestCase)
+            {
+                _flowTestCase = flowTestCase;
+            }
+
+            public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+            {
+                // Create a skill ClaimsIdentity and put it in TurnState so SkillValidation.IsSkillClaim() returns true.
+                var claimsIdentity = new ClaimsIdentity();
+                claimsIdentity.AddClaim(new Claim(AuthenticationConstants.VersionClaim, "2.0"));
+                claimsIdentity.AddClaim(new Claim(AuthenticationConstants.AudienceClaim, _parentBotId));
+
+                if (_flowTestCase == FlowTestCase.Skill)
+                {
+                    claimsIdentity.AddClaim(new Claim(AuthenticationConstants.AuthorizedParty, _skillBotId));
+                }
+
+                turnContext.TurnState.Add(BotAdapter.BotIdentityKey, claimsIdentity);
+
+                await next(cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Fixes #4478

## Description
Adds an additional check to make sure the bot isn't running as a skill before starting to send typing activities.

## Specific Changes

  - Adds a method to check if a bot isn't running as a skill
  - Adds an additional condition on line 67 to make sure the bot isn't running as a skill
  - Modifies the existing ShowTypingMiddleware tests to use a mock bot identity that identifies it as a root bot
  - Adds a test to verify no typing activities are sent if the mock bot identity identifies it as a skill

## Testing
This PR adds a MockBotIdentityMiddleware class for use in the tests to inject a mock bot identity before running the ShowTypingMiddleware. There may be a better solution, but I couldn't find any. I've tried adding the identity in the callback, but that's too late in the pipeline. 