### PR TITLE
Update CrossTrainedRecognizerSet.cs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                 // we have a real intent and it's the first one we found.
                 if (consensusRecognizerId == null)
                 {
-                    if (intent != NoneIntent)
+                    if (intent != NoneIntent || string.IsNullOrEmpty(intent))
                     {
                         consensusRecognizerId = recognizerId;
                     }
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                     // we have a second recognizer result which is either none or real
 
                     // if one of them is None intent, then go with the other one.
-                    if (intent == NoneIntent)
+                    if (intent == NoneIntent || string.IsNullOrEmpty(intent))
                     {
                         // then we are fine with the one we have, just ignore this one
                         continue;


### PR DESCRIPTION
Fixes https://github.com/microsoft/botframework-sdk/issues/5992 <!-- If this addresses a specific issue, please provide the issue number here -->

That issue is because, luis is returning null intent instead of NoneIntent for non-text activity.
Then the crosstrain will always return an OnChooseIntent for non-text activity.

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->