### PR TITLE
4.10 cherry-pick of Set WaterfallStepContext.Parent correctly (#4480) also including 'Enable schema tests' cherry pick

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallStepContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallStepContext.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             _parentWaterfall = parentWaterfall;
             _nextCalled = false;
+            Parent = dc.Parent;
             Index = index;
             Options = options;
             Reason = reason;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
     /// bf plugins:install @microsoft/bf-dialog
     /// </remarks>
     [TestClass]
+    [TestCategory("IgnoreInAutomatedBuild")]
     public class SchemaMergeTests
     {
         public static ResourceExplorer ResourceExplorer { get; set; }


### PR DESCRIPTION
* Set WaterfallStepContext.Parent correctly

* Add test verifying the waterfall step parent is the waterfall dialogs parent

* Remove uneeded test class
