### PR TITLE
always assign sourcemap.path

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -449,12 +449,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                 var (token, range) = SourceScope.ReadTokenRange(readerJson, sourceContext);
 
                 AutoAssignId(resource, token, sourceContext);
-
-                if (resource is FileResource fileResource)
-                {
-                    range.Path = fileResource.FullName;
-                }
-
+                range.Path = resource.FullName ?? resource.Id;
                 return (token, range);
             }
         }


### PR DESCRIPTION
Fixes #4487

## Description

The cycle detection uses sourcemap.path for cycle detection, but we were only optionally setting sourcemap.path if it's a FileResource. PVA has a custom resourceProvider.  

We promoted fullname to resource base class to support resource providers ability to provide "fullname" information., we can rely on that as the value for sourcemap.path.  It's possible that someone might not set FullName, so we fall back to .id

## Specific Changes

*   removed conditional check for fileResource type
*   use resource.fullname, and if it's not there fall back to resource.id

## Testing

all tests pass.