### PR TITLE
Add delay signing configuration for Orchestrator.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,12 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <AssemblyOriginatorKeyFile>$(SolutionDir)\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignAssembly)'=='True' ">
     <DefineConstants>SIGNASSEMBLY</DefineConstants>


### PR DESCRIPTION
Orchestrator is set to target x64. Adding delayed signing for it.