### PR TITLE
Make "string" function return the original content if the parameter is a string type

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/String.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/String.cs
@@ -49,6 +49,10 @@ namespace AdaptiveExpressions.BuiltinFunctions
                         {
                             result = dt.ToString(FunctionUtils.DefaultDateTimeFormat, locale);
                         }
+                        else if (args[0] is string str)
+                        {
+                            result = str;
+                        }
                         else
                         {
                             result = JsonConvert.SerializeObject(args[0]).TrimStart('"').TrimEnd('"');

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -672,6 +672,7 @@ namespace AdaptiveExpressions.Tests
             Test("int('10')", 10),
             Test("int(12345678912345678 + 1)", 12345678912345679),
             Test("string('str')", "str"),
+            Test("string('str\"')", "str\""),
             Test("string(one)", "1"),
             Test("string(bool(1))", "true"),
             Test("string(bag.set)", "{\"four\":4.0}"),


### PR DESCRIPTION
Fixes #4502

## Description
Originally, If the string function accepts a string parameter, `string` function would use `JsonConvert.SerializeObject` to convert the string result.
This PR would directly output the string content if the original parameter type is string.