### PR TITLE
Make "merge" support any kind of object  type

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Merge.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Merge.cs
@@ -24,14 +24,16 @@ namespace AdaptiveExpressions.BuiltinFunctions
             {
                 object result = null;
                 string error = null;
-                if (args[0] is JObject && args[1] is JObject)
+                var arg0 = FunctionUtils.ConvertToJToken(args[0]);
+                var arg1 = FunctionUtils.ConvertToJToken(args[1]);
+                if (arg0 is JObject && arg1 is JObject)
                 {
-                    (args[0] as JObject).Merge(args[1] as JObject, new JsonMergeSettings
+                    (arg0 as JObject).Merge(arg1 as JObject, new JsonMergeSettings
                     {
                         MergeArrayHandling = MergeArrayHandling.Replace
                     });
 
-                    result = args[0];
+                    result = arg0;
                 }
                 else
                 {

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1008,6 +1008,7 @@ namespace AdaptiveExpressions.Tests
             Test("addProperty({}, 'name', user.name).name", null),
             Test("string(merge(json(json1), json(json2)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"Customer\",\"Admin\"]}"),
             Test("string(merge(json(json1), json(json2), json(json3)))", "{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Enabled\":true,\"Roles\":[\"Customer\",\"Admin\"],\"Age\":36}"),
+            Test("merge(callstack[1], callstack[2]).z", 1),
             #endregion
 
             #region  Memory access


### PR DESCRIPTION
Fixes #4417

Originally, "merge" just support JObject parameters. 
It is necessary for it to support different kinds of nested objects. Like: Anonymous object, Dictionary,  JObject .etc.
