### PR TITLE
Add missing XML documentation to Microsoft.Bot.Builder.Dialogs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -113,6 +113,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             ? string.Empty
             : turnContext.Activity.ChannelId;
 
+        /// <summary>
+        /// Ids of the channels supported by the Bot Builder.
+        /// </summary>
         // This class has been deprecated in favor of the class in Microsoft.Bot.Connector.Channels located
         // at https://github.com/Microsoft/botbuilder-dotnet/libraries/Microsoft.Bot.Connector/Channels.cs.
         // This change is non-breaking and this class now inherits from the class in the connector library.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
     public class Choice
 #pragma warning restore CA1724 // Namespace name conflict
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Choice"/> class to add a choice to a choice prompt.
+        /// </summary>
+        /// <param name="value">The value to return when the choice is selected.</param>
         public Choice(string value = null)
         {
             Value = value;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -143,6 +143,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             return List(ToChoices(choices), text, speak, options);
         }
 
+        /// <summary>
+        /// Creates a message activity containing a list of choices that has been formatted as a numbered or bulleted list.
+        /// </summary>
+        /// <param name="choices">The list of choices to render.</param>
+        /// <param name="text">Optional, text of the message.</param>
+        /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <param name="options">Optional, formatting options to tweak the rendering of the list.</param>
+        /// <returns>An activity with choices as a numbered or bulleted list.</returns>
         public static Activity List(IList<Choice> choices, string text = null, string speak = null, ChoiceFactoryOptions options = null)
         {
             choices ??= new List<Choice>();
@@ -181,17 +189,38 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             return MessageFactory.Text(txtBuilder.ToString(), speak, InputHints.ExpectingInput);
         }
 
+        /// <summary>
+        /// Creates a message activity containing a list of choices that have been added as suggested actions.
+        /// </summary>
+        /// <param name="choices">List of strings representing the choices to add.</param>
+        /// <param name="text">Optional, text of the message.</param>
+        /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <returns>An activity with choices as suggested actions.</returns>
         public static IMessageActivity SuggestedAction(IList<string> choices, string text = null, string speak = null)
         {
             return SuggestedAction(ToChoices(choices), text, speak);
         }
 
+        /// <summary>
+        /// Creates a message activity containing a list of choices that have been added as suggested actions.
+        /// </summary>
+        /// <param name="choices">The list of choices to add.</param>
+        /// <param name="text">Optional, text of the message.</param>
+        /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <returns>An activity with choices as suggested actions.</returns>
         public static IMessageActivity SuggestedAction(IList<Choice> choices, string text = null, string speak = null)
         {
             // Return activity with choices as suggested actions
             return MessageFactory.SuggestedActions(ExtractActions(choices), text, speak, InputHints.ExpectingInput);
         }
 
+        /// <summary>
+        /// Creates a message activity that includes a list of choices that have been added as `HeroCard`'s.
+        /// </summary>
+        /// <param name="choices">The list of choices to add.</param>
+        /// <param name="text">Optional, text of the message.</param>
+        /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <returns>An activity with choices as HeroCard with buttons.</returns>
         public static IMessageActivity HeroCard(IList<Choice> choices, string text = null, string speak = null)
         {
             var attachments = new List<Attachment>
@@ -203,6 +232,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             return MessageFactory.Attachment(attachments, null, speak, InputHints.ExpectingInput);
         }
 
+        /// <summary>
+        /// Takes a list of strings and returns them as <see cref="Choice"/>.
+        /// </summary>
+        /// <param name="choices">The list of choices to add.</param>
+        /// <returns>A list of choices.</returns>
         public static IList<Choice> ToChoices(IList<string> choices)
         {
             return choices == null

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// which provides an inner dialog stack that is hidden from the parent dialog.</remarks>
     public class ComponentDialog : DialogContainer
     {
+        /// <summary>
+        /// The id for the persisted dialog state.
+        /// </summary>
         public const string PersistedDialogState = "dialogs";
 
         private bool _initialized;
@@ -29,6 +32,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
         }
 
+        /// <summary>
+        /// Gets or sets the id assigned to the initial dialog.
+        /// </summary>
+        /// <value>The id of the initial dialog.</value>
         public string InitialDialogId { get; set; }
 
         /// <summary>
@@ -226,11 +233,21 @@ namespace Microsoft.Bot.Builder.Dialogs
             return this;
         }
 
+        /// <summary>
+        /// Creates an inner <see cref="DialogContext"/>.
+        /// </summary>
+        /// <param name="dc">The parent <see cref="DialogContext"/>.</param>
+        /// <returns>The created Dialog Context.</returns>
         public override DialogContext CreateChildContext(DialogContext dc)
         {
             return this.CreateInnerDc(dc, dc.ActiveDialog);
         }
 
+        /// <summary>
+        /// Ensures the dialog is initialized.
+        /// </summary>
+        /// <param name="outerDc">The outer <see cref="DialogContext"/>.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected async Task EnsureInitializedAsync(DialogContext outerDc)
         {
             if (!this._initialized)
@@ -240,6 +257,11 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
+        /// <summary>
+        /// Initilizes the dialog.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> to initialize.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual Task OnInitializeAsync(DialogContext dc)
         {
             if (this.InitialDialogId == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// </summary>
     public static class DebugSupport
     {
+        /// <summary>
+        /// Gets or sets the source map instance.
+        /// </summary>
+        /// <value>The <see cref="SourceMap"/> instance.</value>
         public static ISourceMap SourceMap { get; set; } = Debugging.SourceMap.Instance;
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/IDialogDebugger.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/IDialogDebugger.cs
@@ -6,13 +6,37 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
+    /// <summary>
+    /// Defines the Dialog Debugger interface.
+    /// </summary>
     public interface IDialogDebugger
     {
+        /// <summary>
+        /// Task representing information in a given point of an item.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="item">Object item in debugger.</param>
+        /// <param name="more">Additional information.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task StepAsync(DialogContext context, object item, string more, CancellationToken cancellationToken);
     }
 
+    /// <summary>
+    /// Defines the Debugger interface.
+    /// </summary>
     public interface IDebugger
     {
+        /// <summary>
+        /// Task representing a debug output.
+        /// </summary>
+        /// <param name="text">Text to output.</param>
+        /// <param name="item">Object item in debugger.</param>
+        /// <param name="value">Value of the object to output.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task OutputAsync(string text, object item, object value, CancellationToken cancellationToken);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/NullDialogDebugger.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/NullDialogDebugger.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// </summary>
     public class NullDialogDebugger : IDialogDebugger
     {
+        /// <summary>
+        /// Initializes a read-only new instance of the <see cref="NullDialogDebugger"/>.
+        /// </summary>
         public static readonly IDialogDebugger Instance = new NullDialogDebugger();
 
         private NullDialogDebugger()

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/NullSourceMap.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/NullSourceMap.cs
@@ -8,12 +8,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// </summary>
     public class NullSourceMap : ISourceMap
     {
+        /// <summary>
+        /// Initializes a read-only new instance of the <see cref="NullSourceMap"/>.
+        /// </summary>
         public static readonly NullSourceMap Instance = new NullSourceMap();
 
+        /// <summary>
+        /// Add an object and SourceRange information describing where the object was defined.
+        /// </summary>
+        /// <param name="item">Object item to record.</param>
+        /// <param name="range"><see cref="SourceRange"/> for the object.</param>
+        /// <remarks>For a <see cref="NullSourceMap"/> it does nothing.</remarks>
         public void Add(object item, SourceRange range)
         {
         }
 
+        /// <summary>
+        /// Look up the <see cref="SourceRange"/> information for an object.
+        /// </summary>
+        /// <param name="item">Object to look up.</param>
+        /// <param name="range">Place to return the <see cref="SourceRange"/> for the object.</param>
+        /// <returns><c>true</c> if found.</returns>
+        /// <remarks>For a <see cref="NullSourceMap"/> always returns <c>false</c>.</remarks>
         public bool TryGetValue(object item, out SourceRange range)
         {
             range = null;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourceContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourceContext.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
     /// </summary>
     public class SourceContext
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SourceContext"/> class.
+        /// </summary>
         public SourceContext()
         {
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourceMap.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourceMap.cs
@@ -5,11 +5,14 @@ using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
 {
+    /// <summary>
+    /// A simple ISourceMap of objects -> SourceRange.
+    /// </summary>
+    public class SourceMap : Dictionary<object, SourceRange>, ISourceMap
+    {
         /// <summary>
-        /// A simple ISourceMap of objects -> SourceRange.
+        /// Initializes a read-only new instance of the <see cref="SourceMap"/>.
         /// </summary>
-        public class SourceMap : Dictionary<object, SourceRange>, ISourceMap
-        {
-            public static readonly SourceMap Instance = new SourceMap();
-        }
+        public static readonly SourceMap Instance = new SourceMap();
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourcePoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourcePoint.cs
@@ -86,16 +86,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             return item;
         }
 
+        /// <summary>
+        /// Returns a string that represents the current <see cref="SourcePoint"/>.
+        /// </summary>
+        /// <returns>A string that represents the current <see cref="SourcePoint"/>.</returns>
         public override string ToString() => $"{LineIndex}:{CharIndex}";
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="SourcePoint"/>. All properties are recursively cloned.
+        /// </summary>
+        /// <returns>A new instace of the <see cref="SourcePoint"/>.</returns>
         public SourcePoint DeepClone() => new SourcePoint() { LineIndex = LineIndex, CharIndex = CharIndex };
 
+        /// <summary>
+        /// Indicates wether the current <see cref="SourcePoint"/> is equal to another object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this <see cref="SourcePoint"/>.</param>
+        /// <returns><c>true</c> if the current <see cref="SourcePoint"/> is equal to the object parameter; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             // Auto-generated
             return Equals(obj as SourcePoint);
         }
 
+        /// <summary>
+        /// Indicates wether the current <see cref="SourcePoint"/> is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this <see cref="SourcePoint"/>.</param>
+        /// <returns><c>true</c> if the current <see cref="SourcePoint"/> is equal to the other parameter; otherwise, <c>false</c>.</returns>
         public bool Equals(SourcePoint other)
         {
             // Auto-generated
@@ -104,6 +122,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                    CharIndex == other.CharIndex;
         }
 
+        /// <summary>
+        /// Creates a hash code for the current <see cref="SourcePoint"/>.
+        /// </summary>
+        /// <returns>A hash code for the current <see cref="SourcePoint"/>.</returns>
         public override int GetHashCode()
         {
             // Auto-generated

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourceRange.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/SourceRange.cs
@@ -72,8 +72,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         /// </value>
         public SourcePoint EndPoint { get; set; }
 
+        /// <summary>
+        /// Returns a string that represents the current <see cref="SourceRange"/>.
+        /// </summary>
+        /// <returns>A string that represents the current <see cref="SourceRange"/>.</returns>
         public override string ToString() => $"{System.IO.Path.GetFileName(Path)}:{StartPoint}->{EndPoint}";
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="SourceRange"/>. All properties are recursively cloned.
+        /// </summary>
+        /// <returns>A new instace of the <see cref="SourceRange"/>.</returns>
         public SourceRange DeepClone()
             => new SourceRange()
             {
@@ -83,12 +91,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                 EndPoint = EndPoint.DeepClone(),
             };
 
+        /// <summary>
+        /// Indicates wether the current <see cref="SourceRange"/> is equal to another object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this <see cref="SourceRange"/>.</param>
+        /// <returns><c>true</c> if the current <see cref="SourceRange"/> is equal to the object parameter; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             // Auto-generated
             return Equals(obj as SourceRange);
         }
 
+        /// <summary>
+        /// Indicates wether the current <see cref="SourceRange"/> is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this <see cref="SourceRange"/>.</param>
+        /// <returns><c>true</c> if the current <see cref="SourceRange"/> is equal to the other parameter; otherwise, <c>false</c>.</returns>
         public bool Equals(SourceRange other)
         {
             // Auto-generated
@@ -98,6 +116,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                    EqualityComparer<SourcePoint>.Default.Equals(EndPoint, other.EndPoint);
         }
 
+        /// <summary>
+        /// Creates a hash code for the current <see cref="SourceRange"/>.
+        /// </summary>
+        /// <returns>A hash code for the current <see cref="SourceRange"/>.</returns>
         public override int GetHashCode()
         {
             // Auto-generated

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -79,6 +79,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
+        /// <summary>
+        /// Gets the information of the cref="SourceRange"/>.
+        /// </summary>
+        /// <value>The cref="SourceRange"/> information.</value>
         [JsonIgnore]
         public virtual SourceRange Source => DebugSupport.SourceMap.TryGetValue(this, out var range) ? range : null;
 
@@ -247,11 +251,20 @@ namespace Microsoft.Bot.Builder.Dialogs
             return Task.FromResult(false);
         }
 
+        /// <summary>
+        /// Computes an unique ID for a dialog.
+        /// </summary>
+        /// <returns>An unique ID.</returns>
         protected virtual string OnComputeId()
         {
             return this.GetType().Name;
         }
 
+        /// <summary>
+        /// Registers a cref="SourceRange"/> in the provided location.
+        /// </summary>
+        /// <param name="path">The path to the source file.</param>
+        /// <param name="lineNumber">The line number where the source will be located on the file.</param>
         protected void RegisterSourceLocation(string path, int lineNumber)
         {
             if (!string.IsNullOrEmpty(path))

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -11,13 +11,24 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// A container for a set of Dialogs.
+    /// </summary>
     public abstract class DialogContainer : Dialog
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogContainer"/> class.
+        /// </summary>
+        /// <param name="dialogId">The ID to assign to the dialog.</param>
         protected DialogContainer(string dialogId = null)
             : base(dialogId)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the containers <see cref="DialogSet"/>.
+        /// </summary>
+        /// <value>The containers Dialog Set.</value>
         [JsonIgnore]
         public DialogSet Dialogs { get; set; } = new DialogSet();
 
@@ -43,8 +54,18 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
         }
 
+        /// <summary>
+        /// Creates an inner dialog context for the containers active child.
+        /// </summary>
+        /// <param name="dc">Parents dialog context.</param>
+        /// <returns>A new dialog context for the active child.</returns>
         public abstract DialogContext CreateChildContext(DialogContext dc);
 
+        /// <summary>
+        /// Finds a child dialog that was previously added to the container.
+        /// </summary>
+        /// <param name="dialogId">The ID of the dialog to lookup.</param>
+        /// <returns>The Dialog if found; otherwise null.</returns>
         public virtual Dialog FindDialog(string dialogId)
         {
             return this.Dialogs.Find(dialogId);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContextVisibleState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContextVisibleState.cs
@@ -13,16 +13,28 @@ namespace Microsoft.Bot.Builder.Dialogs
     [Obsolete("This class is no longer used and is deprecated. Use DialogContext.State.GetMemorySnapshot() to get all visible memory scope objects.", error: false)]
     public class DialogContextVisibleState
     {
+        /// <summary>
+        /// Gets or sets the User related to the State.
+        /// </summary>
+        /// <value>The user related to the State.</value>
         [JsonProperty(PropertyName = "user")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> User { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets or sets the Conversation related to the State.
+        /// </summary>
+        /// <value>The conversation related to the State.</value>
         [JsonProperty(PropertyName = "conversation")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> Conversation { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets or sets the Dialog related to the State.
+        /// </summary>
+        /// <value>The dialog related to the State.</value>
         [JsonProperty(PropertyName = "dialog")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> Dialog { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvent.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Represents an event related to the "lifecycle" of the dialog.
+    /// </summary>
     [DebuggerDisplay("{Name}")]
     public class DialogEvent
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogEvents.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Represents the events related to the "lifecycle" of the dialog.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class DialogEvents
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManagerResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManagerResult.cs
@@ -5,14 +5,29 @@ using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Represents the result of the Dialog Manager turn.
+    /// </summary>
     public class DialogManagerResult
     {
+        /// <summary>
+        /// Gets or sets the result returned to the caller.
+        /// </summary>
+        /// <value>The result returned to the caller.</value>
         public DialogTurnResult TurnResult { get; set; }
 
+        /// <summary>
+        /// Gets or sets the array of resulting activities.
+        /// </summary>
+        /// <value>The array of resulting activities.</value>
 #pragma warning disable CA1819 // Properties should not return arrays (we can't change this without breaking binary compat)
         public Activity[] Activities { get; set; }
 #pragma warning restore CA1819 // Properties should not return arrays
 
+        /// <summary>
+        /// Gets or sets the resulting new state.
+        /// </summary>
+        /// <value>The resulting new state.</value>
         public PersistedState NewState { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Bot.Builder.Dialogs
             _telemetryClient = NullBotTelemetryClient.Instance;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogSet"/> class with null <see cref="DialogState"/>.
+        /// </summary>
         public DialogSet()
         {
             _dialogState = null;
@@ -200,6 +203,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             return null;
         }
 
+        /// <summary>
+        /// Gets the Dialogs of the set.
+        /// </summary>
+        /// <returns>A collection of <see cref="Dialog"/>.</returns>
         public IEnumerable<Dialog> GetDialogs()
         {
             return _dialogs.Values;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogTurnResult.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogTurnResult.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Bot.Builder.Dialogs
     [DebuggerDisplay("[DialogTurnStatus.{Status}]{Result ?? string.Empty}")]
     public class DialogTurnResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogTurnResult"/> class.
+        /// </summary>
+        /// <param name="status">The status of the stack.</param>
+        /// <param name="result">The result return by the dialog.</param>
         public DialogTurnResult(DialogTurnStatus status, object result = null)
         {
             Status = status;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogTurnStatus.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogTurnStatus.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Enums the possible states of the dialogs on the stack.
+    /// </summary>
     public enum DialogTurnStatus
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogsComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogsComponentRegistration.cs
@@ -8,8 +8,15 @@ using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Makes Dialogs components available to the system registering functionality.
+    /// </summary>
     public class DialogsComponentRegistration : ComponentRegistration, IComponentMemoryScopes, IComponentPathResolvers
     {
+        /// <summary>
+        /// Gets the Dialogs Memory Scopes.
+        /// </summary>
+        /// <returns>A collection of <see cref="MemoryScope"/>.</returns>
         public virtual IEnumerable<MemoryScope> GetMemoryScopes()
         {
             yield return new TurnMemoryScope();
@@ -23,6 +30,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             yield return new UserMemoryScope();
         }
 
+        /// <summary>
+        /// Gets the Dialogs Path Resolvers.
+        /// </summary>
+        /// <returns>A collection of <see cref="IPathResolver"/>.</returns>
         public virtual IEnumerable<IPathResolver> GetPathResolvers()
         {
             yield return new DollarPathResolver();

--- a/libraries/Microsoft.Bot.Builder.Dialogs/IDialogDependencies.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/IDialogDependencies.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines Dialog Dependencies interface for enumerating child dialogs.
+    /// </summary>
     public interface IDialogDependencies
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/IItemIdentity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/IItemIdentity.cs
@@ -1,7 +1,14 @@
 ﻿namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines the interface for getting an items identity.
+    /// </summary>
     public interface IItemIdentity
     {
+        /// <summary>
+        /// Gets the identity of the item.
+        /// </summary>
+        /// <returns>A string representing the identity of the item.</returns>
         string GetIdentity();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogContextPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogContextPath.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines path for available dialog contexts.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class DialogContextPath
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogPath.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines path for available dialogs.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class DialogPath
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         private readonly DialogContext _dialogContext;
         private int _version;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogStateManager"/> class.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="configuration">Configuration for the dialog state manager. Default is <c>null</c>.</param>
         public DialogStateManager(DialogContext dc, DialogStateManagerConfiguration configuration = null)
         {
             ComponentRegistration.Add(new DialogsComponentRegistration());
@@ -66,16 +71,41 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             dc.Context.TurnState.Set(Configuration);
         }
 
+        /// <summary>
+        /// Gets or sets the configured path resolvers and memory scopes for the dialog state manager.
+        /// </summary>
+        /// <value>A <see cref="DialogStateManagerConfiguration"/> with the configuration.</value>
         public DialogStateManagerConfiguration Configuration { get; set; }
 
+        /// <summary>
+        /// Gets an <see cref="ICollection{T}"/> containing the keys of the memory scopes.
+        /// </summary>
+        /// <value>Keys of the memory scopes.</value>
         public ICollection<string> Keys => Configuration.MemoryScopes.Select(ms => ms.Name).ToList();
 
+        /// <summary>
+        /// Gets an <see cref="ICollection{T}"/> containing the values of the memory scopes.
+        /// </summary>
+        /// <value>Values of the memory scopes.</value>
         public ICollection<object> Values => Configuration.MemoryScopes.Select(ms => ms.GetMemory(_dialogContext)).ToList();
 
+        /// <summary>
+        /// Gets the number of memory scopes in the dialog state manager.
+        /// </summary>
+        /// <value>Number of memory scopes in the configuration.</value>
         public int Count => Configuration.MemoryScopes.Count;
 
+        /// <summary>
+        /// Gets a value indicating whether the dialog state manager is read-only.
+        /// </summary>
+        /// <value><c>true</c>.</value>
         public bool IsReadOnly => true;
 
+        /// <summary>
+        /// Gets or sets the elements with the specified key.
+        /// </summary>
+        /// <param name="key">Key to get or set the element.</param>
+        /// <returns>The element with the specified key.</returns>
         public object this[string key]
         {
             get => GetValue<object>(key, () => null);
@@ -407,41 +437,90 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             }
         }
 
+        /// <summary>
+        /// Adds an element to the dialog state manager.
+        /// </summary>
+        /// <param name="key">Key of the element to add.</param>
+        /// <param name="value">Value of the element to add.</param>
         public void Add(string key, object value)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Determines whether the dialog state manager contains an element with the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the dialog state manager.</param>
+        /// <returns><c>true</c> if the dialog state manager contains an element with 
+        /// the key; otherwise, <c>false</c>.</returns>
         public bool ContainsKey(string key)
         {
             return Configuration.MemoryScopes.Any(ms => ms.Name.ToUpperInvariant() == key.ToUpperInvariant());
         }
 
+        /// <summary>
+        /// Removes the element with the specified key from the dialog state manager.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns><c>true</c> if the element is succesfully removed; otherwise, false.</returns>
+        /// <remarks>This method is not supported.</remarks>
         public bool Remove(string key)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <param name="value">When this method returns, the value associated with the specified key, if the
+        /// key is found; otherwise, the default value for the type of the value parameter.
+        /// This parameter is passed uninitialized.</param>
+        /// <returns><c>true</c> if the dialog state manager contains an element with the specified key; 
+        /// otherwise, <c>false</c>.</returns>
         public bool TryGetValue(string key, out object value)
         {
             return TryGetValue<object>(key, out value);
         }
 
+        /// <summary>
+        /// Adds an item to the dialog state manager.
+        /// </summary>
+        /// <param name="item">The <see cref="KeyValuePair{TKey, TValue}"/> with the key and object of 
+        /// the item to add.</param>
+        /// <remarks>This method is not supported.</remarks>
         public void Add(KeyValuePair<string, object> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Removes all items from the dialog state manager.
+        /// </summary>
+        /// <remarks>This method is not supported.</remarks>
         public void Clear()
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Determines whether the dialog state manager contains a specific value.
+        /// </summary>
+        /// <param name="item">The <see cref="KeyValuePair{TKey, TValue}"/> of the item to locate.</param>
+        /// <returns><c>true</c> if item is found in the dialog state manager; otherwise,
+        /// <c>false</c>.</returns>
+        /// <remarks>This method is not supported.</remarks>
         public bool Contains(KeyValuePair<string, object> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Copies the elements of the dialog state manager to an array starting at a particular index.
+        /// </summary>
+        /// <param name="array">The one-dimensional array that is the destination of the elements copied
+        /// from the dialog state manager. The array must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
             foreach (var ms in Configuration.MemoryScopes)
@@ -450,11 +529,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             }
         }
 
+        /// <summary>
+        /// Removes the first occurrence of a specific object from the dialog state manager.
+        /// </summary>
+        /// <param name="item">The object to remove from the dialog state manager.</param>
+        /// <returns><c>true</c> if the item was successfully removed from the dialog state manager;
+        /// otherwise, <c>false</c>.</returns>
+        /// <remarks>This method is not supported.</remarks>
         public bool Remove(KeyValuePair<string, object> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             foreach (var ms in Configuration.MemoryScopes)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManagerConfiguration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManagerConfiguration.cs
@@ -6,6 +6,9 @@ using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory
 {
+    /// <summary>
+    /// Configures the path resolvers and memory scopes for the dialog state manager.
+    /// </summary>
     public class DialogStateManagerConfiguration
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IComponentMemoryScopes.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IComponentMemoryScopes.cs
@@ -6,8 +6,15 @@ using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory
 {
+    /// <summary>
+    /// Defines Component Memory Scopes interface for enumerating memory scopes.
+    /// </summary>
     public interface IComponentMemoryScopes
     {
+        /// <summary>
+        /// Gets the memory scopes.
+        /// </summary>
+        /// <returns>A <see cref="IEnumerable{MemoryScope}"/> with the memory scopes.</returns>
         IEnumerable<MemoryScope> GetMemoryScopes();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/IPathResolver.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.Bot.Builder.Dialogs.Memory
 {
+    /// <summary>
+    /// Defines Path Resolver interface for transforming paths.
+    /// </summary>
     public interface IPathResolver
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AliasPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AliasPathResolver.cs
@@ -13,6 +13,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
         private readonly string _postfix;
         private readonly string _prefix;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AliasPathResolver"/> class.
+        /// </summary>
+        /// <param name="alias">Alias name.</param>
+        /// <param name="prefix">Prefix name.</param>
+        /// <param name="postfix">Postfix name.</param>
         public AliasPathResolver(string alias, string prefix, string postfix = null)
         {
             Alias = alias?.Trim() ?? throw new ArgumentNullException(nameof(alias));
@@ -28,6 +34,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
         /// </value>
         public string Alias { get; }
 
+        /// <summary>
+        /// Transforms the path.
+        /// </summary>
+        /// <param name="path">Path to inspect.</param>
+        /// <returns>Transformed path.</returns>
         public virtual string TransformPath(string path)
         {
             if (path == null)
@@ -46,6 +57,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
             return path;
         }
 
+        /// <summary>
+        /// Verifies if a character is valid for a path.
+        /// </summary>
+        /// <param name="ch">Character to verify.</param>
+        /// <returns><c>true</c> if the character is valid for a path; otherwise, <c>false</c>.</returns>
 #pragma warning disable CA1822 // Mark members as static (we can't change this without breaking binary compat)
         protected bool IsPathChar(char ch)
 #pragma warning restore CA1822 // Mark members as static

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AtAtPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AtAtPathResolver.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
     /// </summary>
     public class AtAtPathResolver : AliasPathResolver
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AtAtPathResolver"/> class.
+        /// </summary>
         public AtAtPathResolver()
             : base(alias: "@@", prefix: "turn.recognized.entities.")
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AtPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/AtPathResolver.cs
@@ -14,11 +14,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
 
         private static readonly char[] _delims = { '.', '[' };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AtPathResolver"/> class.
+        /// </summary>
         public AtPathResolver()
             : base("@", string.Empty)
         {
         }
 
+        /// <summary>
+        /// Transforms the path.
+        /// </summary>
+        /// <param name="path">Path to inspect.</param>
+        /// <returns>Transformed path.</returns>
         public override string TransformPath(string path)
         {
             if (path == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/DollarPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/DollarPathResolver.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
     /// </remarks>
     public class DollarPathResolver : AliasPathResolver
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DollarPathResolver"/> class.
+        /// </summary>
         public DollarPathResolver()
             : base(alias: "$", prefix: "dialog.")
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/HashPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/HashPathResolver.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
     /// </summary>
     public class HashPathResolver : AliasPathResolver
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HashPathResolver"/> class.
+        /// </summary>
         public HashPathResolver()
             : base(alias: "#", prefix: "turn.recognized.intents.")
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/PercentPathResolver.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/PathResolvers/PercentPathResolver.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers
     /// </summary>
     public class PercentPathResolver : AliasPathResolver
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PercentPathResolver"/> class.
+        /// </summary>
         public PercentPathResolver()
             : base(alias: "%", prefix: "class.")
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ScopePath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ScopePath.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines paths for the available scopes.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ScopePath
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
@@ -54,27 +57,59 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public const string Turn = "turn";
 
+        /// <summary>
+        /// User memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.User instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.User instead.")]
         public const string USER = "user";
 
+        /// <summary>
+        /// Conversation memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.Conversation instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.Conversation instead.")]
         public const string CONVERSATION = "conversation";
 
+        /// <summary>
+        /// Dialog memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.Dialog instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.Dialog instead.")]
         public const string DIALOG = "dialog";
 
+        /// <summary>
+        /// DialogClass memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.DialogClass instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.DialogClass instead.")]
         public const string DIALOGCLASS = "dialogclass";
 
+        /// <summary>
+        /// This memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.This instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.This instead.")]
         public const string THIS = "this";
 
+        /// <summary>
+        /// Class memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.Class instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.Class instead.")]
         public const string CLASS = "class";
 
+        /// <summary>
+        /// Settings memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.Settings instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.Settings instead.")]
         public const string SETTINGS = "settings";
 
+        /// <summary>
+        /// Turn memory scope root path.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ScopePath.Turn instead.</remarks>
         [Obsolete("This property is deprecated, use ScopePath.Turn instead.")]
         public const string TURN = "turn";
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/BotStateMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/BotStateMemoryScope.cs
@@ -64,6 +64,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             throw new NotSupportedException("You cannot replace the root BotState object");
         }
 
+        /// <summary>
+        /// Populates the state cache for this <see cref="BotState"/> from the storage layer.
+        /// </summary>
+        /// <param name="dialogContext">The dialog context object for this turn.</param>
+        /// <param name="force">Optional, <c>true</c> to overwrite any existing state cache;
+        /// or <c>false</c> to load state from storage only if the cache doesn't already exist.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
         public override async Task LoadAsync(DialogContext dialogContext, bool force = false, CancellationToken cancellationToken = default)
         {
             var botState = GetBotState(dialogContext);
@@ -74,6 +83,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             }
         }
 
+        /// <summary>
+        /// Writes the state cache for this <see cref="BotState"/> to the storage layer.
+        /// </summary>
+        /// <param name="dialogContext">The dialog context object for this turn.</param>
+        /// <param name="force">Optional, <c>true</c> to save the state cache to storage;
+        /// or <c>false</c> to save state to storage only if a property in the cache has changed.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
         public override async Task SaveChangesAsync(DialogContext dialogContext, bool force = false, CancellationToken cancellationToken = default)
         {
             var botState = GetBotState(dialogContext);
@@ -84,6 +102,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             }
         }
 
+        /// <summary>
+        /// Deletes any state in storage and the cache for this <see cref="BotState"/>.
+        /// </summary>
+        /// <param name="dialogContext">The dialog context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
         public override Task DeleteAsync(DialogContext dialogContext, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ClassMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ClassMemoryScope.cs
@@ -10,12 +10,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public class ClassMemoryScope : MemoryScope
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClassMemoryScope"/> class.
+        /// </summary>
         public ClassMemoryScope()
             : base(ScopePath.Class)
         {
             this.IncludeInSnapshot = false;
         }
 
+        /// <summary>
+        /// Gets the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <returns>Memory for the scope.</returns>
         public override object GetMemory(DialogContext dc)
         {
             if (dc == null)
@@ -36,6 +44,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             return null;
         }
 
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="memory">Memory object to set for the scope.</param>
+        /// <remarks>Method not supported. You can't modify the class scope.</remarks>
         public override void SetMemory(DialogContext dc, object memory)
         {
             throw new NotSupportedException("You can't modify the class scope");

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogClassMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogClassMemoryScope.cs
@@ -10,12 +10,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public class DialogClassMemoryScope : MemoryScope
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogClassMemoryScope"/> class.
+        /// </summary>
         public DialogClassMemoryScope()
             : base(ScopePath.DialogClass)
         {
             this.IncludeInSnapshot = false;
         }
 
+        /// <summary>
+        /// Gets the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <returns>Memory for the scope.</returns>
         public override object GetMemory(DialogContext dc)
         {
             if (dc == null)
@@ -37,6 +45,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             return new ReadOnlyObject(dc.FindDialog(dc.Parent?.ActiveDialog?.Id ?? dc.ActiveDialog?.Id));
         }
 
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="memory">Memory object to set for the scope.</param>
+        /// <remarks>Method not supported. You can't modify the dialogclass scope.</remarks>
         public override void SetMemory(DialogContext dc, object memory)
         {
             throw new NotSupportedException("You can't modify the dialogclass scope");

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogContextMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogContextMemoryScope.cs
@@ -16,15 +16,34 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </remarks>
     public class DialogContextMemoryScope : MemoryScope
     {
+        /// <summary>
+        /// Stack name.
+        /// </summary>
         public const string Stack = "stack";
+
+        /// <summary>
+        /// Active dialog name.
+        /// </summary>
         public const string ActiveDialog = "activeDialog";
+
+        /// <summary>
+        /// Parent name.
+        /// </summary>
         public const string Parent = "parent";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogContextMemoryScope"/> class.
+        /// </summary>
         public DialogContextMemoryScope()
             : base(ScopePath.DialogContext, includeInSnapshot: false)
         {
         }
 
+        /// <summary>
+        /// Gets the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <returns>Memory for the scope.</returns>
         public override object GetMemory(DialogContext dc)
         {
             if (dc == null)
@@ -64,6 +83,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             return memory;
         }
 
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="memory">Memory object to set for the scope.</param>
+        /// <remarks>Method not supported. You can't modify the dialogcontext scope.</remarks>
         public override void SetMemory(DialogContext dc, object memory)
         {
             throw new NotSupportedException("You can't modify the dialogcontext scope");

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/DialogMemoryScope.cs
@@ -11,11 +11,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public class DialogMemoryScope : MemoryScope
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogMemoryScope"/> class.
+        /// </summary>
         public DialogMemoryScope()
             : base(ScopePath.Dialog)
         {
         }
 
+        /// <summary>
+        /// Gets the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <returns>Memory for the scope.</returns>
         public override object GetMemory(DialogContext dc)
         {
             if (dc == null)
@@ -37,6 +45,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             return dc.Parent?.ActiveDialog?.State ?? dc.ActiveDialog?.State;
         }
 
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="memory">Memory object to set for the scope.</param>
         public override void SetMemory(DialogContext dc, object memory)
         {
             if (dc == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/MemoryScope.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public abstract class MemoryScope
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryScope"/> class.
+        /// </summary>
+        /// <param name="name">Name of the scope.</param>
+        /// <param name="includeInSnapshot"><see cref="bool"/> value indicating whether this memory 
+        /// should be included in snapshot. Default value is true.</param>
         public MemoryScope(string name, bool includeInSnapshot = true)
         {
             this.IncludeInSnapshot = includeInSnapshot;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/SettingsMemoryScope.cs
@@ -16,12 +16,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     {
         private readonly Dictionary<string, object> _emptySettings = new Dictionary<string, object>();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SettingsMemoryScope"/> class.
+        /// </summary>
         public SettingsMemoryScope()
             : base(ScopePath.Settings)
         {
             IncludeInSnapshot = false;
         }
 
+        /// <summary>
+        /// Gets the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <returns>Memory for the scope.</returns>
         public override object GetMemory(DialogContext dc)
         {
             if (dc == null)
@@ -42,6 +50,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             return settings ?? _emptySettings;
         }
 
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="memory">Memory object to set for the scope.</param>
+        /// <remarks>Method not supported. You cannot set the memory for a readonly memory scope.</remarks>
         public override void SetMemory(DialogContext dc, object memory)
         {
             throw new NotSupportedException("You cannot set the memory for a readonly memory scope");

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ThisMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/ThisMemoryScope.cs
@@ -11,11 +11,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public class ThisMemoryScope : MemoryScope
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThisMemoryScope"/> class.
+        /// </summary>
         public ThisMemoryScope()
             : base(ScopePath.This)
         {
         }
 
+        /// <summary>
+        /// Gets the backing memory for this scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <returns>Memory for the scope.</returns>
         public override object GetMemory(DialogContext dc)
         {
             if (dc == null)
@@ -26,6 +34,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
             return dc.ActiveDialog?.State;
         }
 
+        /// <summary>
+        /// Changes the backing object for the memory scope.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> object for this turn.</param>
+        /// <param name="memory">Memory object to set for the scope.</param>
         public override void SetMemory(DialogContext dc, object memory)
         {
             if (dc == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/Scopes/TurnMemoryScope.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory.Scopes
     /// </summary>
     public class TurnMemoryScope : MemoryScope
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TurnMemoryScope"/> class.
+        /// </summary>
         public TurnMemoryScope()
             : base(ScopePath.Turn)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ThisPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/ThisPath.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines path passed to the active dialog.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class ThisPath
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
@@ -14,6 +17,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public const string Options = "this.options";
 
+        /// <summary>
+        /// The options that were passed to the active dialog via options argument of BeginDialog.
+        /// </summary>
+        /// <remarks>This property is deprecated, use ThisPath.Options instead.</remarks>
         [Obsolete("This property is deprecated, use ThisPath.Options instead.")]
         public const string OPTIONS = "this.options";
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Defines path for avaiable turns.
+    /// </summary>
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (We can't change this without breaking binary compat)
     public class TurnPath
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
@@ -69,39 +72,87 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         public const string ActivityProcessed = "turn.activityProcessed";
 
+        /// <summary>
+        /// The result from the last dialog that was called.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.LastResult instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.LastResult instead.")]
         public const string LASTRESULT = "turn.lastresult";
 
+        /// <summary>
+        /// The current activity for the turn.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.Activity instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.Activity instead.")]
         public const string ACTIVITY = "turn.activity";
 
+        /// <summary>
+        /// The recognized result for the current turn.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.Recognized instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.Recognized instead.")]
         public const string RECOGNIZED = "turn.recognized";
 
+        /// <summary>
+        /// Path to the top intent.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.TopIntent instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.TopIntent instead.")]
         public const string TOPINTENT = "turn.recognized.intent";
 
+        /// <summary>
+        /// Path to the top score.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.TopScore instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.TopScore instead.")]
         public const string TOPSCORE = "turn.recognized.score";
 
+        /// <summary>
+        /// Original text.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.Text instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.Text instead.")]
         public const string TEXT = "turn.recognized.text";
 
+        /// <summary>
+        /// Original utterance split into unrecognized strings.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.UnrecognizedText instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.UnrecognizedText instead.")]
         public const string UNRECOGNIZEDTEXT = "turn.unrecognizedText";
 
+        /// <summary>
+        /// Entities that were recognized from text.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.RecognizedEntities instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.RecognizedEntities instead.")]
         public const string RECOGNIZEDENTITIES = "turn.recognizedEntities";
 
+        /// <summary>
+        /// If true an interruption has occured.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.Interrupted instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.Interrupted instead.")]
         public const string INTERRUPTED = "turn.interrupted";
 
+        /// <summary>
+        /// The current dialog event (set during event processing).
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.DialogEvent instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.DialogEvent instead.")]
         public const string DIALOGEVENT = "turn.dialogEvent";
 
+        /// <summary>
+        /// Used to track that we don't end up in infinite loop of RepeatDialogs().
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.RepeatedIds instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.RepeatedIds instead.")]
         public const string REPEATEDIDS = "turn.repeatedIds";
 
+        /// <summary>
+        /// This is a bool which if set means that the turncontext.activity has been consumed by some component in the system.
+        /// </summary>
+        /// <remarks>This property is deprecated, use TurnPath.ActivityProcessed instead.</remarks>
         [Obsolete("This property is deprecated, use TurnPath.ActivityProcessed instead.")]
         public const string ACTIVITYPROCESSED = "turn.activityProcessed";
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -24,11 +24,6 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- These documentation warnings excludes should be removed as part of https://github.com/microsoft/botbuilder-dotnet/issues/4052 -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(IsBuildServer)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Obsolete/DialogManagerAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Obsolete/DialogManagerAdapter.cs
@@ -7,26 +7,67 @@ using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Represents a dialog manager adapter that can connect a dialog manager to a service endpoint.
+    /// </summary>
     [Obsolete("This class is not used anymore", error: true)]
     public class DialogManagerAdapter : BotAdapter
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DialogManagerAdapter"/> class.
+        /// </summary>
         public DialogManagerAdapter()
         {
         }
 
+        /// <summary>
+        /// Gets the list of activities.
+        /// </summary>
+        /// <value>The list of activities.</value>
         public List<Activity> Activities { get; private set; } = new List<Activity>();
 
+        /// <summary>
+        /// When overridden in a derived class, sends activities to the conversation.
+        /// </summary>
+        /// <param name="turnContext">The context object for the turn.</param>
+        /// <param name="activities">The activities to send.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>If the activities are successfully sent, the task result contains
+        /// an array of <see cref="ResourceResponse"/> objects containing the IDs that
+        /// the receiving channel assigned to the activities.</remarks>
         public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
         {
             this.Activities.AddRange(activities);
             return Task.FromResult(activities.Select(a => new ResourceResponse(a.Id)).ToArray());
         }
 
+        /// <summary>
+        /// When overridden in a derived class, replaces an existing activity in the
+        /// conversation.
+        /// </summary>
+        /// <param name="turnContext">The context object for the turn.</param>
+        /// <param name="activity">New replacement activity.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>This method is not implemented.</remarks>
         public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// When overridden in a derived class, deletes an existing activity in the
+        /// conversation.
+        /// </summary>
+        /// <param name="turnContext">The context object for the turn.</param>
+        /// <param name="reference">Conversation reference for the activity to delete.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>This method is not implemented.</remarks>
         public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();

--- a/libraries/Microsoft.Bot.Builder.Dialogs/PersistedState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/PersistedState.cs
@@ -6,24 +6,43 @@ using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Dialogs
 {
+    /// <summary>
+    /// Represents the persisted data across turns.
+    /// </summary>
     public class PersistedState
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PersistedState"/> class.
+        /// </summary>
         public PersistedState()
         {
             UserState = new Dictionary<string, object>();
             ConversationState = new Dictionary<string, object>();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PersistedState"/> class.
+        /// </summary>
+        /// <param name="keys">The persisted keys.</param>
+        /// <param name="data">The data containing the state values.</param>
         public PersistedState(PersistedStateKeys keys, IDictionary<string, object> data)
         {
             UserState = data.ContainsKey(keys.UserState) ? (IDictionary<string, object>)data[keys.UserState] : new ConcurrentDictionary<string, object>();
             ConversationState = data.ContainsKey(keys.ConversationState) ? (IDictionary<string, object>)data[keys.ConversationState] : new ConcurrentDictionary<string, object>();
         }
 
+        /// <summary>
+        /// Gets or sets the user profile data.
+        /// </summary>
+        /// <value>The user profile data.</value>
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> UserState { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets or sets the dialog state data.
+        /// </summary>
+        /// <value>The dialog state data.</value>
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
         public IDictionary<string, object> ConversationState { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only

--- a/libraries/Microsoft.Bot.Builder.Dialogs/PersistedStateKeys.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/PersistedStateKeys.cs
@@ -11,10 +11,22 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public class PersistedStateKeys : IEnumerable<string>
     {
+        /// <summary>
+        /// Gets or sets the key for the user state.
+        /// </summary>
+        /// <value>The key for the user state.</value>
         public string UserState { get; set; }
 
+        /// <summary>
+        /// Gets or sets the key for the conversation state.
+        /// </summary>
+        /// <value>The key for the conversation state.</value>
         public string ConversationState { get; set; }
 
+        /// <summary>
+        /// Gets the collection of persisted state keys.
+        /// </summary>
+        /// <returns>A collection of persisted state keys.</returns>
         public IEnumerator<string> GetEnumerator()
         {
             yield return UserState;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ActivityPrompt.cs
@@ -205,6 +205,17 @@ namespace Microsoft.Bot.Builder.Dialogs
         protected virtual async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default)
             => await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
 
+        /// <summary>
+        /// When overridden in a derived class, prompts the user for input.
+        /// </summary>
+        /// <param name="turnContext">Context for the current turn of conversation with the user.</param>
+        /// <param name="state">Contains state for the current instance of the prompt on the dialog stack.</param>
+        /// <param name="options">A prompt options object constructed from the options initially provided
+        /// in the call to <see cref="DialogContext.PromptAsync(string, PromptOptions, CancellationToken)"/>.</param>
+        /// <param name="isRetry">A <see cref="bool"/> representing if the prompt is a retry.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         protected virtual async Task OnPromptAsync(
             ITurnContext turnContext,
             IDictionary<string, object> state,

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/NumberPrompt.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Bot.Builder.Dialogs
     public class NumberPrompt<T> : Prompt<T>
         where T : struct
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NumberPrompt{T}"/> class.
+        /// </summary>
+        /// <param name="dialogId">Unique ID of the dialog within its parent <see cref="DialogSet"/> or <see cref="ComponentDialog"/>.</param>
+        /// <param name="validator">Validator that will be called each time the user responds to the prompt.</param>
+        /// <param name="defaultLocale">Locale to use.</param>
         public NumberPrompt(string dialogId, PromptValidator<T> validator = null, string defaultLocale = null)
             : base(dialogId, validator)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -210,6 +210,18 @@ namespace Microsoft.Bot.Builder.Dialogs
             await OnPromptAsync(turnContext, state, options, false, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called before an event is bubbled to its parent.
+        /// </summary>
+        /// <remarks>
+        /// This is a good place to perform interception of an event as returning `true` will prevent
+        /// any further bubbling of the event to the dialogs parents and will also prevent any child
+        /// dialogs from performing their default processing.
+        /// </remarks>
+        /// <param name="dc">The dialog context for the current turn of conversation.</param>
+        /// <param name="e">The event being raised.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns> Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {
             if (e.Name == DialogEvents.ActivityReceived && dc.Context.Activity.Type == ActivityTypes.Message)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -14,6 +14,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
     {
         private static readonly string[] SupportedLocales = GetSupportedCultures().Select(c => c.Locale).ToArray();
 
+        /// <summary>
+        /// Gets the bulgarian prompt culture model.
+        /// </summary>
+        /// <value>Bulgarian prompt culture model.</value>
         public static PromptCultureModel Bulgarian =>
             new PromptCultureModel
             {
@@ -25,6 +29,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "да",
             };
 
+        /// <summary>
+        /// Gets the chinese prompt culture model.
+        /// </summary>
+        /// <value>Chinese prompt culture model.</value>
         public static PromptCultureModel Chinese =>
             new PromptCultureModel
             {
@@ -36,6 +44,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "是的",
             };
 
+        /// <summary>
+        /// Gets the dutch prompt culture model.
+        /// </summary>
+        /// <value>Dutch prompt culture model.</value>
         public static PromptCultureModel Dutch =>
             new PromptCultureModel
             {
@@ -47,6 +59,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Ja",
             };
 
+        /// <summary>
+        /// Gets the english prompt culture model.
+        /// </summary>
+        /// <value>English prompt culture model.</value>
         public static PromptCultureModel English =>
             new PromptCultureModel
             {
@@ -58,6 +74,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Yes",
             };
 
+        /// <summary>
+        /// Gets the french prompt culture model.
+        /// </summary>
+        /// <value>French prompt culture model.</value>
         public static PromptCultureModel French =>
             new PromptCultureModel
             {
@@ -69,6 +89,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Oui",
             };
 
+        /// <summary>
+        /// Gets the german prompt culture model.
+        /// </summary>
+        /// <value>German prompt culture model.</value>
         public static PromptCultureModel German =>
             new PromptCultureModel
             {
@@ -80,6 +104,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Ja",
             };
 
+        /// <summary>
+        /// Gets the hindi prompt culture model.
+        /// </summary>
+        /// <value>Hindi prompt culture model.</value>
         public static PromptCultureModel Hindi =>
             new PromptCultureModel
             {
@@ -91,6 +119,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "हां",
             };
 
+        /// <summary>
+        /// Gets the italian prompt culture model.
+        /// </summary>
+        /// <value>Italian prompt culture model.</value>
         public static PromptCultureModel Italian =>
             new PromptCultureModel
             {
@@ -102,6 +134,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Si",
             };
 
+        /// <summary>
+        /// Gets the japanese prompt culture model.
+        /// </summary>
+        /// <value>Japanese prompt culture model.</value>
         public static PromptCultureModel Japanese =>
             new PromptCultureModel
             {
@@ -113,6 +149,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "はい",
             };
 
+        /// <summary>
+        /// Gets the korean prompt culture model.
+        /// </summary>
+        /// <value>Korean prompt culture model.</value>
         public static PromptCultureModel Korean =>
             new PromptCultureModel
             {
@@ -124,6 +164,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "예",
             };
 
+        /// <summary>
+        /// Gets the portuguese prompt culture model.
+        /// </summary>
+        /// <value>Portuguese prompt culture model.</value>
         public static PromptCultureModel Portuguese =>
             new PromptCultureModel
             {
@@ -135,6 +179,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Sim",
             };
 
+        /// <summary>
+        /// Gets the spanish prompt culture model.
+        /// </summary>
+        /// <value>Spanish prompt culture model.</value>
         public static PromptCultureModel Spanish =>
             new PromptCultureModel
             {
@@ -146,6 +194,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Sí",
             };
 
+        /// <summary>
+        /// Gets the swedish prompt culture model.
+        /// </summary>
+        /// <value>Swedish prompt culture model.</value>
         public static PromptCultureModel Swedish =>
             new PromptCultureModel
             {
@@ -157,6 +209,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 YesInLanguage = "Ja",
             };
 
+        /// <summary>
+        /// Gets the turkish prompt culture model.
+        /// </summary>
+        /// <value>Turkish prompt culture model.</value>
         public static PromptCultureModel Turkish =>
             new PromptCultureModel
             {
@@ -207,6 +263,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
             return cultureCode;
         }
 
+        /// <summary>
+        /// Gets a list of the supported culture models.
+        /// </summary>
+        /// <returns>Array of <see cref="PromptCultureModel"/> with the supported cultures.</returns>
         public static PromptCultureModel[] GetSupportedCultures() => new PromptCultureModel[]
         {
             Bulgarian,

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/TextPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/TextPrompt.cs
@@ -94,6 +94,18 @@ namespace Microsoft.Bot.Builder.Dialogs
             return Task.FromResult(result);
         }
 
+        /// <summary>
+        /// Called before an event is bubbled to its parent.
+        /// </summary>
+        /// <remarks>
+        /// This is a good place to perform interception of an event as returning `true` will prevent
+        /// any further bubbling of the event to the dialogs parents and will also prevent any child
+        /// dialogs from performing their default processing.
+        /// </remarks>
+        /// <param name="dc">The dialog context for the current turn of conversation.</param>
+        /// <param name="e">The event being raised.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns> Whether the event is handled by the current dialog and further processing should stop.</returns>
         protected override async Task<bool> OnPreBubbleEventAsync(DialogContext dc, DialogEvent e, CancellationToken cancellationToken)
         {
             return await Task.FromResult(false).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
@@ -41,6 +41,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </remarks>
         public const string NoneIntent = "None";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Recognizer"/> class to recognize user input.
+        /// </summary>
+        /// <param name="callerPath">The source file path of the caller.</param>
+        /// <param name="callerLine">The line number on the source file where the method is called.</param>
         public Recognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             if (!string.IsNullOrEmpty(callerPath))

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -25,14 +25,33 @@ namespace Microsoft.Bot.Builder.Dialogs
         private const string DeliverModeStateKey = "deliverymode";
         private const string SkillConversationIdStateKey = "Microsoft.Bot.Builder.Dialogs.SkillDialog.SkillConversationId";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkillDialog"/> class to wrap remote calls to a skill.
+        /// </summary>
+        /// <param name="dialogOptions">The options to execute the skill dialog.</param>
+        /// <param name="dialogId">The id of the dialog.</param>
         public SkillDialog(SkillDialogOptions dialogOptions, string dialogId = null)
             : base(dialogId)
         {
             DialogOptions = dialogOptions ?? throw new ArgumentNullException(nameof(dialogOptions));
         }
 
+        /// <summary>
+        /// Gets the options used to execute the skill dialog.
+        /// </summary>
+        /// <value>The options to execute the skill dialog.</value>
         protected SkillDialogOptions DialogOptions { get; }
 
+        /// <summary>
+        /// Called when the skill dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>If the task is successful, the result indicates whether the dialog is still
+        /// active after the turn has been processed by the dialog.</remarks>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
             var dialogArgs = ValidateBeginDialogArgs(options);
@@ -62,6 +81,17 @@ namespace Microsoft.Bot.Builder.Dialogs
             return EndOfTurn;
         }
 
+        /// <summary>
+        /// Called when the skill dialog is _continued_, where it is the active dialog and the
+        /// user replies with a new activity.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>If the task is successful, the result indicates whether the dialog is still
+        /// active after the turn has been processed by the dialog. The result may also contain a
+        /// return value.</remarks>
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             if (!OnValidateActivity(dc.Context.Activity))
@@ -95,6 +125,14 @@ namespace Microsoft.Bot.Builder.Dialogs
             return EndOfTurn;
         }
 
+        /// <summary>
+        /// Called when the skill dialog should re-prompt the user for input.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="instance">State information for this dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task RepromptDialogAsync(ITurnContext turnContext, DialogInstance instance, CancellationToken cancellationToken = default)
         {
             // Create and send an envent to the skill so it can resume the dialog.
@@ -110,12 +148,31 @@ namespace Microsoft.Bot.Builder.Dialogs
             await SendToSkillAsync(turnContext, (Activity)repromptEvent, skillConversationId, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a child skill dialog completed its turn, returning control to this dialog.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
         {
             await RepromptDialogAsync(dc.Context, dc.ActiveDialog, cancellationToken).ConfigureAwait(false);
             return EndOfTurn;
         }
 
+        /// <summary>
+        /// Called when the skill dialog is ending.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="instance">State information associated with the instance of this dialog on the dialog stack.</param>
+        /// <param name="reason">Reason why the dialog ended.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task EndDialogAsync(ITurnContext turnContext, DialogInstance instance, DialogReason reason, CancellationToken cancellationToken = default)
         {
             // Send of of conversation to the skill if the dialog has been cancelled. 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/WaterfallDialog.cs
@@ -55,6 +55,16 @@ namespace Microsoft.Bot.Builder.Dialogs
             return this;
         }
 
+        /// <summary>
+        /// Called when the waterfall dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>If the task is successful, the result indicates whether the dialog is still
+        /// active after the turn has been processed by the dialog.</remarks>
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
             if (options is CancellationToken)
@@ -86,6 +96,17 @@ namespace Microsoft.Bot.Builder.Dialogs
             return await RunStepAsync(dc, 0, DialogReason.BeginCalled, null, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when the waterfall dialog is _continued_, where it is the active dialog and the
+        /// user replies with a new activity.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>If the task is successful, the result indicates whether the dialog is still
+        /// active after the turn has been processed by the dialog. The result may also contain a
+        /// return value.</remarks>
         public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             if (dc == null)
@@ -103,6 +124,16 @@ namespace Microsoft.Bot.Builder.Dialogs
             return await ResumeDialogAsync(dc, DialogReason.ContinueCalled, dc.Context.Activity.Text, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Called when a child waterfall dialog completed its turn, returning control to this dialog.
+        /// </summary>
+        /// <param name="dc">The dialog context for the current turn of the conversation.</param>
+        /// <param name="reason">Reason why the dialog resumed.</param>
+        /// <param name="result">Optional, value returned from the dialog that was called. The type
+        /// of the value returned is dependent on the child dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result, CancellationToken cancellationToken = default)
         {
             if (dc == null)
@@ -165,6 +196,13 @@ namespace Microsoft.Bot.Builder.Dialogs
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Called when an individual waterfall step is being executed.
+        /// </summary>
+        /// <param name="stepContext">Context for the waterfall step to execute.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
         protected virtual async Task<DialogTurnResult> OnStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var stepName = WaterfallStepName(stepContext.Index);
@@ -179,6 +217,16 @@ namespace Microsoft.Bot.Builder.Dialogs
             return await _steps[stepContext.Index](stepContext, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Excutes a step of the waterfall dialog.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="index">The index of the current waterfall step to execute.</param>
+        /// <param name="reason">The reason the waterfall step is being executed.</param>
+        /// <param name="result">Result returned by a dialog called in the previous waterfall step.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
         protected async Task<DialogTurnResult> RunStepAsync(DialogContext dc, int index, DialogReason reason, object result, CancellationToken cancellationToken)
         {
             if (dc == null)


### PR DESCRIPTION
Fixes #4392

## Description
This pull request adds the missing documentation in the files from the **Microsoft.BotBuilder.Dialogs** library.

## Specific Changes
- Removed the `NoWarn` property group from the .csproj.
- Added all the missing XML documentation in the library files.

## Testing
Below you can see the number of errors for the library when removing the `NoWarn` property and after adding all the missing XML documentation.
![image](https://user-images.githubusercontent.com/38112957/91216097-c977dc00-e6eb-11ea-836c-96453b6d8ae1.png)
