### PR TITLE
Update OAuthInput.cs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -613,6 +613,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         {
             switch (channelId)
             {
+                case Channels.Msteams:
                 case Channels.Cortana:
                 case Channels.Skype:
                 case Channels.Skypeforbusiness:


### PR DESCRIPTION
Added support for MS Teams back in, which was removed prior in https://github.com/microsoft/botbuilder-dotnet/commit/acdaec64488afc9e5c2889933abfaf2e9932f327#diff-8ba2f5749eeeffd205ecea167bd187b0.

Fixes #4477

## Description
MS Teams support was wrongly removed prior, this PR fixes that change.

## Specific Changes
Added Channel.Msteams to the list of channels which support the OAuthCard.

## Testing
No new tests required (private method) and no tests broken in the process.