### PR TITLE
[xUnit] Fix issues on AdaptiveExpressions.Tests

### DIFF
--- a/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             TestWithData(JObject.FromObject(data));
         }
 
-        public void TestWithData(object data)
+        internal void TestWithData(object data)
         {
             TestExpressionPropertyWithValue<byte>("ByteNum", 1, data);
             TestExpressionPropertyWithValue<byte>("=ByteNum", 1, data);
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             TestExpressionPropertyWithValue<List<string>>("=createArray('a','b','c')", list, data);
         }
 
-        public void TestExpressionPropertyWithValue<T>(string value, T expected, object memory = null)
+        internal void TestExpressionPropertyWithValue<T>(string value, T expected, object memory = null)
         {
             var ep = new ExpressionProperty<T>(value);
             var (result, error) = ep.TryGetValue(memory ?? new object());
@@ -105,13 +105,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             }
 
             Assert.Null(error);
-        }
-
-        public void TestErrorExpression<T>(string value, object memory = null)
-        {
-            var ep = new ExpressionProperty<T>(value);
-            var (result, error) = ep.TryGetValue(memory ?? new object());
-            Assert.NotNull(error);
         }
 
         [Fact]

--- a/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             TestWithData(JObject.FromObject(data));
         }
 
-        internal void TestWithData(object data)
+        private void TestWithData(object data)
         {
             TestExpressionPropertyWithValue<byte>("ByteNum", 1, data);
             TestExpressionPropertyWithValue<byte>("=ByteNum", 1, data);
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             TestExpressionPropertyWithValue<List<string>>("=createArray('a','b','c')", list, data);
         }
 
-        internal void TestExpressionPropertyWithValue<T>(string value, T expected, object memory = null)
+        private void TestExpressionPropertyWithValue<T>(string value, T expected, object memory = null)
         {
             var ep = new ExpressionProperty<T>(value);
             var (result, error) = ep.TryGetValue(memory ?? new object());

--- a/tests/AdaptiveExpressions.Tests/LRUCacheTest.cs
+++ b/tests/AdaptiveExpressions.Tests/LRUCacheTest.cs
@@ -116,7 +116,7 @@ namespace AdaptiveExpressions.Tests
             }
         }
 
-        internal void StoreElement(LRUCache<int, int> cache, int numOfOps, int idx)
+        private void StoreElement(LRUCache<int, int> cache, int numOfOps, int idx)
         {
             for (var i = 0; i < numOfOps; i++)
             {

--- a/tests/AdaptiveExpressions.Tests/LRUCacheTest.cs
+++ b/tests/AdaptiveExpressions.Tests/LRUCacheTest.cs
@@ -46,10 +46,10 @@ namespace AdaptiveExpressions.Tests
             var cache = new LRUCache<int, int>(2);
             cache.Set(0, 1);
             cache.Set(1, 1);
-            var fib9999 = 1242044891;
-            var fib100000 = 2132534333;
-            var maxIdx = 10000;
-            for (int i = 2; i <= maxIdx; i++)
+            const int fib9999 = 1242044891;
+            const int fib100000 = 2132534333;
+            const int maxIdx = 10000;
+            for (var i = 2; i <= maxIdx; i++)
             {
                 cache.TryGet(i - 2,  out var prev2);
                 cache.TryGet(i - 1, out var prev1);
@@ -74,10 +74,10 @@ namespace AdaptiveExpressions.Tests
             var cache = new LRUCache<int, int>(500);
             cache.Set(0, 1);
             cache.Set(1, 1);
-            var fib9999 = 1242044891;
-            var fib100000 = 2132534333;
-            var maxIdx = 10000; 
-            for (int i = 2; i <= 10000; i++)
+            const int fib9999 = 1242044891;
+            const int fib100000 = 2132534333;
+            const int maxIdx = 10000; 
+            for (var i = 2; i <= 10000; i++)
             {
                 cache.TryGet(i - 2, out var prev2);
                 cache.TryGet(i - 1, out var prev1);
@@ -101,8 +101,8 @@ namespace AdaptiveExpressions.Tests
         {
             var cache = new LRUCache<int, int>(10);
             var tasks = new List<Task>();
-            var numOfThreads = 10;
-            var numOfOps = 1000;
+            const int numOfThreads = 10;
+            const int numOfOps = 1000;
             for (var i = 0; i < numOfThreads; i++)
             {
                 tasks.Add(Task.Run(() => StoreElement(cache, numOfOps, i)));
@@ -116,9 +116,9 @@ namespace AdaptiveExpressions.Tests
             }
         }
 
-        public void StoreElement(LRUCache<int, int> cache, int numOfOps, int idx)
+        internal void StoreElement(LRUCache<int, int> cache, int numOfOps, int idx)
         {
-            for (int i = 0; i < numOfOps; i++)
+            for (var i = 0; i < numOfOps; i++)
             {
                 var key = i;
                 var value = i;


### PR DESCRIPTION
Addresses #4349

## Description
This PR fixes the xUnit1013 issue in **[AdaptiveExpression.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/AdaptiveExpressions.Tests)** project.

![image](https://user-images.githubusercontent.com/44245136/91736024-7b4b5880-eb83-11ea-83cd-07e5d4ab704a.png)


## Specific Changes
- **_ExpressionPropertyTests_**
      - Fixed xUnit1013 issue by changing the access modifier to private in _TestWithData_ and _TestExpressionPropertyWithValue_ methods.
      - Remove unused method _TestErrorExpression_.  

- **_LRUCacheTest_**
       - Fixed xUnit1013 issue by changing the access modifier to private in _StoreElement_ method.
      - Changed var for const when corresponded.
      - Use var instead of int.

## Testing
The next image shows the tests passing after the changes made:
![image](https://user-images.githubusercontent.com/44245136/91736576-455aa400-eb84-11ea-8313-8d55e9d31f90.png)
