### PR TITLE
[xUnit] Fix issues on Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var semanticAction = activity.SemanticAction;
             Assert.Equal("actionId", semanticAction.Id);
             Assert.Equal(1, semanticAction.Entities.Count);
-            Assert.Equal(true, semanticAction.Entities.ContainsKey("key1"));
+            Assert.True(semanticAction.Entities.ContainsKey("key1"));
             Assert.Equal("entityType", semanticAction.Entities["key1"].Type);
 
             Assert.Equal(1, activity.Attachments.Count);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             // there is no 'greeting' template in b.en-us.lg, no more fallback to b.lg
             var ex = await Assert.ThrowsAsync<Exception>(async () => await generator.GenerateAsync(GetDialogContext(), "${greeting()}", null));
-            Assert.True(ex.Message.Contains("greeting does not have an evaluator"));
+            Assert.Contains("greeting does not have an evaluator", ex.Message);
 
             resource = resourceExplorer.GetResource("a.lg") as FileResource;
             generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);


### PR DESCRIPTION
Addresses #4349

## Description
This PR fixes xUnit2004 and xUnit2009 issues in **[Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests)** project.

![image](https://user-images.githubusercontent.com/62260472/91747898-6a0b4780-eb95-11ea-9942-6a21755ea4d2.png)

## Specific Changes
- **_ActivityFactoryTests_**
      - Fixed xUnit2004 issue by changing `Assert.Equal` to `Assert.True`.

- **_LGGeneratorTests_**
      - Fixed xUnit2009 issue by changing `Assert.True` to `Assert.Contains`.

## Testing
The next image shows the tests passing after the changes made:
![image](https://user-images.githubusercontent.com/62260472/91748183-f3227e80-eb95-11ea-872f-8f434e927b9a.png)