### PR TITLE
[xUnit] Fix issues on Microsoft.Bot.Builder.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.Equal(state, stateFormEvent);
 
             var messageFormEvent = (handoffEvent.Value as JObject)?.Value<string>("message");
-            Assert.Equal(null, messageFormEvent);
+            Assert.Null(messageFormEvent);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
@@ -240,6 +240,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             Assert.Equal(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
         }
 
+        [Fact]
         public async Task TestMessagingExtensionSubmitAction()
         {
             // Arrange

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -266,10 +266,10 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 var cancelToken = new CancellationToken();
                 var reference = await TeamsInfo.SendMessageToTeamsChannelAsync(turnContext, message, channelId, creds, cancelToken);
 
-                Assert.Equal(reference.Item1.ActivityId, "activityId123");
-                Assert.Equal(reference.Item1.ChannelId, channelId);
-                Assert.Equal(reference.Item1.ServiceUrl, turnContext.Activity.ServiceUrl);
-                Assert.Equal(reference.Item2, "activityId123");
+                Assert.Equal("activityId123", reference.Item1.ActivityId);
+                Assert.Equal(channelId, reference.Item1.ChannelId);
+                Assert.Equal(turnContext.Activity.ServiceUrl, reference.Item1.ServiceUrl);
+                Assert.Equal("activityId123", reference.Item2);
             }
 
             private async Task CallGetTeamDetailsAsync(ITurnContext turnContext)

--- a/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
@@ -589,7 +589,8 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.True(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1])["TeamsTenantId"] == "tenantId");
             Assert.True(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1])["TeamsTeamInfo"] == JsonConvert.SerializeObject(teamInfo));
         }
-      
+
+        [Fact]
         public async Task DoNotThrowOnNullActivity()
         {
             // Arrange

--- a/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
@@ -13,192 +13,6 @@ namespace Microsoft.Bot.Builder.Tests
 {
     public class Transcript_MiddlewareTests
     {
-        public static async Task LogActivitiesTest(ITranscriptStore transcriptStore)
-        {
-            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-            TestAdapter adapter = new TestAdapter(conversation)
-                .Use(new TranscriptLoggerMiddleware(transcriptStore));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-            {
-                var typingActivity = new Activity
-                {
-                    Type = ActivityTypes.Typing,
-                    RelatesTo = context.Activity.RelatesTo
-                };
-                await context.SendActivityAsync(typingActivity);
-                await Task.Delay(50);
-                await context.SendActivityAsync("echo:" + context.Activity.Text);
-            })
-                .Send("foo")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
-                    .AssertReply("echo:foo")
-                .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
-                    .AssertReply("echo:bar")
-                .StartTestAsync();
-
-            await Task.Delay(100);
-
-            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(6, pagedResult.Items.Length);
-            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
-            Assert.NotNull(pagedResult.Items[1].AsTypingActivity());
-            Assert.Equal("echo:foo", pagedResult.Items[2].AsMessageActivity().Text);
-            Assert.Equal("bar", pagedResult.Items[3].AsMessageActivity().Text);
-            Assert.NotNull(pagedResult.Items[4].AsTypingActivity());
-            Assert.Equal("echo:bar", pagedResult.Items[5].AsMessageActivity().Text);
-            foreach (var activity in pagedResult.Items)
-            {
-                Assert.True(!string.IsNullOrWhiteSpace(activity.Id));
-                Assert.True(activity.Timestamp > default(DateTimeOffset));
-            }
-        }
-
-        public static async Task EnsureToLogActivitiesWithIdsTest(ITranscriptStore transcriptStore)
-        {
-            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-            var adapter = new AllowNullIdTestAdapter(conversation)
-                .Use(new TranscriptLoggerMiddleware(transcriptStore));
-
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-            {
-                var activityWithId = new Activity
-                {
-                    Id = "TestActivityWithId",
-                    Text = "I am an activity with an Id.",
-                    Type = ActivityTypes.Message,
-                    RelatesTo = context.Activity.RelatesTo
-                };
-                var activityWithNullId = new Activity
-                {
-                    Id = null,
-                    Text = "My Id is null.",
-                    Type = ActivityTypes.Message,
-                    RelatesTo = context.Activity.RelatesTo
-                };
-                
-                await context.SendActivityAsync(activityWithId);
-                await context.SendActivityAsync(activityWithId);
-
-                await context.SendActivityAsync(activityWithNullId);
-            })
-                 .Send("inbound message to TestFlow")
-                    .AssertReply("I am an activity with an Id.")
-                 .Send("2nd inbound message to TestFlow")
-                   .AssertReply((activity) => Assert.Equal(activity.Id, "TestActivityWithId"))
-                 .Send("3rd inbound message to TestFlow")
-                   .AssertReply("My Id is null.")
-                 .StartTestAsync();
-
-            await Task.Delay(100);
-
-            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(12, pagedResult.Items.Length);
-            Assert.Equal("inbound message to TestFlow", pagedResult.Items[0].AsMessageActivity().Text);
-            Assert.NotNull(pagedResult.Items[1].AsMessageActivity());
-            Assert.Equal("I am an activity with an Id.", pagedResult.Items[1].AsMessageActivity().Text);
-            Assert.Equal("2nd inbound message to TestFlow", pagedResult.Items[4].AsMessageActivity().Text);
-            Assert.Equal("TestActivityWithId", pagedResult.Items[5].Id);
-            Assert.Equal("3rd inbound message to TestFlow", pagedResult.Items[8].AsMessageActivity().Text);
-            Assert.Equal("My Id is null.", pagedResult.Items[11].AsMessageActivity().Text);
-            Assert.Contains("g_", pagedResult.Items[11].AsMessageActivity().Id);
-            foreach (var activity in pagedResult.Items)
-            {
-                Assert.True(activity.Timestamp > default(DateTimeOffset));
-            }
-        }
-
-        public static async Task LogUpdateActivitiesTest(ITranscriptStore transcriptStore)
-        {
-            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-            TestAdapter adapter = new TestAdapter(conversation)
-                .Use(new TranscriptLoggerMiddleware(transcriptStore));
-            Activity activityToUpdate = null;
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-            {
-                if (context.Activity.Text == "update")
-                {
-                    activityToUpdate.Text = "new response";
-                    await context.UpdateActivityAsync(activityToUpdate);
-                }
-                else
-                {
-                    var activity = context.Activity.CreateReply("response");
-                    var response = await context.SendActivityAsync(activity);
-                    activity.Id = response.Id;
-
-                    // clone the activity, so we can use it to do an update
-                    activityToUpdate = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
-                }
-            })
-                .Send("foo")
-                .Send("update")
-                    .AssertReply("new response")
-                .StartTestAsync();
-
-            await Task.Delay(100);
-
-            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
-            Assert.Equal(3, pagedResult.Items.Length);
-            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
-            Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
-            Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
-        }
-
-        public static async Task TestDateLogUpdateActivitiesTest(ITranscriptStore transcriptStore)
-        {
-            var dateTimeStartOffset1 = new DateTimeOffset(DateTime.Now);
-            var dateTimeStartOffset2 = new DateTimeOffset(DateTime.UtcNow);
-
-            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
-            TestAdapter adapter = new TestAdapter(conversation)
-                .Use(new TranscriptLoggerMiddleware(transcriptStore));
-            Activity activityToUpdate = null;
-            await new TestFlow(adapter, async (context, cancellationToken) =>
-            {
-                if (context.Activity.Text == "update")
-                {
-                    activityToUpdate.Text = "new response";
-                    await context.UpdateActivityAsync(activityToUpdate);
-                }
-                else
-                {
-                    var activity = context.Activity.CreateReply("response");
-
-                    var response = await context.SendActivityAsync(activity);
-                    activity.Id = response.Id;
-
-                    // clone the activity, so we can use it to do an update
-                    activityToUpdate = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
-                }
-            })
-                .Send("foo")
-                .Send("update")
-                    .AssertReply("new response")
-                .StartTestAsync();
-
-            await Task.Delay(100);
-
-            // Perform some queries
-            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, dateTimeStartOffset1.DateTime);
-            Assert.Equal(3, pagedResult.Items.Length);
-            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
-            Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
-            Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
-
-            // Perform some queries
-            pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MinValue);
-            Assert.Equal(3, pagedResult.Items.Length);
-            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
-            Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
-            Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
-
-            // Perform some queries
-            pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MaxValue);
-            Assert.Equal(0, pagedResult.Items.Length);
-        }
-
         [Fact]
         public async Task MemoryTranscript_EnsureToLogActivitiesWithIdsTest()
         {
@@ -294,6 +108,192 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.NotNull(pagedResult.Items[1].AsMessageDeleteActivity());
             Assert.Equal(ActivityTypes.MessageDelete, pagedResult.Items[1].Type);
             Assert.Equal("deleteIt", pagedResult.Items[2].AsMessageActivity().Text);
+        }
+
+        private static async Task LogActivitiesTest(ITranscriptStore transcriptStore)
+        {
+            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
+            TestAdapter adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(transcriptStore));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var typingActivity = new Activity
+                {
+                    Type = ActivityTypes.Typing,
+                    RelatesTo = context.Activity.RelatesTo
+                };
+                await context.SendActivityAsync(typingActivity);
+                await Task.Delay(50);
+                await context.SendActivityAsync("echo:" + context.Activity.Text);
+            })
+                .Send("foo")
+                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:foo")
+                .Send("bar")
+                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply("echo:bar")
+                .StartTestAsync();
+
+            await Task.Delay(100);
+
+            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
+            Assert.Equal(6, pagedResult.Items.Length);
+            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+            Assert.NotNull(pagedResult.Items[1].AsTypingActivity());
+            Assert.Equal("echo:foo", pagedResult.Items[2].AsMessageActivity().Text);
+            Assert.Equal("bar", pagedResult.Items[3].AsMessageActivity().Text);
+            Assert.NotNull(pagedResult.Items[4].AsTypingActivity());
+            Assert.Equal("echo:bar", pagedResult.Items[5].AsMessageActivity().Text);
+            foreach (var activity in pagedResult.Items)
+            {
+                Assert.True(!string.IsNullOrWhiteSpace(activity.Id));
+                Assert.True(activity.Timestamp > default(DateTimeOffset));
+            }
+        }
+
+        private static async Task EnsureToLogActivitiesWithIdsTest(ITranscriptStore transcriptStore)
+        {
+            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
+            var adapter = new AllowNullIdTestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(transcriptStore));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var activityWithId = new Activity
+                {
+                    Id = "TestActivityWithId",
+                    Text = "I am an activity with an Id.",
+                    Type = ActivityTypes.Message,
+                    RelatesTo = context.Activity.RelatesTo
+                };
+                var activityWithNullId = new Activity
+                {
+                    Id = null,
+                    Text = "My Id is null.",
+                    Type = ActivityTypes.Message,
+                    RelatesTo = context.Activity.RelatesTo
+                };
+
+                await context.SendActivityAsync(activityWithId);
+                await context.SendActivityAsync(activityWithId);
+
+                await context.SendActivityAsync(activityWithNullId);
+            })
+                 .Send("inbound message to TestFlow")
+                    .AssertReply("I am an activity with an Id.")
+                 .Send("2nd inbound message to TestFlow")
+                   .AssertReply((activity) => Assert.Equal("TestActivityWithId", activity.Id))
+                 .Send("3rd inbound message to TestFlow")
+                   .AssertReply("My Id is null.")
+                 .StartTestAsync();
+
+            await Task.Delay(100);
+
+            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
+            Assert.Equal(12, pagedResult.Items.Length);
+            Assert.Equal("inbound message to TestFlow", pagedResult.Items[0].AsMessageActivity().Text);
+            Assert.NotNull(pagedResult.Items[1].AsMessageActivity());
+            Assert.Equal("I am an activity with an Id.", pagedResult.Items[1].AsMessageActivity().Text);
+            Assert.Equal("2nd inbound message to TestFlow", pagedResult.Items[4].AsMessageActivity().Text);
+            Assert.Equal("TestActivityWithId", pagedResult.Items[5].Id);
+            Assert.Equal("3rd inbound message to TestFlow", pagedResult.Items[8].AsMessageActivity().Text);
+            Assert.Equal("My Id is null.", pagedResult.Items[11].AsMessageActivity().Text);
+            Assert.Contains("g_", pagedResult.Items[11].AsMessageActivity().Id);
+            foreach (var activity in pagedResult.Items)
+            {
+                Assert.True(activity.Timestamp > default(DateTimeOffset));
+            }
+        }
+
+        private static async Task LogUpdateActivitiesTest(ITranscriptStore transcriptStore)
+        {
+            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
+            TestAdapter adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(transcriptStore));
+            Activity activityToUpdate = null;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Text == "update")
+                {
+                    activityToUpdate.Text = "new response";
+                    await context.UpdateActivityAsync(activityToUpdate);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("response");
+                    var response = await context.SendActivityAsync(activity);
+                    activity.Id = response.Id;
+
+                    // clone the activity, so we can use it to do an update
+                    activityToUpdate = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+                }
+            })
+                .Send("foo")
+                .Send("update")
+                    .AssertReply("new response")
+                .StartTestAsync();
+
+            await Task.Delay(100);
+
+            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id);
+            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+            Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
+            Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
+        }
+
+        private static async Task TestDateLogUpdateActivitiesTest(ITranscriptStore transcriptStore)
+        {
+            var dateTimeStartOffset1 = new DateTimeOffset(DateTime.Now);
+            var dateTimeStartOffset2 = new DateTimeOffset(DateTime.UtcNow);
+
+            var conversation = TestAdapter.CreateConversation(Guid.NewGuid().ToString("n"));
+            TestAdapter adapter = new TestAdapter(conversation)
+                .Use(new TranscriptLoggerMiddleware(transcriptStore));
+            Activity activityToUpdate = null;
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                if (context.Activity.Text == "update")
+                {
+                    activityToUpdate.Text = "new response";
+                    await context.UpdateActivityAsync(activityToUpdate);
+                }
+                else
+                {
+                    var activity = context.Activity.CreateReply("response");
+
+                    var response = await context.SendActivityAsync(activity);
+                    activity.Id = response.Id;
+
+                    // clone the activity, so we can use it to do an update
+                    activityToUpdate = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+                }
+            })
+                .Send("foo")
+                .Send("update")
+                    .AssertReply("new response")
+                .StartTestAsync();
+
+            await Task.Delay(100);
+
+            // Perform some queries
+            var pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, dateTimeStartOffset1.DateTime);
+            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+            Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
+            Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
+
+            // Perform some queries
+            pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MinValue);
+            Assert.Equal(3, pagedResult.Items.Length);
+            Assert.Equal("foo", pagedResult.Items[0].AsMessageActivity().Text);
+            Assert.Equal("new response", pagedResult.Items[1].AsMessageActivity().Text);
+            Assert.Equal("update", pagedResult.Items[2].AsMessageActivity().Text);
+
+            // Perform some queries
+            pagedResult = await transcriptStore.GetTranscriptActivitiesAsync(conversation.ChannelId, conversation.Conversation.Id, null, DateTimeOffset.MaxValue);
+            Assert.Empty(pagedResult.Items);
         }
 
         private FileTranscriptLogger GetFileTranscriptLogger()

--- a/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TurnContextTests.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Bot.Builder.Tests
             }
         }
 
-        public async Task MyBotLogic(ITurnContext turnContext, CancellationToken cancellationToken)
+        private async Task MyBotLogic(ITurnContext turnContext, CancellationToken cancellationToken)
         {
             switch (turnContext.Activity.AsMessageActivity().Text)
             {


### PR DESCRIPTION
Addresses #4349

## Description
This PR fixes xUnit1013, xUnit2000 and xUnit2003 issues in **[Microsoft.Bot.Builder.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Tests)** project.

![image](https://user-images.githubusercontent.com/62260472/91751757-b3f72c00-eb9b-11ea-91ce-2e7e8dbc83a8.png)

## Specific Changes
- **_EventFactoryTests_**
      - Fixed xUnit2003 issue by changing `Assert.Equal` to `Assert.Null`.

- **_TeamsActivityHandlerNotImplementedTests_**
      - Fixed xUnit1013 issue by adding `[Fact]` to a test.

- **_TeamsInfoTests_**
      - Fixed xUnit2000 issue by changing the **expected** and **actual** values.

- **_TelemetryMiddlewareTests_**
      - Fixed xUnit1013 issue by adding `[Fact]` to a test.

- **_Transcript_MiddlewareTests_**
      - Fixed xUnit1013 issue by changing the access modifier to `private` in multiple methods.
      - Fixed xUnit2000 issue by changing the **expected** and **actual** values.
      - Fixed xUnit2003 issue by changing `Assert.Equal` to `Assert.Empty`.

- **_Transcript_MiddlewareTests_**
      - Fixed xUnit1013 issue by changing the access modifier to `private` in the `MyBotLogic` method.

## Testing
The next image shows the tests passing after the changes made:
![image](https://user-images.githubusercontent.com/62260472/91753364-2bc65600-eb9e-11ea-89ce-5aa355f66d5e.png)