### PR TITLE
Make DisplayQnAResultAsync protected

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -512,7 +512,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// <param name="stepContext">stepContext.</param>
         /// <param name="cancellationToken">cancellationToken.</param>
         /// <returns>An object of Task of type <see cref="DialogTurnResult"></see>.</returns>
-        protected async Task<DialogTurnResult> DisplayQnAResultAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        protected virtual async Task<DialogTurnResult> DisplayQnAResultAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
         {
             var dialogOptions = ObjectPath.GetPathValue<QnAMakerDialogOptions>(stepContext.ActiveDialog.State, Options);
             var reply = stepContext.Context.Activity.Text;

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -505,7 +505,62 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 CardNoMatchResponse = await this.CardNoMatchResponse.BindAsync(dc).ConfigureAwait(false)
             };
         }
-        
+
+        /// <summary>
+        /// Displays QnA Result from stepContext through Activity - with first answer from QnA Maker response.
+        /// </summary>
+        /// <param name="stepContext">stepContext.</param>
+        /// <param name="cancellationToken">cancellationToken.</param>
+        /// <returns>An object of Task of type <see cref="DialogTurnResult"></see>.</returns>
+        protected async Task<DialogTurnResult> DisplayQnAResultAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            var dialogOptions = ObjectPath.GetPathValue<QnAMakerDialogOptions>(stepContext.ActiveDialog.State, Options);
+            var reply = stepContext.Context.Activity.Text;
+
+            if (reply.Equals(dialogOptions.ResponseOptions.CardNoMatchText, StringComparison.OrdinalIgnoreCase))
+            {
+                var activity = dialogOptions.ResponseOptions.CardNoMatchResponse;
+                if (activity == null)
+                {
+                    await stepContext.Context.SendActivityAsync(DefaultCardNoMatchResponse, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await stepContext.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+
+                return await stepContext.EndDialogAsync().ConfigureAwait(false);
+            }
+
+            // If previous QnAId is present, replace the dialog
+            var previousQnAId = ObjectPath.GetPathValue<int>(stepContext.ActiveDialog.State, PreviousQnAId, 0);
+            if (previousQnAId > 0)
+            {
+                // restart the waterfall to step 0
+                return await RunStepAsync(stepContext, index: 0, reason: DialogReason.BeginCalled, result: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            // If response is present then show that response, else default answer.
+            if (stepContext.Result is List<QueryResult> response && response.Count > 0)
+            {
+                await stepContext.Context.SendActivityAsync(response.First().Answer, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var activity = dialogOptions.ResponseOptions.NoAnswer;
+                if (activity == null)
+                {
+                    await stepContext.Context.SendActivityAsync(DefaultNoAnswer, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await stepContext.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return await stepContext.EndDialogAsync().ConfigureAwait(false);
+        }
+
         private static void ResetOptions(DialogContext dc, QnAMakerDialogOptions dialogOptions)
         {
             // Resetting context and QnAId
@@ -692,55 +747,6 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             }
 
             return await stepContext.NextAsync(stepContext.Result, cancellationToken).ConfigureAwait(false);
-        }
-
-        private async Task<DialogTurnResult> DisplayQnAResultAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
-        {
-            var dialogOptions = ObjectPath.GetPathValue<QnAMakerDialogOptions>(stepContext.ActiveDialog.State, Options);
-            var reply = stepContext.Context.Activity.Text;
-
-            if (reply.Equals(dialogOptions.ResponseOptions.CardNoMatchText, StringComparison.OrdinalIgnoreCase))
-            {
-                var activity = dialogOptions.ResponseOptions.CardNoMatchResponse;
-                if (activity == null)
-                {
-                    await stepContext.Context.SendActivityAsync(DefaultCardNoMatchResponse, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await stepContext.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-
-                return await stepContext.EndDialogAsync().ConfigureAwait(false);
-            }
-
-            // If previous QnAId is present, replace the dialog
-            var previousQnAId = ObjectPath.GetPathValue<int>(stepContext.ActiveDialog.State, PreviousQnAId, 0);
-            if (previousQnAId > 0)
-            {
-                // restart the waterfall to step 0
-                return await RunStepAsync(stepContext, index: 0, reason: DialogReason.BeginCalled, result: null, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-
-            // If response is present then show that response, else default answer.
-            if (stepContext.Result is List<QueryResult> response && response.Count > 0)
-            {
-                await stepContext.Context.SendActivityAsync(response.First().Answer, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                var activity = dialogOptions.ResponseOptions.NoAnswer;
-                if (activity == null)
-                {
-                    await stepContext.Context.SendActivityAsync(DefaultNoAnswer, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await stepContext.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            return await stepContext.EndDialogAsync().ConfigureAwait(false);
         }
 
         internal class ValueProperty


### PR DESCRIPTION
Fixes #4510

## Description
Make DisplayQnAResultAsync method protected so that user has flexibility of changing the display of answer.
Example: Via adaptive cards

## Specific Changes
DisplayQnAResultAsync access modifier change
Refactor to bring it before private methods
Added comments


## Testing
Not a new feature