### PR TITLE
Allow resource explorer to accept the set of declarative type registrations

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         private readonly ConcurrentDictionary<string, Type> kindToType = new ConcurrentDictionary<string, Type>();
         private readonly ConcurrentDictionary<Type, List<string>> typeToKinds = new ConcurrentDictionary<Type, List<string>>();
         private List<ResourceProvider> resourceProviders = new List<ResourceProvider>();
+        private List<IComponentDeclarativeTypes> declarativeTypes;
         private CancellationTokenSource cancelReloadToken = new CancellationTokenSource();
         private ConcurrentBag<Resource> changedResources = new ConcurrentBag<Resource>();
         private bool typesLoaded = false;
@@ -49,9 +50,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// </summary>
         /// <param name="providers">The list of resource providers to initialize the current instance.</param>
         public ResourceExplorer(IEnumerable<ResourceProvider> providers)
-            : this()
+            : this(providers, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceExplorer"/> class.
+        /// </summary>
+        /// <param name="providers">The list of resource providers to initialize the current instance.</param>
+        /// <param name="declarativeTypes">A list of declarative types to use. Falls back to <see cref="ComponentRegistration.Components" /> if set to null.</param>
+        public ResourceExplorer(IEnumerable<ResourceProvider> providers, IEnumerable<IComponentDeclarativeTypes> declarativeTypes)
         {
             this.resourceProviders = providers.ToList();
+            this.declarativeTypes = declarativeTypes?.ToList();
         }
 
         /// <summary>
@@ -495,6 +506,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             Changed?.Invoke(this, resources);
         }
 
+        private IEnumerable<IComponentDeclarativeTypes> GetComponentRegistrations()
+        {
+            return this.declarativeTypes ?? ComponentRegistration.Components.OfType<IComponentDeclarativeTypes>();
+        }
+
         private void RegisterTypeInternal(string kind, Type type, ICustomDeserializer loader = null)
         {
             // Default loader if none specified
@@ -543,7 +559,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                     // this can be reentrant, and we only want to do once.
                     this.typesLoaded = true;
 
-                    foreach (var component in ComponentRegistration.Components.OfType<IComponentDeclarativeTypes>())
+                    foreach (var component in GetComponentRegistrations())
                     {
                         if (component != null)
                         {


### PR DESCRIPTION
## Description
The current implementation of ResourceExplorer requires declarative types to be defined statically. Power Virtual Agents has different implementations of certain extended declarative assets for design time vs runtime, and we expect possible variation in declarative types by Bot in the future. 

A multi-bot process that allows variable declarative type configuration would need to specify a set of declarative types in an instance-bound manner as opposed to a static manner. 

## Specific Changes
- Add a new constructor overload to `ResourceExplorer` that accepts an `IEnumerable<IComponentDeclarativeTypes>`. This field can be null, which is the default value when using other constructors. 
- When resolving declarative types, use the local field when available instead of the static `ComponentRegistration.Components`.

## Testing
- This is pending, will need some help from @tomlm to recommend a suggested course of action.