### PR TITLE
Update doc XML

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -126,10 +126,10 @@ namespace Microsoft.Bot.Builder.AI.Luis
         }
 
         /// <summary>
-        /// Gets the default HttpClient to be used when calling the LUIS API.
+        /// Gets the default <see cref="System.Net.Http.HttpClient"/> to use when calling the LUIS API.
         /// </summary>
         /// <value>
-        /// A <see cref="HttpClient"/>.
+        /// The default HTTP client to use.
         /// </value>
         [Obsolete("This property is deprecated and will be removed in future versions of the SDK.")]
         public static HttpClient DefaultHttpClient { get; private set; }


### PR DESCRIPTION
Fixes warnings that appear in the generated ref doc build

## Description
- Disambiguate class reference. 

## Specific Changes
- Update comments for LuisRecognizer.DefaultHttpClient.

## Testing
- Not sure how to test this. However, the change did not generate any new build warnings in VS, and the link in IntelliSense links to the correct class.