### PR TITLE
Migrate Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests to xUnit

### DIFF
--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -21,8 +21,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/ServiceResolutionTests.cs
@@ -7,19 +7,14 @@ using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Bot.Builder.ApplicationInsights;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
-    [TestClass]
-    [TestCategory("ApplicationInsights")]
+    [Trait("TestCategory", "ApplicationInsights")]
     public class ServiceResolutionTests
     {
-        public ServiceResolutionTests()
-        {
-        }
-
-        [TestMethod]
+        [Fact]
         public void AppSettings_NoBot_NoAppSettings()
         {
             ArrangeBotFile(null); // No bot file
@@ -30,14 +25,14 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             // Telemetry Client should be active, just not configured.
             // This is not an error condition so samples can degrade.
             var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsTrue(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(typeof(NullBotTelemetryClient), telemetryClient.GetType());
 
             // App Insights Telemetry obviously can't work.
-            Assert.IsTrue(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+            Assert.Null(server.Host.Services.GetService(typeof(TelemetryClient)));
         }
 
-        [TestMethod]
+        [Fact]
         public void AppSettings_NoBot_AppSettings_NoInstrumentation()
         {
             ArrangeBotFile(null); // No bot file
@@ -48,14 +43,14 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             // Telemetry Client should be active, just not configured.
             // This is not an error condition so samples can degrade.
             var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsTrue(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(typeof(NullBotTelemetryClient), telemetryClient.GetType());
 
             // App Insights Telemetry obviously can't work.
-            Assert.IsTrue(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+            Assert.Null(server.Host.Services.GetService(typeof(TelemetryClient)));
         }
 
-        [TestMethod]
+        [Fact]
         public void AppSettings_NoBot_AppSettings()
         {
             ArrangeBotFile(null); // No bot file
@@ -65,12 +60,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Telemetry Client should be active
             var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsFalse(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
-            Assert.IsFalse(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+            Assert.NotNull(telemetryClient);
+            Assert.NotEqual(typeof(NullBotTelemetryClient), telemetryClient.GetType());
+            Assert.NotNull(server.Host.Services.GetService(typeof(TelemetryClient)));
         }
 
-        [TestMethod]
+        [Fact]
         public void AppSettings_NoConfig_AppSettings()
         {
             ArrangeBotFile(null); // No bot file
@@ -80,12 +75,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Telemetry Client should be active
             var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsFalse(typeof(NullBotTelemetryClient).Equals(telemetryClient.GetType()));
-            Assert.IsFalse(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+            Assert.NotNull(telemetryClient);
+            Assert.NotEqual(typeof(NullBotTelemetryClient), telemetryClient.GetType());
+            Assert.NotNull(server.Host.Services.GetService(typeof(TelemetryClient)));
         }
 
-        [TestMethod]
+        [Fact]
         public void AppSettings_NoBot_AppSettings_InvalidKey()
         {
             ArrangeBotFile(null); // No bot file
@@ -96,124 +91,126 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
             // Bot Telemetry Client should be active.
             // This is not an error condition so samples can degrade.
             var telemetryClient = server.Host.Services.GetService(typeof(IBotTelemetryClient));
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsTrue(typeof(BotTelemetryClient).Equals(telemetryClient.GetType()));
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(typeof(BotTelemetryClient), telemetryClient.GetType());
 
             // App Insights just rolls with it.  It's technically invalid, but App Insights doesn't (currently) error even when logging.
-            Assert.IsFalse(server.Host.Services.GetService(typeof(TelemetryClient)) == null);
+            Assert.NotNull(server.Host.Services.GetService(typeof(TelemetryClient)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Botfile_NoAppSettings()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings(null); // No appsettings file
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<Startup>());
 
             // Telemetry Client should be active, just not configured.
             // This is not an error condition so samples can degrade.
             var telemetryClient = new TelemetryClient();
-            Assert.IsTrue(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
+            Assert.True(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
         }
 
-        [TestMethod]
+        [Fact]
         public void Botfile_NoAppInsights()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings("no_app_insights"); // Bad app insights appsettings file
 
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<Startup>());
 
             // Telemetry Client should be active, just not configured.
             // This is not an error condition so samples can degrade.
             var telemetryClient = new TelemetryClient();
-            Assert.IsTrue(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
+            Assert.True(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
         }
 
-        [TestMethod]
+        [Fact]
         public void Botfile_NoAppInsightsKey()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings("no_instrumentation_key"); // Bad app insights appsettings file
 
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<Startup>());
 
             // Telemetry Client should be active, just not configured.
             // This is not an error condition so samples can degrade.
             var telemetryClient = new TelemetryClient();
-            Assert.IsTrue(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
+            Assert.True(string.IsNullOrWhiteSpace(telemetryClient.InstrumentationKey));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(FileNotFoundException))]
+        [Fact]
         public void BotFile_NoBotFile()
         {
-            ArrangeBotFile(null); // No bot file
-            ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
-                .UseStartup<Startup>());
+            Assert.Throws<FileNotFoundException>(() =>
+            {
+                ArrangeBotFile(null); // No bot file
+                ArrangeAppSettings(); // Default app settings
+                new TestServer(new WebHostBuilder()
+                    .UseStartup<Startup>());
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void BotFile_NoAppInsightsInBot()
         {
             // Should default to the Null TelemetryClient
             ArrangeBotFile("no_app_insights"); // Invalid bot file
             ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<StartupVerifyNullTelemetry>());
         }
 
-        [TestMethod]
+        [Fact]
         public void ServiceResolution_GoodLoad()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<Startup>());
-            Assert.IsTrue(true);
         }
 
-        [TestMethod]
+        [Fact]
         public void ServiceResolution_VerifyTelemetryClient()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseApplicationInsights()
                 .UseStartup<StartupVerifyTelemetryClient>());
         }
 
-        [TestMethod]
+        [Fact]
         public void ServiceResolution_OverrideTelemetry()
         {
             ArrangeBotFile(); // Default bot file
             ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<StartupOverideTelemClient>());
-            Assert.IsTrue(true);
         }
 
-        [TestMethod]
+        [Fact]
         public void ServiceResolution_MultipleAppInsights()
         {
             ArrangeBotFile("multiple_app_insights"); // Default bot file
             ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
+            new TestServer(new WebHostBuilder()
                 .UseStartup<StartupMultipleAppInsights>());
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
+        [Fact]
         public void ServiceResolution_InvalidInstance()
         {
-            ArrangeBotFile("multiple_app_insights"); // Default bot file
-            ArrangeAppSettings(); // Default app settings
-            var server = new TestServer(new WebHostBuilder()
-                .UseStartup<StartupInvalidInstance>());
+            Assert.Throws<ArgumentException>(() =>
+            {
+                ArrangeBotFile("multiple_app_insights"); // Default bot file
+                ArrangeAppSettings(); // Default app settings
+                new TestServer(new WebHostBuilder()
+                    .UseStartup<StartupInvalidInstance>());
+            });
         }
 
         /// <summary>
@@ -222,7 +219,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         /// <remarks>Ensures appsettings.json file is set up (copy based on different sample files,
         /// post-pended with a version.)  ie, appsettings.json.no_app_insights. </remarks>
         /// <param name="version">Post-pended onto the file name to copy (ie, "no_app_insights"). If null, put no file.</param>
-        public void ArrangeAppSettings(string version = "default")
+        private void ArrangeAppSettings(string version = "default")
         {
             try
             {
@@ -244,7 +241,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
         /// <remarks>Ensures testbot.bot file is set up (copy based on different sample files,
         /// post-pended with a version.)  ie, testbot.bot.no_app_insights. </remarks>
         /// <param name="version">Post-pended onto the file name to copy (ie, "no_app_insights"). If null, put no file.</param>
-        public void ArrangeBotFile(string version = "default")
+        private void ArrangeBotFile(string version = "default")
         {
             try
             {

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Startup.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Startup.cs
@@ -4,7 +4,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Configuration;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -32,14 +31,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Startup.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Startup.cs
@@ -36,7 +36,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupAppSettingsOnly.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupAppSettingsOnly.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,18 +25,16 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddBotApplicationInsights(this.Configuration);
+            services.AddBotApplicationInsights(Configuration);
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupAppSettingsOnly.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupAppSettingsOnly.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
             Assert.NotNull(telemetryClient);
             Assert.Equal(typeof(NullBotTelemetryClient), telemetryClient.GetType());

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupInvalidInstance.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -32,17 +32,15 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsTrue(telemetryClient is NullBotTelemetryClient);
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(typeof(NullBotTelemetryClient), telemetryClient.GetType());
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
@@ -7,7 +7,7 @@ using Microsoft.Bot.Builder.ApplicationInsights;
 using Microsoft.Bot.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -34,17 +34,15 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsTrue(telemetryClient is BotTelemetryClient);
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(typeof(BotTelemetryClient), telemetryClient.GetType());
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupMultipleAppInsights.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
             Assert.NotNull(telemetryClient);
             Assert.Equal(typeof(BotTelemetryClient), telemetryClient.GetType());

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupNoParameters.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupNoParameters.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupNoParameters.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupNoParameters.cs
@@ -26,14 +26,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupOverideTelemClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupOverideTelemClient.cs
@@ -6,8 +6,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -31,22 +31,20 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void ConfigureServices(IServiceCollection services)
         {
-            var botConfig = BotConfiguration.Load("testbot.bot", null);
+            BotConfiguration.Load("testbot.bot", null);
             services.AddBotApplicationInsights(_telemClient.Object);
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
-            Assert.IsNotNull(telemetryClient);
-            Assert.AreEqual(telemetryClient, _telemClient.Object);
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(telemetryClient, _telemClient.Object);
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupOverideTelemClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupOverideTelemClient.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
             Assert.NotNull(telemetryClient);
             Assert.Equal(telemetryClient, _telemClient.Object);

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
             Assert.NotNull(telemetryClient);
             Assert.Equal(typeof(NullBotTelemetryClient), telemetryClient.GetType());

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyNullTelemetry.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -32,17 +32,15 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
             var telemetryClient = app.ApplicationServices.GetService<IBotTelemetryClient>();
-            Assert.IsNotNull(telemetryClient);
-            Assert.IsTrue(telemetryClient is NullBotTelemetryClient);
+            Assert.NotNull(telemetryClient);
+            Assert.Equal(typeof(NullBotTelemetryClient), telemetryClient.GetType());
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyTelemetryClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyTelemetryClient.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
@@ -32,15 +32,13 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             // Adding IConfiguration in sample test server.  Otherwise this appears to be
             // registered.
-            services.AddSingleton<IConfiguration>(this.Configuration);
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
-#pragma warning restore CS0618 // Type or member is obsolete
-            Assert.IsNotNull(app.ApplicationServices.GetService<IBotTelemetryClient>());
+            Assert.NotNull(app.ApplicationServices.GetService<IBotTelemetryClient>());
         }
     }
 }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyTelemetryClient.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/StartupVerifyTelemetryClient.cs
@@ -37,7 +37,9 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             app.UseBotApplicationInsights();
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.NotNull(app.ApplicationServices.GetService<IBotTelemetryClient>());
         }
     }

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/TelemetryInitializerTests.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
@@ -13,17 +11,16 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 {
-    [TestClass]
-    [TestCategory("ApplicationInsights")]
+    [Trait("TestCategory", "ApplicationInsights")]
     public class TelemetryInitializerTests
     {
-        [TestMethod]
+        [Fact]
         public void VerifyAllTelemtryPropoerties()
         {
             var configuration = new TelemetryConfiguration();
@@ -60,20 +57,20 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             telemetryClient.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as EventTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
-            Assert.IsTrue(telem.Properties["hello"] == "value");
-            Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
+            Assert.Equal("value", telem.Properties["hello"]);
+            Assert.Equal(0.6, telem.Metrics["metric"]);
         }
 
-        [TestMethod]
+        [Fact]
         public void VerifyOverriddenProperties()
         {
             var configuration = new TelemetryConfiguration();
@@ -121,37 +118,37 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                     0.6
                 },
             };
-            telemetryClient.TrackEvent("test", new Dictionary<string, string>()
+
+            var properties = new Dictionary<string, string>()
             {
                 { "activityId", activityIdValue },  // The activityId can be overridden.
                 { "channelId", channelIdValue },
                 { "activityType", activityTypeValue },
-            },
-#pragma warning disable SA1117 // Parameters should be on same line or separate lines
-            metrics);
-#pragma warning restore SA1117 // Parameters should be on same line or separate lines
+            };
 
-            Assert.IsTrue(sentItems.Count == 1);
+            telemetryClient.TrackEvent("test", properties, metrics);
+
+            Assert.Single(sentItems);
             var telem = sentItems[0] as EventTelemetry;
-            Assert.IsTrue(telem != null);
+            Assert.NotNull(telem);
 
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
 
             // The TelemetryInitializer honors being overridden
             // What we get out should be what we originally put in, and not what the Initializer
             // normally does.
-            Assert.IsFalse(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityId"] == activityIdValue);
-            Assert.IsTrue(telem.Properties["channelId"] == channelIdValue);
-            Assert.IsFalse(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["activityType"] == activityTypeValue);
-            Assert.IsFalse(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+            Assert.NotEqual(activityID, telem.Properties["activityId"]);
+            Assert.Equal(activityIdValue, telem.Properties["activityId"]);
+            Assert.Equal(channelIdValue, telem.Properties["channelId"]);
+            Assert.NotEqual("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(activityTypeValue, telem.Properties["activityType"]);
+            Assert.NotEqual("message", telem.Properties["activityType"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(0.6, telem.Metrics["metric"]);
         }
 
-        [TestMethod]
+        [Fact]
         public void VerifyTraceProperties()
         {
             var configuration = new TelemetryConfiguration();
@@ -188,18 +185,18 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             telemetryClient.TrackTrace("test");
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as TraceTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void VerifyRequestProperties()
         {
             var configuration = new TelemetryConfiguration();
@@ -236,18 +233,18 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             telemetryClient.TrackRequest("Foo", DateTimeOffset.Now, TimeSpan.FromSeconds(1.0), "response", true);
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as RequestTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void VerifyDependencyProperties()
         {
             var configuration = new TelemetryConfiguration();
@@ -284,18 +281,18 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             telemetryClient.TrackDependency("Foo", "Bar", "Data", DateTimeOffset.Now, TimeSpan.FromSeconds(1.0), true);
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as DependencyTelemetry;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(telem.Properties["activityId"] == activityID);
-            Assert.IsTrue(telem.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Properties["conversationId"] == conversationID);
-            Assert.IsTrue(telem.Context.Session.Id == sessionId);
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, telem.Properties["activityId"]);
+            Assert.Equal("message", telem.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(conversationID, telem.Properties["conversationId"]);
+            Assert.Equal(sessionId, telem.Context.Session.Id);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void InvalidMessage_NoConversation()
         {
             var configuration = new TelemetryConfiguration();
@@ -329,20 +326,20 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             telemetryClient.TrackEvent("test", new Dictionary<string, string>() { { "hello", "value" } }, new Dictionary<string, double>() { { "metric", 0.6 } });
 
-            Assert.IsTrue(sentItems.Count == 1);
+            Assert.Single(sentItems);
             var telem = sentItems[0] as EventTelemetry;
             var properties = (ISupportProperties)telem;
-            Assert.IsTrue(telem != null);
-            Assert.IsTrue(properties.Properties["activityId"] == activityID);
-            Assert.IsTrue(properties.Properties["activityType"] == "message");
-            Assert.IsTrue(telem.Properties["channelId"] == "CHANNELID");
-            Assert.IsTrue(telem.Context.User.Id == channelID + fromID);
-            Assert.IsTrue(telem.Properties["hello"] == "value");
-            Assert.IsTrue(telem.Metrics["metric"] == 0.6);
+            Assert.NotNull(telem);
+            Assert.Equal(activityID, properties.Properties["activityId"]);
+            Assert.Equal("message", properties.Properties["activityType"]);
+            Assert.Equal("CHANNELID", telem.Properties["channelId"]);
+            Assert.Equal(channelID + fromID, telem.Context.User.Id);
+            Assert.Equal("value", telem.Properties["hello"]);
+            Assert.Equal(0.6, telem.Metrics["metric"]);
         }
 
-        [TestMethod]
-        [TestCategory("Telemetry")]
+        [Fact]
+        [Trait("TestCategory", "Telemetry")]
         public async Task Telemetry_InitializerMiddleware_LogActivities_Enabled()
         {
             // Arrange
@@ -372,21 +369,21 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
             // Assert
-            Assert.IsNotNull(mockHttpContextAccessor.Object.HttpContext.Items);
-            Assert.IsTrue(mockHttpContextAccessor.Object.HttpContext.Items.Count == 1);
-            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 6);
+            Assert.NotNull(mockHttpContextAccessor.Object.HttpContext.Items);
+            Assert.Single(mockHttpContextAccessor.Object.HttpContext.Items);
+            Assert.Equal(6, mockTelemetryClient.Invocations.Count);
         }
 
-        [TestMethod]
-        [TestCategory("Telemetry")]
+        [Fact]
+        [Trait("TestCategory", "Telemetry")]
         public async Task Telemetry_InitializerMiddleware_LogActivities_Disabled()
         {
             // Arrange
@@ -416,21 +413,21 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
             // Assert
-            Assert.IsNotNull(mockHttpContextAccessor.Object.HttpContext.Items);
-            Assert.IsTrue(mockHttpContextAccessor.Object.HttpContext.Items.Count == 1);
-            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 0);
+            Assert.NotNull(mockHttpContextAccessor.Object.HttpContext.Items);
+            Assert.Single(mockHttpContextAccessor.Object.HttpContext.Items);
+            Assert.Empty(mockTelemetryClient.Invocations);
         }
 
-        [TestMethod]
-        [TestCategory("Telemetry")]
+        [Fact]
+        [Trait("TestCategory", "Telemetry")]
         public async Task Telemetry_InitializerMiddleware_Null_HttpContext_NoError()
         {
             // Arrange
@@ -459,16 +456,16 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.AreEqual(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
             // Assert
-            Assert.IsNull(mockHttpContextAccessor.Object.HttpContext);
-            Assert.AreEqual(mockTelemetryClient.Invocations.Count, 0);
+            Assert.Null(mockHttpContextAccessor.Object.HttpContext);
+            Assert.Empty(mockTelemetryClient.Invocations);
         }
     }
 }


### PR DESCRIPTION
Fixes #4108

## Description
This PR migrates all [Microsoft.Bot.Builder.Integration.ApplicationInsights.Core](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests) tests from **MSTest** to **xUnit**.

## Specific Changes
- Replaced `MSTest` packages with `xUnit` in the `.csproj`.
- Changed `[TestCategory]` to `[Trait]`.
- Changed `[TestMethod]` to `[Fact]`.
- Improved tests Assertions.

## Testing
In the following image there are the passing tests.
![imagen](https://user-images.githubusercontent.com/62260472/92130878-9ca68180-eddb-11ea-84ff-6736cf3b8339.png)