### PR TITLE
Add catch for JsonException in GetBodyContent.

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -211,7 +211,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
         private static T GetBodyContent<T>(string content)
         {
-            return JsonConvert.DeserializeObject<T>(content);
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(content);
+            }
+            catch (JsonException)
+            {
+                // This will only happen when the skill didn't return valid json in the content (e.g. when the status code is 500 or there's a bug in the skill)
+                return default;
+            }
         }
 
         private async Task<InvokeResponse<T>> SecurePostActivityAsync<T>(Uri toUrl, Activity activity, string token, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #4556

## Description
Added a catch for JsonExeption in GetBodyContent (this catch was in 4.7 but was removed in 4.8 when BotFrameworkHttpClient was refactored).
This catch allows the user to check the status code of the response (but the content won't be returned because its type us unknown). 