### PR TITLE
Add missing XML documentation to Bot.Builder.Dialogs.Adaptive/Recognizers

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </remarks>
     public class CrossTrainedRecognizerSet : Recognizer
     {
+        /// <summary>
+        /// Class idenfifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.CrossTrainedRecognizerSet";
 
@@ -39,6 +42,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// </summary>
         public const string DeferPrefix = "DeferToRecognizer_";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CrossTrainedRecognizerSet"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public CrossTrainedRecognizerSet([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(callerPath, callerLine)
@@ -56,6 +64,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         public List<Recognizer> Recognizers { get; set; } = new List<Recognizer>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Runs current DialogContext.TurnContext.Activity through a recognizer and returns a <see cref="RecognizerResult"/>.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="activity"><see cref="Activity"/> to recognize.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <param name="telemetryProperties">Optional, additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryMetrics">Optional, additional metrics to be logged to telemetry with the LuisResult event.</param>
+        /// <returns>Analysis of utterance.</returns>
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             if (dialogContext == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/AgeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/AgeEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes age input.
+    /// </summary>
     public class AgeEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.AgeEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgeEntityRecognizer"/> class.
+        /// </summary>
         public AgeEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Age recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberWithUnitRecognizer.RecognizeAge(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ConfirmationEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ConfirmationEntityRecognizer.cs
@@ -10,13 +10,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </summary>
     public class ConfirmationEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ConfirmationEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfirmationEntityRecognizer"/> class.
+        /// </summary>
         public ConfirmationEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Yes/no confirmation style input recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return ChoiceRecognizer.RecognizeBoolean(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/CurrencyEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/CurrencyEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes currency input.
+    /// </summary>
     public class CurrencyEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.CurrencyEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CurrencyEntityRecognizer"/> class.
+        /// </summary>
         public CurrencyEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Currency recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberWithUnitRecognizer.RecognizeCurrency(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DateTimeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DateTimeEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes DateTime input.
+    /// </summary>
     public class DateTimeEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DateTimeEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateTimeEntityRecognizer"/> class.
+        /// </summary>
         public DateTimeEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// DateTime recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return DateTimeRecognizer.RecognizeDateTime(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DimensionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DimensionEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes dimension input.
+    /// </summary>
     public class DimensionEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.DimensionEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DimensionEntityRecognizer"/> class.
+        /// </summary>
         public DimensionEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Dimension recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberWithUnitRecognizer.RecognizeDimension(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EmailEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EmailEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes email input.
+    /// </summary>
     public class EmailEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EmailEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailEntityRecognizer"/> class.
+        /// </summary>
         public EmailEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Email recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizeEmail(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
@@ -10,17 +10,38 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Entity recognizers base class.
+    /// </summary>
     public class EntityRecognizer
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityRecognizer"/> class.
+        /// </summary>
         public EntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Recognizes entities from an <see cref="Entity"/> list.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="entities">The enumerated <see cref="Entity"/> to be recognized.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> from the task.</param>
+        /// <returns>Recognized <see cref="Entity"/> list.</returns>
         public virtual Task<IEnumerable<Entity>> RecognizeEntitiesAsync(DialogContext dialogContext, IEnumerable<Entity> entities, CancellationToken cancellationToken = default)
         {
             return this.RecognizeEntitiesAsync(dialogContext, dialogContext.Context.Activity, entities, cancellationToken);
         }
 
+        /// <summary>
+        /// Recognizes entities from an <see cref="Entity"/> list.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="activity">The dialog's <see cref="Activity"/>.</param>
+        /// <param name="entities">The enumerated <see cref="Entity"/> to be recognized.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> from the task.</param>
+        /// <returns>Recognized <see cref="Entity"/> list.</returns>
         public virtual async Task<IEnumerable<Entity>> RecognizeEntitiesAsync(DialogContext dialogContext, Activity activity, IEnumerable<Entity> entities, CancellationToken cancellationToken = default)
         {
             if (activity.Type == ActivityTypes.Message)
@@ -31,6 +52,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             return new List<Entity>();
         }
 
+        /// <summary>
+        /// Recognizes entities from an <see cref="Entity"/> list.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="locale">Locale to use.</param>
+        /// <param name="entities">The enumerated <see cref="Entity"/> to be recognized.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> from the task.</param>
+        /// <returns>Recognized <see cref="Entity"/> list.</returns>
         public virtual Task<IEnumerable<Entity>> RecognizeEntitiesAsync(DialogContext dialogContext, string text, string locale, IEnumerable<Entity> entities, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IEnumerable<Entity>>(Array.Empty<Entity>());

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
@@ -12,13 +12,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </summary>
     public class EntityRecognizerSet : List<EntityRecognizer>
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.EntityRecognizerSet";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityRecognizerSet"/> class.
+        /// </summary>
         public EntityRecognizerSet()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntityRecognizerSet"/> class.
+        /// </summary>
+        /// <param name="recognizers"><see cref="EntityRecognizer"/> instances pool.</param>
         public EntityRecognizerSet(IEnumerable<EntityRecognizer> recognizers)
             : base(recognizers)
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/GuidEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/GuidEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes GUID input.
+    /// </summary>
     public class GuidEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.GuidEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuidEntityRecognizer"/> class.
+        /// </summary>
         public GuidEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// GUID recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizeGUID(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/HashtagEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/HashtagEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes hashtag input.
+    /// </summary>
     public class HashtagEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.HashtagEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HashtagEntityRecognizer"/> class.
+        /// </summary>
         public HashtagEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Hashtag recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizeHashtag(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/IpEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/IpEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes IP input.
+    /// </summary>
     public class IpEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.IpEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IpEntityRecognizer"/> class.
+        /// </summary>
         public IpEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// IP recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizeIpAddress(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes mention input.
+    /// </summary>
     public class MentionEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.MentionEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MentionEntityRecognizer"/> class.
+        /// </summary>
         public MentionEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Mention recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizeMention(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes number input.
+    /// </summary>
     public class NumberEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.NumberEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NumberEntityRecognizer"/> class.
+        /// </summary>
         public NumberEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Number recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberRecognizer.RecognizeNumber(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberRangeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberRangeEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes number range input.
+    /// </summary>
     public class NumberRangeEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.NumberRangeEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NumberRangeEntityRecognizer"/> class.
+        /// </summary>
         public NumberRangeEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Number range recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberRecognizer.RecognizeNumberRange(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/OrdinalEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/OrdinalEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes ordinal input.
+    /// </summary>
     public class OrdinalEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.OrdinalEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrdinalEntityRecognizer"/> class.
+        /// </summary>
         public OrdinalEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Ordinal recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberRecognizer.RecognizeOrdinal(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PercentageEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PercentageEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes percentage input.
+    /// </summary>
     public class PercentageEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.PercentageEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PercentageEntityRecognizer"/> class.
+        /// </summary>
         public PercentageEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Percentage recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberRecognizer.RecognizePercentage(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PhoneNumberEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PhoneNumberEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes phone number input.
+    /// </summary>
     public class PhoneNumberEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.PhoneNumberEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PhoneNumberEntityRecognizer"/> class.
+        /// </summary>
         public PhoneNumberEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Phone number recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizePhoneNumber(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/RegExEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/RegExEntityRecognizer.cs
@@ -7,21 +7,42 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Matches input against a regular expression.
+    /// </summary>
     public class RegexEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.RegexEntityRecognizer";
 
         private string pattern;
         private Regex regex;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegexEntityRecognizer"/> class.
+        /// </summary>
         public RegexEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Gets or sets the name match result TypeName value.
+        /// </summary>
+        /// <value>
+        /// Name value.
+        /// </value>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the regular expression pattern value.
+        /// </summary>
+        /// <value>
+        /// Pattern value.
+        /// </value>
         [JsonProperty("pattern")]
         public string Pattern
         {
@@ -37,6 +58,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             }
         }
 
+        /// <summary>
+        /// Match recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to match.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The matched <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             List<ModelResult> results = new List<ModelResult>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TemperatureEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TemperatureEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes temperature input.
+    /// </summary>
     public class TemperatureEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.TemperatureEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemperatureEntityRecognizer"/> class.
+        /// </summary>
         public TemperatureEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Temperature recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return NumberWithUnitRecognizer.RecognizeTemperature(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntity.cs
@@ -3,21 +3,40 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Text entity base class.
+    /// </summary>
     public class TextEntity : Entity
     {
+        /// <summary>
+        /// Result TypeName value.
+        /// </summary>
         public const string TypeName = "text";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextEntity"/> class.
+        /// </summary>
         public TextEntity()
             : base(TypeName)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextEntity"/> class.
+        /// </summary>
+        /// <param name="text">Text value.</param>
         public TextEntity(string text)
             : base(TypeName)
         {
             Text = text;
         }
 
+        /// <summary>
+        /// Gets or sets the text value.
+        /// </summary>
+        /// <value>
+        /// Text value.
+        /// </value>
         [JsonProperty("text")]
         public string Text { get; set; }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
@@ -17,10 +17,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     {
         private static JsonSerializer serializer = new JsonSerializer() { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextEntityRecognizer"/> class.
+        /// </summary>
         public TextEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// Recognizes entities from an <see cref="Entity"/> list.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="locale">Locale to use.</param>
+        /// <param name="entities">The enumerated <see cref="Entity"/> to be recognized.</param>
+        /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> from the task.</param>
+        /// <returns>Recognized <see cref="Entity"/> list.</returns>
         public override Task<IEnumerable<Entity>> RecognizeEntitiesAsync(DialogContext dialogContext, string text, string locale, IEnumerable<Entity> entities, CancellationToken cancellationToken = default)
         {
             List<Entity> newEntities = new List<Entity>();
@@ -42,6 +54,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             return Task.FromResult<IEnumerable<Entity>>(newEntities);
         }
 
+        /// <summary>
+        /// Text recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected abstract List<ModelResult> Recognize(string text, string culture);
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/UrlEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/UrlEntityRecognizer.cs
@@ -5,15 +5,30 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
+    /// <summary>
+    /// Recognizes URL input.
+    /// </summary>
     public class UrlEntityRecognizer : TextEntityRecognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.UrlEntityRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UrlEntityRecognizer"/> class.
+        /// </summary>
         public UrlEntityRecognizer()
         {
         }
 
+        /// <summary>
+        /// URL recognizing implementation.
+        /// </summary>
+        /// <param name="text">Text to recognize.</param>
+        /// <param name="culture"><see cref="Culture"/> to use.</param>
+        /// <returns>The recognized <see cref="ModelResult"/> list.</returns>
         protected override List<ModelResult> Recognize(string text, string culture)
         {
             return SequenceRecognizer.RecognizeURL(text, culture);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/IntentPattern.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/IntentPattern.cs
@@ -14,10 +14,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         private Regex regex;
         private string pattern;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntentPattern"/> class.
+        /// </summary>
         public IntentPattern()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntentPattern"/> class.
+        /// </summary>
+        /// <param name="intent">The intent.</param>
+        /// <param name="pattern">The regex pattern to match.</param>
         public IntentPattern(string intent, string pattern)
         {
             this.Intent = intent;
@@ -54,6 +62,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="Regex"/> instance.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Regex"/> instance.
+        /// </value>
         [JsonIgnore]
         public Regex Regex => this.regex;
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -16,9 +16,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </summary>
     public class MultiLanguageRecognizer : Recognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.MultiLanguageRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiLanguageRecognizer"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public MultiLanguageRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(callerPath, callerLine)
@@ -47,6 +55,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         public IDictionary<string, Recognizer> Recognizers { get; set; } = new Dictionary<string, Recognizer>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Runs current DialogContext.TurnContext.Activity through a recognizer and returns a <see cref="RecognizerResult"/>.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="activity"><see cref="Activity"/> to recognize.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <param name="telemetryProperties">Optional, additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryMetrics">Optional, additional metrics to be logged to telemetry with the LuisResult event.</param>
+        /// <returns>Analysis of utterance.</returns>
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             var policy = new List<string>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RecognizerSet.cs
@@ -25,9 +25,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </remarks>
     public class RecognizerSet : Recognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.RecognizerSet";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecognizerSet"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public RecognizerSet([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(callerPath, callerLine)
@@ -45,6 +53,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         public List<Recognizer> Recognizers { get; set; } = new List<Recognizer>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Runs current DialogContext.TurnContext.Activity through a recognizer and returns a <see cref="RecognizerResult"/>.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="activity"><see cref="Activity"/> to recognize.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <param name="telemetryProperties">Optional, additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryMetrics">Optional, additional metrics to be logged to telemetry with the LuisResult event.</param>
+        /// <returns>Analysis of utterance.</returns>
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             if (dialogContext == null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
@@ -21,9 +21,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </summary>
     public class RegexRecognizer : Recognizer
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.RegexRecognizer";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegexRecognizer"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public RegexRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(callerPath, callerLine)
@@ -52,6 +60,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         public List<EntityRecognizer> Entities { get; set; } = new List<EntityRecognizer>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Runs current DialogContext.TurnContext.Activity through a recognizer and returns a <see cref="RecognizerResult"/>.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="activity"><see cref="Activity"/> to recognize.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <param name="telemetryProperties">Optional, additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryMetrics">Optional, additional metrics to be logged to telemetry with the LuisResult event.</param>
+        /// <returns>Analysis of utterance.</returns>
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             // Identify matched intents


### PR DESCRIPTION
Address # 4321

## Description
This PR adds the missing XML documentation to all visible classes, methods, properties, and parameters in [Bot.Builder.Dialogs.Adaptive/Recognizers](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers), removing 104 errors.

Note: the NoWarn-CS1591 property is removed in the last PR of the series adding the documentation to avoid build failures.

## Specific Changes
- Adds all missing documentation instances to all *.cs* files found within *Microsoft.Bot.Builder.Dialogs.Adaptive* Recognizers directory.

## Testing
Below you can see the number of errors shown before and after the changes when de NoWarn-CS1591 property is removed.
![image](https://user-images.githubusercontent.com/38112957/92282102-64826a00-eed3-11ea-8ed6-2aaac4026ad7.png)
