### PR TITLE
Improve Facebook adapter diagnostics

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
@@ -86,8 +86,11 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                         var stringResponse = JsonConvert.DeserializeObject<FacebookResponseOk>(responseBody);
                         return stringResponse.MessageId;
                     }
-
-                    return string.Empty;
+                    else
+                    {
+                        // In Azure view this exception via Application Insights/Failures.
+                        throw new HttpRequestException($"SendMessageAsync(): {res.ToString()}");
+                    }
                 }
             }
         }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
@@ -63,14 +64,16 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendMessageAsyncShouldReturnAnEmptyStringWithWrongPath()
+        public async void SendMessageAsyncShouldThrowAnExceptionWithWrongPath()
         {
             var facebookMessageJson = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/FacebookMessages.json");
             var facebookMessage = JsonConvert.DeserializeObject<List<FacebookMessage>>(facebookMessageJson)[5];
             var facebookWrapper = new FacebookClientWrapper(_testOptions);
-            var response = await facebookWrapper.SendMessageAsync("wrongPath", facebookMessage, null, default(CancellationToken));
 
-            Assert.Equal(string.Empty, response);
+            await Assert.ThrowsAsync<HttpRequestException>(async () => 
+            {
+                await facebookWrapper.SendMessageAsync("wrongPath", facebookMessage, null, default(CancellationToken));
+            });
         }
 
         [Fact]


### PR DESCRIPTION
When Facebook rejects an http request through the Facebook adapter, that response is swallowed, making it hard to discover what happened.

This throws an exception containing the Facebook rejection message. That exception is discoverable in Azure via Application Insights/Failures.

An example Facebook rejection:

StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
{
  x-app-usage: {"call_count":0,"total_cputime":0,"total_time":0}
  WWW-Authenticate: OAuth "Facebook Platform" "invalid_request" "(#10) This message is sent outside of allowed window. Learn more about the new policy here: https://developers.facebook.com/docs/messenger-platform/policy-overview"
  facebook-api-version: v6.0
  Strict-Transport-Security: max-age=15552000; preload
  Pragma: no-cache
  x-fb-rev: 1002589312
  Access-Control-Allow-Origin: *
  Cache-Control: no-store
  x-fb-trace-id: Cjg3nf1GK0e
  x-fb-request-id: AjGe7SjF1twZHhcv5Ey63is
  X-FB-Debug: IMVdwzFYn9owk8GY810mKNVktIcuWfzjwvz3M8WyWxYOfsawj6RihPPXXhMRY5GZBvd8qLIoppyR0O8AIsw1OA==
  Date: Fri, 28 Aug 2020 22:30:46 GMT
  Alt-Svc: h3-29=":443"; ma=3600,h3-27=":443"; ma=3600
  Connection: keep-alive
  Content-Type: text/javascript; charset=UTF-8
  Expires: Sat, 01 Jan 2000 00:00:00 GMT
  Content-Length: 289
}
