### PR TITLE
Cherry-pick to 4.10 MultiLanguageRecognizer: Remove activity locale check while adding default policy

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                 policy.AddRange(targetpolicy);
             }
 
-            if (activity.Locale.Length != 0 && LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
+            if (LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
             {
                 // we now explictly add defaultPolicy instead of coding that into target's policy
                 policy.AddRange(defaultPolicy);


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/BotFramework-Composer/issues/4073
and
https://github.com/microsoft/botbuilder-dotnet/issues/4599