### PR TITLE
[#4096] Migrate Microsoft.Bot.Builder.Dialogs.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
@@ -15,11 +15,10 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class DialogManagerTests
     {
         // An App ID for a parent bot.
@@ -60,9 +59,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             LeafSkill
         }
 
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_ConversationState_PersistedAcrossTurns()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -80,7 +77,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_AlternateProperty()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -98,7 +95,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_ConversationState_ClearedAcrossConversations()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -122,7 +119,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_UserState_PersistedAcrossConversations()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -144,7 +141,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_UserState_NestedDialogs_PersistedAcrossConversations()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -169,25 +166,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_OnErrorEvent_Leaf()
         {
             await TestUtilities.RunTestScript();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_OnErrorEvent_Parent()
         {
             await TestUtilities.RunTestScript();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_OnErrorEvent_Root()
         {
             await TestUtilities.RunTestScript();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogManager_DialogSet()
         {
             var storage = new MemoryStorage();
@@ -230,20 +227,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dm.Dialogs.Add(new SimpleDialog() { Id = "test" });
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
-                {
-                    await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
-                })
+            {
+                await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+            })
                 .SendConversationUpdate()
                     .AssertReply("simple")
                     .AssertReply("simple")
                 .StartTestAsync();
         }
 
-        [TestMethod]
-        [DataRow(SkillFlowTestCase.RootBotOnly, false)]
-        [DataRow(SkillFlowTestCase.RootBotConsumingSkill, false)]
-        [DataRow(SkillFlowTestCase.MiddleSkill, true)]
-        [DataRow(SkillFlowTestCase.LeafSkill, true)]
+        [Theory]
+        [InlineData(SkillFlowTestCase.RootBotOnly, false)]
+        [InlineData(SkillFlowTestCase.RootBotConsumingSkill, false)]
+        [InlineData(SkillFlowTestCase.MiddleSkill, true)]
+        [InlineData(SkillFlowTestCase.LeafSkill, true)]
         public async Task HandlesBotAndSkillsTestCases(SkillFlowTestCase testCase, bool shouldSendEoc)
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -255,23 +252,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .Send("SomeName")
                 .AssertReply("Hello SomeName, nice to meet you!")
                 .StartTestAsync();
-            
-            Assert.AreEqual(DialogTurnStatus.Complete, _dmTurnResult.TurnResult.Status);
+
+            Assert.Equal(DialogTurnStatus.Complete, _dmTurnResult.TurnResult.Status);
 
             if (shouldSendEoc)
             {
-                Assert.IsNotNull(_eocSent, "Skills should send EndConversation to channel");
-                Assert.AreEqual(ActivityTypes.EndOfConversation, _eocSent.Type);
-                Assert.AreEqual("SomeName", _eocSent.Value);
-                Assert.AreEqual("en-GB", _eocSent.Locale);
+                Assert.NotNull(_eocSent);
+                Assert.Equal(ActivityTypes.EndOfConversation, _eocSent.Type);
+                Assert.Equal("SomeName", _eocSent.Value);
+                Assert.Equal("en-GB", _eocSent.Locale);
             }
             else
             {
-                Assert.IsNull(_eocSent, "Root bot should not send EndConversation to channel");
+                Assert.Null(_eocSent);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SkillHandlesEoCFromParent()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -287,10 +284,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .Send(eocActivity)
                 .StartTestAsync();
 
-            Assert.AreEqual(DialogTurnStatus.Cancelled, _dmTurnResult.TurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Cancelled, _dmTurnResult.TurnResult.Status);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SkillHandlesRepromptFromParent()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -307,10 +304,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .AssertReply("Hello, what is your name?")
                 .StartTestAsync();
 
-            Assert.AreEqual(DialogTurnStatus.Waiting, _dmTurnResult.TurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Waiting, _dmTurnResult.TurnResult.Status);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SkillShouldReturnEmptyOnRepromptWithNoDialog()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -324,7 +321,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .Send(repromptEvent)
                 .StartTestAsync();
 
-            Assert.AreEqual(DialogTurnStatus.Empty, _dmTurnResult.TurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Empty, _dmTurnResult.TurnResult.Status);
         }
 
         private Dialog CreateTestDialog(string property)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -3,51 +3,48 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class DialogSetTests
     {
-        [TestMethod]
+        [Fact]
         public void DialogSet_ConstructorValid()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
-            var ds = new DialogSet(dialogStateProperty);
+            new DialogSet(dialogStateProperty);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void DialogSet_ConstructorNullProperty()
         {
-            var ds = new DialogSet(null);
+            Assert.Throws<ArgumentNullException>(() => new DialogSet(null));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_CreateContextAsync()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
             var ds = new DialogSet(dialogStateProperty);
             var context = TestUtilities.CreateEmptyContext();
-            var dc = await ds.CreateContextAsync(context);
+            await ds.CreateContextAsync(context);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_NullCreateContextAsync()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
             var ds = new DialogSet(dialogStateProperty);
             var context = TestUtilities.CreateEmptyContext();
-            var dc = await ds.CreateContextAsync(context);
+            await ds.CreateContextAsync(context);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_AddWorks()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -55,42 +52,42 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var ds = new DialogSet(dialogStateProperty)
                 .Add(new WaterfallDialog("A"))
                 .Add(new WaterfallDialog("B"));
-            Assert.IsNotNull(ds.Find("A"), "A is missing");
-            Assert.IsNotNull(ds.Find("B"), "B is missing");
-            Assert.IsNull(ds.Find("C"), "C should not be found");
+            Assert.NotNull(ds.Find("A"));
+            Assert.NotNull(ds.Find("B"));
+            Assert.Null(ds.Find("C"));
             await Task.CompletedTask;
         }
 
-        [TestMethod]
+        [Fact]
         public void DialogSet_GetVersion()
         {
             var ds = new DialogSet();
             var version1 = ds.GetVersion();
-            Assert.IsNotNull(version1);
+            Assert.NotNull(version1);
 
             var ds2 = new DialogSet();
             var version2 = ds.GetVersion();
-            Assert.IsNotNull(version2);
-            Assert.AreEqual(version1, version2, "Same configuration should give same version");
+            Assert.NotNull(version2);
+            Assert.Equal(version1, version2);
 
             ds2.Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
             var version3 = ds2.GetVersion();
-            Assert.IsNotNull(version3);
-            Assert.AreNotEqual(version2, version3, "version should change if there is a change");
+            Assert.NotNull(version3);
+            Assert.NotEqual(version2, version3);
 
             var version4 = ds2.GetVersion();
-            Assert.IsNotNull(version3);
-            Assert.AreEqual(version3, version4, "version be same if there is no change");
+            Assert.NotNull(version3);
+            Assert.Equal(version3, version4);
 
             var ds3 = new DialogSet()
                 .Add(new LamdaDialog((dc, ct) => null) { Id = "A" });
 
             var version5 = ds3.GetVersion();
-            Assert.IsNotNull(version5);
-            Assert.AreEqual(version5, version4, "version be same if there is no change");
+            Assert.NotNull(version5);
+            Assert.Equal(version5, version4);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_TelemetrySet()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -98,18 +95,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var ds = new DialogSet(dialogStateProperty)
                 .Add(new WaterfallDialog("A"))
                 .Add(new WaterfallDialog("B"));
-            Assert.IsTrue(ds.Find("A").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
-            Assert.IsTrue(ds.Find("B").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
+            Assert.Equal(typeof(NullBotTelemetryClient), ds.Find("A").TelemetryClient.GetType());
+            Assert.Equal(typeof(NullBotTelemetryClient), ds.Find("B").TelemetryClient.GetType());
 
             var botTelemetryClient = new MyBotTelemetryClient();
             ds.TelemetryClient = botTelemetryClient;
 
-            Assert.IsTrue(ds.Find("A").TelemetryClient is MyBotTelemetryClient, "A not MyBotTelemetryClient");
-            Assert.IsTrue(ds.Find("B").TelemetryClient is MyBotTelemetryClient, "A not MyBotTelemetryClient");
+            Assert.Equal(typeof(MyBotTelemetryClient), ds.Find("A").TelemetryClient.GetType());
+            Assert.Equal(typeof(MyBotTelemetryClient), ds.Find("B").TelemetryClient.GetType());
             await Task.CompletedTask;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_NullTelemetrySet()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -120,12 +117,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             ds.TelemetryClient = new MyBotTelemetryClient();
             ds.TelemetryClient = null;
-            Assert.IsTrue(ds.Find("A").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
-            Assert.IsTrue(ds.Find("B").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
+            Assert.Equal(typeof(NullBotTelemetryClient), ds.Find("A").TelemetryClient.GetType());
+            Assert.Equal(typeof(NullBotTelemetryClient), ds.Find("B").TelemetryClient.GetType());
             await Task.CompletedTask;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_AddTelemetrySet()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -137,11 +134,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             ds.TelemetryClient = new MyBotTelemetryClient();
             ds.Add(new WaterfallDialog("C"));
 
-            Assert.IsTrue(ds.Find("C").TelemetryClient is MyBotTelemetryClient, "C (added dialog) not MyBotTelemetryClient");
+            Assert.Equal(typeof(MyBotTelemetryClient), ds.Find("C").TelemetryClient.GetType());
             await Task.CompletedTask;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DialogSet_HeterogeneousLoggers()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -154,9 +151,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             // Make sure we can override (after Adding) the TelemetryClient and "sticks"
             ds.Find("C").TelemetryClient = new MyBotTelemetryClient();
 
-            Assert.IsTrue(ds.Find("A").TelemetryClient is NullBotTelemetryClient, "A not NullBotTelemetryClient");
-            Assert.IsTrue(ds.Find("B").TelemetryClient is NullBotTelemetryClient, "B not NullBotTelemetryClient");
-            Assert.IsTrue(ds.Find("C").TelemetryClient is MyBotTelemetryClient, "C (added dialog) not MyBotTelemetryClient");
+            Assert.Equal(typeof(NullBotTelemetryClient), ds.Find("A").TelemetryClient.GetType());
+            Assert.Equal(typeof(NullBotTelemetryClient), ds.Find("B").TelemetryClient.GetType());
+            Assert.Equal(typeof(MyBotTelemetryClient), ds.Find("C").TelemetryClient.GetType());
             await Task.CompletedTask;
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -4,21 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Memory;
 using Microsoft.Bot.Builder.Dialogs.Memory.PathResolvers;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class DialogStateManagerTests
     {
-        private Foo foo = new Foo()
+        private readonly Foo foo = new Foo()
         {
             Name = "Tom",
             Age = 15,
@@ -31,22 +33,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }
         };
 
-        public TestContext TestContext { get; set; }
+        private readonly string _testName;
 
-        public TestFlow CreateDialogContext(Func<DialogContext, CancellationToken, Task> handler)
+        public DialogStateManagerTests(ITestOutputHelper testOutputHelper)
         {
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName));
-            adapter
-                .UseStorage(new MemoryStorage())
-                .UseBotState(new UserState(new MemoryStorage()))
-                .UseBotState(new ConversationState(new MemoryStorage()));
-
-            DialogManager dm = new DialogManager(new LamdaDialog(handler));
-            dm.InitialTurnState.Set<ResourceExplorer>(new ResourceExplorer());
-            return new TestFlow(adapter, dm.OnTurnAsync).SendConversationUpdate();
+            // Obtains the current running test name.
+            var helper = (TestOutputHelper)testOutputHelper;
+            var test = (ITest)helper.GetType().GetField("test", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(helper);
+            _testName = test.TestCase.TestMethod.Method.Name;
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestMemoryScopeNullChecks()
         {
             await CreateDialogContext(async (context, ct) =>
@@ -56,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     try
                     {
                         memoryScope.GetMemory(null);
-                        Assert.Fail($"Should have thrown exception with null for {memoryScope.Name}");
+                        throw new XunitException($"Should have thrown exception with null for {memoryScope.Name}");
                     }
                     catch (Exception)
                     {
@@ -65,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     try
                     {
                         memoryScope.SetMemory(null, new object());
-                        Assert.Fail($"Should have thrown exception with null dc for SetMemory {memoryScope.Name}");
+                        throw new XunitException($"Should have thrown exception with null dc for SetMemory {memoryScope.Name}");
                     }
                     catch (Exception)
                     {
@@ -75,7 +73,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestPathResolverNullChecks()
         {
             var ac = new DialogsComponentRegistration();
@@ -85,7 +83,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 try
                 {
                     resolver.TransformPath(null);
-                    Assert.Fail($"Should have thrown exception with null for matches() {resolver.GetType().Name}");
+                    throw new XunitException($"Should have thrown exception with null for matches() {resolver.GetType().Name}");
                 }
                 catch (ArgumentNullException)
                 {
@@ -93,70 +91,70 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestMemorySnapshot()
         {
             await CreateDialogContext(async (context, ct) =>
             {
-                JObject snapshot = context.State.GetMemorySnapshot();
+                var snapshot = context.State.GetMemorySnapshot();
                 var dsm = new DialogStateManager(context);
                 foreach (var memoryScope in dsm.Configuration.MemoryScopes)
                 {
                     if (memoryScope.IncludeInSnapshot)
                     {
-                        Assert.IsNotNull(snapshot.Property(memoryScope.Name));
+                        Assert.NotNull(snapshot.Property(memoryScope.Name));
                     }
                     else
                     {
-                        Assert.IsNull(snapshot.Property(memoryScope.Name));
+                        Assert.Null(snapshot.Property(memoryScope.Name));
                     }
                 }
             })
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestPathResolverTransform()
         {
             // dollar tests
-            Assert.AreEqual("$", new DollarPathResolver().TransformPath("$"));
-            Assert.AreEqual("$23", new DollarPathResolver().TransformPath("$23"));
-            Assert.AreEqual("$$", new DollarPathResolver().TransformPath("$$"));
-            Assert.AreEqual("dialog.foo", new DollarPathResolver().TransformPath("$foo"));
-            Assert.AreEqual("dialog.foo.bar", new DollarPathResolver().TransformPath("$foo.bar"));
-            Assert.AreEqual("dialog.foo.bar[0]", new DollarPathResolver().TransformPath("$foo.bar[0]"));
+            Assert.Equal("$", new DollarPathResolver().TransformPath("$"));
+            Assert.Equal("$23", new DollarPathResolver().TransformPath("$23"));
+            Assert.Equal("$$", new DollarPathResolver().TransformPath("$$"));
+            Assert.Equal("dialog.foo", new DollarPathResolver().TransformPath("$foo"));
+            Assert.Equal("dialog.foo.bar", new DollarPathResolver().TransformPath("$foo.bar"));
+            Assert.Equal("dialog.foo.bar[0]", new DollarPathResolver().TransformPath("$foo.bar[0]"));
 
             // hash tests
-            Assert.AreEqual("#", new HashPathResolver().TransformPath("#"));
-            Assert.AreEqual("#23", new HashPathResolver().TransformPath("#23"));
-            Assert.AreEqual("##", new HashPathResolver().TransformPath("##"));
-            Assert.AreEqual("turn.recognized.intents.foo", new HashPathResolver().TransformPath("#foo"));
-            Assert.AreEqual("turn.recognized.intents.foo.bar", new HashPathResolver().TransformPath("#foo.bar"));
-            Assert.AreEqual("turn.recognized.intents.foo.bar[0]", new HashPathResolver().TransformPath("#foo.bar[0]"));
+            Assert.Equal("#", new HashPathResolver().TransformPath("#"));
+            Assert.Equal("#23", new HashPathResolver().TransformPath("#23"));
+            Assert.Equal("##", new HashPathResolver().TransformPath("##"));
+            Assert.Equal("turn.recognized.intents.foo", new HashPathResolver().TransformPath("#foo"));
+            Assert.Equal("turn.recognized.intents.foo.bar", new HashPathResolver().TransformPath("#foo.bar"));
+            Assert.Equal("turn.recognized.intents.foo.bar[0]", new HashPathResolver().TransformPath("#foo.bar[0]"));
 
             // @ test
-            Assert.AreEqual("@", new AtPathResolver().TransformPath("@"));
-            Assert.AreEqual("@23", new AtPathResolver().TransformPath("@23"));
-            Assert.AreEqual("@@foo", new AtPathResolver().TransformPath("@@foo"));
-            Assert.AreEqual("turn.recognized.entities.foo.first()", new AtPathResolver().TransformPath("@foo"));
-            Assert.AreEqual("turn.recognized.entities.foo.first().bar", new AtPathResolver().TransformPath("@foo.bar"));
+            Assert.Equal("@", new AtPathResolver().TransformPath("@"));
+            Assert.Equal("@23", new AtPathResolver().TransformPath("@23"));
+            Assert.Equal("@@foo", new AtPathResolver().TransformPath("@@foo"));
+            Assert.Equal("turn.recognized.entities.foo.first()", new AtPathResolver().TransformPath("@foo"));
+            Assert.Equal("turn.recognized.entities.foo.first().bar", new AtPathResolver().TransformPath("@foo.bar"));
 
             // @@ teest
-            Assert.AreEqual("@@", new AtAtPathResolver().TransformPath("@@"));
-            Assert.AreEqual("@@23", new AtAtPathResolver().TransformPath("@@23"));
-            Assert.AreEqual("@@@@", new AtAtPathResolver().TransformPath("@@@@"));
-            Assert.AreEqual("turn.recognized.entities.foo", new AtAtPathResolver().TransformPath("@@foo"));
+            Assert.Equal("@@", new AtAtPathResolver().TransformPath("@@"));
+            Assert.Equal("@@23", new AtAtPathResolver().TransformPath("@@23"));
+            Assert.Equal("@@@@", new AtAtPathResolver().TransformPath("@@@@"));
+            Assert.Equal("turn.recognized.entities.foo", new AtAtPathResolver().TransformPath("@@foo"));
 
             // % config tests
-            Assert.AreEqual("%", new PercentPathResolver().TransformPath("%"));
-            Assert.AreEqual("%23", new PercentPathResolver().TransformPath("%23"));
-            Assert.AreEqual("%%", new PercentPathResolver().TransformPath("%%"));
-            Assert.AreEqual("class.foo", new PercentPathResolver().TransformPath("%foo"));
-            Assert.AreEqual("class.foo.bar", new PercentPathResolver().TransformPath("%foo.bar"));
-            Assert.AreEqual("class.foo.bar[0]", new PercentPathResolver().TransformPath("%foo.bar[0]"));
+            Assert.Equal("%", new PercentPathResolver().TransformPath("%"));
+            Assert.Equal("%23", new PercentPathResolver().TransformPath("%23"));
+            Assert.Equal("%%", new PercentPathResolver().TransformPath("%%"));
+            Assert.Equal("class.foo", new PercentPathResolver().TransformPath("%foo"));
+            Assert.Equal("class.foo.bar", new PercentPathResolver().TransformPath("%foo.bar"));
+            Assert.Equal("class.foo.bar[0]", new PercentPathResolver().TransformPath("%foo.bar[0]"));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestSimpleValues()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -164,101 +162,111 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 // simple value types
                 dc.State.SetValue("UseR.nuM", 15);
                 dc.State.SetValue("uSeR.NuM", 25);
-                Assert.AreEqual(25, dc.State.GetValue<int>("user.num"));
+                Assert.Equal(25, dc.State.GetValue<int>("user.num"));
 
                 dc.State.SetValue("UsEr.StR", "string1");
                 dc.State.SetValue("usER.STr", "string2");
-                Assert.AreEqual("string2", dc.State.GetValue<string>("USer.str"));
+                Assert.Equal("string2", dc.State.GetValue<string>("USer.str"));
 
                 // simple value types
                 dc.State.SetValue("ConVErsation.nuM", 15);
                 dc.State.SetValue("ConVErSation.NuM", 25);
-                Assert.AreEqual(25, dc.State.GetValue<int>("conversation.num"));
+                Assert.Equal(25, dc.State.GetValue<int>("conversation.num"));
 
                 dc.State.SetValue("ConVErsation.StR", "string1");
                 dc.State.SetValue("CoNVerSation.STr", "string2");
-                Assert.AreEqual("string2", dc.State.GetValue<string>("conversation.str"));
+                Assert.Equal("string2", dc.State.GetValue<string>("conversation.str"));
 
                 // simple value types
                 dc.State.SetValue("tUrn.nuM", 15);
                 dc.State.SetValue("turN.NuM", 25);
-                Assert.AreEqual(25, dc.State.GetValue<int>("turn.num"));
+                Assert.Equal(25, dc.State.GetValue<int>("turn.num"));
 
                 dc.State.SetValue("tuRn.StR", "string1");
                 dc.State.SetValue("TuRn.STr", "string2");
-                Assert.AreEqual("string2", dc.State.GetValue<string>("turn.str"));
+                Assert.Equal("string2", dc.State.GetValue<string>("turn.str"));
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestEntitiesRetrieval()
         {
             await CreateDialogContext(async (dc, ct) =>
             {
-                var array = new JArray();
-                array.Add("test1");
-                array.Add("test2");
-                array.Add("test3");
+                var array = new JArray
+                {
+                    "test1",
+                    "test2",
+                    "test3"
+                };
 
-                var array2 = new JArray();
-                array2.Add("testx");
-                array2.Add("testy");
-                array2.Add("testz");
+                var array2 = new JArray
+                {
+                    "testx",
+                    "testy",
+                    "testz"
+                };
 
-                var arrayarray = new JArray();
-                arrayarray.Add(array2);
-                arrayarray.Add(array);
+                var arrayarray = new JArray
+                {
+                    array2,
+                    array
+                };
 
                 dc.State.SetValue("turn.recognized.entities.single", array);
                 dc.State.SetValue("turn.recognized.entities.double", arrayarray);
 
-                Assert.AreEqual("test1", dc.State.GetValue<string>("@single"));
-                Assert.AreEqual("testx", dc.State.GetValue<string>("@double"));
-                Assert.AreEqual("test1", dc.State.GetValue<string>("turn.recognized.entities.single.First()"));
-                Assert.AreEqual("testx", dc.State.GetValue<string>("turn.recognized.entities.double.First()"));
+                Assert.Equal("test1", dc.State.GetValue<string>("@single"));
+                Assert.Equal("testx", dc.State.GetValue<string>("@double"));
+                Assert.Equal("test1", dc.State.GetValue<string>("turn.recognized.entities.single.First()"));
+                Assert.Equal("testx", dc.State.GetValue<string>("turn.recognized.entities.double.First()"));
 
                 arrayarray = new JArray();
-                array = new JArray();
-                array.Add(JObject.Parse("{'name':'test1'}"));
-                array.Add(JObject.Parse("{'name':'test2'}"));
-                array.Add(JObject.Parse("{'name':'test2'}"));
+                array = new JArray
+                {
+                    JObject.Parse("{'name':'test1'}"),
+                    JObject.Parse("{'name':'test2'}"),
+                    JObject.Parse("{'name':'test2'}")
+                };
 
-                array2 = new JArray();
-                array2.Add(JObject.Parse("{'name':'testx'}"));
-                array2.Add(JObject.Parse("{'name':'testy'}"));
-                array2.Add(JObject.Parse("{'name':'testz'}"));
+                array2 = new JArray
+                {
+                    JObject.Parse("{'name':'testx'}"),
+                    JObject.Parse("{'name':'testy'}"),
+                    JObject.Parse("{'name':'testz'}")
+                };
                 arrayarray.Add(array2);
                 arrayarray.Add(array);
                 dc.State.SetValue("turn.recognized.entities.single", array);
                 dc.State.SetValue("turn.recognized.entities.double", arrayarray);
 
-                Assert.AreEqual("test1", dc.State.GetValue<string>("@single.name"));
-                Assert.AreEqual("testx", dc.State.GetValue<string>("@double.name"));
-                Assert.AreEqual("test1", dc.State.GetValue<string>("turn.recognized.entities.single.First().name"));
-                Assert.AreEqual("testx", dc.State.GetValue<string>("turn.recognized.entities.double.First().name"));
+                Assert.Equal("test1", dc.State.GetValue<string>("@single.name"));
+                Assert.Equal("testx", dc.State.GetValue<string>("@double.name"));
+                Assert.Equal("test1", dc.State.GetValue<string>("turn.recognized.entities.single.First().name"));
+                Assert.Equal("testx", dc.State.GetValue<string>("turn.recognized.entities.double.First().name"));
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestComplexValuePaths()
         {
             await CreateDialogContext(async (dc, ct) =>
             {
                 // complex type paths
                 dc.State.SetValue("UseR.fOo", foo);
-                Assert.AreEqual("bob", dc.State.GetValue<string>("user.foo.SuBname.name"));
+                Assert.Equal("bob", dc.State.GetValue<string>("user.foo.SuBname.name"));
 
                 // complex type paths
                 dc.State.SetValue("ConVerSation.FOo", foo);
-                Assert.AreEqual("bob", dc.State.GetValue<string>("conversation.foo.SuBname.name"));
+                Assert.Equal("bob", dc.State.GetValue<string>("conversation.foo.SuBname.name"));
 
                 // complex type paths
                 dc.State.SetValue("TurN.fOo", foo);
-                Assert.AreEqual("bob", dc.State.GetValue<string>("TuRN.foo.SuBname.name"));
+                Assert.Equal("bob", dc.State.GetValue<string>("TuRN.foo.SuBname.name"));
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestComplexPathExpressions()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -269,56 +277,61 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 dc.State.SetValue("conversation.stuff['frank']", "test2");
                 dc.State.SetValue("conversation.stuff[\"susan\"]", "test3");
                 dc.State.SetValue("conversation.stuff['Jo.Bob']", "test4");
-                Assert.AreEqual("test", dc.State.GetValue<string>("conversation.stuff.joe"), "complex set should set");
-                Assert.AreEqual("test", dc.State.GetValue<string>("conversation.stuff[user.name]"), "complex get should get");
-                Assert.AreEqual("test2", dc.State.GetValue<string>("conversation.stuff['frank']"), "complex get should get");
-                Assert.AreEqual("test3", dc.State.GetValue<string>("conversation.stuff[\"susan\"]"), "complex get should get");
-                Assert.AreEqual("test4", dc.State.GetValue<string>("conversation.stuff[\"Jo.Bob\"]"), "complex get should get");
+                Assert.Equal("test", dc.State.GetValue<string>("conversation.stuff.joe"));
+                Assert.Equal("test", dc.State.GetValue<string>("conversation.stuff[user.name]"));
+                Assert.Equal("test2", dc.State.GetValue<string>("conversation.stuff['frank']"));
+                Assert.Equal("test3", dc.State.GetValue<string>("conversation.stuff[\"susan\"]"));
+                Assert.Equal("test4", dc.State.GetValue<string>("conversation.stuff[\"Jo.Bob\"]"));
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestGetValue()
         {
             await CreateDialogContext(async (dc, ct) =>
             {
                 // complex type paths
                 dc.State.SetValue("user.name.first", "joe");
-                Assert.AreEqual("joe", dc.State.GetValue<string>("user.name.first"));
+                Assert.Equal("joe", dc.State.GetValue<string>("user.name.first"));
 
-                Assert.AreEqual(null, dc.State.GetValue<string>("user.xxx"));
-                Assert.AreEqual("default", dc.State.GetValue<string>("user.xxx", () => "default"));
+                Assert.Null(dc.State.GetValue<string>("user.xxx"));
+                Assert.Equal("default", dc.State.GetValue<string>("user.xxx", () => "default"));
 
                 foreach (var key in dc.State.Keys)
                 {
                     if (key != "dialogContext")
                     {
-                        Assert.AreEqual(dc.State.GetValue<object>(key), dc.State[key]);
+                        var expected = dc.State[key];
+                        var actual = dc.State.GetValue<object>(key);
+
+                        // xUnit Migration: Assert.Equal(expected, actual) will throw a NotImplementedException error on the GetEnumerator method when the key is 'dialogClass'.
+                        // Workaround: Assert.True(expected.Equals(actual));.
+                        Assert.True(expected.Equals(actual));
                     }
                 }
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestGetValueT()
         {
             await CreateDialogContext(async (dc, ct) =>
             {
                 // complex type paths
                 dc.State.SetValue("UseR.fOo", foo);
-                Assert.AreEqual(dc.State.GetValue<Foo>("user.foo").SubName.Name, "bob");
+                Assert.Equal("bob", dc.State.GetValue<Foo>("user.foo").SubName.Name);
 
                 // complex type paths
                 dc.State.SetValue("ConVerSation.FOo", foo);
-                Assert.AreEqual(dc.State.GetValue<Foo>("conversation.foo").SubName.Name, "bob");
+                Assert.Equal("bob", dc.State.GetValue<Foo>("conversation.foo").SubName.Name);
 
                 // complex type paths
                 dc.State.SetValue("TurN.fOo", foo);
-                Assert.AreEqual(dc.State.GetValue<Foo>("turn.foo").SubName.Name, "bob");
+                Assert.Equal("bob", dc.State.GetValue<Foo>("turn.foo").SubName.Name);
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestSetValue_RootScope()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -326,27 +339,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 try
                 {
                     dc.State.SetValue(null, 13);
-                    Assert.Fail("Should have thrown with null memory scope");
+                    throw new XunitException("Should have thrown with null memory scope");
                 }
                 catch (ArgumentNullException err)
                 {
-                    Assert.IsTrue(err.Message.Contains("path"));
+                    Assert.Contains("path", err.Message);
                 }
 
                 try
                 {
                     // complex type paths
                     dc.State.SetValue("xxx", 13);
-                    Assert.Fail("Should have thrown with unknown memory scope");
+                    throw new XunitException("Should have thrown with unknown memory scope");
                 }
                 catch (ArgumentOutOfRangeException err)
                 {
-                    Assert.IsTrue(err.Message.Contains("does not match memory scope"));
+                    Assert.Contains("does not match memory scope", err.Message);
                 }
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRemoveValue_RootScope()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -354,17 +367,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 try
                 {
                     dc.State.RemoveValue(null);
-                    Assert.Fail("Should have thrown with null memory scope");
+                    throw new XunitException("Should have thrown with null memory scope");
                 }
                 catch (ArgumentNullException err)
                 {
-                    Assert.IsTrue(err.Message.Contains("path"));
+                    Assert.Contains("path", err.Message);
                 }
 
                 try
                 {
                     dc.State.RemoveValue("user");
-                    Assert.Fail("Should have thrown with known root memory scope");
+                    throw new XunitException("Should have thrown with known root memory scope");
                 }
                 catch (NotSupportedException)
                 {
@@ -373,7 +386,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 try
                 {
                     dc.State.RemoveValue("xxx");
-                    Assert.Fail("Should have thrown with unknown memory scope");
+                    throw new XunitException("Should have thrown with unknown memory scope");
                 }
                 catch (NotSupportedException)
                 {
@@ -381,7 +394,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestHashResolver()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -390,14 +403,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 dc.State.SetValue($"turn.recognized.intents.test", "intent1");
                 dc.State.SetValue($"#test2", "intent2");
 
-                Assert.AreEqual("intent1", dc.State.GetValue<string>("turn.recognized.intents.test"));
-                Assert.AreEqual("intent1", dc.State.GetValue<string>("#test"));
-                Assert.AreEqual("intent2", dc.State.GetValue<string>("turn.recognized.intents.test2"));
-                Assert.AreEqual("intent2", dc.State.GetValue<string>("#test2"));
+                Assert.Equal("intent1", dc.State.GetValue<string>("turn.recognized.intents.test"));
+                Assert.Equal("intent1", dc.State.GetValue<string>("#test"));
+                Assert.Equal("intent2", dc.State.GetValue<string>("turn.recognized.intents.test2"));
+                Assert.Equal("intent2", dc.State.GetValue<string>("#test2"));
             }).StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestEntityResolvers()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -408,15 +421,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 dc.State.SetValue($"turn.recognized.entities.test", testEntities);
                 dc.State.SetValue($"@@test2", testEntities2);
 
-                Assert.AreEqual(testEntities.First(), dc.State.GetValue<string>("turn.recognized.entities.test[0]"));
-                Assert.AreEqual(testEntities.First(), dc.State.GetValue<string>("@test"));
-                Assert.IsTrue(testEntities.SequenceEqual(dc.State.GetValue<string[]>("turn.recognized.entities.test")));
-                Assert.IsTrue(testEntities.SequenceEqual(dc.State.GetValue<string[]>("@@test")));
+                Assert.Equal(testEntities.First(), dc.State.GetValue<string>("turn.recognized.entities.test[0]"));
+                Assert.Equal(testEntities.First(), dc.State.GetValue<string>("@test"));
+                Assert.True(testEntities.SequenceEqual(dc.State.GetValue<string[]>("turn.recognized.entities.test")));
+                Assert.True(testEntities.SequenceEqual(dc.State.GetValue<string[]>("@@test")));
 
-                Assert.AreEqual(testEntities2.First(), dc.State.GetValue<string>("turn.recognized.entities.test2[0]"));
-                Assert.AreEqual(testEntities2.First(), dc.State.GetValue<string>("@test2"));
-                Assert.IsTrue(testEntities2.SequenceEqual(dc.State.GetValue<string[]>("turn.recognized.entities.test2")));
-                Assert.IsTrue(testEntities2.SequenceEqual(dc.State.GetValue<string[]>("@@test2")));
+                Assert.Equal(testEntities2.First(), dc.State.GetValue<string>("turn.recognized.entities.test2[0]"));
+                Assert.Equal(testEntities2.First(), dc.State.GetValue<string>("@test2"));
+                Assert.True(testEntities2.SequenceEqual(dc.State.GetValue<string[]>("turn.recognized.entities.test2")));
+                Assert.True(testEntities2.SequenceEqual(dc.State.GetValue<string[]>("@@test2")));
             }).StartTestAsync();
         }
 
@@ -445,7 +458,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             public D1Dialog()
                 : base("d1")
             {
-                this.AddDialog(new D2Dialog());
+                AddDialog(new D2Dialog());
             }
 
             public int MaxValue { get; set; } = 10;
@@ -464,7 +477,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             public IEnumerable<Dialog> GetDependencies()
             {
-                return this.Dialogs.GetDialogs();
+                return Dialogs.GetDialogs();
             }
 
             public override async Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
@@ -475,7 +488,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestDollarScope()
         {
             await CreateFlow(new D1Dialog())
@@ -521,7 +534,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 outerDc.State.SetValue("$name", "d2");
                 var name = outerDc.State.GetValue<string>("$name");
                 await outerDc.Context.SendActivityAsync($"nested {name}");
-                return await outerDc.EndDialogAsync(this.Id);
+                return await outerDc.EndDialogAsync(Id);
             }
         }
 
@@ -539,7 +552,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 await dc.Context.SendActivityAsync($"nested {name}");
                 name = dc.State.GetValue<string>("dialog.name");
                 await dc.Context.SendActivityAsync($"nested {name}");
-                return await dc.EndDialogAsync(this.Id);
+                return await dc.EndDialogAsync(Id);
             }
         }
 
@@ -582,7 +595,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestNestedContainerDialogs()
         {
             await CreateFlow(new NestedContainerDialog())
@@ -597,13 +610,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestExpressionSet()
         {
             await CreateDialogContext(async (dc, ct) =>
             {
                 dc.State.SetValue($"turn.x.y.z", null);
-                Assert.AreEqual(null, dc.State.GetValue<object>("turn.x.y.z"));
+                Assert.Null(dc.State.GetValue<object>("turn.x.y.z"));
             }).StartTestAsync();
         }
 
@@ -633,7 +646,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestConversationResetOnException()
         {
             var storage = new MemoryStorage();
@@ -670,7 +683,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestConversationResetOnExpiration()
         {
             var storage = new MemoryStorage();
@@ -710,7 +723,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestChangeTracking()
         {
             await CreateDialogContext(async (dc, ct) =>
@@ -719,28 +732,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 var dialogPaths = state.TrackPaths(new List<string> { "dialog.user.first", "dialog.user.last" });
 
                 state.SetValue("dialog.eventCounter", 0);
-                Assert.IsFalse(state.AnyPathChanged(0, dialogPaths));
+                Assert.False(state.AnyPathChanged(0, dialogPaths));
 
                 state.SetValue("dialog.eventCounter", 1);
                 state.SetValue("dialog.foo", 3);
-                Assert.IsFalse(state.AnyPathChanged(0, dialogPaths));
+                Assert.False(state.AnyPathChanged(0, dialogPaths));
 
                 state.SetValue("dialog.eventCounter", 2);
                 state.SetValue("dialog.user.first", "bart");
-                Assert.IsTrue(state.AnyPathChanged(1, dialogPaths));
+                Assert.True(state.AnyPathChanged(1, dialogPaths));
 
                 state.SetValue("dialog.eventCounter", 3);
                 state.SetValue("dialog.user", new Dictionary<string, object> { { "first", "tom" }, { "last", "starr" } });
-                Assert.IsTrue(state.AnyPathChanged(2, dialogPaths));
+                Assert.True(state.AnyPathChanged(2, dialogPaths));
 
                 state.SetValue("dialog.eventCounter", 4);
-                Assert.IsFalse(state.AnyPathChanged(3, dialogPaths));
+                Assert.False(state.AnyPathChanged(3, dialogPaths));
             }).StartTestAsync();
         }
 
         private TestFlow CreateFlow(Dialog dialog, ConversationState convoState = null, UserState userState = null, bool sendTrace = false)
         {
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName), sendTrace)
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(_testName), sendTrace)
                 .UseStorage(new MemoryStorage())
                 .UseBotState(new UserState(new MemoryStorage()))
                 .UseBotState(convoState ?? new ConversationState(new MemoryStorage()))
@@ -752,6 +765,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
             });
+        }
+
+        private TestFlow CreateDialogContext(Func<DialogContext, CancellationToken, Task> handler)
+        {
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(_testName));
+            adapter
+                .UseStorage(new MemoryStorage())
+                .UseBotState(new UserState(new MemoryStorage()))
+                .UseBotState(new ConversationState(new MemoryStorage()));
+
+            var dm = new DialogManager(new LamdaDialog(handler));
+            dm.InitialTurnState.Set(new ResourceExplorer());
+            return new TestFlow(adapter, dm.OnTurnAsync).SendConversationUpdate();
         }
     }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -22,6 +22,11 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/NumberPromptTests.cs
@@ -6,87 +6,84 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.Recognizers.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class NumberPromptTests
     {
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void NumberPromptWithEmptyIdShouldFail()
         {
-            var emptyId = string.Empty;
-            var numberPrompt = new NumberPrompt<int>(emptyId);
+            Assert.Throws<ArgumentNullException>(() => new NumberPrompt<int>(string.Empty));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void NumberPromptWithNullIdShouldFail()
         {
-            var nullId = string.Empty;
-            nullId = null;
-            var numberPrompt = new NumberPrompt<int>(nullId);
+            Assert.Throws<ArgumentNullException>(() => new NumberPrompt<int>(null));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(NotSupportedException))]
+        [Fact]
         public void NumberPromptWithUnsupportedTypeShouldFail()
         {
-            var nullId = string.Empty;
-            nullId = null;
-            var numberPrompt = new NumberPrompt<short>("prompt");
+            Assert.Throws<NotSupportedException>(() => new NumberPrompt<short>("prompt"));
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public async Task NumberPromptWithNullTurnContextShouldFail()
         {
-            var numberPromptMock = new NumberPromptMock("NumberPromptMock");
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                var numberPromptMock = new NumberPromptMock("NumberPromptMock");
 
-            var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "Please send a number." } };
+                var options = new PromptOptions { Prompt = new Activity { Type = ActivityTypes.Message, Text = "Please send a number." } };
 
-            await numberPromptMock.OnPromptNullContext(options);
+                await numberPromptMock.OnPromptNullContext(options);
+            });
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public async Task OnPromptErrorsWithNullOptions()
         {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
-            var adapter = new TestAdapter()
-                .Use(new AutoSaveStateMiddleware(convoState));
-
-            // Create new DialogSet.
-            var dialogs = new DialogSet(dialogState);
-
-            // Create and add custom activity prompt to DialogSet.
-            var numberPromptMock = new NumberPromptMock("NumberPromptMock");
-            dialogs.Add(numberPromptMock);
-
-            await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
             {
-                var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+                var convoState = new ConversationState(new MemoryStorage());
+                var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-                await numberPromptMock.OnPromptNullOptions(dc);
-            })
-            .Send("hello")
-            .StartTestAsync();
+                var adapter = new TestAdapter()
+                    .Use(new AutoSaveStateMiddleware(convoState));
+
+                // Create new DialogSet.
+                var dialogs = new DialogSet(dialogState);
+
+                // Create and add custom activity prompt to DialogSet.
+                var numberPromptMock = new NumberPromptMock("NumberPromptMock");
+                dialogs.Add(numberPromptMock);
+
+                await new TestFlow(adapter, async (turnContext, cancellationToken) =>
+                {
+                    var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
+
+                    await numberPromptMock.OnPromptNullOptions(dc);
+                })
+                .Send("hello")
+                .StartTestAsync();
+            });
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public async Task OnRecognizeWithNullTurnContextShouldFail()
         {
-            var numberPromptMock = new NumberPromptMock("NumberPromptMock");
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                var numberPromptMock = new NumberPromptMock("NumberPromptMock");
 
-            await numberPromptMock.OnRecognizeNullContext();
+                await numberPromptMock.OnRecognizeNullContext();
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task NumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -125,7 +122,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task NumberPromptRetry()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -168,7 +165,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task NumberPromptValidator()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -222,7 +219,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task FloatNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -262,7 +259,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task LongNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -302,7 +299,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DoubleNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -342,7 +339,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CurrencyNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -382,7 +379,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task AgeNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -422,7 +419,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DimensionNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -462,7 +459,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TemperatureNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -502,7 +499,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CultureThruNumberPromptCtor()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -532,7 +529,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 else if (results.Status == DialogTurnStatus.Complete)
                 {
                     var numberResult = (double)results.Result;
-                    Assert.AreEqual(3.14, numberResult);
+                    Assert.Equal(3.14, numberResult);
                 }
             })
             .Send("hello")
@@ -541,7 +538,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CultureThruActivityNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -571,7 +568,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 else if (results.Status == DialogTurnStatus.Complete)
                 {
                     var numberResult = (double)results.Result;
-                    Assert.AreEqual(3.14, numberResult);
+                    Assert.Equal(3.14, numberResult);
                 }
             })
             .Send("hello")
@@ -580,7 +577,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task NumberPromptDefaultsToEnUsLocale()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -620,7 +617,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DecimalNumberPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -660,7 +657,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task NoNumberButUnitPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Startup.cs
@@ -1,16 +1,18 @@
-﻿using Microsoft.Bot.Builder.Dialogs;
-using Microsoft.Bot.Builder.Dialogs.Adaptive;
+﻿using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Microsoft.Bot.Builder.Startup", "Microsoft.Bot.Builder.Dialogs.Tests")]
 
 namespace Microsoft.Bot.Builder
 {
-    [TestClass]
-    public class Startup
+    public class Startup : XunitTestFramework
     {
-        [AssemblyInitialize]
-        public static void Initialize(TestContext testContext)
+        public Startup(IMessageSink messageSink)
+            : base(messageSink)
         {
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());


### PR DESCRIPTION
Fixes #4096

## Description
This PR migrates **the following test files** inside the [Microsoft.Bot.Builder.Dialogs.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Tests) folder from **MSTest** to **xUnit**.
- DialogManagerTests.cs
- DialogSetTests.cs
- DialogStateManagerTests.cs
- MemoryScopeTests.cs
- NumberPromptTests.cs
- OAuthPromptTests.cs
- Startup.cs

## Specific Changes
- Added `xUnit` packages to `.csproj`.
- Changed `[TestMethod]` to `[Fact]`.
- Changed `[ExpectedException]` to `Assert.Throws`/`Assert.ThrowsAsync`.
- Changed `Assert.AreEqual` to `Assert.Equal`.
- Changed `Assert.IsNotNull` to `Assert.NotNull`.
- Changed `Assert.IsNull` to `Assert.Null`.
- Changed `Assert.IsTrue` to `Assert.True`.
- Added `[assembly: TestFramework("Microsoft.Bot.Builder.Startup", "Microsoft.Bot.Builder.Dialogs.Tests")]` to the Startup class to replace `[AssemblyInitialize]`.
- Improved tests Assertions.
- **xUnit Migration:** Due to a `NotImplementedException` error when executing `ReadOnlyObject.GetEnumerator` method on the `Assert.Equal` comparison, we added a workaround to be compared as ` Assert.True(expected.Equals(actual))` instead of `Assert.Equal(expected, actual)`.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/62260472/92728727-a97d2500-f347-11ea-89d5-c2f0b62fab37.png)