### PR TITLE
Make Bot Cache state public

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -339,7 +339,11 @@ namespace Microsoft.Bot.Builder
         public class CachedBotState
 #pragma warning restore CA1034 // Nested types should not be visible
         {
-            internal CachedBotState(IDictionary<string, object> state = null)
+            /// <summary>
+            /// Initializes a new instance of the <see cref="CachedBotState"/> class.
+            /// </summary>
+            /// <param name="state">Initial state for the <see cref="CachedBotState"/>.</param>
+            public CachedBotState(IDictionary<string, object> state = null)
             {
                 State = state ?? new Dictionary<string, object>();
                 Hash = ComputeHash(State);


### PR DESCRIPTION
## Description
In order to properly manage internal variable state in memory, we override some of the data access in derived versions of memory scopes. Since parts of the memory management system have a strict dependency on CachedBotState, we would like to instantiate CachedBotState from our extensions.

## Specific Changes
Make the CachedBotState constructor **public**