### PR TITLE
[#4096] Migrate Microsoft.Bot.Builder.Dialogs.Tests to xUnit

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -22,6 +22,11 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ObjectPathTests.cs
@@ -2,20 +2,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.Bot.Builder.Adapters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class ObjectPathTests
     {
         private static JsonSerializerSettings settings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
 
-        [TestMethod]
+        [Fact]
         public void Typed_OnlyDefaultTest()
         {
             var defaultOptions = new Options()
@@ -28,15 +26,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var overlay = new Options() { };
 
             var result = ObjectPath.Merge(defaultOptions, overlay);
-            Assert.AreEqual(result.LastName, defaultOptions.LastName);
-            Assert.AreEqual(result.FirstName, defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, defaultOptions.Age);
-            Assert.AreEqual(result.Bool, defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, defaultOptions.LastName);
+            Assert.Equal(result.FirstName, defaultOptions.FirstName);
+            Assert.Equal(result.Age, defaultOptions.Age);
+            Assert.Equal(result.Bool, defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Typed_OnlyOverlay()
         {
             var defaultOptions = new Options() { };
@@ -50,15 +48,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
 
             var result = ObjectPath.Merge(defaultOptions, overlay);
-            Assert.AreEqual(result.LastName, overlay.LastName);
-            Assert.AreEqual(result.FirstName, overlay.FirstName);
-            Assert.AreEqual(result.Age, overlay.Age);
-            Assert.AreEqual(result.Bool, overlay.Bool);
-            Assert.AreEqual(result.Location.Lat, overlay.Location.Lat);
-            Assert.AreEqual(result.Location.Long, overlay.Location.Long);
+            Assert.Equal(result.LastName, overlay.LastName);
+            Assert.Equal(result.FirstName, overlay.FirstName);
+            Assert.Equal(result.Age, overlay.Age);
+            Assert.Equal(result.Bool, overlay.Bool);
+            Assert.Equal(result.Location.Lat, overlay.Location.Lat);
+            Assert.Equal(result.Location.Long, overlay.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Typed_FullOverlay()
         {
             var defaultOptions = new Options()
@@ -80,15 +78,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Merge(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, overlay.LastName);
-            Assert.AreEqual(result.FirstName, overlay.FirstName);
-            Assert.AreEqual(result.Age, overlay.Age);
-            Assert.AreEqual(result.Bool, overlay.Bool);
-            Assert.AreEqual(result.Location.Lat, overlay.Location.Lat);
-            Assert.AreEqual(result.Location.Long, overlay.Location.Long);
+            Assert.Equal(result.LastName, overlay.LastName);
+            Assert.Equal(result.FirstName, overlay.FirstName);
+            Assert.Equal(result.Age, overlay.Age);
+            Assert.Equal(result.Bool, overlay.Bool);
+            Assert.Equal(result.Location.Lat, overlay.Location.Lat);
+            Assert.Equal(result.Location.Long, overlay.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Typed_PartialOverlay()
         {
             var defaultOptions = new Options()
@@ -106,15 +104,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Merge(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, overlay.LastName);
-            Assert.AreEqual(result.FirstName, defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, defaultOptions.Age);
-            Assert.AreEqual(result.Bool, defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, overlay.LastName);
+            Assert.Equal(result.FirstName, defaultOptions.FirstName);
+            Assert.Equal(result.Age, defaultOptions.Age);
+            Assert.Equal(result.Bool, defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Anonymous_OnlyDefaultTest()
         {
             dynamic defaultOptions = new
@@ -128,15 +126,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dynamic overlay = new { };
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
-            Assert.AreEqual(result.LastName, defaultOptions.LastName);
-            Assert.AreEqual(result.FirstName, defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, defaultOptions.Age);
-            Assert.AreEqual(result.Bool, defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, defaultOptions.LastName);
+            Assert.Equal(result.FirstName, defaultOptions.FirstName);
+            Assert.Equal(result.Age, defaultOptions.Age);
+            Assert.Equal(result.Bool, defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Anonymous_OnlyOverlay()
         {
             dynamic defaultOptions = new { };
@@ -152,15 +150,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, overlay.LastName);
-            Assert.AreEqual(result.FirstName, overlay.FirstName);
-            Assert.AreEqual(result.Age, overlay.Age);
-            Assert.AreEqual(result.Bool, overlay.Bool);
-            Assert.AreEqual(result.Location.Lat, overlay.Location.Lat);
-            Assert.AreEqual(result.Location.Long, overlay.Location.Long);
+            Assert.Equal(result.LastName, overlay.LastName);
+            Assert.Equal(result.FirstName, overlay.FirstName);
+            Assert.Equal(result.Age, overlay.Age);
+            Assert.Equal(result.Bool, overlay.Bool);
+            Assert.Equal(result.Location.Lat, overlay.Location.Lat);
+            Assert.Equal(result.Location.Long, overlay.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Anonymous_FullOverlay()
         {
             dynamic defaultOptions = new
@@ -183,15 +181,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, overlay.LastName);
-            Assert.AreEqual(result.FirstName, overlay.FirstName);
-            Assert.AreEqual(result.Age, overlay.Age);
-            Assert.AreEqual(result.Bool, overlay.Bool);
-            Assert.AreEqual(result.Location.Lat, overlay.Location.Lat);
-            Assert.AreEqual(result.Location.Long, overlay.Location.Long);
+            Assert.Equal(result.LastName, overlay.LastName);
+            Assert.Equal(result.FirstName, overlay.FirstName);
+            Assert.Equal(result.Age, overlay.Age);
+            Assert.Equal(result.Bool, overlay.Bool);
+            Assert.Equal(result.Location.Lat, overlay.Location.Lat);
+            Assert.Equal(result.Location.Long, overlay.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void Anonymous_PartialOverlay()
         {
             dynamic defaultOptions = new
@@ -209,15 +207,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, overlay.LastName);
-            Assert.AreEqual(result.FirstName, defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, defaultOptions.Age);
-            Assert.AreEqual(result.Bool, defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, overlay.LastName);
+            Assert.Equal(result.FirstName, defaultOptions.FirstName);
+            Assert.Equal(result.Age, defaultOptions.Age);
+            Assert.Equal(result.Bool, defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void JObject_OnlyDefaultTest()
         {
             dynamic defaultOptions = JObject.FromObject(new Options()
@@ -230,15 +228,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             dynamic overlay = JObject.FromObject(new Options() { });
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
-            Assert.AreEqual(result.LastName, (string)defaultOptions.LastName);
-            Assert.AreEqual(result.FirstName, (string)defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, (int?)defaultOptions.Age);
-            Assert.AreEqual(result.Bool, (bool?)defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, (float?)defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, (float?)defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, (string)defaultOptions.LastName);
+            Assert.Equal(result.FirstName, (string)defaultOptions.FirstName);
+            Assert.Equal(result.Age, (int?)defaultOptions.Age);
+            Assert.Equal(result.Bool, (bool?)defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, (float?)defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, (float?)defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void JObject_OnlyOverlay()
         {
             dynamic defaultOptions = JObject.FromObject(new Options() { });
@@ -253,15 +251,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, (string)overlay.LastName);
-            Assert.AreEqual(result.FirstName, (string)overlay.FirstName);
-            Assert.AreEqual(result.Age, (int?)overlay.Age);
-            Assert.AreEqual(result.Bool, (bool?)overlay.Bool);
-            Assert.AreEqual(result.Location.Lat, (float?)overlay.Location.Lat);
-            Assert.AreEqual(result.Location.Long, (float?)overlay.Location.Long);
+            Assert.Equal(result.LastName, (string)overlay.LastName);
+            Assert.Equal(result.FirstName, (string)overlay.FirstName);
+            Assert.Equal(result.Age, (int?)overlay.Age);
+            Assert.Equal(result.Bool, (bool?)overlay.Bool);
+            Assert.Equal(result.Location.Lat, (float?)overlay.Location.Lat);
+            Assert.Equal(result.Location.Long, (float?)overlay.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void JObject_FullOverlay()
         {
             dynamic defaultOptions = JObject.FromObject(new Options()
@@ -283,15 +281,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, (string)overlay.LastName);
-            Assert.AreEqual(result.FirstName, (string)overlay.FirstName);
-            Assert.AreEqual(result.Age, (int?)overlay.Age);
-            Assert.AreEqual(result.Bool, (bool?)overlay.Bool);
-            Assert.AreEqual(result.Location.Lat, (float?)overlay.Location.Lat);
-            Assert.AreEqual(result.Location.Long, (float?)overlay.Location.Long);
+            Assert.Equal(result.LastName, (string)overlay.LastName);
+            Assert.Equal(result.FirstName, (string)overlay.FirstName);
+            Assert.Equal(result.Age, (int?)overlay.Age);
+            Assert.Equal(result.Bool, (bool?)overlay.Bool);
+            Assert.Equal(result.Location.Lat, (float?)overlay.Location.Lat);
+            Assert.Equal(result.Location.Long, (float?)overlay.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void JObject_PartialOverlay()
         {
             dynamic defaultOptions = JObject.FromObject(new Options()
@@ -309,15 +307,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             var result = ObjectPath.Assign<Options>(defaultOptions, overlay);
 
-            Assert.AreEqual(result.LastName, (string)overlay.LastName);
-            Assert.AreEqual(result.FirstName, (string)defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, (int?)defaultOptions.Age);
-            Assert.AreEqual(result.Bool, (bool?)defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, (float?)defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, (float?)defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, (string)overlay.LastName);
+            Assert.Equal(result.FirstName, (string)defaultOptions.FirstName);
+            Assert.Equal(result.Age, (int?)defaultOptions.Age);
+            Assert.Equal(result.Bool, (bool?)defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, (float?)defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, (float?)defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void NullStartObject()
         {
             var defaultOptions = new Options()
@@ -329,15 +327,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
 
             var result = ObjectPath.Assign<Options>(null, defaultOptions);
-            Assert.AreEqual(result.LastName, defaultOptions.LastName);
-            Assert.AreEqual(result.FirstName, defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, defaultOptions.Age);
-            Assert.AreEqual(result.Bool, defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, defaultOptions.LastName);
+            Assert.Equal(result.FirstName, defaultOptions.FirstName);
+            Assert.Equal(result.Age, defaultOptions.Age);
+            Assert.Equal(result.Bool, defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void NullOverlay()
         {
             var defaultOptions = new Options()
@@ -349,15 +347,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
 
             var result = ObjectPath.Assign<Options>(defaultOptions, null);
-            Assert.AreEqual(result.LastName, defaultOptions.LastName);
-            Assert.AreEqual(result.FirstName, defaultOptions.FirstName);
-            Assert.AreEqual(result.Age, defaultOptions.Age);
-            Assert.AreEqual(result.Bool, defaultOptions.Bool);
-            Assert.AreEqual(result.Location.Lat, defaultOptions.Location.Lat);
-            Assert.AreEqual(result.Location.Long, defaultOptions.Location.Long);
+            Assert.Equal(result.LastName, defaultOptions.LastName);
+            Assert.Equal(result.FirstName, defaultOptions.FirstName);
+            Assert.Equal(result.Age, defaultOptions.Age);
+            Assert.Equal(result.Bool, defaultOptions.Bool);
+            Assert.Equal(result.Location.Lat, defaultOptions.Location.Lat);
+            Assert.Equal(result.Location.Long, defaultOptions.Location.Long);
         }
 
-        [TestMethod]
+        [Fact]
         public void TryGetPathValue()
         {
             var test = new
@@ -390,105 +388,97 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             // set with anonymous object
             {
-                Assert.AreEqual(test, ObjectPath.GetPathValue<object>(test, string.Empty), "empty should return root");
-                Assert.AreEqual(test.test, ObjectPath.GetPathValue<string>(test, "test"));
-                Assert.AreEqual(test.bar.options.Age, ObjectPath.GetPathValue<int>(test, "bar.options.age"));
+                Assert.Equal(test, ObjectPath.GetPathValue<object>(test, string.Empty));
+                Assert.Equal(test.test, ObjectPath.GetPathValue<string>(test, "test"));
+                Assert.Equal(test.bar.options.Age, ObjectPath.GetPathValue<int>(test, "bar.options.age"));
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<Options>(test, "options", out Options options));
-                Assert.AreEqual(test.options.Age, options.Age);
-                Assert.AreEqual(test.options.FirstName, options.FirstName);
+                Assert.True(ObjectPath.TryGetPathValue<Options>(test, "options", out Options options));
+                Assert.Equal(test.options.Age, options.Age);
+                Assert.Equal(test.options.FirstName, options.FirstName);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<Options>(test, "bar.options", out Options barOptions));
-                Assert.AreEqual(test.bar.options.Age, barOptions.Age);
-                Assert.AreEqual(test.bar.options.FirstName, barOptions.FirstName);
+                Assert.True(ObjectPath.TryGetPathValue<Options>(test, "bar.options", out Options barOptions));
+                Assert.Equal(test.bar.options.Age, barOptions.Age);
+                Assert.Equal(test.bar.options.FirstName, barOptions.FirstName);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int[]>(test, "bar.numbers", out int[] numbers));
-                Assert.AreEqual(5, numbers.Length);
+                Assert.True(ObjectPath.TryGetPathValue<int[]>(test, "bar.numbers", out int[] numbers));
+                Assert.Equal(5, numbers.Length);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[1]", out int number));
-                Assert.AreEqual(2, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[1]", out int number));
+                Assert.Equal(2, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar['options'].Age", out number));
-                Assert.AreEqual(1, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(test, "bar['options'].Age", out number));
+                Assert.Equal(1, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar[\"options\"].Age", out number));
-                Assert.AreEqual(1, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(test, "bar[\"options\"].Age", out number));
+                Assert.Equal(1, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar.numIndex]", out number));
-                Assert.AreEqual(3, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar.numIndex]", out number));
+                Assert.Equal(3, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar[bar.objIndex].Age]", out number));
-                Assert.AreEqual(2, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(test, "bar.numbers[bar[bar.objIndex].Age]", out number));
+                Assert.Equal(2, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "bar.options[bar.strIndex]", out string name));
-                Assert.AreEqual("joe", name);
+                Assert.True(ObjectPath.TryGetPathValue<string>(test, "bar.options[bar.strIndex]", out string name));
+                Assert.Equal("joe", name);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(test, "bar[bar.objIndex].Age", out int age));
-                Assert.AreEqual(1, age);
+                Assert.True(ObjectPath.TryGetPathValue<int>(test, "bar[bar.objIndex].Age", out int age));
+                Assert.Equal(1, age);
             }
 
             // now try with JObject
             {
                 var json = JsonConvert.SerializeObject(test, settings);
                 dynamic jtest = JsonConvert.DeserializeObject(json);
-                Assert.AreEqual(json, JsonConvert.SerializeObject(ObjectPath.GetPathValue<object>(jtest, string.Empty), settings), "empty should return root");
-                Assert.AreEqual((string)jtest.test, ObjectPath.GetPathValue<string>(jtest, "test"));
-                Assert.AreEqual((int)jtest.bar.options.Age, ObjectPath.GetPathValue<int>(jtest, "bar.options.age"));
+                Assert.Equal(json, JsonConvert.SerializeObject(ObjectPath.GetPathValue<object>(jtest, string.Empty), settings));
+                Assert.Equal((string)jtest.test, ObjectPath.GetPathValue<string>(jtest, "test"));
+                Assert.Equal((int)jtest.bar.options.Age, ObjectPath.GetPathValue<int>(jtest, "bar.options.age"));
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<Options>(jtest, "options", out Options options));
-                Assert.AreEqual((int)jtest.options.Age, options.Age);
-                Assert.AreEqual((string)jtest.options.FirstName, options.FirstName);
+                Assert.True(ObjectPath.TryGetPathValue<Options>(jtest, "options", out Options options));
+                Assert.Equal((int)jtest.options.Age, options.Age);
+                Assert.Equal((string)jtest.options.FirstName, options.FirstName);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<Options>(jtest, "bar.options", out Options barOptions));
-                Assert.AreEqual((int)jtest.bar.options.Age, barOptions.Age);
-                Assert.AreEqual((string)jtest.bar.options.FirstName, barOptions.FirstName);
+                Assert.True(ObjectPath.TryGetPathValue<Options>(jtest, "bar.options", out Options barOptions));
+                Assert.Equal((int)jtest.bar.options.Age, barOptions.Age);
+                Assert.Equal((string)jtest.bar.options.FirstName, barOptions.FirstName);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int[]>(jtest, "bar.numbers", out int[] numbers));
-                Assert.AreEqual(5, numbers.Length);
+                Assert.True(ObjectPath.TryGetPathValue<int[]>(jtest, "bar.numbers", out int[] numbers));
+                Assert.Equal(5, numbers.Length);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(jtest, "bar.numbers[1]", out int number));
-                Assert.AreEqual(2, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(jtest, "bar.numbers[1]", out int number));
+                Assert.Equal(2, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(jtest, "bar['options'].Age", out number));
-                Assert.AreEqual(1, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(jtest, "bar['options'].Age", out number));
+                Assert.Equal(1, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(jtest, "bar[\"options\"].Age", out number));
-                Assert.AreEqual(1, number);
+                Assert.True(ObjectPath.TryGetPathValue<int>(jtest, "bar[\"options\"].Age", out number));
+                Assert.Equal(1, number);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(jtest, "bar.numbers[bar.numIndex]", out int number2));
-                Assert.AreEqual(3, number2);
+                Assert.True(ObjectPath.TryGetPathValue<int>(jtest, "bar.numbers[bar.numIndex]", out int number2));
+                Assert.Equal(3, number2);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(jtest, "bar.numbers[bar[bar.objIndex].Age]", out int number3));
-                Assert.AreEqual(2, number3);
+                Assert.True(ObjectPath.TryGetPathValue<int>(jtest, "bar.numbers[bar[bar.objIndex].Age]", out int number3));
+                Assert.Equal(2, number3);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<string>(jtest, "bar.options[bar.strIndex]", out string name));
-                Assert.AreEqual("joe", name);
+                Assert.True(ObjectPath.TryGetPathValue<string>(jtest, "bar.options[bar.strIndex]", out string name));
+                Assert.Equal("joe", name);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<int>(jtest, "bar[bar.objIndex].Age", out int age));
-                Assert.AreEqual(1, age);
+                Assert.True(ObjectPath.TryGetPathValue<int>(jtest, "bar[bar.objIndex].Age", out int age));
+                Assert.Equal(1, age);
 
                 jtest.bar["x.y.z"] = "test";
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<string>(jtest, "bar['x.y.z']", out string split));
-                Assert.AreEqual("test", split);
+                Assert.True(ObjectPath.TryGetPathValue<string>(jtest, "bar['x.y.z']", out string split));
+                Assert.Equal("test", split);
 
-                Assert.IsTrue(ObjectPath.TryGetPathValue<string>(jtest, "bar[\"x.y.z\"]", out split));
-                Assert.AreEqual("test", split);
+                Assert.True(ObjectPath.TryGetPathValue<string>(jtest, "bar[\"x.y.z\"]", out split));
+                Assert.Equal("test", split);
             }
         }
 
-        public void AssertGetSetValueType<T>(object test, T val)
-        {
-            ObjectPath.SetPathValue(test, val.GetType().Name, val);
-            var result = ObjectPath.GetPathValue<T>(test, typeof(T).Name);
-            Assert.AreEqual(val, result);
-            Assert.AreEqual(val.GetType(), result.GetType());
-        }
-
-        [TestMethod]
+        [Fact]
         public void SetPathValue()
         {
-            Dictionary<string, object> test = new Dictionary<string, object>();
+            var test = new Dictionary<string, object>();
             ObjectPath.SetPathValue(test, "x.y.z", 15);
             ObjectPath.SetPathValue(test, "x.p", "hello");
             ObjectPath.SetPathValue(test, "foo", new { Bar = 15, Blat = "yo" });
@@ -497,17 +487,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             ObjectPath.SetPathValue(test, "null", null);
             ObjectPath.SetPathValue(test, "enum", TypeCode.Empty);
 
-            Assert.AreEqual(15, ObjectPath.GetPathValue<int>(test, "x.y.z"));
-            Assert.AreEqual("hello", ObjectPath.GetPathValue<string>(test, "x.p"));
-            Assert.AreEqual(15, ObjectPath.GetPathValue<int>(test, "foo.bar"));
-            Assert.AreEqual("yo", ObjectPath.GetPathValue<string>(test, "foo.Blat"));
-            Assert.IsFalse(ObjectPath.TryGetPathValue<string>(test, "foo.Blatxxx", out var value));
-            Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "x.a[1]", out var value2));
-            Assert.AreEqual("yabba", value2);
-            Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "x.a[0]", out value2));
-            Assert.AreEqual("dabba", value2);
-            Assert.IsFalse(ObjectPath.TryGetPathValue<object>(test, "null", out var nullValue));
-            Assert.AreEqual(TypeCode.Empty, ObjectPath.GetPathValue<TypeCode>(test, "enum"));
+            Assert.Equal(15, ObjectPath.GetPathValue<int>(test, "x.y.z"));
+            Assert.Equal("hello", ObjectPath.GetPathValue<string>(test, "x.p"));
+            Assert.Equal(15, ObjectPath.GetPathValue<int>(test, "foo.bar"));
+            Assert.Equal("yo", ObjectPath.GetPathValue<string>(test, "foo.Blat"));
+            Assert.False(ObjectPath.TryGetPathValue<string>(test, "foo.Blatxxx", out var value));
+            Assert.True(ObjectPath.TryGetPathValue<string>(test, "x.a[1]", out var value2));
+            Assert.Equal("yabba", value2);
+            Assert.True(ObjectPath.TryGetPathValue<string>(test, "x.a[0]", out value2));
+            Assert.Equal("dabba", value2);
+            Assert.False(ObjectPath.TryGetPathValue<object>(test, "null", out var nullValue));
+            Assert.Equal(TypeCode.Empty, ObjectPath.GetPathValue<TypeCode>(test, "enum"));
 
             // value type tests
 #pragma warning disable SA1121 // Use built-in type alias
@@ -527,10 +517,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 #pragma warning restore SA1121 // Use built-in type alias
         }
 
-        [TestMethod]
+        [Fact]
         public void RemovePathValue()
         {
-            Dictionary<string, object> test = new Dictionary<string, object>();
+            var test = new Dictionary<string, object>();
             ObjectPath.SetPathValue(test, "x.y.z", 15);
             ObjectPath.SetPathValue(test, "x.p", "hello");
             ObjectPath.SetPathValue(test, "foo", new { Bar = 15, Blat = "yo" });
@@ -541,19 +531,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             try
             {
                 ObjectPath.GetPathValue<int>(test, "x.y.z");
-                Assert.Fail("should have throw exception");
+                throw new XunitException("should have throw exception");
             }
             catch
             {
             }
 
-            Assert.IsNull(ObjectPath.GetPathValue<string>(test, "x.y.z", null));
-            Assert.AreEqual(99, ObjectPath.GetPathValue<int>(test, "x.y.z", 99));
-            Assert.IsFalse(ObjectPath.TryGetPathValue<string>(test, "x.y.z", out var value));
+            Assert.Null(ObjectPath.GetPathValue<string>(test, "x.y.z", null));
+            Assert.Equal(99, ObjectPath.GetPathValue<int>(test, "x.y.z", 99));
+            Assert.False(ObjectPath.TryGetPathValue<string>(test, "x.y.z", out var value));
             ObjectPath.RemovePathValue(test, "x.a[1]");
-            Assert.IsFalse(ObjectPath.TryGetPathValue<string>(test, "x.a[1]", out string value2));
-            Assert.IsTrue(ObjectPath.TryGetPathValue<string>(test, "x.a[0]", out value2));
-            Assert.AreEqual("dabba", value2);
+            Assert.False(ObjectPath.TryGetPathValue<string>(test, "x.a[1]", out string value2));
+            Assert.True(ObjectPath.TryGetPathValue<string>(test, "x.a[0]", out value2));
+            Assert.Equal("dabba", value2);
+        }
+
+        private void AssertGetSetValueType<T>(object test, T val)
+        {
+            ObjectPath.SetPathValue(test, val.GetType().Name, val);
+            var result = ObjectPath.GetPathValue<T>(test, typeof(T).Name);
+            Assert.Equal(val, result);
+            Assert.Equal(val.GetType(), result.GetType());
         }
     }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptCultureModelsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptCultureModelsTests.cs
@@ -4,59 +4,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Prompts;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using static Microsoft.Bot.Builder.Dialogs.Prompts.PromptCultureModels;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
-    [TestCategory("Prompts")]
-    [TestCategory("Prompt Culture Models Tests")]
+    [Trait("TestCategory", "Prompts")]
+    [Trait("TestCategory", "Prompt Culture Models Tests")]
     public class PromptCultureModelsTests
     {
-        [TestMethod]
-        [DynamicData(nameof(GetLocaleVariationTest), DynamicDataSourceType.Method)]
-        public void ShouldCorrectlyMapToNearesLanguage(string localeVariation, string expectedResult)
-        {
-            var result = MapToNearestLanguage(localeVariation);
-            Assert.AreEqual(expectedResult, result);
-        }
-
-        [TestMethod]
-        public void ShouldReturnAllSupportedCultures()
-        {
-            var expected = new PromptCultureModel[]
-            {
-                Bulgarian,
-                Chinese,
-                Dutch,
-                English,
-                French,
-                German,
-                Hindi,
-                Italian,
-                Japanese,
-                Korean,
-                Portuguese,
-                Spanish,
-                Swedish,
-                Turkish
-            };
-
-            var supportedCultures = GetSupportedCultures();
-
-            Assert.IsTrue(expected.All(expectedCulture =>
-            {
-                return supportedCultures.Any(supportedCulture => expectedCulture.Locale == supportedCulture.Locale);
-            }));
-
-            Assert.IsTrue(supportedCultures.All(supportedCulture =>
-            {
-                return expected.Any(expectedCulture => supportedCulture.Locale == expectedCulture.Locale);
-            }));
-        }
-
-        private static IEnumerable<object[]> GetLocaleVariationTest()
+        public static IEnumerable<object[]> GetLocaleVariationTest()
         {
             var testLocales = new TestLocale[]
             {
@@ -84,6 +41,48 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 yield return new object[] { locale.CapTwoLetter, locale.Culture.Locale };
                 yield return new object[] { locale.LowerTwoLetter, locale.Culture.Locale };
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLocaleVariationTest), DisableDiscoveryEnumeration = true)]
+        public void ShouldCorrectlyMapToNearesLanguage(string localeVariation, string expectedResult)
+        {
+            var result = MapToNearestLanguage(localeVariation);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void ShouldReturnAllSupportedCultures()
+        {
+            var expected = new PromptCultureModel[]
+            {
+                Bulgarian,
+                Chinese,
+                Dutch,
+                English,
+                French,
+                German,
+                Hindi,
+                Italian,
+                Japanese,
+                Korean,
+                Portuguese,
+                Spanish,
+                Swedish,
+                Turkish
+            };
+
+            var supportedCultures = GetSupportedCultures();
+
+            Assert.True(expected.All(expectedCulture =>
+            {
+                return supportedCultures.Any(supportedCulture => expectedCulture.Locale == supportedCulture.Locale);
+            }));
+
+            Assert.True(supportedCultures.All(supportedCulture =>
+            {
+                return expected.Any(expectedCulture => supportedCulture.Locale == expectedCulture.Locale);
+            }));
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptValidatorContextTests.cs
@@ -4,14 +4,13 @@
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class PromptValidatorContextTests
     {
-        [TestMethod]
+        [Fact]
         public async Task PromptValidatorContextEnd()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -61,7 +60,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task PromptValidatorContextRetryEnd()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -123,7 +122,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task PromptValidatorNumberOfAttempts()
         {
             var convoState = new ConversationState(new MemoryStorage());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ReplaceDialogTest.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ReplaceDialogTest.cs
@@ -4,15 +4,14 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class ReplaceDialogTest
     {
-        [TestMethod]
+        [Fact]
         public async Task ReplaceDialogNoBranchAsync()
         {
             var dialog = new FirstDialog();
@@ -40,7 +39,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ReplaceDialogBranchAsync()
         {
             var dialog = new FirstDialog();
@@ -69,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ReplaceDialogTelemetryClientNotNull()
         {
             var botTelemetryClient = new Mock<IBotTelemetryClient>();
@@ -86,7 +85,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 await dialogManager.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-                Assert.IsNotNull(dialog.TelemetryClient);
+                Assert.NotNull(dialog.TelemetryClient);
             })
             .Send("hello")
             .StartTestAsync();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
@@ -13,39 +13,38 @@ using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Builder.Testing;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class SkillDialogTests
     {
-        [TestMethod]
+        [Fact]
         public void ConstructorValidationTests()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => new SkillDialog(null));
+            Assert.Throws<ArgumentNullException>(() => { new SkillDialog(null); });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task BeginDialogOptionsValidation()
         {
             var dialogOptions = new SkillDialogOptions();
             var sut = new SkillDialog(dialogOptions);
             var client = new DialogTestClient(Channels.Test, sut);
-            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"), "null options should fail");
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"));
 
             client = new DialogTestClient(Channels.Test, sut, new Dictionary<string, string>());
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"), "options should be of type DialogArgs");
+            await Assert.ThrowsAsync<ArgumentException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"));
 
             client = new DialogTestClient(Channels.Test, sut, new BeginSkillDialogOptions());
-            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"), "Activity in DialogArgs should be set");
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"));
         }
 
-        [TestMethod]
-        [DataRow(null)]
-        [DataRow(DeliveryModes.ExpectReplies)]
+        [Theory]
+        [InlineData(null)]
+        [InlineData(DeliveryModes.ExpectReplies)]
         public async Task BeginDialogCallsSkill(string deliveryMode)
         {
             Activity activitySent = null;
@@ -77,35 +76,35 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             activityToSend.Text = Guid.NewGuid().ToString();
             var client = new DialogTestClient(Channels.Test, sut, new BeginSkillDialogOptions { Activity = activityToSend }, conversationState: conversationState);
 
-            Assert.AreEqual(0, ((SimpleConversationIdFactory)dialogOptions.ConversationIdFactory).CreateCount);
+            Assert.Equal(0, ((SimpleConversationIdFactory)dialogOptions.ConversationIdFactory).CreateCount);
             
             // Send something to the dialog to start it
             await client.SendActivityAsync<Activity>("irrelevant");
 
             // Assert results and data sent to the SkillClient for fist turn
-            Assert.AreEqual(1, ((SimpleConversationIdFactory)dialogOptions.ConversationIdFactory).CreateCount);
-            Assert.AreEqual(dialogOptions.BotId, fromBotIdSent);
-            Assert.AreEqual(dialogOptions.Skill.AppId, toBotIdSent);
-            Assert.AreEqual(dialogOptions.Skill.SkillEndpoint.ToString(), toUriSent.ToString());
-            Assert.AreEqual(activityToSend.Text, activitySent.Text);
-            Assert.AreEqual(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
+            Assert.Equal(1, ((SimpleConversationIdFactory)dialogOptions.ConversationIdFactory).CreateCount);
+            Assert.Equal(dialogOptions.BotId, fromBotIdSent);
+            Assert.Equal(dialogOptions.Skill.AppId, toBotIdSent);
+            Assert.Equal(dialogOptions.Skill.SkillEndpoint.ToString(), toUriSent.ToString());
+            Assert.Equal(activityToSend.Text, activitySent.Text);
+            Assert.Equal(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
 
             // Send a second message to continue the dialog
             await client.SendActivityAsync<Activity>("Second message");
-            Assert.AreEqual(1, ((SimpleConversationIdFactory)dialogOptions.ConversationIdFactory).CreateCount);
+            Assert.Equal(1, ((SimpleConversationIdFactory)dialogOptions.ConversationIdFactory).CreateCount);
 
             // Assert results for second turn
-            Assert.AreEqual("Second message", activitySent.Text);
-            Assert.AreEqual(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
+            Assert.Equal("Second message", activitySent.Text);
+            Assert.Equal(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
 
             // Send EndOfConversation to the dialog
             await client.SendActivityAsync<IEndOfConversationActivity>((Activity)Activity.CreateEndOfConversationActivity());
 
             // Assert we are done.
-            Assert.AreEqual(DialogTurnStatus.Complete, client.DialogTurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Complete, client.DialogTurnResult.Status);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldHandleInvokeActivities()
         {
             Activity activitySent = null;
@@ -140,28 +139,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await client.SendActivityAsync<Activity>("irrelevant");
 
             // Assert results and data sent to the SkillClient for fist turn
-            Assert.AreEqual(dialogOptions.BotId, fromBotIdSent);
-            Assert.AreEqual(dialogOptions.Skill.AppId, toBotIdSent);
-            Assert.AreEqual(dialogOptions.Skill.SkillEndpoint.ToString(), toUriSent.ToString());
-            Assert.AreEqual(activityToSend.Name, activitySent.Name);
-            Assert.AreEqual(DeliveryModes.ExpectReplies, activitySent.DeliveryMode);
-            Assert.AreEqual(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
+            Assert.Equal(dialogOptions.BotId, fromBotIdSent);
+            Assert.Equal(dialogOptions.Skill.AppId, toBotIdSent);
+            Assert.Equal(dialogOptions.Skill.SkillEndpoint.ToString(), toUriSent.ToString());
+            Assert.Equal(activityToSend.Name, activitySent.Name);
+            Assert.Equal(DeliveryModes.ExpectReplies, activitySent.DeliveryMode);
+            Assert.Equal(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
 
             // Send a second message to continue the dialog
             await client.SendActivityAsync<Activity>("Second message");
 
             // Assert results for second turn
-            Assert.AreEqual("Second message", activitySent.Text);
-            Assert.AreEqual(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
+            Assert.Equal("Second message", activitySent.Text);
+            Assert.Equal(DialogTurnStatus.Waiting, client.DialogTurnResult.Status);
 
             // Send EndOfConversation to the dialog
             await client.SendActivityAsync<IEndOfConversationActivity>((Activity)Activity.CreateEndOfConversationActivity());
 
             // Assert we are done.
-            Assert.AreEqual(DialogTurnStatus.Complete, client.DialogTurnResult.Status);
+            Assert.Equal(DialogTurnStatus.Complete, client.DialogTurnResult.Status);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CancelDialogSendsEoC()
         {
             Activity activitySent = null;
@@ -192,10 +191,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             // Cancel the dialog so it sends an EoC to the skill
             await client.DialogContext.CancelAllDialogsAsync(CancellationToken.None);
 
-            Assert.AreEqual(ActivityTypes.EndOfConversation, activitySent.Type);
+            Assert.Equal(ActivityTypes.EndOfConversation, activitySent.Type);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldThrowHttpExceptionOnPostFailure()
         {
             // Create a mock skill client to intercept calls and capture what is sent.
@@ -212,10 +211,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var client = new DialogTestClient(Channels.Test, sut, new BeginSkillDialogOptions { Activity = activityToSend }, conversationState: conversationState);
 
             // Send something to the dialog 
-            await Assert.ThrowsExceptionAsync<HttpRequestException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"));
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await client.SendActivityAsync<IMessageActivity>("irrelevant"));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldInterceptOAuthCardsForSso()
         {
             var connectionName = "connectionName";
@@ -240,10 +239,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var client = new DialogTestClient(testAdapter, sut, new BeginSkillDialogOptions { Activity = activityToSend }, conversationState: conversationState);
             testAdapter.AddExchangeableToken(connectionName, Channels.Test, "user1", "https://test", "https://test1");
             var finalActivity = await client.SendActivityAsync<IMessageActivity>("irrelevant");
-            Assert.IsNull(finalActivity);
+            Assert.Null(finalActivity);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldNotInterceptOAuthCardsForEmptyConnectionName()
         {
             var connectionName = "connectionName";
@@ -267,11 +266,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var client = new DialogTestClient(testAdapter, sut, new BeginSkillDialogOptions { Activity = activityToSend }, conversationState: conversationState);
             testAdapter.AddExchangeableToken(connectionName, Channels.Test, "user1", "https://test", "https://test1");
             var finalActivity = await client.SendActivityAsync<IMessageActivity>("irrelevant");
-            Assert.IsNotNull(finalActivity);
-            Assert.IsTrue(finalActivity.Attachments.Count == 1);
+            Assert.NotNull(finalActivity);
+            Assert.True(finalActivity.Attachments.Count == 1);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldNotInterceptOAuthCardsForEmptyToken()
         {
             var firstResponse = new ExpectedReplies(new List<Activity> { CreateOAuthCardAttachmentActivity("https://test") });
@@ -295,11 +294,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             // Don't add exchangeable token to test adapter
             var finalActivity = await client.SendActivityAsync<IMessageActivity>("irrelevant");
-            Assert.IsNotNull(finalActivity);
-            Assert.IsTrue(finalActivity.Attachments.Count == 1);
+            Assert.NotNull(finalActivity);
+            Assert.Single(finalActivity.Attachments);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldNotInterceptOAuthCardsForTokenException()
         {
             var connectionName = "connectionName";
@@ -324,11 +323,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var client = new DialogTestClient(testAdapter, sut, initialDialogOptions, conversationState: conversationState);
             testAdapter.ThrowOnExchangeRequest(connectionName, Channels.Test, "user1", "https://test");
             var finalActivity = await client.SendActivityAsync<IMessageActivity>("irrelevant");
-            Assert.IsNotNull(finalActivity);
-            Assert.IsTrue(finalActivity.Attachments.Count == 1);
+            Assert.NotNull(finalActivity);
+            Assert.Single(finalActivity.Attachments);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ShouldNotInterceptOAuthCardsForBadRequest()
         {
             var connectionName = "connectionName";
@@ -353,8 +352,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var client = new DialogTestClient(testAdapter, sut, new BeginSkillDialogOptions { Activity = activityToSend }, conversationState: conversationState);
             testAdapter.AddExchangeableToken(connectionName, Channels.Test, "user1", "https://test", "https://test1");
             var finalActivity = await client.SendActivityAsync<IMessageActivity>("irrelevant");
-            Assert.IsNotNull(finalActivity);
-            Assert.IsTrue(finalActivity.Attachments.Count == 1);
+            Assert.NotNull(finalActivity);
+            Assert.Single(finalActivity.Attachments);
         }
 
         private static Activity CreateOAuthCardAttachmentActivity(string uri)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             testAdapter.AddExchangeableToken(connectionName, Channels.Test, "user1", "https://test", "https://test1");
             var finalActivity = await client.SendActivityAsync<IMessageActivity>("irrelevant");
             Assert.NotNull(finalActivity);
-            Assert.True(finalActivity.Attachments.Count == 1);
+            Assert.Single(finalActivity.Attachments);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SourceMapTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SourceMapTests.cs
@@ -3,16 +3,13 @@
 
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class SourceMapTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
+        [Fact]
         public void TestSourceMap()
         {
             ISourceMap sourceMap = new SourceMap();
@@ -32,18 +29,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             SourceRange range;
             foreach (var item in items)
             {
-                Assert.IsTrue(sourceMap.TryGetValue(item, out range), "couldn't find item");
-                Assert.AreEqual($"{item.Index}.txt", range.Path);
-                Assert.AreEqual(10 + item.Index, range.StartPoint.LineIndex);
-                Assert.AreEqual(20 + item.Index, range.StartPoint.CharIndex);
-                Assert.AreEqual(30 + item.Index, range.EndPoint.LineIndex);
-                Assert.AreEqual(40 + item.Index, range.EndPoint.CharIndex);
+                Assert.True(sourceMap.TryGetValue(item, out range), "couldn't find item");
+                Assert.Equal($"{item.Index}.txt", range.Path);
+                Assert.Equal(10 + item.Index, range.StartPoint.LineIndex);
+                Assert.Equal(20 + item.Index, range.StartPoint.CharIndex);
+                Assert.Equal(30 + item.Index, range.EndPoint.LineIndex);
+                Assert.Equal(40 + item.Index, range.EndPoint.CharIndex);
             }
 
-            Assert.IsFalse(sourceMap.TryGetValue(new object(), out range), "shouldn't find item");
+            Assert.False(sourceMap.TryGetValue(new object(), out range), "shouldn't find item");
         }
 
-        [TestMethod]
+        [Fact]
         public void TestNullSourceMap()
         {
             ISourceMap sourceMap = new NullSourceMap();
@@ -63,7 +60,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             SourceRange range;
             foreach (var item in items)
             {
-                Assert.IsFalse(sourceMap.TryGetValue(item, out range), "shouldn't find item");
+                Assert.False(sourceMap.TryGetValue(item, out range), "shouldn't find item");
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
@@ -8,39 +8,31 @@ using System.Threading.Tasks;
 using Castle.Core.Internal;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class TextPromptTests
     {
-        public TestContext TestContext { get; set; }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void TextPromptWithEmptyIdShouldFail()
         {
-            var emptyId = string.Empty;
-            var textPrompt = new TextPrompt(emptyId);
+            Assert.Throws<ArgumentNullException>(() => { new TextPrompt(string.Empty); });
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void TextPromptWithNullIdShouldFail()
         {
-            var nullId = string.Empty;
-            nullId = null;
-            var textPrompt = new TextPrompt(nullId);
+            Assert.Throws<ArgumentNullException>(() => { new TextPrompt(null); });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TextPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TextPrompt)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
@@ -72,13 +64,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TextPromptWithNaughtyStrings()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TextPromptWithNaughtyStrings)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
@@ -132,13 +124,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             while (!string.IsNullOrEmpty(naughtyString));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TextPromptValidator()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TextPromptValidator)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
@@ -186,13 +178,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TextPromptWithRetryPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TextPromptWithRetryPrompt)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 
@@ -240,13 +232,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TextPromptValidatorWithMessageShouldNotSendRetryPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
             var dialogState = convoState.CreateProperty<DialogState>("dialogState");
 
-            var adapter = new TestAdapter(TestAdapter.CreateConversation(TestContext.TestName))
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(TextPromptValidatorWithMessageShouldNotSendRetryPrompt)))
                 .Use(new AutoSaveStateMiddleware(convoState))
                 .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
@@ -8,11 +8,10 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Microsoft.Bot.Schema;
 using Microsoft.Recognizers.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Tests
 {
-    [TestClass]
     public class WaterfallTests
     {
         public static WaterfallDialog Create_Waterfall3()
@@ -51,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 steps);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task Waterfall()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -101,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallStepParentIsWaterfallParent()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -118,7 +117,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 async (step, cancellationToken) =>
                 {
-                    Assert.AreEqual(step.Parent.ActiveDialog.Id, waterfallParent.Id);
+                    Assert.Equal(step.Parent.ActiveDialog.Id, waterfallParent.Id);
                     await step.Context.SendActivityAsync("verified");
                     return Dialog.EndOfTurn;
                 }
@@ -144,7 +143,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallWithCallback()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -196,15 +195,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
+        [Fact]
         public void WaterfallWithStepsNull()
         {
-            var waterfall = new WaterfallDialog("test");
-            waterfall.AddStep(null);
+            Assert.Throws<ArgumentNullException>(() => { new WaterfallDialog("test").AddStep(null); });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallWithClass()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -234,7 +231,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallPrompt()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -279,7 +276,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallNested()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -317,7 +314,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallDateTimePromptFirstInvalidThenValidInput()
         {
             var convoState = new ConversationState(new MemoryStorage());
@@ -333,7 +330,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 },
                 async (stepContext, cancellationToken) =>
                 {
-                    Assert.IsNotNull(stepContext);
+                    Assert.NotNull(stepContext);
                     return await stepContext.EndDialogAsync();
                 },
             };
@@ -365,7 +362,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             .StartTestAsync();
         }
 
-        [TestMethod]
+        [Fact]
         public async Task WaterfallCancel()
         {
             const string id = "waterfall";
@@ -376,7 +373,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             dialog.TelemetryClient = new MyBotTelemetryClient(stepName =>
             {
-                Assert.AreEqual(stepName, "Waterfall2_Step2");
+                Assert.Equal("Waterfall2_Step2", stepName);
                 trackEventCalled = true;
             });
 
@@ -393,7 +390,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 },
                 DialogReason.CancelCalled);
 
-            Assert.IsTrue(trackEventCalled, "TrackEvent was never called.");
+            Assert.True(trackEventCalled, "TrackEvent was never called.");
         }
 
         private static WaterfallDialog Create_Waterfall2()


### PR DESCRIPTION
Fixes #4096

## Description
This PR migrates **the following test files** inside the [Microsoft.Bot.Builder.Dialogs.Tests](https://github.com/microsoft/botbuilder-dotnet/tree/main/tests/Microsoft.Bot.Builder.Dialogs.Tests) folder from **MSTest** to **xUnit**.
- ObjectPathTests
- PromptCultureModelsTests
- PromptValidatorContextTests
- ReplaceDialogTest
- SkillDialogTests
- SourceMapTests
- TextPromptTests
- WaterfallTests

## Specific Changes
- Added `xUnit` packages to `.csproj`.
- Changed `[TestMethod]` to `[Fact]` or `[Theory]`.
- Changed `[TestCategory]` to `[Trait]`.
- Changed `[DataRow]` to `[InlineData]`.
- Changed `[ExpectedException]` to `Assert.Throws`.
- Changed `Assert.AreEqual` to `Assert.Equal`.
- Changed `Assert.IsNotNull` to `Assert.NotNull`.
- Changed `Assert.IsNull` to `Assert.Null`.
- Changed `Assert.IsTrue` to `Assert.True` or `AssertSingle`.
- Changed `Assert.IsFalse` to `Assert.False`.
- Replaced `Assert.Fail` with `throw new XunitException`.
- Replaced `TestContext.TestName` with `nameof()` and `TestContext `related data.
- Made private method `GetLocaleVariationTest` public and relocated it.

## Testing
In the following image there are the passing tests.
![image](https://user-images.githubusercontent.com/64803884/92639842-c74c7a80-f2b2-11ea-9ecb-f2f252dfa862.png)
