### PR TITLE
[#4321] Add missing XML documentation to Bot.Builder.Dialogs.Adaptive/TriggerConditions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnActivity.cs
@@ -14,9 +14,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnActivity : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnActivity"/> class.
+        /// </summary>
+        /// <param name="type">Optional, ActivityType which must be matched for this event to trigger.</param>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnActivity(string type = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(@event: AdaptiveEvents.ActivityReceived, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)
@@ -33,6 +44,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         [JsonProperty("type")]
         public string Type { get; set; }
 
+        /// <summary>
+        /// Gets the identity for the activity.
+        /// </summary>
+        /// <returns>Identity.</returns>
         public override string GetIdentity()
         {
             if (this.GetType() == typeof(OnActivity))
@@ -43,6 +58,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return $"{this.GetType().Name}[{this.Condition}]";
         }
 
+        /// <summary>
+        /// Gets this activity's representing expresion.
+        /// </summary>
+        /// <returns>An <see cref="Expression"/> representing the activity.</returns>
         public override Expression GetExpression()
         {
             // add constraints for activity type

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnConversationUpdateActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnConversationUpdateActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnConversationUpdateActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnConversationUpdateActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnConversationUpdateActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnConversationUpdateActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.ConversationUpdate, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnEndOfConversationActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnEndOfConversationActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnEndOfConversationActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnEndOfConversationActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnEndOfConversationActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnEndOfConversationActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.EndOfConversation, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnEventActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnEventActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnEventActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnEventActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnEventActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnEventActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.Event, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnHandoffActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnHandoffActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnHandoffActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnHandoffActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnHandoffActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnHandoffActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.Handoff, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnInvokeActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnInvokeActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnInvokeActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnInvokeActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnInvokeActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnInvokeActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.Invoke, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageActivity.cs
@@ -17,9 +17,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </remarks>
     public class OnMessageActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnMessageActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnMessageActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnMessageActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.Message, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageDeleteActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageDeleteActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnMessageDeleteActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnMessageDeleteActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnMessageDeleteActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnMessageDeleteActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.MessageDelete, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageReactionActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageReactionActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnMessageReactionActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnMessageReactionActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnMessageReactionActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnMessageReactionActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.MessageReaction, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageUpdateActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnMessageUpdateActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnMessageUpdateActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnMessageUpdateActivity";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnMessageUpdateActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnMessageUpdateActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.MessageUpdate, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnTypingActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnTypingActivity.cs
@@ -13,9 +13,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnTypingActivity : OnActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnTypingActivity";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnTypingActivity"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, list of <see cref="Dialog"/> actions.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnTypingActivity(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(type: ActivityTypes.Typing, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Extensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Extensions.cs
@@ -14,6 +14,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     public static partial class Extensions
 #pragma warning restore CA1724 // Type names should not match namespaces
     {
+        /// <summary>
+        /// Call into active IDialogDebugger and let it know that we are at given point.
+        /// </summary>
+        /// <param name="context">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="conditional">Condition to trigger the event.</param>
+        /// <param name="dialogEvent">The event being raised.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for this task.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task DebuggerStepAsync(this DialogContext context, OnCondition conditional, DialogEvent dialogEvent, CancellationToken cancellationToken)
         {
             await context.GetDebugger().StepAsync(context, conditional, more: dialogEvent?.Name ?? string.Empty, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnAssignEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnAssignEntity.cs
@@ -12,9 +12,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnAssignEntity : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnAssignEntity";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnAssignEntity"/> class.
+        /// </summary>
+        /// <param name="property">Optional, property to be assigned for filtering events.</param>
+        /// <param name="entity">Optional, entity name being assigned for filtering events.</param>
+        /// <param name="operation">Optional, operation being used to assign the entity for filtering events.</param>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnAssignEntity(string property = null, string entity = null, string operation = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
@@ -50,9 +63,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         [JsonProperty("operation")]
         public string Operation { get; set; }
 
+        /// <summary>
+        /// Gets the identity for this rule's action.
+        /// </summary>
+        /// <returns>String with the identity.</returns>
         public override string GetIdentity()
             => $"{this.GetType().Name}({this.Property}, {this.Entity})";
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             var expressions = new List<Expression> { base.GetExpression() };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnBeginDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnBeginDialog.cs
@@ -12,9 +12,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnBeginDialog : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnBeginDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnBeginDialog"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnBeginDialog(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(@event: AdaptiveEvents.BeginDialog, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCancelDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCancelDialog.cs
@@ -12,9 +12,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnCancelDialog : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnCancelDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnCancelDialog"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnCancelDialog(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(@event: AdaptiveEvents.CancelDialog, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
@@ -12,9 +12,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnChooseEntity : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnChooseEntity";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnChooseEntity"/> class.
+        /// </summary>
+        /// <param name="property">Optional, property to be assigned for filtering events.</param>
+        /// <param name="entity">Optional, entity name being assigned for filtering events.</param>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnChooseEntity(string property = null, string entity = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
@@ -42,9 +54,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         [JsonProperty("entity")]
         public string Entity { get; set; }
 
+        /// <summary>
+        /// Gets the identity for this rule's action.
+        /// </summary>
+        /// <returns>String with the identity.</returns>
         public override string GetIdentity()
             => $"{this.GetType().Name}({this.Property}, {this.Entity})";
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             var expressions = new List<Expression> { base.GetExpression() };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseIntent.cs
@@ -18,9 +18,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </remarks>
     public class OnChooseIntent : OnIntent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnChooseIntent";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnChooseIntent"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnChooseIntent(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(CrossTrainedRecognizerSet.ChooseIntent, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)
@@ -36,6 +46,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public List<string> Intents { get; set; } = new List<string>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             // add constraints for the intents property if set

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseProperty.cs
@@ -12,9 +12,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnChooseProperty : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnChooseProperty";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnChooseProperty"/> class.
+        /// </summary>
+        /// <param name="properties">Optional, list of properties being chosen between to filter events.</param>
+        /// <param name="entities">Optional, list of entities being chosen between to filter events.</param>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnChooseProperty(List<string> properties = null, List<string> entities = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
@@ -46,9 +58,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public List<string> Entities { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets the identity for this rule's action.
+        /// </summary>
+        /// <returns>String with the identity.</returns>
         public override string GetIdentity()
             => $"{this.GetType().Name}([{string.Join(",", this.Properties)}], {this.Entities})";
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             var expressions = new List<Expression> { base.GetExpression() };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     [DebuggerDisplay("{GetIdentity()}")]
     public class OnCondition : IItemIdentity, IDialogDependencies
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.OnCondition";
 
@@ -35,6 +38,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         // cached expression representing all constraints (constraint AND extraConstraints AND childrenConstraints)
         private Expression fullConstraint = null;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnCondition"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnCondition(string condition = null, List<Dialog> actions = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
@@ -67,6 +77,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public List<Dialog> Actions { get; set; } = new List<Dialog>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets the source.
+        /// </summary>
+        /// <value>Source map value from <see cref="DebugSupport"/>.</value>
         [JsonIgnore]
         public virtual SourceRange Source => DebugSupport.SourceMap.TryGetValue(this, out var range) ? range : null;
 
@@ -91,6 +105,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         [JsonIgnore]
         public string Id { get; set; }
 
+        /// <summary>
+        /// Gets the action scope.
+        /// </summary>
+        /// <value>The scope obtained from the action.</value>
         protected ActionScope ActionScope
         {
             get
@@ -251,11 +269,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return $"{this.GetType().Name}()";
         }
 
+        /// <summary>
+        /// Enumerate child dialog dependencies so they can be added to the containers dialog set.
+        /// </summary>
+        /// <returns>dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()
         {
             yield return this.ActionScope;
         }
 
+        /// <summary>
+        /// Called when a change list is created.
+        /// </summary>
+        /// <param name="actionContext">Context to use for evaluation.</param>
+        /// <param name="dialogOptions">Optional, object with dialog options.</param>
+        /// <returns>An <see cref="ActionChangeList"/> with the list of actions.</returns>
         protected virtual ActionChangeList OnCreateChangeList(ActionContext actionContext, object dialogOptions = null)
         {
             var changeList = new ActionChangeList()
@@ -272,6 +300,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return changeList;
         }
 
+        /// <summary>
+        /// Registers the source location.
+        /// </summary>
+        /// <param name="path">Path to source file.</param>
+        /// <param name="lineNumber">Line number in source file.</param>
         protected void RegisterSourceLocation(string path, int lineNumber)
         {
             if (path != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -41,8 +41,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Initializes a new instance of the <see cref="OnCondition"/> class.
         /// </summary>
-        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
         /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
@@ -270,7 +270,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         }
 
         /// <summary>
-        /// Enumerate child dialog dependencies so they can be added to the containers dialog set.
+        /// Enumerates child dialog dependencies so they can be added to the containers dialog set.
         /// </summary>
         /// <returns>dialog enumeration.</returns>
         public virtual IEnumerable<Dialog> GetDependencies()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnContinueConversation.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnContinueConversation.cs
@@ -8,11 +8,24 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
 {
+    /// <summary>
+    /// Action triggered when a conversation continues.
+    /// </summary>
     public class OnContinueConversation : OnEventActivity
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnContinueConversation";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnContinueConversation"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnContinueConversation(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(actions, condition, callerPath, callerLine)
@@ -20,6 +33,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             this.RegisterSourceLocation(callerPath, callerLine);
         }
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             // add constraints for activity type

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnContinueConversation.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnContinueConversation.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         }
 
         /// <summary>
-        /// Get the expression for this rule.
+        /// Gets the expression for this rule.
         /// </summary>
         /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnDialogEvent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnDialogEvent.cs
@@ -13,9 +13,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnDialogEvent : OnCondition
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnDialogEvent";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnDialogEvent"/> class.
+        /// </summary>
+        /// <param name="event">Optional, the event to fire on.</param>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnDialogEvent(string @event = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(condition: condition, actions: actions, callerPath: callerPath, callerLine: callerLine)
@@ -32,11 +43,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// </value>
         public string Event { get; set; }
 
+        /// <summary>
+        /// Gets the identity for this rule's action.
+        /// </summary>
+        /// <returns>String with the identity.</returns>
         public override string GetIdentity()
         {
             return $"{this.GetType().Name}({this.Event})";
         }
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             return Expression.AndExpression(Expression.Parse($"{TurnPath.DialogEvent}.name == '{this.Event}'"), base.GetExpression());

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnDialogEvent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnDialogEvent.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         }
 
         /// <summary>
-        /// Get the expression for this rule.
+        /// Gets the expression for this rule.
         /// </summary>
         /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnEndOfActions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnEndOfActions.cs
@@ -12,9 +12,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnEndOfActions : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnEndOfActions";
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnEndOfActions"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnEndOfActions(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
@@ -12,15 +12,31 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnError : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnError";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnError"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnError(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(@event: AdaptiveEvents.Error, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)
         {
         }
 
+        /// <summary>
+        /// Called when a change list is created.
+        /// </summary>
+        /// <param name="actionContext">Context to use for evaluation.</param>
+        /// <param name="dialogOptions">Optional, object with dialog options.</param>
+        /// <returns>An <see cref="ActionChangeList"/> with the list of actions.</returns>
         protected override ActionChangeList OnCreateChangeList(ActionContext actionContext, object dialogOptions = null)
         {
             var changeList = base.OnCreateChangeList(actionContext, dialogOptions);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
@@ -16,9 +16,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnIntent : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnIntent";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnIntent"/> class.
+        /// </summary>
+        /// <param name="intent">Optional, intent to match on.</param>
+        /// <param name="entities">Optional, entities which must be recognized for this rule to trigger.</param>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnIntent(string intent = null, List<string> entities = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
@@ -52,11 +64,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public List<string> Entities { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
+        /// <summary>
+        /// Gets the identity for this rule's action.
+        /// </summary>
+        /// <returns>String with the identity.</returns>
         public override string GetIdentity()
         {
             return $"{this.GetType().Name}({this.Intent})[{string.Join(",", this.Entities)}]";
         }
 
+        /// <summary>
+        /// Get the expression for this rule.
+        /// </summary>
+        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()
         {
             // add constraints for the intents property
@@ -86,6 +106,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return Expression.AndExpression(intentExpression, base.GetExpression());
         }
 
+        /// <summary>
+        /// Called when a change list is created.
+        /// </summary>
+        /// <param name="actionContext">Context to use for evaluation.</param>
+        /// <param name="dialogOptions">Optional, object with dialog options.</param>
+        /// <returns>An <see cref="ActionChangeList"/> with the list of actions.</returns>
         protected override ActionChangeList OnCreateChangeList(ActionContext actionContext, object dialogOptions = null)
         {
             var recognizerResult = actionContext.State.GetValue<RecognizerResult>($"{TurnPath.DialogEvent}.value");

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         }
 
         /// <summary>
-        /// Get the expression for this rule.
+        /// Gets the expression for this rule.
         /// </summary>
         /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
         public override Expression GetExpression()

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnQnAMatch.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnQnAMatch.cs
@@ -15,12 +15,22 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </remarks>
     public class OnQnAMatch : OnIntent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnQnAMatch";
 
         // this is a duplicate of QnAMakerRecognizer.QnAMatchIntent, but copying this here removes need to have dependency between QnA and Adaptive assemblies.
         private const string QnAMatchIntent = "QnAMatch";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnQnAMatch"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnQnAMatch(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(QnAMatchIntent, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnRepromptDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnRepromptDialog.cs
@@ -12,9 +12,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </summary>
     public class OnRepromptDialog : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnRepromptDialog";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnRepromptDialog"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnRepromptDialog(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(@event: AdaptiveEvents.RepromptDialog, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnUnknownIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnUnknownIntent.cs
@@ -19,9 +19,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
     /// </remarks>
     public class OnUnknownIntent : OnDialogEvent
     {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
         [JsonProperty("$kind")]
         public new const string Kind = "Microsoft.OnUnknownIntent";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnUnknownIntent"/> class.
+        /// </summary>
+        /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
+        /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
         public OnUnknownIntent(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(


### PR DESCRIPTION
Address #4321

## Description
This PR adds the missing XML documentation to all visible classes, methods, properties, and parameters in [Bot.Builder.Dialogs.Adaptive/TriggerConditions](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions), removing 75 errors.

**Note**: the NoWarn-CS1591 property is removed in the last PR of the series adding the documentation, to avoid build failures.

## Specific Changes
- Adds all missing documentation instances to all *.cs* files found within [*Microsoft.Bot.Builder.Dialogs.Adaptive* TriggerConditions directory](https://github.com/microsoft/botbuilder-dotnet/tree/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions).

## Testing
Below you can see the number of errors shown before and after the changes when de NoWarn-CS1591 property is removed.
![image](https://user-images.githubusercontent.com/38112957/92280654-42d3b380-eed0-11ea-8f8e-fb8547d47a3f.png)
