### PR TITLE
Move version tagging to parent signing yaml

### DIFF
--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -41,12 +41,6 @@ variables:
 jobs:
 - job: Build_and_Sign
   steps:
-  - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-    displayName: 'Tag build with package version'
-    inputs:
-      tags: 'Version=$(ReleasePackageVersion)'
-    continueOnError: true
-
   - powershell: |
      # Replace {DateStamp} and {CommitHash} tokens with the actual values in vars ReleasePackageVersion and PreviewPackageVersion
      $dateStamp = (Get-Date -format "yyyyMMdd");
@@ -62,6 +56,14 @@ jobs:
      Write-Host "##vso[task.setvariable variable=PreviewPackageVersion;]$ppv";
      "Resolved PreviewPackageVersion = $ppv";
     displayName: 'Resolve package version variables'
+
+  - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+    displayName: 'Tag build with release and preview versions'
+    inputs:
+      tags: |
+       Release: $(ReleasePackageVersion)
+       Preview: $(PreviewPackageVersion)
+    continueOnError: true
 
   - template: ci-build-steps.yml
   - template: sign-steps.yml

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -41,6 +41,12 @@ variables:
 jobs:
 - job: Build_and_Sign
   steps:
+  - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+    displayName: 'Tag build with package version'
+    inputs:
+      tags: 'Version=$(ReleasePackageVersion)'
+    continueOnError: true
+
   - powershell: |
      # Replace {DateStamp} and {CommitHash} tokens with the actual values in vars ReleasePackageVersion and PreviewPackageVersion
      $dateStamp = (Get-Date -format "yyyyMMdd");

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -4,12 +4,6 @@ steps:
 
 # Variables ReleasePackageVersion and PreviewPackageVersion are consumed by projects in Microsoft.Bot.Builder.sln.
 # For the signed build, they should be settable at queue time. To set that up, define the variables in Azure on the Variables tab.
-- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-  displayName: 'Tag build with package version'
-  inputs:
-    tags: 'Version=$(ReleasePackageVersion)'
-  continueOnError: true
-
 - task: NuGetToolInstaller@0
   displayName: 'Use NuGet 4.9.1'
   inputs:

--- a/build/yaml/sign-steps.yml
+++ b/build/yaml/sign-steps.yml
@@ -148,32 +148,38 @@ steps:
    
    [int] $packageCount = $outvar.Length;
    $PackagesDescription = "$packageCount packages";
-   Write-Host $PackagesDescription
+   $PackagesDescription;
+   $outvar;
+
    "##vso[task.setvariable variable=PackagesDescription;]$PackagesDescription";
-   
-   ## Log the package names
-   for ($i = 0; $i -lt $packageCount; $i++ ) {
-       Write-Host $outvar[$i];
-   }
-   
-   if ($packageCount -gt 30) {
-       ## Too many packages for tags. Show this message instead
-       $message = "See the 'Get package names' log output for their names";
-       Write-Host "##vso[task.setvariable variable=pkg0;]$message";
-       $packageCount = 1;
+   [int] $maxTags = 5;
+
+   if ($packageCount -gt $maxTags) {
+       # Too many packages for tags.
+
+       # Set a few package name variables for tags
+       for ($i = 0; $i -lt $maxTags; $i++ ) {
+           $p = $outvar[$i];
+           "##vso[task.setvariable variable=pkg$i;]$p";
+       }
+
+       $message = "(See 'Package names' task log for full list)";
+       Write-Host "##vso[task.setvariable variable=pkg$i;]$message";
+       Write-Host $message;
+       $packageCount = ++$i;
    } else {
-       ## Set package name variables for tags
+       # Set package name variables for tags
        for ($i = 0; $i -lt $packageCount; $i++ ) {
            $p = $outvar[$i];
            "##vso[task.setvariable variable=pkg$i;]$p";
        }
    }
-   
+
    for ($i = $packageCount; $i -le 30; $i++ ) {
-       ## Set remaining variables to an empty string
+       # Set remaining variables to an empty string
        "##vso[task.setvariable variable=pkg$i;]";
    }
-  displayName: 'Get package names'
+  displayName: 'Package names'
   continueOnError: true
 
 - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0


### PR DESCRIPTION
This removes version display from CI and PR builds. It is not relevant there, and it generates OAuth warnings in forked builds.
Also improves displayed tags.