### PR TITLE
Add an option to enable ETag support for objects even after they are …

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorageOptions.cs
@@ -85,5 +85,15 @@ namespace Microsoft.Bot.Builder.Azure
         /// The default for backwards compatibility is 255 <see cref="CosmosDbKeyEscape.MaxKeyLength"/>.
         /// </value>
         public bool CompatibilityMode { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to look for ETag property values in store 
+        /// values. The property name is not case sensitive. Objects that already implement 
+        /// <see cref="IStoreItem"/> use optimistic concurrency behavior regardless of this flag.
+        /// </summary>
+        /// <value>
+        /// True if optimistic concurrency should be checked explicitly, otherwise false.
+        /// </value>
+        public bool OptimisticConcurrencyEnabled { get; set; } = false;
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbEmulatorStatus.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbEmulatorStatus.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    internal static class CosmosDbEmulatorStatus
+    {
+        public const string NoEmulatorMessage = "This test requires CosmosDB Emulator! go to https://aka.ms/documentdb-emulator-docs to download and install.";
+
+        private static readonly string EmulatorPath = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe");
+
+        private static readonly Lazy<bool> HasEmulatorLazy = new Lazy<bool>(() =>
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
+            {
+                return false;
+            }
+
+            if (File.Exists(EmulatorPath))
+            {
+                var p = new Process
+                {
+                    StartInfo =
+                    {
+                        UseShellExecute = true,
+                        FileName = EmulatorPath,
+                        Arguments = "/GetStatus",
+                    },
+                };
+                p.Start();
+                p.WaitForExit();
+
+                return p.ExitCode == 2;
+            }
+
+            return false;
+        });
+
+        public static bool HasEmulator => HasEmulatorLazy.Value;
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/IgnoreOnNoEmulatorTheory.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/IgnoreOnNoEmulatorTheory.cs
@@ -5,9 +5,9 @@ using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    public sealed class IgnoreOnNoEmulatorFact : FactAttribute
+    public sealed class IgnoreOnNoEmulatorTheory : TheoryAttribute
     {
-        public IgnoreOnNoEmulatorFact()
+        public IgnoreOnNoEmulatorTheory()
         {
             if (!CosmosDbEmulatorStatus.HasEmulator)
             {


### PR DESCRIPTION
…converted to JObject

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
A customer reported an issue with concurrent requests. It appears the concurrency conflicts no longer happen after the JObject conversion of memory state. To enable customers to continue to have concurrency support on their memory, they will need to define a property "ETag" 

## Specific Changes
  -  Introduce `CosmosDbPartitionedStorageOptions.OptimisticConcurrencyEnabled` with a description of how it behaves.
  -  Place the ETag from the Cosmos DB document into the document's content when the flag is enabled on Read.
  -  Use the ETag from the JObject when the flag is enabled on Write.

## Testing
 - Added a new unit test to ensure the exception is thrown when writing concurrently.
 - Added a test case to ensure the existing waterfall dialog works end to end with this option enabled.
