### PR TITLE
Change vmImage from 'windows-2019' to 'vs2017-win2016'

### DIFF
--- a/build/yaml/-experimentalDummy.yml
+++ b/build/yaml/-experimentalDummy.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 variables:
   TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]

--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-slack-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slack-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'vs2017-win2016' # This gets an agent quicker than 'windows-2019'.
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'vs2017-win2016' # This gets an agent quicker than 'windows-2019'.
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'vs2017-win2016' # This gets an agent quicker than 'windows-2019'.
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'vs2017-win2016' # This gets an agent quicker than 'windows-2019'.
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-simple-build-test.yml
+++ b/build/yaml/botbuilder-dotnet-simple-build-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'vs2017-win2016'
 
 trigger: none
 

--- a/build/yaml/botbuilder-dotnet-simple-build-test.yml
+++ b/build/yaml/botbuilder-dotnet-simple-build-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'vs2017-win2016' # This gets an agent quicker than 'windows-2019'.
 
 trigger: none
 


### PR DESCRIPTION
I have found build agent provisioning is faster for 'vs2017-win2016' than it is for 'windows-2019'.

When a build has been waiting a minute or more for an agent, and there are agents available in the pool, I have found that (1) it was specifying windows-2019, and (2) when I re-queued the build specifying vs2017-win2016, that build started right away while the first build continued waiting for an agent. I have since been switching builds over to vs2017-win2016 in the interest of speed.