### PR TITLE
[Expression] Support return null result in stack memory

### DIFF
--- a/libraries/AdaptiveExpressions/Memory/StackedMemory.cs
+++ b/libraries/AdaptiveExpressions/Memory/StackedMemory.cs
@@ -55,7 +55,7 @@ namespace AdaptiveExpressions.Memory
             {
                 var memory = it.Current;
 
-                if (memory.TryGetValue(path, out var result) && result != null)
+                if (memory.TryGetValue(path, out var result))
                 {
                     value = result;
                     
@@ -68,7 +68,7 @@ namespace AdaptiveExpressions.Memory
                 }
             }
 
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1351,6 +1351,49 @@ namespace AdaptiveExpressions.Tests
             Assert.True(error != null);
         }
 
+        [Fact]
+        public void TestStackMemory()
+        {
+            var sM = new StackedMemory();
+            var jObj1 = new JObject
+            {
+                ["a"] = "a",
+                ["b"] = "b",
+                ["c"] = null
+            };
+
+            var jObj2 = new JObject
+            {
+                ["c"] = "c"
+            };
+
+            var jObj3 = new JObject
+            {
+                ["a"] = "newa",
+                ["b"] = null,
+                ["d"] = "d"
+            };
+
+            sM.Push(new SimpleObjectMemory(jObj1));
+            sM.Push(new SimpleObjectMemory(jObj2));
+            sM.Push(new SimpleObjectMemory(jObj3));
+
+            // Achieve value from stack memory
+            var (value, error) = Expression.Parse("d").TryEvaluate(sM);
+            Assert.Equal("d", value);
+
+            // Achieve valule from the top value firstly
+            (value, error) = Expression.Parse("a").TryEvaluate(sM);
+            Assert.Equal("newa", value);
+
+            (value, error) = Expression.Parse("c").TryEvaluate(sM);
+            Assert.Equal("c", value);
+
+            // null is also the valid value
+            (value, error) = Expression.Parse("b").TryEvaluate(sM);
+            Assert.Null(value);
+        }
+
         private void AssertResult<T>(string text, T expected)
         {
             var memory = new object();


### PR DESCRIPTION

## Description
- `StackMemory` would always return true. It is not correct.
- `StackMemory` would ignore `null` result. This would cause the memory breakdown.

For example:  There is such a stack memory:
-- IMemory1: a = null
-- IMemory2: b = "b"

If `a` is called, the step is: firstly achieve value from memory1, the result is `null`, originally, the Adaptive-expression would drop this result and find the result in memory2. After this change, the `null` result would return directly.
