### PR TITLE
Remove xUnit2000 error from templates test in Microsoft.Bot.Builder.LanguageGeneration.Tests

### DIFF
--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal(evaledArray, actualArr);
 
             var evaledMultilineResult = templates.Evaluate("evalMultiLineObj");
-            Assert.Equal(evaledMultilineResult, "{\"a\":1,\"b\":2,\"c\":{\"d\":4,\"e\":5}}");
+            Assert.Equal("{\"a\":1,\"b\":2,\"c\":{\"d\":4,\"e\":5}}", evaledMultilineResult);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes xUnit2000 error. The first parameter in Assert.Equal, should be the expected value.