### PR TITLE
Disable build warning CS8002 in Microsoft.Bot.Builder.FunctionalTests

### DIFF
--- a/FunctionalTests/Directory.Build.props
+++ b/FunctionalTests/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- SA0001;CS1573,CS1591,CS1712: For tests, we don't generate documentation. Supress related rules. -->
     <!-- SX1309: FieldNamesShouldBeginWithUnderscores should be fixed as part of https://github.com/microsoft/botframework-sdk/issues/5933 -->
-    <NoWarn>$(NoWarn);SA0001;CS1573;CS1591;CS1712;SX1309</NoWarn>
+    <NoWarn>$(NoWarn);SA0001;CS1573;CS1591;CS1712;SX1309;CS8002</NoWarn>
   </PropertyGroup>
 
   <!-- This ensures that Directory.Build.props in parent folders are merged with this one -->


### PR DESCRIPTION
## Description
The following third party libraries that do not have strong names:

- NAudio
- Twilio
- Thrzn41.WebexTeams

This change disables the warning in the FunctionalTests project.

Fixes #4458