### PR TITLE
Revert TranscriptMiddleware to not wait on logging (#4644)

### DIFF
--- a/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
@@ -109,28 +109,23 @@ namespace Microsoft.Bot.Builder
             await nextTurn(cancellationToken).ConfigureAwait(false);
 
             // flush transcript at end of turn
-            var logTasks = new List<Task>();
-            while (transcript.Count > 0)
-            {
-                // Process the queue and log all the activities in parallel.
-                var activity = transcript.Dequeue();
-
-                // Add the logging task to the list (we don't call await here, we await all the calls together later).
-                logTasks.Add(TryLogActivityAsync(_logger, activity));
-            }
-
-            if (logTasks.Any())
-            {
-                // Wait for all the activities to be logged before continuing.
-                await Task.WhenAll(logTasks).ConfigureAwait(false);
-            }
+            // NOTE: We are not awaiting this task by design, TryLogTranscriptAsync() observes all exceptions and we don't need to or want to block execution on the completion.
+            _ = TryLogTranscriptAsync(_logger, transcript);
         }
 
-        private static async Task TryLogActivityAsync(ITranscriptLogger logger, IActivity activity)
+        /// <summary>
+        /// Helper to sequentially flush the transcript queue to the log.
+        /// </summary>
+        private static async Task TryLogTranscriptAsync(ITranscriptLogger logger, Queue<IActivity> transcript)
         {
             try
             {
-                await logger.LogActivityAsync(activity).ConfigureAwait(false);
+                while (transcript.Count > 0)
+                {
+                    // Process the queue and log all the activities in parallel.
+                    var activity = transcript.Dequeue();
+                    await logger.LogActivityAsync(activity).ConfigureAwait(false);
+                }
             }
 #pragma warning disable CA1031 // Do not catch general exception types (this should probably be addressed later, but for now we just log the error and continue the execution)
             catch (Exception ex)


### PR DESCRIPTION
* don't wait on logging

* Move the loop that iterates over the transcript into the async method to avoid triggering multiple async tasks that could cause concurrency issues.

Co-authored-by: Gabo Gilabert <ggilaber@microsoft.com>

Fixes #4642