### PR TITLE
fix DefaultValueResponce can't access DialogContext.State 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 }
             }
 
-            return await dc.EndDialogAsync().ConfigureAwait(false);
+            return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     var (value, error) = this.DefaultValue.TryGetValue(dc.State);
                     if (this.DefaultValueResponse != null)
                     {
-                        var response = await this.DefaultValueResponse.BindAsync(dc, cancellationToken).ConfigureAwait(false);
+                        var response = await this.DefaultValueResponse.BindAsync(dc, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                         var properties = new Dictionary<string, string>()
                         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                         var (value, _) = this.DefaultValue.TryGetValue(dc.State);
                         if (this.DefaultValueResponse != null)
                         {
-                            var response = await this.DefaultValueResponse.BindAsync(dc, cancellationToken).ConfigureAwait(false);
+                            var response = await this.DefaultValueResponse.BindAsync(dc, cancellationToken: cancellationToken).ConfigureAwait(false);
                             var properties = new Dictionary<string, string>()
                             {
                                 { "template", JsonConvert.SerializeObject(this.DefaultValueResponse) },

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/ActivityTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/ActivityTemplate.cs
@@ -59,6 +59,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
         /// <returns>Instance of <see cref="Activity"/>.</returns>
         public virtual async Task<Activity> BindAsync(DialogContext dialogContext, object data = null, CancellationToken cancellationToken = default)
         {
+            if (dialogContext == null)
+            {
+                throw new ArgumentNullException(nameof(dialogContext));
+            }
+
+            if (data is CancellationToken)
+            {
+                throw new ArgumentException($"{nameof(data)} cannot be a cancellation token");
+            }
+
             if (!string.IsNullOrEmpty(this.Template))
             {
                 var languageGenerator = dialogContext.Services.Get<LanguageGenerator>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
@@ -49,6 +49,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
         /// <returns>Instance of string.</returns>
         public virtual async Task<string> BindAsync(DialogContext dialogContext, object data = null, CancellationToken cancellationToken = default)
         {
+            if (dialogContext == null)
+            {
+                throw new ArgumentNullException(nameof(dialogContext));
+            }
+
+            if (data is CancellationToken)
+            {
+                throw new ArgumentException($"{nameof(data)} cannot be a cancellation token");
+            }
+
             if (string.IsNullOrEmpty(this.Template))
             {
                 throw new InvalidOperationException($"The {nameof(this.Template)} property can't be empty.");

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -244,6 +244,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_NumberInputWithDefaultResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_RepeatDialog()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -33,6 +33,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Tests\ActionTests\Action_NumberInputWithDefaultResponse.test.dialog">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Tests\AskTests\Action_AskRetriesDeleteProperties.test.dialog">
       <SubType>Component</SubType>
     </None>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_NumberInputWithDefaultResponse.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_NumberInputWithDefaultResponse.test.dialog
@@ -1,0 +1,61 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                  {
+                    "$kind": "Microsoft.NumberInput",
+                    "defaultLocale": "en-us",
+                    "disabled": false,
+                    "maxTurnCount": 2,
+                    "alwaysPrompt": true,
+                    "allowInterruptions": false,
+                    "prompt": "Give me your favorite number (1-10)",
+                    "unrecognizedPrompt": "Sorry, ${turn.activity.text} did not include a valid number.",
+                    "invalidPrompt": "Sorry, ${this.value} does not work. Can you give me a different number that is between 1-10?",
+                    "defaultValueResponse": "Sorry, we have tried for ${class.MaxTurnCount} number of times and I'm still not getting it. For now, I'm setting ${class.property} to ${class.DefaultValue}",
+                    "property": "user.favoriteNumber",
+                    "outputFormat": "=string(this.value)",
+                    "validations": [
+                      "=int(this.value) >=1",
+                      "=int(this.value) <= 10"
+                    ],
+                    "defaultValue": 9
+                  }
+                ]
+              }
+        ],
+        "defaultResultProperty": "dialog.result"
+    },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Give me your favorite number (1-10)"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1000"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Sorry, 1000 does not work. Can you give me a different number that is between 1-10?"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "25"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Sorry, we have tried for 2 number of times and I'm still not getting it. For now, I'm setting user.favoriteNumber to 9"
+    }
+  ]
+}


### PR DESCRIPTION
closes: #4409 

I have an E2E test for this fix: Here is the dialog file

```JSON
{
  "$schema": "../../testbot.schema",
  "$kind": "Microsoft.AdaptiveDialog",
  "triggers": [
    {
      "$kind": "Microsoft.OnBeginDialog",
      "actions": [
        {
          "$kind": "Microsoft.SendActivity",
          "$designer": {
            "id": "859266",
            "name": "Send a response"
          },
          "activity": "Welcome User!"
        },
        {
          "$kind": "Microsoft.NumberInput",
          "defaultLocale": "en-us",
          "disabled": false,
          "maxTurnCount": 2,
          "alwaysPrompt": true,
          "allowInterruptions": false,
          "prompt": "Give me your favorite number (1-10)",
          "unrecognizedPrompt": "Sorry, ${turn.activity.text} did not include a valid number.",
          "invalidPrompt": "Sorry, ${this.value} does not work. Can you give me a different number that is between 1-10?",
          "defaultValueResponse": "Sorry, we have tried for ${class.MaxTurnCount} number of times and I'm still not getting it. For now, I'm setting ${class.property} to ${class.DefaultValue}",
          "property": "user.favoriteNumber",
          "outputFormat": "=string(this.value)",
          "validations": [
            "=int(this.value) >=1",
            "=int(this.value) <= 10"

          ],
          "defaultValue": 9
        },
        {
          "$kind": "Microsoft.SendActivity",
          "activity": "${user.favoriteNumber}"
        }
      ]
    }
  ]
}
```
The result is:
![image](https://user-images.githubusercontent.com/17074777/93997739-4fa84080-fdc6-11ea-8042-0b2b51ce8550.png)

