### PR TITLE
Add a default user-agent in  the header of HttpRequest action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -267,6 +267,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 }
             }
 
+            // if there no usr-agent in the header, set the user-agent to Mozzila/5.0
+            if (!client.DefaultRequestHeaders.Contains("user-agent"))
+            {
+                client.DefaultRequestHeaders.TryAddWithoutValidation("user-agent", "Mozilla/5.0");
+            }
+
             dynamic traceInfo = new JObject();
 
             traceInfo.request = new JObject();


### PR DESCRIPTION
closes: #4524 
Only if user didn't give a specified user-agent in the header. The default value is "Mozilla/5.0"
