### PR TITLE
Adding mappings between components and Intellisense options

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.uischema
@@ -9,6 +9,13 @@
             "options",
             "resultProperty",
             "*"
-        ]
+        ],
+        "properties": {
+            "resultProperty": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Connect to a skill",
         "subtitle": "Skill Dialog",
-        "helpLink": "https://aka.ms/bf-composer-docs-connect-skill"
+        "helpLink": "https://aka.ms/bf-composer-docs-connect-skill",
+        "properties": {
+            "resultProperty": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperties.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperties.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Delete properties",
         "subtitle": "Delete Properties",
-        "helpLink": "https://aka.ms/bfc-using-memory"
+        "helpLink": "https://aka.ms/bfc-using-memory",
+        "properties": {
+            "properties": {
+                "intellisenseScopes": [
+                    "user-variables"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperty.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperty.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Delete a property",
         "subtitle": "Delete Property",
-        "helpLink": "https://aka.ms/bfc-using-memory"
+        "helpLink": "https://aka.ms/bfc-using-memory",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "user-variables"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.uischema
@@ -3,6 +3,18 @@
     "form": {
         "label": "Edit an array property",
         "subtitle": "Edit Array",
-        "helpLink": "https://aka.ms/bfc-using-memory"
+        "helpLink": "https://aka.ms/bfc-using-memory",
+        "properties": {
+            "itemsProperty": {
+                "intellisenseScopes": [
+                    "user-variables"
+                ]
+            },
+            "resultProperty": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.uischema
@@ -10,6 +10,23 @@
         "hidden": [
             "actions"
         ],
-        "helpLink": "https://aka.ms/bfc-controlling-conversation-flow"
+        "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+        "properties": {
+            "itemsProperty": {
+                "intellisenseScopes": [
+                    "user-variables"
+                ]
+            },
+            "index": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            },
+            "value": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ForeachPage.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ForeachPage.uischema
@@ -11,6 +11,23 @@
         "hidden": [
             "actions"
         ],
-        "helpLink": "https://aka.ms/bfc-controlling-conversation-flow"
+        "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+        "properties": {
+            "itemsProperty": {
+                "intellisenseScopes": [
+                    "user-variables"
+                ]
+            },
+            "pageIndex": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            },
+            "page": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.uischema
@@ -10,6 +10,13 @@
             "headers",
             "*"
         ],
-        "helpLink": "https://aka.ms/bfc-using-http"
+        "helpLink": "https://aka.ms/bfc-using-http",
+        "properties": {
+            "resultProperty": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperties.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperties.uischema
@@ -3,6 +3,17 @@
     "form": {
         "label": "Set properties",
         "subtitle": "Set Properties",
-        "helpLink": "https://aka.ms/bfc-using-memory"
+        "helpLink": "https://aka.ms/bfc-using-memory",
+        "properties": {
+            "assignments": {
+                "properties": {
+                    "property": {
+                        "intellisenseScopes": [
+                            "variable-scopes"
+                        ]
+                    }
+                }
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperty.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperty.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Set a property",
         "subtitle": "Set Property",
-        "helpLink": "https://aka.ms/bfc-using-memory"
+        "helpLink": "https://aka.ms/bfc-using-memory",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.uischema
@@ -12,6 +12,11 @@
                 "hidden": [
                     "actions"
                 ]
+            },
+            "condition": {
+                "intellisenseScopes": [
+                    "user-variables"
+                ]
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.AttachmentInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.AttachmentInput.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Prompt for a file or an attachment",
         "subtitle": "Attachment Input",
-        "helpLink": "https://aka.ms/bfc-ask-for-user-input"
+        "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Prompt with multi-choice",
         "subtitle": "Choice Input",
-        "helpLink": "https://aka.ms/bfc-ask-for-user-input"
+        "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Prompt for confirmation",
         "subtitle": "Confirm Input",
-        "helpLink": "https://aka.ms/bfc-ask-for-user-input"
+        "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.DateTimeInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.DateTimeInput.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Prompt for a date or a time",
         "subtitle": "Date Time Input",
-        "helpLink": "https://aka.ms/bfc-ask-for-user-input"
+        "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.NumberInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.NumberInput.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Prompt for a number",
         "subtitle": "Number Input",
-        "helpLink": "https://aka.ms/bfc-ask-for-user-input"
+        "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.TextInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.TextInput.uischema
@@ -3,6 +3,13 @@
     "form": {
         "label": "Prompt for text",
         "subtitle": "Text Input",
-        "helpLink": "https://aka.ms/bfc-ask-for-user-input"
+        "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+        "properties": {
+            "property": {
+                "intellisenseScopes": [
+                    "variable-scopes"
+                ]
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes 
https://github.com/microsoft/BotFramework-Composer/issues/4187
https://github.com/microsoft/BotFramework-Composer/issues/4189


## Description
Mappings between components and Intellisense options were previously hardcoded in Composer.
This PR aims at leveraging the uiSchema instead for the mappings, while bringing in Intellisense to remaining components.

![image](https://user-images.githubusercontent.com/66701106/94189964-4d92c000-fe60-11ea-9b12-4988cef4ca25.png)
