### PR TITLE
Update BotFrameworkAdapter, Fixes : #4710

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -530,7 +531,7 @@ namespace Microsoft.Bot.Builder
                 {
                     // The Activity Schema doesn't have a delay type built in, so it's simulated
                     // here in the Bot. This matches the behavior in the Node connector.
-                    var delayMs = Convert.ToInt32(activity.Value);
+                    var delayMs = Convert.ToInt32(activity.Value, CultureInfo.InvariantCulture);
                     await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
 
                     // No need to create a response. One will be created below.

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Bot.Builder
                 {
                     // The Activity Schema doesn't have a delay type built in, so it's simulated
                     // here in the Bot. This matches the behavior in the Node connector.
-                    var delayMs = (int)activity.Value;
+                    var delayMs = Convert.ToInt32(activity.Value);
                     await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
 
                     // No need to create a response. One will be created below.


### PR DESCRIPTION
Fixes #4710 

## Description
Avoid cast exception System.InvalidCastException - Unable to cast object of type ‘System.Int64’ to type ‘System.Int32

## Specific Changes
Using Convert.Int32 instead of (int) in Line 533
