### PR TITLE
Cherry pick: Fix split function results with whitespace separator

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Split.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Split.cs
@@ -35,12 +35,12 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                 seperator = FunctionUtils.ParseStringOrNull(args[1]);
                             }
 
-                            if (string.IsNullOrWhiteSpace(seperator))
+                            if (string.IsNullOrEmpty(seperator))
                             {
                                 return inputStr.Select(c => c.ToString()).ToArray();
                             }
 
-                            return inputStr.Split(seperator.ToCharArray());
+                            return inputStr.Split(new string[] { seperator }, 0);
                         }, FunctionUtils.VerifyStringOrNull);
         }
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -323,6 +323,7 @@ namespace AdaptiveExpressions.Tests
         public static IEnumerable<object[]> Data => new[]
         {
             #region locale specific tests
+            
             //on *nix OS, 'de-DE' will return 'MM.dd.YY HH:mm:ss', on Windows it's 'MM.dd.YYYY HH:mm:ss'
             Test("replace(addDays(timestamp, 1, '', 'de-DE'), '20', '')", "16.03.18 13:00:00"),
             Test("replace(addHours(timestamp, 2, '', 'de-DE'), '20', '')", "15.03.18 15:00:00"),
@@ -517,6 +518,9 @@ namespace AdaptiveExpressions.Tests
             Test(@"replace('hello\n', '\n', '\\\\')", @"hello\\"),
             Test("replaceIgnoreCase('hello', 'L', 'k')", "hekko"),
             Test("replaceIgnoreCase(nullObj, 'L', 'k')", string.Empty),
+            Test("split('token1 token2 token3', ' ')", new string[] { "token1", "token2", "token3" }),
+            Test("split('token1 token2 token3', '  ')", new string[] { "token1 token2 token3" }),
+            Test("split('token one', '')", new string[] { "t", "o", "k", "e", "n", " ", "o", "n", "e" }),
             Test("split('hello','e')", new string[] { "h", "llo" }),
             Test("split('hello','')", new string[] { "h", "e", "l", "l", "o" }),
             Test("split('','')", new string[] { }),


### PR DESCRIPTION
closes: #4639 
Fix the split function results when the separator is whitespace.
```
split('token1 token2 token3', ' ') 
``` 
returns `["token1", "token2", "token3"]`
```
split('token1 token2 token3', '  ') 
``` 
returns `["token1 token2 token3"]`

```
split('token one', '') 
``` 
returns `["t", "o", "k", "e", "n", " ", "o", "n", "e"]`

The changed is introduced in this PR:
https://github.com/microsoft/botbuilder-dotnet/pull/4278/files?file-filters%5B%5D=.cs#diff-91d35031c5cb26ad523273c98506f94f

