### PR TITLE
Make missing test environment vars cause a functional test build to fail

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,6 +48,10 @@
     <DefineConstants>SIGNASSEMBLY</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TF_BUILD)'=='True' ">
+    <DefineConstants>$(DefineConstants);AUTOMATEDBUILD</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
     <PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,7 +48,7 @@
     <DefineConstants>SIGNASSEMBLY</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TF_BUILD)'=='True' ">
+  <PropertyGroup Condition="'$(TF_BUILD)' != '' ">
     <DefineConstants>$(DefineConstants);AUTOMATEDBUILD</DefineConstants>
   </PropertyGroup>
 

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 {
     [TestClass]
     [TestCategory("FunctionalTests")]
+#if !AUTOMATEDBUILD
+    [Ignore]
+#endif
     public class DirectLineClientTests
     {
         private static string directLineSecret = null;
@@ -114,13 +117,13 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                 directLineSecret = Environment.GetEnvironmentVariable("DIRECTLINE");
                 if (string.IsNullOrWhiteSpace(directLineSecret))
                 {
-                    Assert.Inconclusive("Environment variable 'DIRECTLINE' not found.");
+                    Assert.Fail("Environment variable 'DIRECTLINE' not found.");
                 }
 
                 botId = Environment.GetEnvironmentVariable("BOTID");
                 if (string.IsNullOrWhiteSpace(botId))
                 {
-                    Assert.Inconclusive("Environment variable 'BOTID' not found.");
+                    Assert.Fail("Environment variable 'BOTID' not found.");
                 }
             }
         }

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineSpeechTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineSpeechTests.cs
@@ -19,7 +19,6 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.FunctionalTests
 {
     [TestClass]
-
     [TestCategory("FunctionalTests")]
     [Ignore("DirectLine Speech tests require updates to the REST API and CLI to be able to properly provision a bot.")]
     public class DirectLineSpeechTests
@@ -91,14 +90,14 @@ namespace Microsoft.Bot.Builder.FunctionalTests
             speechBotSecret = Environment.GetEnvironmentVariable("SPEECHBOTSECRET");
             if (string.IsNullOrWhiteSpace(speechBotSecret))
             {
-                Assert.Inconclusive("Environment variable 'SPEECHBOTSECRET' not found.");
+                Assert.Fail("Environment variable 'SPEECHBOTSECRET' not found.");
             }
 
             // The cog services key for use with DLS.
             speechSubscription = Environment.GetEnvironmentVariable("SPEECHSUBSCRIPTION");
             if (string.IsNullOrWhiteSpace(speechSubscription))
             {
-                Assert.Inconclusive("Environment variable 'SPEECHSUBSCRIPTION' not found.");
+                Assert.Fail("Environment variable 'SPEECHSUBSCRIPTION' not found.");
             }
         }
 

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Bot.Builder.FunctionalTests
     [TestClass]
     [TestCategory("FunctionalTests")]
     [TestCategory("Adapters")]
+#if !AUTOMATEDBUILD
+    [Ignore]
+#endif
     public class FacebookChatTests
     {
         private const string FacebookUrlBase = "https://graph.facebook.com/v5.0";

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/SlackClientTest.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Bot.Builder.FunctionalTests
     [TestClass]
     [TestCategory("FunctionalTests")]
     [TestCategory("Adapters")]
+#if !AUTOMATEDBUILD
+    [Ignore]
+#endif
     public class SlackClientTest
     {
         private const string SlackUrlBase = "https://slack.com/api";
@@ -136,31 +139,31 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                 _slackChannel = Environment.GetEnvironmentVariable("SlackChannel");
                 if (string.IsNullOrWhiteSpace(_slackChannel))
                 {
-                    Assert.Inconclusive("Environment variable 'SlackChannel' not found.");
+                    Assert.Fail("Environment variable 'SlackChannel' not found.");
                 }
 
                 _slackBotToken = Environment.GetEnvironmentVariable("SlackBotToken");
                 if (string.IsNullOrWhiteSpace(_slackBotToken))
                 {
-                    Assert.Inconclusive("Environment variable 'SlackBotToken' not found.");
+                    Assert.Fail("Environment variable 'SlackBotToken' not found.");
                 }
 
                 _slackClientSigningSecret = Environment.GetEnvironmentVariable("SlackClientSigningSecret");
                 if (string.IsNullOrWhiteSpace(_slackClientSigningSecret))
                 {
-                    Assert.Inconclusive("Environment variable 'SlackClientSigningSecret' not found.");
+                    Assert.Fail("Environment variable 'SlackClientSigningSecret' not found.");
                 }
 
                 _slackVerificationToken = Environment.GetEnvironmentVariable("SlackVerificationToken");
                 if (string.IsNullOrWhiteSpace(_slackVerificationToken))
                 {
-                    Assert.Inconclusive("Environment variable 'SlackVerificationToken' not found.");
+                    Assert.Fail("Environment variable 'SlackVerificationToken' not found.");
                 }
 
                 _botName = Environment.GetEnvironmentVariable("BotName");
                 if (string.IsNullOrWhiteSpace(_botName))
                 {
-                    Assert.Inconclusive("Environment variable 'BotName' not found.");
+                    Assert.Fail("Environment variable 'BotName' not found.");
                 }
             }
         }

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/TwilioNumberTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/TwilioNumberTests.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Bot.Builder.FunctionalTests
     [TestClass]
     [TestCategory("FunctionalTests")]
     [TestCategory("Adapters")]
+#if !AUTOMATEDBUILD
+    [Ignore]
+#endif
     public class TwilioNumberTests
     {
         private string _botEndpoint;
@@ -101,31 +104,31 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                 _twilioNumber = Environment.GetEnvironmentVariable("TWILIO_NUMBER");
                 if (string.IsNullOrWhiteSpace(_twilioNumber))
                 {
-                    Assert.Inconclusive("Environment variable 'TwilioNumber' not found.");
+                    Assert.Fail("Environment variable 'TwilioNumber' not found.");
                 }
 
                 _twilioAuthToken = Environment.GetEnvironmentVariable("TWILIO_AUTH_TOKEN");
                 if (string.IsNullOrWhiteSpace(_twilioAuthToken))
                 {
-                    Assert.Inconclusive("Environment variable 'TWILIO_AUTH_TOKEN' not found.");
+                    Assert.Fail("Environment variable 'TWILIO_AUTH_TOKEN' not found.");
                 }
 
                 _twilioAccountSid = Environment.GetEnvironmentVariable("TWILIO_ACCOUNT_SID");
                 if (string.IsNullOrWhiteSpace(_twilioAccountSid))
                 {
-                    Assert.Inconclusive("Environment variable 'TWILIO_ACCOUNT_SID' not found.");
+                    Assert.Fail("Environment variable 'TWILIO_ACCOUNT_SID' not found.");
                 }
 
                 _senderNumber = Environment.GetEnvironmentVariable("SENDER_NUMBER");
                 if (string.IsNullOrWhiteSpace(_senderNumber))
                 {
-                    Assert.Inconclusive("Environment variable 'SENDER_NUMBER' not found.");
+                    Assert.Fail("Environment variable 'SENDER_NUMBER' not found.");
                 }
 
                 _botEndpoint = Environment.GetEnvironmentVariable("TwilioValidationUrl");
                 if (string.IsNullOrWhiteSpace(_botEndpoint))
                 {
-                    Assert.Inconclusive("Environment variable 'TwilioValidationUrl' not found.");
+                    Assert.Fail("Environment variable 'TwilioValidationUrl' not found.");
                 }
             }
         }

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/WebexClientTest.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/WebexClientTest.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Bot.Builder.FunctionalTests
     [TestClass]
     [TestCategory("FunctionalTests")]
     [TestCategory("Adapters")]
+#if !AUTOMATEDBUILD
+    [Ignore]
+#endif
     public class WebexClientTest
     {        
         private const string WebexUrlBase = "https://api.ciscospark.com/v1";

--- a/build/yaml/botbuilder-dotnet-ci-slack-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slack-test.yml
@@ -35,9 +35,8 @@ variables:
   BuildPlatform: 'any cpu'
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false -p:RunAnalyzersDuringBuild=false
   Parameters.solution: Microsoft.Bot.Builder.sln
-  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber)
+  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by Microsoft.Bot.Builder.sln projects.
   SlackBotToken: $(SlackTestBotSlackBotToken)
-  SlackChannel: $(SlackTestBotSlackChannel)
   SlackClientSigningSecret: $(SlackTestBotSlackClientSigningSecret)
   SlackVerificationToken: $(SlackTestBotSlackVerificationToken)
   SolutionDir: $(System.DefaultWorkingDirectory) # Consumed in dotnet publish by Directory.Build.props and a few test projects.
@@ -49,7 +48,7 @@ variables:
 #  SlackTestBotSlackBotToken: define this in Azure
 #  SlackTestBotSlackChannel: define this in Azure
 #  SlackTestBotSlackClientSigningSecret: define this in Azure
-#  SlackTestBotSlackVerificationToken: define this in Azure
+    #  SlackTestBotSlackVerificationToken: define this in Azure
 
 steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
@@ -63,17 +62,6 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj'
     arguments: '--configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\PublishedBot -p:TreatWarningsAsErrors=false'
     modifyOutputPath: false
-
-#- powershell: |
-#   echo '##vso[task.setvariable variable=AppId]$(SlackTestBotAppId)'
-#   echo '##vso[task.setvariable variable=AppSecret]$(SlackTestBotAppSecret)'
-#   echo '##vso[task.setvariable variable=BotGroup]$(SlackTestBotBotGroup)'
-#   echo '##vso[task.setvariable variable=BotName]$(SlackTestBotBotName)'
-#   echo '##vso[task.setvariable variable=SlackBotToken]$(SlackTestBotSlackBotToken)'
-#   echo '##vso[task.setvariable variable=SlackChannel]$(SlackTestBotSlackChannel)'
-#   echo '##vso[task.setvariable variable=SlackClientSigningSecret]$(SlackTestBotSlackClientSigningSecret)'
-#   echo '##vso[task.setvariable variable=SlackVerificationToken]$(SlackTestBotSlackVerificationToken)'
-#  displayName: 'Set Environment Variables'
 
 - task: AzureCLI@1
   displayName: 'Create resources'
@@ -106,6 +94,12 @@ steps:
      FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj
     arguments: '-v n --configuration $(BuildConfiguration) --filter SlackClientTest'
     workingDirectory: tests
+  env:
+    BotName: $(SlackTestBotBotName)
+    SlackBotToken: $(SlackTestBotSlackBotToken)
+    SlackChannel: $(SlackTestBotSlackChannel)
+    SlackClientSigningSecret: $(SlackTestBotSlackClientSigningSecret)
+    SlackVerificationToken: $(SlackTestBotSlackVerificationToken)
 
 - task: AzureCLI@1
   displayName: 'Delete Resources'

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -64,20 +64,18 @@ steps:
      call az deployment create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" twilioNumber="$(TwilioNumber)" twilioAccountSid="$(TwilioAccountSid)"  twilioAuthToken="$(TwilioAuthToken)"
      call az webapp deployment source config-zip --resource-group "$(BotGroup)" --name "$(BotName)" --src "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Twilio.TestBot\PublishedBot\PublishedBot.zip"
 
-- powershell: |
-   echo '##vso[task.setvariable variable=SENDER_NUMBER]$(SenderNumber)'
-   echo '##vso[task.setvariable variable=TWILIO_ACCOUNT_SID]$(TwilioAccountSid)'
-   echo '##vso[task.setvariable variable=TWILIO_NUMBER]$(TwilioNumber)'
-   echo '##vso[task.setvariable variable=TWILIO_AUTH_TOKEN]$(TwilioAuthToken)'
-   echo '##vso[task.setvariable variable=TwilioValidationUrl]https://$(BotName).azurewebsites.net/api/messages'
-  displayName: 'Set environment variables'
-
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'
   inputs:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\Microsoft.Bot.Builder.FunctionalTests.csproj'
     arguments: '-v n --configuration $(BuildConfiguration) --filter TwilioNumberTests'
+  env:
+    SENDER_NUMBER: $(SenderNumber)
+    TWILIO_ACCOUNT_SID: $(TwilioAccountSid)
+    TWILIO_AUTH_TOKEN: $(TwilioAuthToken)
+    TWILIO_NUMBER: $(TwilioNumber)
+    TwilioValidationUrl: https://$(BotName).azurewebsites.net/api/messages
 
 - task: AzureCLI@1
   displayName: 'Delete resources'

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -87,9 +87,9 @@ steps:
    $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json
    $key = $json.properties.properties.sites.key
    echo "##vso[task.setvariable variable=DIRECTLINE;]$key"
-   echo "##vso[task.setvariable variable=BOTID;]$(BotName)"
+   echo "##vso[task.setvariable variable=BOTID;]$(LinuxTestBotBotName)"
    Write-Host "DIRECTLINE=$key";
-   Write-Host "BOTID=$(BotName)";
+   Write-Host "BOTID=$(LinuxTestBotBotName)";
   displayName: 'Set directline key for test'
 
 - task: DotNetCoreCLI@2

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -84,16 +84,16 @@ steps:
   displayName: 'Git bot deployment'
 
 - powershell: |
-   $content = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String
-   Write-Host $content
-   $json = $content | ConvertFrom-Json
+   $json = Get-Content '$(System.DefaultWorkingDirectory)\DirectLineCreate.json' | Out-String | ConvertFrom-Json
    $key = $json.properties.properties.sites.key
    echo "##vso[task.setvariable variable=DIRECTLINE;]$key"
-   echo "##vso[task.setvariable variable=BOTID;]$(LinuxTestBotBotName)"
-  displayName: 'Get bot keys'
+   echo "##vso[task.setvariable variable=BOTID;]$(BotName)"
+   Write-Host "DIRECTLINE=$key";
+   Write-Host "BOTID=$(BotName)";
+  displayName: 'Set directline key for test'
 
 - task: DotNetCoreCLI@2
-  displayName: 'Run Functional tests'
+  displayName: 'dotnet test'
   inputs:
     command: test
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\**\*FunctionalTests.csproj'

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -87,7 +87,7 @@ steps:
    echo "##vso[task.setvariable variable=BOTID;]$(BotName)"
    Write-Host "DIRECTLINE=$key";
    Write-Host "BOTID=$(BotName)";
-  displayName: 'Set up directline keys'
+  displayName: 'Set directline key for test'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'


### PR DESCRIPTION
This PR sets up functional tests to:
(1) Be skipped in local test runs and only run in automated builds. The tests fail when run locally, creating a headache for devs. 
    Using the AUTOMATEDBUILD preprocessor constant accomplishes this.
(2) Make an automated build fail if an essential environment variable for a test is missing.
    Using Assert.Fail() accomplishes this. Assert.Inconclusive() causes the test to be skipped and lets a build pass.

Issue #4716 