### PR TITLE
[LG] Redo the default fallback of namespace

### DIFF
--- a/libraries/AdaptiveExpressions/Expression.cs
+++ b/libraries/AdaptiveExpressions/Expression.cs
@@ -734,7 +734,7 @@ namespace AdaptiveExpressions
 #pragma warning restore CA1710 // Identifiers should have correct suffix
 #pragma warning restore CA1034 // Nested types should not be visible
         {
-            private readonly ConcurrentDictionary<string, ExpressionEvaluator> _customFunctions = new ConcurrentDictionary<string, ExpressionEvaluator>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly ConcurrentDictionary<string, ExpressionEvaluator> _customFunctions = new ConcurrentDictionary<string, ExpressionEvaluator>();
 
             /// <summary>
             /// Gets a collection of string values that represent the keys of the StandardFunctions. 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -648,19 +648,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             var result = ExtractOptionsByKey(_namespaceKey, options);
 
-            if (result == null)
-            {
-                if (Path.IsPathRooted(Source))
-                {
-                    result = Path.GetFileNameWithoutExtension(Source);
-                }
-                else
-                {
-                    throw new Exception("namespace is required or the id should be an absoulte path!");
-                }
-            }
-
-            return result;
+            // If there is no namespace, use the file name parsed from Id.
+            return result ?? Path.GetFileNameWithoutExtension(Id ?? string.Empty);
         }
 
         private IList<string> GetGlobalFunctionTable(IList<string> options)

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -452,7 +452,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 {
                     if (curTemplates.Any(u => u.Name == templateName))
                     {
-                        var newGlobalName = $"{curTemplates.Namespace}.{templateName}";
+                        var prefix = string.IsNullOrWhiteSpace(curTemplates.Namespace) ? string.Empty : curTemplates.Namespace + ".";
+                        var newGlobalName = prefix + templateName;
                         Expression.Functions.Add(newGlobalName, new ExpressionEvaluator(
                             newGlobalName, 
                             (expression, state, options) =>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/injectWithoutNamespace.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/injectWithoutNamespace.lg
@@ -1,4 +1,4 @@
-﻿> !# @Exports = myGreeting
+﻿> !# @Exports = greeting
 
-# myGreeting
+# greeting
 - hi ${name}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/injectWithoutNamespace.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/injectWithoutNamespace.lg
@@ -1,4 +1,4 @@
-﻿> !# @Exports = greeting
+﻿> !# @Exports = myGreeting
 
-#greeting
+# myGreeting
 - hi ${name}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/injectWithoutNamespace.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/InjectionTest/injectWithoutNamespace.lg
@@ -1,0 +1,4 @@
+﻿> !# @Exports = greeting
+
+#greeting
+- hi ${name}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -45,6 +45,7 @@
     <None Remove="Examples\import2.lg" />
     <None Remove="Examples\InjectionTest\common.lg" />
     <None Remove="Examples\InjectionTest\inject.lg" />
+    <None Remove="Examples\InjectionTest\injectWithoutNamespace.lg" />
     <None Remove="Examples\IsTemplate.lg" />
     <None Remove="Examples\LGOptionTest.lg" />
     <None Remove="Examples\MultilineTextForAdaptiveCard.lg" />
@@ -186,6 +187,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Examples\InjectionTest\inject.lg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Examples\InjectionTest\injectWithoutNamespace.lg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Examples\StringInterpolation.lg">

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1582,7 +1582,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var resource = new LGResource("myId", lgPath, File.ReadAllText(lgPath));
             Templates.ParseResource(resource);
 
-            var (evaled, error) = Expression.Parse("myId.greeting()").TryEvaluate(new { name = "Alice" });
+            var (evaled, error) = Expression.Parse("myId.myGreeting()").TryEvaluate(new { name = "Alice" });
             Assert.Null(error);
             Assert.Equal("hi Alice", evaled.ToString());
 
@@ -1590,7 +1590,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             resource = new LGResource("./path/myNewId.lg", lgPath, File.ReadAllText(lgPath));
             Templates.ParseResource(resource);
 
-            (evaled, error) = Expression.Parse("myNewId.greeting()").TryEvaluate(new { name = "Alice" });
+            (evaled, error) = Expression.Parse("myNewId.myGreeting()").TryEvaluate(new { name = "Alice" });
             Assert.Null(error);
             Assert.Equal("hi Alice", evaled.ToString());
 
@@ -1598,7 +1598,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             resource = new LGResource(string.Empty, lgPath, File.ReadAllText(lgPath));
             Templates.ParseResource(resource);
 
-            (evaled, error) = Expression.Parse("greeting()").TryEvaluate(new { name = "Alice" });
+            (evaled, error) = Expression.Parse("myGreeting()").TryEvaluate(new { name = "Alice" });
             Assert.Null(error);
             Assert.Equal("hi Alice", evaled.ToString());
         }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1582,7 +1582,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var resource = new LGResource("myId", lgPath, File.ReadAllText(lgPath));
             Templates.ParseResource(resource);
 
-            var (evaled, error) = Expression.Parse("myId.myGreeting()").TryEvaluate(new { name = "Alice" });
+            var (evaled, error) = Expression.Parse("myId.greeting()").TryEvaluate(new { name = "Alice" });
             Assert.Null(error);
             Assert.Equal("hi Alice", evaled.ToString());
 
@@ -1590,7 +1590,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             resource = new LGResource("./path/myNewId.lg", lgPath, File.ReadAllText(lgPath));
             Templates.ParseResource(resource);
 
-            (evaled, error) = Expression.Parse("myNewId.myGreeting()").TryEvaluate(new { name = "Alice" });
+            (evaled, error) = Expression.Parse("myNewId.greeting()").TryEvaluate(new { name = "Alice" });
             Assert.Null(error);
             Assert.Equal("hi Alice", evaled.ToString());
 
@@ -1598,7 +1598,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             resource = new LGResource(string.Empty, lgPath, File.ReadAllText(lgPath));
             Templates.ParseResource(resource);
 
-            (evaled, error) = Expression.Parse("myGreeting()").TryEvaluate(new { name = "Alice" });
+            (evaled, error) = Expression.Parse("greeting()").TryEvaluate(new { name = "Alice" });
             Assert.Null(error);
             Assert.Equal("hi Alice", evaled.ToString());
         }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1574,6 +1574,35 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal("10", evaled.ToString());
         }
 
+        [Fact]
+        public void TestInjectLGWithoutNamespace()
+        {
+            // using Id as the namespace
+            var lgPath = GetExampleFilePath("./InjectionTest/injectWithoutNamespace.lg");
+            var resource = new LGResource("myId", lgPath, File.ReadAllText(lgPath));
+            Templates.ParseResource(resource);
+
+            var (evaled, error) = Expression.Parse("myId.greeting()").TryEvaluate(new { name = "Alice" });
+            Assert.Null(error);
+            Assert.Equal("hi Alice", evaled.ToString());
+
+            // using the fuileName parsed from Id as the namespace
+            resource = new LGResource("./path/myNewId.lg", lgPath, File.ReadAllText(lgPath));
+            Templates.ParseResource(resource);
+
+            (evaled, error) = Expression.Parse("myNewId.greeting()").TryEvaluate(new { name = "Alice" });
+            Assert.Null(error);
+            Assert.Equal("hi Alice", evaled.ToString());
+
+            // With empty id
+            resource = new LGResource(string.Empty, lgPath, File.ReadAllText(lgPath));
+            Templates.ParseResource(resource);
+
+            (evaled, error) = Expression.Parse("greeting()").TryEvaluate(new { name = "Alice" });
+            Assert.Null(error);
+            Assert.Equal("hi Alice", evaled.ToString());
+        }
+
         public class LoopClass
         {
             public string Name { get; set; }


### PR DESCRIPTION
Issue: https://github.com/microsoft/BotFramework-Composer/issues/3982


## Description
Originally, the injection of LG function into Expression require a namespace option. If there is no namespace option, a absolute path is require. It is too strict.


## Specific Changes
Loose the namespace fallback policy. The priority order is:
1. If there is a namespace option, use it
2. If there is an un-empty id, parse the file name from the id, and get the namespace
3. If the Id is empty, just drop the namespace and use the template name as the expression name directly.

For example:
If there is an option in LG file, like:
```
> !# @Namespace = general
```

`general` is the namespace, the export function could be presented as `general.xxx`

If there does not exist a namespace option, use the name of Id by default, for example:
If the id is: `./a.lg` -> `a` is the namespace, `a.xxx` is the expression name
if the id is: `abc` -> `abc` is the namespace, `abc.xxx` is the expression name
If the is is empty string, just drop the namespace, and use template name directly, `xxx` is the final expression name

