### PR TITLE
Enable overriding AttachmentInput dialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -180,7 +180,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
             var choices = options.Choices;
 
-            var result = new PromptRecognizerResult<FoundChoice>();
             if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
                 var opt = this.RecognizerOptions?.GetValue(dc.State) ?? new FindChoicesOptions();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -516,7 +516,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             bool activityProcessed = dc.State.GetBoolValue(TurnPath.ActivityProcessed);
             if (!activityProcessed && input == null && turnCount > 0)
             {
-                if (this.GetType().Name == nameof(AttachmentInput))
+                if (typeof(AttachmentInput).IsAssignableFrom(this.GetType()))
                 {
                     input = dc.Context.Activity.Attachments ?? new List<Attachment>();
                 }


### PR DESCRIPTION
This fixes a bug where a custom dialog inheriting from AttachmentInput will currently fail.  

(Comparing class names does not cover inheritance.)