### PR TITLE
update resource explorer load to use GetComponentRegistration instead…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             var converters = new List<JsonConverter>();
 
             // Get converters
-            foreach (var component in ComponentRegistration.Components.OfType<IComponentDeclarativeTypes>())
+            foreach (var component in GetComponentRegistrations())
             {
                 var result = component.GetConverters(this, sourceContext);
                 if (result.Any())


### PR DESCRIPTION

#Fixes
Update the load in resource explorer to leverage the declarative types passed in the constructor
