### PR TITLE
Adds CreateMessageFromActivity method to facebook adapter. 

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                 }
                 else
                 {
-                    var message = FacebookHelper.ActivityToFacebook(activity);
+                    var message = CreateFacebookMessageFromActivity(activity);
 
                     if (message.Message?.Attachment != null)
                     {
@@ -265,6 +265,16 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Factory method to create the <see cref="FacebookMessage"/> instance of the <see cref="Activity"/> to be sent to Facebook.
+        /// </summary>
+        /// <param name="activity">An <see cref="Activity"/> instance to build the message.</param>
+        /// <returns>A <see cref="FacebookMessage"/> built from the activity instance.</returns>
+        protected virtual FacebookMessage CreateFacebookMessageFromActivity(Activity activity)
+        {
+            return FacebookHelper.ActivityToFacebook(activity);
         }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/FacebookAdapterWithTag.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/FacebookAdapterWithTag.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot
             // https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#sending
             // This bypasses the 24 hrs check for responses to a bot that don't go through the messenger client.
             var message = base.CreateFacebookMessageFromActivity(activity);
+            message.MessagingType = "MESSAGE_TAG";
             message.Tag = "ACCOUNT_UPDATE";
             return message;
         }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/FacebookAdapterWithTag.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/FacebookAdapterWithTag.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot
+{
+    /// <summary>
+    /// A <see cref="FacebookAdapter"/> specialized to append tags to messages.
+    /// </summary>
+    public class FacebookAdapterWithTag : FacebookAdapter
+    {
+        public FacebookAdapterWithTag(IConfiguration configuration, FacebookAdapterOptions options = null, ILogger logger = null)
+            : base(configuration, options, logger)
+        {
+        }
+
+        public FacebookAdapterWithTag(FacebookClientWrapper facebookClient, FacebookAdapterOptions options, ILogger logger = null)
+            : base(facebookClient, options, logger)
+        {
+        }
+
+        protected override FacebookMessage CreateFacebookMessageFromActivity(Activity activity)
+        {
+            // This override takes the facebook message created by the base adapter
+            // and sets the tag to "ACCOUNT_UPDATE" as defined in
+            // https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#sending
+            // This bypasses the 24 hrs check for responses to a bot that don't go through the messenger client.
+            var message = base.CreateFacebookMessageFromActivity(activity);
+            message.Tag = "ACCOUNT_UPDATE";
+            return message;
+        }
+    }
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Startup.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Startup.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot;
 using Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.Bots;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +18,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.TestBot
             services.AddControllers().AddNewtonsoftJson();
 
             // Create the Bot Framework Facebook Adapter.
-            services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>();
+            services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapterWithTag>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, PrimaryBot>();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogStateManagerTests.cs
@@ -318,27 +318,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             await CreateDialogContext(async (dc, ct) =>
             {
                 dc.State.SetValue("user.name.first", "joe");
-                Assert.Equal(false, dc.State.TryGetValue<int>("user.name.first", out var val));
-                Assert.Equal(true, dc.State.TryGetValue<string>("user.name.first", out var val2));
+                Assert.False(dc.State.TryGetValue<int>("user.name.first", out var val));
+                Assert.True(dc.State.TryGetValue<string>("user.name.first", out var val2));
                 Assert.Equal("joe", val2);
 
                 dc.State.SetValue("user.age", 19);
-                Assert.Equal(true, dc.State.TryGetValue<string>("user.age", out var val3));
+                Assert.True(dc.State.TryGetValue<string>("user.age", out var val3));
                 Assert.Equal("19", val3);
-                Assert.Equal(true, dc.State.TryGetValue<int>("user.age", out var val4));
+                Assert.True(dc.State.TryGetValue<int>("user.age", out var val4));
                 Assert.Equal(19, val4);
 
                 dc.State.SetValue("user.salary", "10000");
-                Assert.Equal(true, dc.State.TryGetValue<string>("user.salary", out var val5));
+                Assert.True(dc.State.TryGetValue<string>("user.salary", out var val5));
                 Assert.Equal("10000", val5);
-                Assert.Equal(true, dc.State.TryGetValue<int>("user.salary", out var val6));
+                Assert.True(dc.State.TryGetValue<int>("user.salary", out var val6));
                 Assert.Equal(10000, val6);
                 dc.State.SetValue("user.foo", foo);
 
-                Assert.Equal(false, dc.State.TryGetValue<string>("user.foo", out var val7));
-                Assert.Equal(true, dc.State.TryGetValue<Foo>("user.foo", out var val8));
-                Assert.Equal(false, dc.State.TryGetValue<IDictionary<string, string>>("user.foo", out var val9));
-                Assert.Equal(true, dc.State.TryGetValue<Bar>("user.foo", out var val10));
+                Assert.False(dc.State.TryGetValue<string>("user.foo", out var val7));
+                Assert.True(dc.State.TryGetValue<Foo>("user.foo", out var val8));
+                Assert.False(dc.State.TryGetValue<IDictionary<string, string>>("user.foo", out var val9));
+                Assert.True(dc.State.TryGetValue<Bar>("user.foo", out var val10));
             }).StartTestAsync();
         }
 


### PR DESCRIPTION
Fixes #4743

Refactored FacebookAdapter to add a virtual method for FB message creation that allows the devs to manipulate the FB message instance before it gets sent to Facebook.

Added FacebookAdapterWithTag adapter to FB test bot so we can add the "ACCOUNT_UPDATE" tag as defined in https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags#sending