### PR TITLE
Change Assert.Inconclusive() to Assert.Fail() in tests

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Configuration/EnvironmentConfig.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Configuration/EnvironmentConfig.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests.Configuration
             var testAppId = Environment.GetEnvironmentVariable("TESTAPPID");
             if (string.IsNullOrWhiteSpace(testAppId))
             {
-                Assert.Inconclusive("Environment variable 'TestAppId' not found.");
+                Assert.Fail("Environment variable 'TestAppId' not found.");
             }
 
             return testAppId;
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests.Configuration
 
             if (string.IsNullOrWhiteSpace(testPassword))
             {
-                Assert.Inconclusive("Environment variable 'TestPassword' not found.");
+                Assert.Fail("Environment variable 'TestPassword' not found.");
             }
 
             return testPassword;

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/GetTokenRefreshTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/GetTokenRefreshTests.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 {
     [TestClass]
     [TestCategory("FunctionalTests")]
+#if !AUTOMATEDBUILD
+    [Ignore]
+#endif
     public class GetTokenRefreshTests
     {
         private string testAppId = null;

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -99,6 +99,9 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\**\*FunctionalTests.csproj'
     arguments: '-v n --configuration $(BuildConfiguration) --filter "TestCategory=FunctionalTests&TestCategory!=Adapters" --collect:"Code Coverage" --settings $(System.DefaultWorkingDirectory)\CodeCoverage.runsettings '
     workingDirectory: '$(System.DefaultWorkingDirectory)\'
+  env:
+    TestAppId: $(LinuxTestBotAppId)
+    TestPassword: $(LinuxTestBotAppSecret)
 
 - task: AzureCLI@1
   displayName: 'Delete test resource group'

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -28,9 +28,7 @@ pr: none # no pr trigger
 
 variables:
   AppId: $(WinTestBotAppId)
-  TESTAPPID: $(WinTestBotAppId)
   AppSecret: $(WinTestBotAppSecret)
-  TESTAPPSECRET: $(WinTestBotAppSecret)
   BotGroup: $(WinTestBotBotGroup)
   BotName: $(WinTestBotBotName)
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false -p:RunAnalyzersDuringBuild=false
@@ -98,6 +96,10 @@ steps:
     projects: '$(System.DefaultWorkingDirectory)\FunctionalTests\**\*FunctionalTests.csproj'
     arguments: '-v n --configuration $(BuildConfiguration) --filter "TestCategory=FunctionalTests&TestCategory!=Adapters"'
     workingDirectory: tests
+  env:
+    TestAppId: $(WinTestBotAppId)
+    TestAppSecret: $(WinTestBotAppSecret)
+    
 
 - task: AzureCLI@1
   displayName: 'Delete Resources'

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -28,7 +28,9 @@ pr: none # no pr trigger
 
 variables:
   AppId: $(WinTestBotAppId)
+  TESTAPPID: $(WinTestBotAppId)
   AppSecret: $(WinTestBotAppSecret)
+  TESTAPPSECRET: $(WinTestBotAppSecret)
   BotGroup: $(WinTestBotBotGroup)
   BotName: $(WinTestBotBotName)
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false -p:RunAnalyzersDuringBuild=false

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -98,7 +98,7 @@ steps:
     workingDirectory: tests
   env:
     TestAppId: $(WinTestBotAppId)
-    TestAppSecret: $(WinTestBotAppSecret)
+    TestPassword: $(WinTestBotAppSecret)
     
 
 - task: AzureCLI@1

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -99,7 +99,6 @@ steps:
   env:
     TestAppId: $(WinTestBotAppId)
     TestPassword: $(WinTestBotAppSecret)
-    
 
 - task: AzureCLI@1
   displayName: 'Delete Resources'


### PR DESCRIPTION
These 7 tests were being skipped in BotBuilder-DotNet-Functional-Tests-Windows-yaml:
  √ SendDirectLineMessage [13s 651ms]
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.2+2d84eb3141 (64-bit .NET Core 4.6.29220.03)
  ! SendDirectLineSpeechVoiceMessage
  ! TokenTests_GetCredentialsWorks [384ms]
  ! TokenTests_RefreshTokenWorks [4ms]
  ! TokenTests_RefreshTestLoad [6ms]
  ! Connector_TokenExtractor_NullRequiredEndorsements_ShouldFail [18ms]
  ! Connector_TokenExtractor_EmptyRequireEndorsements_ShouldValidate [3ms]
  ! Connector_TokenExtractor_RequiredEndorsementsPresent_ShouldValidate [3ms]
[xUnit.net 00:00:02.96]   Discovering: Microsoft.Bot.Builder.FunctionalTests
[xUnit.net 00:00:02.99]   Discovered:  Microsoft.Bot.Builder.FunctionalTests
Results File: D:\a\_temp\VssAdministrator_fv-az630_2020-10-05_16_43_22.trx

Test Run Successful.
Total tests: 8
     Passed: 1
    Skipped: 7
 Total time: 23.8433 Seconds
Test run for D:\a\1\s\FunctionalTests\Microsoft.Bot.Builder.FunctionalTests\bin\Release\netcoreapp3.1\Microsoft.Bot.Builder.FunctionalTests.dll(.NETCoreApp,Version=v3.1)
