### PR TITLE
fix the default behavior when cloud environments are configured

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 }
                 else
                 {
-                    throw new Exception("A ChannelService was given but the value was not recognized.");
+                    throw new ArgumentException("A ChannelService was given but the value was not recognized.");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Bot.Connector.Authentication
                 }
                 else
                 {
-                    throw new ArgumentException("A ChannelService was given but the value was not recognized.");
+                    // The ChannelService value is used an indicator of which built in set of constants to use. If it is not recognized, a full configuration is expected.
+
+                    throw new ArgumentException("The provided ChannelService value is not supported.");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
 
@@ -43,18 +44,18 @@ namespace Microsoft.Bot.Connector.Authentication
             HttpClient httpClient,
             ILogger logger)
         {
-            if (string.IsNullOrEmpty(channelService))
+            if (
+                !string.IsNullOrEmpty(toChannelFromBotLoginUrl) || 
+                !string.IsNullOrEmpty(toChannelFromBotOAuthScope) || 
+                !string.IsNullOrEmpty(toBotFromChannelTokenIssuer) || 
+                !string.IsNullOrEmpty(oAuthUrl) ||
+                !string.IsNullOrEmpty(toBotFromChannelOpenIdMetadataUrl) ||
+                !string.IsNullOrEmpty(toBotFromEmulatorOpenIdMetadataUrl) ||
+                !string.IsNullOrEmpty(callerId))
             {
-                return new PublicCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClient, logger);
-            }
-            else if (channelService == GovernmentAuthenticationConstants.ChannelService)
-            {
-                return new GovernmentCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClient, logger);
-            }
-            else
-            {
+                // if we have any of the 'parameterized' properties defined we'll assume this is the parameterized code
+
                 return new ParameterizedBotFrameworkAuthentication(
-                    channelService,
                     validateAuthority,
                     toChannelFromBotLoginUrl,
                     toChannelFromBotOAuthScope,
@@ -67,6 +68,23 @@ namespace Microsoft.Bot.Connector.Authentication
                     authConfiguration,
                     httpClient,
                     logger);
+            }
+            else
+            {
+                // else apply the built in default behavior, which is either the public cloud or the gov cloud depending on whether we have a channelService value present 
+
+                if (string.IsNullOrEmpty(channelService))
+                {
+                    return new PublicCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClient, logger);
+                }
+                else if (channelService == GovernmentAuthenticationConstants.ChannelService)
+                {
+                    return new GovernmentCloudBotFrameworkAuthentication(credentialFactory, authConfiguration, httpClient, logger);
+                }
+                else
+                {
+                    throw new Exception("A ChannelService was given but the value was not recognized.");
+                }
             }
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Bot.Connector.Authentication
     {
         private static HttpClient _defaultHttpClient = new HttpClient();
 
-        private readonly string _channelService;
         private readonly bool _validateAuthority;
         private readonly string _toChannelFromBotLoginUrl;
         private readonly string _toChannelFromBotOAuthScope;
@@ -34,7 +33,6 @@ namespace Microsoft.Bot.Connector.Authentication
         private readonly ILogger _logger;
 
         public ParameterizedBotFrameworkAuthentication(
-            string channelService,
             bool validateAuthority,
             string toChannelFromBotLoginUrl,
             string toChannelFromBotOAuthScope,
@@ -48,7 +46,6 @@ namespace Microsoft.Bot.Connector.Authentication
             HttpClient httpClient = null,
             ILogger logger = null)
         {
-            _channelService = channelService;
             _validateAuthority = validateAuthority;
             _toChannelFromBotLoginUrl = toChannelFromBotLoginUrl;
             _toChannelFromBotOAuthScope = toChannelFromBotOAuthScope;

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 { "MicrosoftAppId", "appId" },
                 { "MicrosoftAppPassword", "appPassword" },
-                { "ChannelService", "channelService" }
+                { "ChannelService", GovernmentAuthenticationConstants.ChannelService }
             };
 
             var configuration = new ConfigurationBuilder()


### PR DESCRIPTION
Change the behavior for configured cloud environments.

If there is any configuration for a cloud environment fall into the parameterized code path.

Otherwise, the default is the public cloud with no configuration and the gov cloud if the (legacy) ChannelService property indicates that.
