### PR TITLE
Check for var VMImage to override the default build agent VM image

### DIFF
--- a/build/yaml/-experimentalDummy.yml
+++ b/build/yaml/-experimentalDummy.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 variables:
   TriggeredReason: $[ coalesce( variables['TriggeringBuildReason'], variables['Build.Reason'] ) ]

--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-slack-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slack-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-twilio-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  name: Hosted Windows 2019 with VS2019
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
   demands:
   - msbuild
   - visualstudio

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: # ci trigger
   batch: true

--- a/build/yaml/botbuilder-dotnet-functional-tests-setup.yml
+++ b/build/yaml/botbuilder-dotnet-functional-tests-setup.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  name: Hosted Windows 2019 with VS2019
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
   demands:
   - msbuild
   - visualstudio

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -6,7 +6,7 @@
 name: $(Date:yyyyMMdd).$(Build.BuildId)
 
 pool:
-  name: Hosted Windows 2019 with VS2019
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
   demands:
   - msbuild
   - visualstudio

--- a/build/yaml/botbuilder-dotnet-simple-build-test.yml
+++ b/build/yaml/botbuilder-dotnet-simple-build-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: none
 


### PR DESCRIPTION
Lets the build agent VM image for pipelines be settable at queue time. 
Issue #4765 