### PR TITLE
Inject 'template' function into Expression

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -567,13 +567,6 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 return new ExpressionEvaluator(templateName, FunctionUtils.Apply(this.TemplateEvaluator(name)), ReturnType.Object, this.ValidTemplateReference);
             }
 
-            const string template = "template";
-
-            if (name.Equals(template, StringComparison.Ordinal))
-            {
-                return new ExpressionEvaluator(template, FunctionUtils.Apply(this.TemplateFunction()), ReturnType.Object, this.ValidateTemplateFunction);
-            }
-
             const string fromFile = "fromFile";
 
             if (name.Equals(fromFile, StringComparison.Ordinal))
@@ -682,26 +675,6 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var newScope = this.ConstructScope(templateName, args.Skip(1).ToList());
             return this.EvaluateTemplate(templateName, newScope);
         };
-
-        // Validator for template(...)
-        private void ValidateTemplateFunction(Expression expression)
-        {
-            FunctionUtils.ValidateAtLeastOne(expression);
-
-            var children0 = expression.Children[0];
-
-            if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
-            {
-                throw new Exception(TemplateErrors.InvalidTemplateNameType);
-            }
-
-            // Validate more if the name is string constant
-            if (children0.Type == ExpressionType.Constant)
-            {
-                var templateName = (children0 as Constant).Value.ToString();
-                CheckTemplateReference(templateName, expression.Children.Skip(1));
-            }
-        }
 
         private Func<IReadOnlyList<object>, object> TemplateEvaluator(string templateName)
         => (IReadOnlyList<object> args) =>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Fallback/inject.dialog
@@ -60,6 +60,25 @@
         {
           "$kind": "Microsoft.SendActivity",
           "activity": "${user.obj.SR.Q2}"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.number1",
+          "value": "=1"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.number2",
+          "value": "=2"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.sum",
+          "value": "=template('Sum', user.number1, user.number2)"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${user.sum}"
         }
       ]
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -424,6 +424,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 .AssertReply("Jonathan : 2003-03-20")
                 .AssertReply("Jonathan, your tasks: car, washing, food and laundry")
                 .AssertReply("2")
+                .AssertReply("3")
             .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/inject.lg
@@ -25,3 +25,6 @@
 
 # ShowTasks(tasks)
 - ${sentenceCase(user.name)}, your tasks: ${join(foreach(tasks, task, task.value), ', ', ' and ')}
+
+# Sum(a, b)
+- ${a + b}

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/Expand.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/Expand.lg
@@ -83,9 +83,6 @@ They are ${ShowAlarm(alarms[1])}
 - ELSE:
     - ${TimeOfDay()}
 
-# template3(templateName)
-  - ${template(templateName)}
-
 # GetAge
 - how old are you?
 - what's your age?

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1607,6 +1607,31 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var scope2 = new { i = 1, j = 2, k = 3, l = 4 };
             (evaled, error) = Expression.Parse("common.sumFourNumbers(i, j, k, l)").TryEvaluate(scope2);
             Assert.Equal("10", evaled.ToString());
+
+            // inject template test
+            (evaled, error) = Expression.Parse("template('sumAll')").TryEvaluate(null);
+            Assert.Null(error);
+            Assert.Equal(3L, evaled);
+
+            // inject template test with scope
+            (evaled, error) = Expression.Parse("template('addTwoNum', first, second)").TryEvaluate(new { first = 1, second = 2 });
+            Assert.Null(error);
+            Assert.Equal(3L, evaled);
+
+            // inject template test with a non-exist template name
+            (evaled, error) = Expression.Parse("template('addTwoNum', first, second)").TryEvaluate(new { first = 1, second = 2 });
+            Assert.Null(error);
+            Assert.Equal(3L, evaled);
+
+            // inject template test without template name
+            (evaled, error) = Expression.Parse("template()").TryEvaluate(null);
+            Assert.Null(evaled);
+            Assert.Equal("Expression 'template' should have at least 1 children.", error);
+
+            // inject template test with a wrong template name type
+            (evaled, error) = Expression.Parse("template(123)").TryEvaluate(null);
+            Assert.Null(evaled);
+            Assert.Equal("template name should be string.", error);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -654,17 +654,6 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         }
 
         [Fact]
-        public void TestExpandTemplateWithTemplateFunction()
-        {
-            var templates = Templates.ParseFile(GetExampleFilePath("Expand.lg"));
-
-            var evaled = templates.ExpandTemplate("template3", new { templateName = "Greeting" });
-            Assert.Equal(2, evaled.Count);
-            Assert.Equal("Hi", evaled[0]);
-            Assert.Equal("Hello", evaled[1]);
-        }
-
-        [Fact]
         public void TestExpandTemplateWithDoubleQuotation()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("Expand.lg"));


### PR DESCRIPTION
Related issue: https://github.com/microsoft/botbuilder-dotnet/issues/4730

## Description
Currently, some customers want to apply LG templates in Expression. The only way currently is to use namespace/export options. The Doc link is here: https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lg-file-format?view=azure-bot-service-4.0#namespace-option

But if there are many template functions that need to be exported to Expression, the workload will be heavy and the readability will be poor.


## Specific Changes
The `template` function originally could be achieved only in LG scope. Introduction of `template` function:
https://docs.microsoft.com/en-us/azure/bot-service/language-generation/functions-injected-from-language-generation?view=azure-bot-service-4.0#template

Now introduce it into Expression.

Inject the LG function `template` into Expression when the template file is loaded by the LG system.

For example, if file a.lg is loaded, and in the file exists such template:
```
# Sum(a, b)
- ${a + b}
```

In some usage scenarios of Expression(most properties in Adaptive), the user can direct use `template` function to achieve the LG template. For the below dialog section:
```
...
       {
          "$kind": "Microsoft.SetProperty",
          "property": "user.number1",
          "value": "=1"
        },
        {
          "$kind": "Microsoft.SetProperty",
          "property": "user.number2",
          "value": "=2"
        },
        {
          "$kind": "Microsoft.SetProperty",
          "property": "user.sum",
          "value": "=template('Sum', user.number1, user.number2)"
        },
        {
          "$kind": "Microsoft.SendActivity",
          "activity": "${user.sum}"
        }
...
```
Would get result `3` after the evaluation.