### PR TITLE
Make language policy in MultiLanguageRecognizer align with the policy in UseLanguagePolicy

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
@@ -143,8 +143,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         /// <param name="testName">Name of the test.</param>
         /// <param name="callback">The bot logic.</param>
         /// <param name="adapter">optional test adapter.</param>
+        /// <param name="languagePolicy">The default language policy.</param>
         /// <returns>Runs the exchange between the user and the bot.</returns>
-        public async Task ExecuteAsync(ResourceExplorer resourceExplorer, [CallerMemberName] string testName = null, BotCallbackHandler callback = null, TestAdapter adapter = null)
+        public async Task ExecuteAsync(ResourceExplorer resourceExplorer, [CallerMemberName] string testName = null, BotCallbackHandler callback = null, TestAdapter adapter = null, LanguagePolicy languagePolicy = null)
         {
             if (adapter == null)
             {
@@ -184,6 +185,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
                 var dm = new DialogManager(Dialog)
                     .UseResourceExplorer(resourceExplorer)
                     .UseLanguageGeneration();
+
+                if (languagePolicy != null)
+                {
+                    dm.UseLanguagePolicy(languagePolicy);
+                }
 
                 foreach (var testAction in Script)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// </value>
         [JsonProperty("languagePolicy")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public LanguagePolicy LanguagePolicy { get; set; } = new LanguagePolicy();
+        public LanguagePolicy LanguagePolicy { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
@@ -66,13 +66,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <returns>Analysis of utterance.</returns>
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
+            var languagePolicy = LanguagePolicy ??
+                    dialogContext.Services.Get<LanguagePolicy>() ??
+                    new LanguagePolicy();
+
             var policy = new List<string>();
-            if (activity.Locale != null && LanguagePolicy.TryGetValue(activity.Locale, out string[] targetpolicy))
+            if (activity.Locale != null && languagePolicy.TryGetValue(activity.Locale, out string[] targetpolicy))
             {
                 policy.AddRange(targetpolicy);
             }
 
-            if (LanguagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
+            if (languagePolicy.TryGetValue(string.Empty, out string[] defaultPolicy))
             {
                 // we now explictly add defaultPolicy instead of coding that into target's policy
                 policy.AddRange(defaultPolicy);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
@@ -46,5 +46,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
+
+        [Fact]
+        public async Task MultiLanguageRecognizerTest_LanguagePolicy()
+        {
+            var languagePolicy = new LanguagePolicy("en-gb");
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, languagePolicy: languagePolicy);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestUtils.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestUtils.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             return Directory.EnumerateFiles(testFolder, "*.test.dialog", SearchOption.AllDirectories).Select(s => new object[] { Path.GetFileName(s) }).ToArray();
         }
 
-        public static async Task RunTestScript(ResourceExplorer resourceExplorer, string resourceId = null, IConfiguration configuration = null, [CallerMemberName] string testName = null)
+        public static async Task RunTestScript(ResourceExplorer resourceExplorer, string resourceId = null, IConfiguration configuration = null, [CallerMemberName] string testName = null, LanguagePolicy languagePolicy = null)
         {
             var script = resourceExplorer.LoadType<TestScript>(resourceId ?? $"{testName}.test.dialog");
             script.Configuration = configuration ?? new ConfigurationBuilder().AddInMemoryCollection().Build();
             script.Description = script.Description ?? resourceId;
-            await script.ExecuteAsync(testName: testName, resourceExplorer: resourceExplorer).ConfigureAwait(false);
+            await script.ExecuteAsync(testName: testName, resourceExplorer: resourceExplorer, languagePolicy: languagePolicy).ConfigureAwait(false);
         }
 
         public static string GetProjectPath()

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/MultiLanguageRecognizerTests/MultiLanguageRecognizerTest_LanguagePolicy.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/MultiLanguageRecognizerTests/MultiLanguageRecognizerTest_LanguagePolicy.test.dialog
@@ -1,0 +1,123 @@
+﻿{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "recognizer": {
+      "$kind": "Microsoft.MultiLanguageRecognizer",
+      "recognizers": {
+        "en-us": {
+          "$kind": "Microsoft.RegexRecognizer",
+          "intents": [
+            {
+              "intent": "Greeting",
+              "pattern": "(?i)howdy"
+            },
+            {
+              "intent": "Goodbye",
+              "pattern": "(?i)bye"
+            }
+          ]
+        },
+        "en-gb": {
+          "$kind": "Microsoft.RegexRecognizer",
+          "intents": [
+            {
+              "intent": "Greeting",
+              "pattern": "(?i)hiya"
+            },
+            {
+              "intent": "Goodbye",
+              "pattern": "(?i)cheerio"
+            }
+          ]
+        },
+        "en": {
+          "$kind": "Microsoft.RegexRecognizer",
+          "intents": [
+            {
+              "intent": "Greeting",
+              "pattern": "(?i)hello"
+            },
+            {
+              "intent": "Goodbye",
+              "pattern": "(?i)goodbye"
+            }
+          ]
+        },
+        "": {
+          "$kind": "Microsoft.RegexRecognizer",
+          "intents": [
+            {
+              "intent": "Greeting",
+              "pattern": "(?i)salve"
+            },
+            {
+              "intent": "Goodbye",
+              "pattern": "(?i)vale dicere"
+            }
+          ]
+        }
+      }
+    },
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "Greeting",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "greeting intent"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "Goodbye",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "goodbye intent"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnUnknownIntent",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "default rule"
+          }
+        ]
+      }
+    ],
+    "defaultResultProperty": "dialog.result"
+  },
+  "locale": "",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hiya"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "greeting intent"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "howdy"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "default rule"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "cheerio"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "goodbye intent"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #4143

## Description
Make language policy in MultiLanguageRecognizer follow the LG UseLanguagePolicy convention 

## Specific Changes
Change the default policy assignment with composite value achievement.
The step is: 
- Get value from the property  `LanguagePolicy` directly
- Get value from the value from `UseLanguagePolicy`
- Use default languagePolicy `new LanguagePolicy()`

