### PR TITLE
Delete nuget.config

### DIFF
--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -12,10 +12,7 @@ steps:
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:
-    command: 'restore'
     restoreSolution: '$(Parameters.solution)'
-    feedsToUse: 'config'
-    nugetConfigPath: 'nuget.config'
 
 - task: VSBuild@1
   displayName: 'Build solution Microsoft.Bot.Builder.sln'

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="ConversationalAI" value="https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
We no longer need nuget.config (with an entry for Conversational AI feed) since we push Microsoft.BotFramework.Orchestrator version 4.11.0-daily* to nuget.  


## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->