### PR TITLE
Add logging to test.

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -68,12 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                     var error = process.StandardError.ReadToEnd();
                     process.WaitForExit();
 
-                    if (error.Length > 0)
-                    {
-                        Trace.WriteLine(error);
-                    }
-
-                    Assert.Equal(string.Empty, error);
+                    Assert.True(error.Length == 0, error);
                 }
             }
             catch (Exception err)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                     var error = process.StandardError.ReadToEnd();
                     process.WaitForExit();
 
+                    if (error.Length > 0)
+                    {
+                        Trace.WriteLine(error);
+                    }
+
                     Assert.Equal(string.Empty, error);
                 }
             }


### PR DESCRIPTION
Schema merge tests do not display enough information in logs.