### PR TITLE
Support async local version of DebugSupport

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                     };
                 }
 
-                throw new Exception($"{id} error: {err.Message}\n{err.InnerException?.Message}");
+                throw new Exception($"{id} error: {err.Message}\n{err.InnerException?.Message}", err);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebugSupportTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebugSupportTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+{
+    public class DebugSupportTests : IDisposable
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DebugSupport_HasDifferentInstancesInDifferentContexts_WhenAsyncLocal(bool isAsyncLocal)
+        {
+            DebugSupport.UseAsyncLocal = isAsyncLocal;
+
+            var sourceMap1 = await GetLocalSourceMapAsync();
+            var sourceMap2 = await GetLocalSourceMapAsync();
+
+            bool isSameInstance = object.ReferenceEquals(sourceMap1, sourceMap2);
+            if (isSameInstance && isAsyncLocal)
+            {
+                throw new Exception("Expected a different instance in each AsyncLocal context when AsyncLocal is used.");
+            }
+
+            if (!isSameInstance && !isAsyncLocal)
+            {
+                throw new Exception("Expected a singleton instance when AsyncLocal is not used. ");
+            }
+        }
+
+        public void Dispose()
+        {
+            // do not interfere with other tests
+            DebugSupport.UseAsyncLocal = false;
+        }
+
+        private async Task<ISourceMap> GetLocalSourceMapAsync()
+        {
+            await Task.Yield();
+            return DebugSupport.SourceMap;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4807

## Description
Attempting to use AsyncLocal to enable multiple concurrent resource managers to avoid interference with each other.

## Specific Changes
- Add a new `UseAsyncLocal` capabilty to `DebugSupport`. Default is off.
- Changed the implementation of `DebugSupport.SourceMap` to use an Async Local instead of a static value, depending on `UseAsyncLocal`.

## Testing
- Added unit test coverage on the new code 
- Validating the change locally.