### PR TITLE
Change type of property EventType.Item from string to JObject in Slack Adapter

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -19,7 +20,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 
         public string Ts { get; set; }
 
-        public string Item { get; set; }
+#pragma warning disable CA2227 // Collection properties should be read only
+        public JObject Item { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         [JsonProperty(PropertyName = "event_ts")]
         public string EventTs { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
@@ -20,9 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 
         public string Ts { get; set; }
 
-#pragma warning disable CA2227 // Collection properties should be read only
-        public JObject Item { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Item { get; } = new JObject();
 
         [JsonProperty(PropertyName = "event_ts")]
         public string EventTs { get; set; }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Files/ReactionAddedEvent.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Files/ReactionAddedEvent.json
@@ -1,0 +1,21 @@
+﻿{
+    "token": "VerificationToken",
+    "team_id": "teamId",
+    "api_app_id": "apiAppId",
+    "event": {
+      "client_msg_id": "clientId",
+      "user": "userId",
+      "type": "reaction_added",
+      "reaction": "thumbsup",
+      "item_user": "U0G9QF9C6",
+      "item": {
+        "type": "message",
+        "channel": "C0G9QF9GZ",
+        "ts": "1360782400.498405"
+      }
+    },
+    "type": "event_callback",
+    "event_id": "eventId",
+    "event_time": 1568915625,
+    "event_ts": "1568915625.001000"
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -38,6 +38,9 @@
     <None Update="Files\InteractiveMessageBody.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\ReactionAddedEvent.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Files\SlackActivity.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #4594

## Description
User reported. The Slack adapter does not know how to deserialize EventType.Item as it was set as a string.

## Specific Changes
I changed the type of `Item` from `string` to `JObject`. I was not able to find anywhere in the Slack Events API documentation an instance of EventType.Item used as a string. See [Event Type](https://api.slack.com/types/event) and [Event Wrapper](https://github.com/slackapi/slack-api-specs/blob/master/events-api/slack_common_event_wrapper_schema.json)

## Testing

- Added unit test `ProcessAsyncShouldSucceedWithReactionAddedEventType` that verifies the payload is processed as expected.
- Refactored common code to methods for reuse. 
- All unit tests passed.

![image](https://user-images.githubusercontent.com/44449640/96306616-dc54b180-0fb4-11eb-8404-0a7ad9b65544.png)

