### PR TITLE
Ignore the null or empty result of the OutputFormat in TextInput

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -54,7 +54,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 var (outputValue, error) = this.OutputFormat.TryGetValue(dc.State);
                 if (error == null)
                 {
-                    input = outputValue.ToString();
+                    if (!string.IsNullOrWhiteSpace(outputValue))
+                    {
+                        // if the result is null or empty string, ignore it.
+                        input = outputValue.ToString();
+                    }
                 }
                 else
                 {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInput.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInput.test.dialog
@@ -30,7 +30,8 @@
                         "unrecognizedPrompt": "How should I call you?",
                         "validations": [
                             "this.value.Length > 3"
-                        ]
+                        ],
+                        "outputFormat": ""
                     },
                     {
                         "$kind": "Microsoft.SendActivity",


### PR DESCRIPTION
Fixes #4758

## Description
If someone assigns an empty string or `null` value or whitespace string to property `OutputFormat`, would trigger the unrecognized prompt error.

## Specific Changes
Ignore the `null` or whitespace string in `OutputFormat`.

## Testing
Such action:
```
{
           "$kind": "Microsoft.TextInput",
           "property": "user.name",
           "alwaysPrompt": true,
           "prompt": "Hello, what is your name?",
            "unrecognizedPrompt": "How should I call you?",
            "validations": [
                   "this.value.Length > 3"
             ],
             "outputFormat": "" // would ignore this property
 }
```