### PR TITLE
Adding UI schema to handle form dialogs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.uischema
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "form": {
+        "label": "Send a response to ask a question",
+        "subtitle": "Ask Activity",
+        "helpLink": "https://aka.ms/bfc-send-activity",
+        "order": [
+            "activity",
+            "*"
+        ]
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnAssignEntity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnAssignEntity.uischema
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "form": {
+        "order": [
+            "condition",
+            "*"
+        ],
+        "hidden": [
+            "actions"
+        ],
+        "label": "Handle a condition when an entity is assigned",
+        "subtitle": "EntityAssigned activity"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfActions.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfActions.uischema
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "form": {
+        "order": [
+            "condition",
+            "*"
+        ],
+        "hidden": [
+            "actions"
+        ],
+        "label": "Handle a condition when actions have ended",
+        "subtitle": "EndOfActions activity"
+    }
+}


### PR DESCRIPTION
This assists form dialogs in Composer - https://github.com/microsoft/BotFramework-Composer/issues/4360

## Description
This adds missing UI schema for Microsoft.Ask, Microsoft.OnAssignEntity, and Microsoft.OnEndOfActions necessary to have them render property in composers flow designer and property pane.

## Specific Changes
  - Add UI schemas

## Testing
N/A