### PR TITLE
Remove extra skill dialog trace activities

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
@@ -7,7 +7,6 @@ using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Skills;
-using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 
@@ -49,9 +48,6 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                     var activeDialogContext = GetActiveDialogContext(dialogContext);
 
-                    var remoteCancelText = "Skill was canceled through an EndOfConversation activity from the parent.";
-                    await turnContext.TraceActivityAsync($"{typeof(Dialog).Name}.RunAsync()", label: $"{remoteCancelText}", cancellationToken: cancellationToken).ConfigureAwait(false);
-
                     // Send cancellation message to the top dialog in the stack to ensure all the parents are canceled in the right order. 
                     await activeDialogContext.CancelAllDialogsAsync(true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -84,9 +80,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             {
                 if (SendEoCToParent(turnContext))
                 {
-                    var endMessageText = $"Dialog {dialog.Id} has **completed**. Sending EndOfConversation.";
-                    await turnContext.TraceActivityAsync($"{typeof(Dialog).Name}.RunAsync()", label: $"{endMessageText}", value: result.Result, cancellationToken: cancellationToken).ConfigureAwait(false);
-
                     // Send End of conversation at the end.
                     var code = result.Status == DialogTurnStatus.Complete ? EndOfConversationCodes.CompletedSuccessfully : EndOfConversationCodes.UserCancelled;
                     var activity = new Activity(ActivityTypes.EndOfConversation) { Value = result.Result, Locale = turnContext.Activity.Locale, Code = code };

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -311,9 +311,6 @@ namespace Microsoft.Bot.Builder.Dialogs
                 // Handle remote cancellation request from parent.
                 var activeDialogContext = GetActiveDialogContext(dc);
 
-                var remoteCancelText = "Skill was canceled through an EndOfConversation activity from the parent.";
-                await turnContext.TraceActivityAsync($"{GetType().Name}.OnTurnAsync()", label: $"{remoteCancelText}", cancellationToken: cancellationToken).ConfigureAwait(false);
-
                 // Send cancellation message to the top dialog in the stack to ensure all the parents are canceled in the right order. 
                 return await activeDialogContext.CancelAllDialogsAsync(true, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
@@ -337,8 +334,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (turnResult.Status == DialogTurnStatus.Empty)
             {
                 // restart root dialog
-                var startMessageText = $"Starting {_rootDialogId}.";
-                await turnContext.TraceActivityAsync($"{GetType().Name}.OnTurnAsync()", label: $"{startMessageText}", cancellationToken: cancellationToken).ConfigureAwait(false);
                 turnResult = await dc.BeginDialogAsync(_rootDialogId, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
@@ -346,9 +341,6 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             if (ShouldSendEndOfConversationToParent(turnContext, turnResult))
             {
-                var endMessageText = $"Dialog {_rootDialogId} has **completed**. Sending EndOfConversation.";
-                await turnContext.TraceActivityAsync($"{GetType().Name}.OnTurnAsync()", label: $"{endMessageText}", value: turnResult.Result, cancellationToken: cancellationToken).ConfigureAwait(false);
-
                 // Send End of conversation at the end.
                 var activity = new Activity(ActivityTypes.EndOfConversation)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -7,7 +7,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Skills;
-using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json.Linq;
 
@@ -56,8 +55,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             var dialogArgs = ValidateBeginDialogArgs(options);
 
-            await dc.Context.TraceActivityAsync($"{GetType().Name}.BeginDialogAsync()", label: $"Using activity of type: {dialogArgs.Activity.Type}", cancellationToken: cancellationToken).ConfigureAwait(false);
-
             // Create deep clone of the original activity to avoid altering it before forwarding it.
             var skillActivity = ObjectPath.Clone(dialogArgs.Activity);
 
@@ -99,12 +96,9 @@ namespace Microsoft.Bot.Builder.Dialogs
                 return EndOfTurn;
             }
 
-            await dc.Context.TraceActivityAsync($"{GetType().Name}.ContinueDialogAsync()", label: $"ActivityType: {dc.Context.Activity.Type}", cancellationToken: cancellationToken).ConfigureAwait(false);
-
             // Handle EndOfConversation from the skill (this will be sent to the this dialog by the SkillHandler if received from the Skill)
             if (dc.Context.Activity.Type == ActivityTypes.EndOfConversation)
             {
-                await dc.Context.TraceActivityAsync($"{GetType().Name}.ContinueDialogAsync()", label: $"Got {ActivityTypes.EndOfConversation}", cancellationToken: cancellationToken).ConfigureAwait(false);
                 return await dc.EndDialogAsync(dc.Context.Activity.Value, cancellationToken).ConfigureAwait(false);
             }
 
@@ -178,7 +172,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Send of of conversation to the skill if the dialog has been cancelled. 
             if (reason == DialogReason.CancelCalled || reason == DialogReason.ReplaceCalled)
             {
-                await turnContext.TraceActivityAsync($"{GetType().Name}.EndDialogAsync()", label: $"ActivityType: {turnContext.Activity.Type}", cancellationToken: cancellationToken).ConfigureAwait(false);
                 var activity = (Activity)Activity.CreateEndOfConversationActivity();
 
                 // Apply conversation reference and common properties from incoming activity before sending.


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4645

This reduces tracing, but does not address the other issues raised in 4645:

> I would expect to be able to have a setting or configuration or something which controls the traceactivities.