### PR TITLE
Debugging: Breakpoint to instance mapping from 'first wins' to 'last wins' and lay foundation for multiple items [Option 1]

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggerSourceMap.cs
@@ -257,6 +257,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
                     orderby distance
                     select sourceItem;
 
+                // We could have many options with the same distance -- add them all to the row
                 options = options.GroupBy(o => row.SourceBreakpoint.Line - o.Value.StartPoint.LineIndex).FirstOrDefault();
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Row.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Row.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs.Debugging.Protocol;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
@@ -26,6 +27,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
 
         public Breakpoint Breakpoint { get; } = new Breakpoint();
 
-        public object Item { get; set; }
+        public IList<object> Items { get; set; } = new List<object>();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
         private readonly ResourceExplorer resourceExplorer;
         private readonly List<IJsonLoadObserver> observers = new List<IJsonLoadObserver>();
         private readonly SourceContext sourceContext;
-        private readonly ConcurrentDictionary<string, T> cachedRefDialogs = new ConcurrentDictionary<string, T>();
+        private readonly Dictionary<string, T> cachedRefDialogs = new Dictionary<string, T>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InterfaceConverter{T}"/> class.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -203,9 +203,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
 
         private static JToken TryAssignId(JToken jToken, SourceContext sourceContext)
         {
-            // This is the jToken we'll use to build the concrete type.
-            var tokenToBuild = jToken;
-
             // If our JToken does not have an id, try to get an id from the resource explorer
             // in a best-effort manner.
             if (jToken is JObject jObj && !jObj.ContainsKey("id"))
@@ -213,15 +210,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
                 // Check if we have an id registered for this token
                 if (sourceContext is ResourceSourceContext rsc && rsc.DefaultIdMap.ContainsKey(jToken))
                 {
-                    // Clone the token since we'll alter it from the file version.
-                    // If we don't clone, future ranges will be calculated based on the altered token.
-                    // which will end in a wrong source range.
-                    tokenToBuild = jToken.DeepClone();
-                    tokenToBuild["id"] = rsc.DefaultIdMap[jToken];
+                    jToken["id"] = rsc.DefaultIdMap[jToken];
                 }
             }
 
-            return tokenToBuild;
+            return jToken;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         /// Gets or sets the source map instance.
         /// </summary>
         /// <value>The <see cref="SourceMap"/> instance.</value>
-        public static ISourceMap SourceMap { get; set; } = Debugging.SourceMap.Instance;
+        public static ISourceMap SourceMap { get; set; } = NullSourceMap.Instance;
 
         /// <summary>
         /// Extension method to get IDialogDebugger from TurnContext.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Debugging/DebugSupport.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
         /// Gets or sets the source map instance.
         /// </summary>
         /// <value>The <see cref="SourceMap"/> instance.</value>
-        public static ISourceMap SourceMap { get; set; } = NullSourceMap.Instance;
+        public static ISourceMap SourceMap { get; set; } = Debugging.SourceMap.Instance;
 
         /// <summary>
         /// Extension method to get IDialogDebugger from TurnContext.


### PR DESCRIPTION
Debugging improvements:

- Fix debugging of declarative assets
- Move breakpoint to instance tracking from first wins to last wins. When we reload an object, we always retain the latest instance for a given range
- Declarative perf: Interface converter has a non-concurrent dictionary since the process does not reqiure concurrency control
- Remove cloning from interface converter due to bug in json.net: https://github.com/JamesNK/Newtonsoft.Json/issues/2410

