### PR TITLE
remove trusted service url check in appcredentials

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -231,13 +231,6 @@ namespace Microsoft.Bot.Connector.Authentication
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
-#pragma warning disable CA1801 // Review unused parameters
-        private static bool IsTrustedUrl(Uri uri, ILogger logger)
-#pragma warning restore CA1801 // Review unused parameters
-        {
-            return true;
-        }
-
         private bool ShouldSetToken()
         {
             if (string.IsNullOrEmpty(MicrosoftAppId) || MicrosoftAppId == AuthenticationConstants.AnonymousSkillAppId)

--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public abstract class AppCredentials : ServiceClientCredentials
     {
+        [Obsolete]
         internal static readonly IDictionary<string, DateTime> TrustedHostNames = new Dictionary<string, DateTime>
         {
             // { "state.botframework.com", DateTime.MaxValue }, // deprecated state api
@@ -145,9 +146,10 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="serviceUrl">The service URL.</param>
         /// <remarks>If expiration time is not provided, the expiration time will DateTime.UtcNow.AddDays(1).</remarks>
+#pragma warning disable CA1801 // Review unused parameters
         public static void TrustServiceUrl(string serviceUrl)
+#pragma warning restore CA1801 // Review unused parameters
         {
-            TrustServiceUrl(serviceUrl, DateTime.UtcNow.Add(TimeSpan.FromDays(1)));
         }
 
         /// <summary>
@@ -155,12 +157,10 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="serviceUrl">The service URL.</param>
         /// <param name="expirationTime">The expiration time after which this service url is not trusted anymore.</param>
+#pragma warning disable CA1801 // Review unused parameters
         public static void TrustServiceUrl(string serviceUrl, DateTime expirationTime)
+#pragma warning restore CA1801 // Review unused parameters
         {
-            lock (TrustedHostNames)
-            {
-                TrustedHostNames[new Uri(serviceUrl).Host] = expirationTime;
-            }
         }
 
         /// <summary>
@@ -168,14 +168,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="serviceUrl">The service url.</param>
         /// <returns>True if the host of the service url is trusted; False otherwise.</returns>
+#pragma warning disable CA1801 // Review unused parameters
         public static bool IsTrustedServiceUrl(string serviceUrl)
+#pragma warning restore CA1801 // Review unused parameters
         {
-            if (Uri.TryCreate(serviceUrl, UriKind.Absolute, out var uri))
-            {
-                return IsTrustedUrl(uri, NullLogger.Instance);
-            }
-
-            return false;
+            return true;
         }
 
         /// <summary>
@@ -185,7 +182,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public override async Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (ShouldSetToken(request, Logger))
+            if (ShouldSetToken())
             {
                 var token = await GetTokenAsync().ConfigureAwait(false);
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -234,28 +231,14 @@ namespace Microsoft.Bot.Connector.Authentication
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
+#pragma warning disable CA1801 // Review unused parameters
         private static bool IsTrustedUrl(Uri uri, ILogger logger)
+#pragma warning restore CA1801 // Review unused parameters
         {
-            lock (TrustedHostNames)
-            {
-                if (TrustedHostNames.TryGetValue(uri.Host, out var trustedServiceUrlExpiration))
-                {
-                    // check if the trusted service url is still valid
-                    if (trustedServiceUrlExpiration > DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(5)))
-                    {
-                        return true;
-                    }
-
-                    logger.LogWarning($"{typeof(AppCredentials).FullName}.IsTrustedUrl(): '{uri}' found in TrustedHostNames but it expired (Expiration is set to: {trustedServiceUrlExpiration}, current time is {DateTime.UtcNow}).");
-                    return false;
-                }
-
-                logger.LogWarning($"{typeof(AppCredentials).FullName}.IsTrustedUrl(): '{uri}' not found in TrustedHostNames.");
-                return false;
-            }
+            return true;
         }
 
-        private bool ShouldSetToken(HttpRequestMessage request, ILogger logger)
+        private bool ShouldSetToken()
         {
             if (string.IsNullOrEmpty(MicrosoftAppId) || MicrosoftAppId == AuthenticationConstants.AnonymousSkillAppId)
             {
@@ -263,13 +246,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 return false;
             }
 
-            if (IsTrustedUrl(request.RequestUri, logger))
-            {
-                return true;
-            }
-
-            logger.LogWarning($"{typeof(AppCredentials).FullName}.ShouldSetToken(): '{request.RequestUri.Authority}' is not trusted and JwtToken cannot be sent to it.");
-            return false;
+            return true;
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -305,9 +305,6 @@ namespace Microsoft.Bot.Builder.Tests
                 var scope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey);
                 Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, scope);
 
-                // Ensure the serviceUrl was added to the trusted hosts
-                //Assert.True(AppCredentials.TrustedHostNames.ContainsKey(new Uri(channelServiceUrl).Host));
-
                 return Task.CompletedTask;
             });
 

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Bot.Builder.Tests
                 Assert.Equal(AuthenticationConstants.ToChannelFromBotOAuthScope, scope);
 
                 // Ensure the serviceUrl was added to the trusted hosts
-                Assert.True(AppCredentials.TrustedHostNames.ContainsKey(new Uri(channelServiceUrl).Host));
+                //Assert.True(AppCredentials.TrustedHostNames.ContainsKey(new Uri(channelServiceUrl).Host));
 
                 return Task.CompletedTask;
             });
@@ -315,7 +315,7 @@ namespace Microsoft.Bot.Builder.Tests
             var refs = new ConversationReference(serviceUrl: channelServiceUrl);
 
             // Ensure the serviceUrl is NOT in the trusted hosts
-            Assert.False(AppCredentials.TrustedHostNames.ContainsKey(new Uri(channelServiceUrl).Host));
+            //Assert.False(AppCredentials.TrustedHostNames.ContainsKey(new Uri(channelServiceUrl).Host));
 
             await adapter.ContinueConversationAsync(skillsIdentity, refs, callback, default);
         }
@@ -369,7 +369,7 @@ namespace Microsoft.Bot.Builder.Tests
                 Assert.Equal(skill2AppId, scope);
 
                 // Ensure the serviceUrl was added to the trusted hosts
-                Assert.True(AppCredentials.TrustedHostNames.ContainsKey(new Uri(skill2ServiceUrl).Host));
+                //Assert.True(AppCredentials.TrustedHostNames.ContainsKey(new Uri(skill2ServiceUrl).Host));
 
                 return Task.CompletedTask;
             });
@@ -378,7 +378,7 @@ namespace Microsoft.Bot.Builder.Tests
             var refs = new ConversationReference(serviceUrl: skill2ServiceUrl);
 
             // Ensure the serviceUrl is NOT in the trusted hosts
-            Assert.False(AppCredentials.TrustedHostNames.ContainsKey(new Uri(skill2ServiceUrl).Host));
+            //Assert.False(AppCredentials.TrustedHostNames.ContainsKey(new Uri(skill2ServiceUrl).Host));
 
             await adapter.ContinueConversationAsync(skillsIdentity, refs, skill2AppId, callback, default);
         }

--- a/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotFrameworkAdapterTests.cs
@@ -311,9 +311,6 @@ namespace Microsoft.Bot.Builder.Tests
             // Create ConversationReference to send a proactive message from Skill1 to a channel
             var refs = new ConversationReference(serviceUrl: channelServiceUrl);
 
-            // Ensure the serviceUrl is NOT in the trusted hosts
-            //Assert.False(AppCredentials.TrustedHostNames.ContainsKey(new Uri(channelServiceUrl).Host));
-
             await adapter.ContinueConversationAsync(skillsIdentity, refs, callback, default);
         }
 
@@ -365,17 +362,11 @@ namespace Microsoft.Bot.Builder.Tests
                 var scope = turnContext.TurnState.Get<string>(BotAdapter.OAuthScopeKey);
                 Assert.Equal(skill2AppId, scope);
 
-                // Ensure the serviceUrl was added to the trusted hosts
-                //Assert.True(AppCredentials.TrustedHostNames.ContainsKey(new Uri(skill2ServiceUrl).Host));
-
                 return Task.CompletedTask;
             });
 
             // Create ConversationReference to send a proactive message from Skill1 to Skill2
             var refs = new ConversationReference(serviceUrl: skill2ServiceUrl);
-
-            // Ensure the serviceUrl is NOT in the trusted hosts
-            //Assert.False(AppCredentials.TrustedHostNames.ContainsKey(new Uri(skill2ServiceUrl).Host));
 
             await adapter.ContinueConversationAsync(skillsIdentity, refs, skill2AppId, callback, default);
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -27,8 +27,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
 
             // Set a special base address so then we can make sure the connector client is honoring this http client
             customHttpClient.BaseAddress = baseUri;
-            var connectorClient = new ConnectorClient(new Uri("https://test.coffee"), new MicrosoftAppCredentials("big-guid-here", "appPasswordHere"), customHttpClient);
             
+            var connectorClient = new ConnectorClient(new Uri("https://test.coffee"), MicrosoftAppCredentials.Empty, customHttpClient);
+
             var activity = new Activity
             {
                 Type = "message",
@@ -42,8 +43,8 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     },
                 },
             };
-            
-            var turnContext = new TurnContext(new BotFrameworkAdapter(new SimpleCredentialProvider("big-guid-here", "appPasswordHere"), customHttpClient: customHttpClient), activity);
+
+            var turnContext = new TurnContext(new BotFrameworkAdapter(new SimpleCredentialProvider(), customHttpClient: customHttpClient), activity);
             turnContext.TurnState.Add<IConnectorClient>(connectorClient);
             turnContext.Activity.ServiceUrl = "https://test.coffee";
             var handler = new TestTeamsActivityHandler();
@@ -301,7 +302,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             {
                 var message = MessageFactory.Text("hi");
                 var channelId = "channelId123";
-                var creds = new MicrosoftAppCredentials("big-guid-here", "appPasswordHere");
+                var creds = new MicrosoftAppCredentials(string.Empty, string.Empty);
                 var cancelToken = new CancellationToken();
                 var reference = await TeamsInfo.SendMessageToTeamsChannelAsync(turnContext, message, channelId, creds, cancelToken);
 

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -110,26 +110,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         /// <summary>
-        /// Tests with a valid Token and invalid service url; and ensures that Service url is NOT added to Trusted service url list.
-        /// </summary>
-        [Fact]
-        public async void Channel_MsaHeader_Invalid_ServiceUrlShouldNotBeTrusted()
-        {
-            string header = $"Bearer {await new MicrosoftAppCredentials("2cd87869-38a0-4182-9251-d056e8f0ac24", "2.30Vs3VQLKt974F").GetTokenAsync()}";
-            var credentials = new SimpleCredentialProvider("7f74513e-6f96-4dbc-be9d-9a81fea22b88", string.Empty);
-
-            await Assert.ThrowsAsync<UnauthorizedAccessException>(
-                async () => await JwtTokenValidation.AuthenticateRequest(
-                new Activity { ServiceUrl = "https://webchat.botframework.com/" },
-                header,
-                credentials,
-                new SimpleChannelProvider(),
-                emptyClient));
-
-            Assert.False(MicrosoftAppCredentials.IsTrustedServiceUrl("https://webchat.botframework.com/"));
-        }
-
-        /// <summary>
         /// Tests with no authentication header and makes sure the service URL is not added to the trusted list.
         /// </summary>
         [Fact]
@@ -172,25 +152,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
             Assert.Equal(AuthenticationConstants.AnonymousAuthType, claimsPrincipal.AuthenticationType);
             Assert.Equal(AuthenticationConstants.AnonymousSkillAppId, JwtTokenValidation.GetAppIdFromClaims(claimsPrincipal.Claims));
-        }
-
-        /// <summary>
-        /// Tests with no authentication header and makes sure the service URL is not added to the trusted list.
-        /// </summary>
-        [Fact]
-        public async void Channel_AuthenticationDisabled_ServiceUrlShouldNotBeTrusted()
-        {
-            var header = string.Empty;
-            var credentials = new SimpleCredentialProvider();
-
-            var claimsPrincipal = await JwtTokenValidation.AuthenticateRequest(
-                new Activity { ServiceUrl = "https://webchat.botframework.com/" },
-                header,
-                credentials,
-                new SimpleChannelProvider(),
-                emptyClient);
-
-            Assert.False(MicrosoftAppCredentials.IsTrustedServiceUrl("https://webchat.botframework.com/"));
         }
 
         [Fact]


### PR DESCRIPTION
This PR removed the check on Trusted Service Url in the custom AppCredentials class.

Some of the internal implementation has been removed and the public methods obsoleted.

Tests have been updated and removed. (Also note the odd behavior in the TeamsInfo test. It seems there is a subtle distinction between null and empty string in no-auth scenarios.)

This check is redundant as all the logic does is add to a collection and then a couple of stack frames later check for the presence of the value in that same collection.

This was never a security feature exactly. It was a feature added in V3 to stop accidental deployment of code to production that didn't contain the ASP MVC auth attribute. In v4 the inbound / outbound nature of the protocol is fully encapsulated with the adapter and it does not rely on the user adding attributes to a ASP MVC controller.  

This code had more confusion in the world of Skills because the ContinueConversation implementation also needs to add to this collection just to get the lower level function to behave.

