### PR TITLE
Perf + Resource Utilization: Ensure proper dispose of disposable members

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Inspection/InspectionSession.cs
+++ b/libraries/Microsoft.Bot.Builder/Inspection/InspectionSession.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Bot.Builder
         private readonly ConversationReference _conversationReference;
         private readonly ILogger _logger;
 
+        // To detect redundant calls to Dispose()
+        private bool _disposed = false;
+
         public InspectionSession(ConversationReference conversationReference, MicrosoftAppCredentials credentials, HttpClient httpClient, ILogger logger)
         {
             _conversationReference = conversationReference;
@@ -44,9 +47,22 @@ namespace Microsoft.Bot.Builder
             return true;
         }
 
-        public void Dispose()
+        public void Dispose() => Dispose(true);
+
+        protected virtual void Dispose(bool disposing)
         {
-            _connectorClient?.Dispose();
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // Dispose managed state (managed objects).
+                _connectorClient?.Dispose();
+            }
+
+            _disposed = true;
         }
     }
 }


### PR DESCRIPTION
One more round of improvements around disposable patterns that should have a substantial impact in bots that have medium to large scale, in terms of resource utilization, including connections (clients), memory (dead references) and CPU (because of the GC having to do heavy passes in large size chunks)