### PR TITLE
Add new NormalizeMentionsMiddleware class

### DIFF
--- a/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    ///  Middleware to normalize mention Entities from channels that apply &lt;at&gt; markup tags since they don't conform to expected values.
+    ///  Bots that interact with Skype and/or teams should use this middleware if mentions are used.
+    /// </summary>
+    /// <description>
+    ///  This will 
+    ///  * remove mentions if they mention the recipient (aka the bot) as that text can cause confusion with intent processing.
+    ///  * remove extra &lt;at&gt; markup tags on mentions and in the activity.text.
+    /// </description>
+    public class NormalizeMentionsMiddleware : IMiddleware
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NormalizeMentionsMiddleware"/> class.
+        /// </summary>
+        public NormalizeMentionsMiddleware()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the any recipient mentions should be removed.
+        /// </summary>
+        /// <value>If true, @mentions of the recipient will be completely stripped from the .text and .entities.</value>
+        public bool RemoveRecipientMention { get; set; } = true;
+
+        /// <summary>
+        /// Middleware implementation which corrects Enity.Mention.Text to a value RemoveMentionText can work with.
+        /// </summary>
+        /// <param name="turnContext">turn context.</param>
+        /// <param name="next">next middleware.</param>
+        /// <param name="cancellationToken">cancellationToken.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            NormalizeActivity(turnContext.Activity);
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Normalize the activity.
+        /// </summary>
+        /// <param name="activity">activity.</param>
+        private void NormalizeActivity(Activity activity)
+        {
+            if (activity.Type == ActivityTypes.Message)
+            {
+                if (this.RemoveRecipientMention)
+                {
+                    // strip recipient mention tags and text.
+                    activity.RemoveRecipientMention();
+
+                    if (activity.Entities != null)
+                    {
+                        // strip entity.mention records for recipient id.
+                        activity.Entities = activity.Entities.Where(entity => entity.Type == "mention" &&
+                           ((dynamic)entity.Properties["mentioned"]).id != activity.Recipient.Id).ToList();
+                    }
+                }
+
+                // remove <at> </at> tags keeping the inner text.
+                activity.Text = RemoveAt(activity.Text);
+
+                if (activity.Entities != null)
+                {
+                    // remove <at> </at> tags from mention records keeping the inner text.
+                    foreach (var entity in activity.Entities)
+                    {
+                        if (entity.Type == "mention")
+                        {
+                            string entityText = (string)entity.Properties["text"];
+                            entity.Properties["text"] = RemoveAt(entityText?.Trim());
+                        }
+                    }
+                }
+            }
+        }
+
+        private string RemoveAt(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            bool foundTag;
+            do
+            {
+                foundTag = false;
+                int iAtStart = text.IndexOf("<at", StringComparison.InvariantCultureIgnoreCase);
+                if (iAtStart >= 0)
+                {
+                    int iAtEnd = text.IndexOf(">", iAtStart, StringComparison.InvariantCultureIgnoreCase);
+                    if (iAtEnd > 0)
+                    {
+                        int iAtClose = text.IndexOf("</at>", iAtEnd, StringComparison.InvariantCultureIgnoreCase);
+                        if (iAtClose > 0)
+                        {
+                            // replace </at> 
+                            var followingText = text.Substring(iAtClose + 5);
+
+                            // if first char of followingText is not whitespace
+                            if (!char.IsWhiteSpace(followingText.FirstOrDefault()))
+                            {
+                                // insert space because teams does => <at>Tom</at>is cool => Tomis cool
+                                followingText = $" {followingText}";
+                            }
+
+                            text = text.Substring(0, iAtClose) + followingText;
+
+                            // replace <at ...>
+                            text = text.Substring(0, iAtStart) + text.Substring(iAtEnd + 1);
+
+                            // we found one, try again, there may be more.
+                            foundTag = true;
+                        }
+                    }
+                }
+            }
+            while (foundTag);
+
+            return text;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder
                         if (entity.Type == "mention")
                         {
                             string entityText = (string)entity.Properties["text"];
-                            entity.Properties["text"] = RemoveAt(entityText?.Trim());
+                            entity.Properties["text"] = RemoveAt(entityText)?.Trim();
                         }
                     }
                 }

--- a/libraries/Microsoft.Bot.Builder/SkypeMentionNormalizeMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SkypeMentionNormalizeMiddleware.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Bot.Builder
     ///  the entity from Activity.Text.
     ///  This will remove the &lt;at&gt; nodes, leaving just the name.
     /// </description>
+    [Obsolete("You should use NormalizeMentionsMiddleware instead of this class.")]
     public class SkypeMentionNormalizeMiddleware : IMiddleware
     {
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Tests/NormalizeMentionsMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/NormalizeMentionsMiddlewareTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    public class NormalizeMentionsMiddlewareTests
+    {
+        private static Regex regex = new Regex(@"(?:^|[^a-zA-Z0-9_＠!@#$%&*])(?:(?:@|＠)(?!\/))([a-zA-Z0-9/_]{1,15})(?:\b(?!@|＠)|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        [Fact]
+        public async Task NormalizeMentionsVariations()
+        {
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(NormalizeMentionsVariations)))
+                .Use(new NormalizeMentionsMiddleware());
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                Assert.False(context.Activity.Text.Contains("<at") && context.Activity.Text.Contains("</at>"));
+                if (context.Activity.Entities != null)
+                {
+                    int i = 1;
+                    foreach (var entity in context.Activity.Entities)
+                    {
+                        dynamic props = (dynamic)entity.Properties;
+                        var entityText = (string)props.text;
+                        var mentionedId = (string)props.mentioned.id;
+                        Assert.DoesNotContain("<at", entityText);
+                        Assert.DoesNotContain("</at>", entityText);
+                        Assert.Contains(entityText, context.Activity.Text);
+                        Assert.Equal($"user{i++}", mentionedId);
+                    }
+                }
+
+                await context.SendActivityAsync("OK");
+            })
+                .Send(CreateMentionActivity("this is <at>Tom</at>", CreateEntity("<at>Tom</at>", "user1")))
+                    .AssertReply("OK")
+                .Send(CreateMentionActivity("this is <at id='123123'>Tom</at> asdfasdf", CreateEntity("<at id='123123'>Tom</at>", "user1")))
+                    .AssertReply("OK")
+                .Send(CreateMentionActivity("<at>Tom</at>", CreateEntity("<at>Tom</at>", "user1")))
+                    .AssertReply("OK")
+                .Send(CreateMentionActivity("<at>Tom</at>test", CreateEntity("<at>Tom</at>test", "user1")))
+                    .AssertReply("OK")
+                .Send(CreateMentionActivity("<at>Tomtest"))
+                    .AssertReply("OK")
+                .Send(CreateMentionActivity("at>Tomtest</at>"))
+                    .AssertReply("OK")
+                .Send(CreateMentionActivity("<at>Tom</at><at>John</at>", CreateEntity("<at>Tom</at>", "user1"), CreateEntity("<at>John</at>", "user2")))
+                    .AssertReply("OK")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task StripRecipientMentionsAndEntities()
+        {
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(NormalizeMentionsVariations)))
+                .Use(new NormalizeMentionsMiddleware());
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                Assert.False(context.Activity.Text.Contains("<at") && context.Activity.Text.Contains("</at>"));
+                Assert.DoesNotContain("bot", context.Activity.Text);
+                Assert.True(context.Activity.Entities == null || context.Activity.Entities.Count == 0);
+                await context.SendActivityAsync("OK");
+            })
+                .Send(CreateMentionActivity("this is <at>Bot</at>", CreateEntity("<at>Bot</at>", "bot")))
+                    .AssertReply("OK")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotStripRecipientMentionsAndEntities()
+        {
+            var adapter = new TestAdapter(TestAdapter.CreateConversation(nameof(NormalizeMentionsVariations)))
+                .Use(new NormalizeMentionsMiddleware() { RemoveRecipientMention = false });
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                Assert.False(context.Activity.Text.Contains("<at") && context.Activity.Text.Contains("</at>"));
+                Assert.Contains("Bot", context.Activity.Text);
+                Assert.NotNull(context.Activity.Entities);
+                var entity = context.Activity.Entities.Single();
+                dynamic props = (dynamic)entity.Properties;
+                var entityText = (string)props.text;
+                var mentionedId = (string)props.mentioned.id;
+                Assert.DoesNotContain("<at", entityText);
+                Assert.DoesNotContain("</at>", entityText);
+                Assert.Contains(entityText, context.Activity.Text);
+                Assert.Equal($"bot", mentionedId);
+                await context.SendActivityAsync("OK");
+            })
+                .Send(CreateMentionActivity("this is <at>Bot</at>", CreateEntity("<at>Bot</at>", "bot")))
+                    .AssertReply("OK")
+                .StartTestAsync();
+        }
+
+        public Activity CreateMentionActivity(string text, params Entity[] entities)
+        {
+            Activity activity = new Activity();
+            activity.Text = text;
+            activity.Entities = entities.ToList();
+            return activity;
+        }
+
+        public Entity CreateEntity(string atText, string userId)
+        {
+            var entity = new Entity()
+            {
+                Type = "mention"
+            };
+            dynamic props = entity.Properties;
+            props.text = atText;
+            props.mentioned = new JObject();
+            props.mentioned.id = userId;
+            props.mentioned.name = "User";
+            return entity;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4842 

## Description
Skype and teams both annotate raw text with <at>user</at> tags.  The current middleware that attempts to solve this only removes the markup from the text, but not from the mention object.  And it is named "SkypeNormalize" when it is also needed for teams (or for that matter, any channel which is passing <at> markup ).

## Specific Changes
* marked SkypeMentionNormalizeMiddleware as obsolete
* Created new NormalizeMentionsMiddleware class
  * removes <at> tags from text and mention entities.
  * has option to remove Recipient from text and mention entities for recipient (aka bot).
  * works for any channel (it's not just skype)

## Testing
* added unit tests