### PR TITLE
Johtaylo/cloudadapter proactive

### DIFF
--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -240,13 +240,13 @@ namespace Microsoft.Bot.Builder
         protected async Task ProcessProactiveAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             // Use the cloud environment to create the credentials for proactive requests.
-            var credentials = await _botFrameworkAuthentication.GetProactiveCredentialsAsync(claimsIdentity, audience, cancellationToken).ConfigureAwait(false);
+            var proactiveCredentialsResult = await _botFrameworkAuthentication.GetProactiveCredentialsAsync(claimsIdentity, audience, cancellationToken).ConfigureAwait(false);
 
             // Create the connector client to use for outbound requests.
-            using (var connectorClient = new ConnectorClient(new Uri(reference.ServiceUrl), credentials, _httpClient, disposeHttpClient: _httpClient == null))
+            using (var connectorClient = new ConnectorClient(new Uri(reference.ServiceUrl), proactiveCredentialsResult.Credentials, _httpClient, disposeHttpClient: _httpClient == null))
             {
                 // Create a turn context and run the pipeline.
-                using (var context = CreateTurnContext(reference.GetContinuationActivity(), claimsIdentity, audience, connectorClient, callback))
+                using (var context = CreateTurnContext(reference.GetContinuationActivity(), claimsIdentity, proactiveCredentialsResult.Scope, connectorClient, callback))
                 {
                     // Run the pipeline.
                     await RunPipelineAsync(context, callback, cancellationToken).ConfigureAwait(false);
@@ -260,7 +260,7 @@ namespace Microsoft.Bot.Builder
         /// <summary>
         /// The implementation for processing an Activity sent to this bot.
         /// </summary>
-        /// <param name="authHeader">The authorization header from teh http request.</param>
+        /// <param name="authHeader">The authorization header from the http request.</param>
         /// <param name="activity">The <see cref="Activity"/> to process.</param>
         /// <param name="callback">The method to call for the resulting bot turn.</param>
         /// <param name="cancellationToken">Cancellation token.</param>

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticateRequestResult.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticateRequestResult.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Security.Claims;
-using Microsoft.Rest;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
     /// <summary>
     /// The result from a call to authenticate a Bot Framework Protocol request.
     /// </summary>
-    public class AuthenticateRequestResult
+    public class AuthenticateRequestResult : ProactiveCredentialsResult
     {
         /// <summary>
         /// Gets or sets a value for the ClaimsIdentity.
@@ -18,22 +17,6 @@ namespace Microsoft.Bot.Connector.Authentication
         /// A value for the ClaimsIdentity.
         /// </value>
         public ClaimsIdentity ClaimsIdentity { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value for the Credentials.
-        /// </summary>
-        /// <value>
-        /// A value for the Credentials.
-        /// </value>
-        public ServiceClientCredentials Credentials { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value for the Scope.
-        /// </summary>
-        /// <value>
-        /// A value for the Scope.
-        /// </value>
-        public string Scope { get; set; }
 
         /// <summary>
         /// Gets or sets a value for the CallerId.

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="activity">The inbound Activity.</param>
         /// <param name="authHeader">The http auth header.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>Asynchronous Task with Authentication results.</returns>
+        /// <returns>Asynchronous Task with <see cref="AuthenticateRequestResult"/>.</returns>
         /// <exception cref="UnauthorizedAccessException">If the validation returns false.</exception>
         public abstract Task<AuthenticateRequestResult> AuthenticateRequestAsync(Activity activity, string authHeader, CancellationToken cancellationToken);
 
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="claimsIdentity">The inbound Activity.</param>
         /// <param name="audience">The http auth header.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>Asynchronous Task with Authentication results.</returns>
-        public abstract Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken);
+        /// <returns>Asynchronous Task with <see cref="ProactiveCredentialsResult"/>.</returns>
+        public abstract Task<ProactiveCredentialsResult> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken);
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/BuiltinBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BuiltinBotFrameworkAuthentication.cs
@@ -65,9 +65,15 @@ namespace Microsoft.Bot.Connector.Authentication
             return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Credentials = credentials, Scope = scope, CallerId = callerId };
         }
 
-        public override Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
+        public override async Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            var scope = audience ?? _toChannelFromBotOAuthScope;
+
+            var appId = GetAppId(claimsIdentity);
+
+            var credentials = await _credentialFactory.CreateCredentialsAsync(appId, scope, _loginEndpoint, true, cancellationToken).ConfigureAwait(false);
+
+            return credentials;
         }
 
         private IChannelProvider GetChannelProvider()

--- a/libraries/Microsoft.Bot.Connector/Authentication/BuiltinBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BuiltinBotFrameworkAuthentication.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
@@ -9,10 +8,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
-using Microsoft.Rest;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
+    /// <summary>
+    /// Note regarding porting to other languages.
+    /// 
+    /// This INTERNAL code leverages the existing auth implementation in the .NET repo. Ultimately, the "parameterized"
+    /// version of this code can do everything this code does. In the future this "buildin" implementation will be
+    /// replaced with the "parameterized" version appropriately parameterized with the builtin constants.
+    /// </summary>
     internal abstract class BuiltinBotFrameworkAuthentication : BotFrameworkAuthentication
     {
         private readonly string _toChannelFromBotOAuthScope;
@@ -65,7 +70,7 @@ namespace Microsoft.Bot.Connector.Authentication
             return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Credentials = credentials, Scope = scope, CallerId = callerId };
         }
 
-        public override async Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
+        public override async Task<ProactiveCredentialsResult> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
         {
             var scope = audience ?? _toChannelFromBotOAuthScope;
 
@@ -73,7 +78,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
             var credentials = await _credentialFactory.CreateCredentialsAsync(appId, scope, _loginEndpoint, true, cancellationToken).ConfigureAwait(false);
 
-            return credentials;
+            return new ProactiveCredentialsResult { Credentials = credentials, Scope = scope };
         }
 
         private IChannelProvider GetChannelProvider()

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.Rest;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -75,9 +74,15 @@ namespace Microsoft.Bot.Connector.Authentication
             return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Credentials = credentials, Scope = scope, CallerId = callerId };
         }
 
-        public override Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
+        public override async Task<ProactiveCredentialsResult> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            var scope = audience ?? _toChannelFromBotOAuthScope;
+
+            var appId = BuiltinBotFrameworkAuthentication.GetAppId(claimsIdentity);
+
+            var credentials = await _credentialFactory.CreateCredentialsAsync(appId, scope, _toChannelFromBotLoginUrl, true, cancellationToken).ConfigureAwait(false);
+
+            return new ProactiveCredentialsResult { Credentials = credentials, Scope = scope };
         }
 
         private async Task<string> GenerateCallerIdAsync(ServiceClientCredentialsFactory credentialFactory, ClaimsIdentity claimsIdentity, CancellationToken cancellationToken)

--- a/libraries/Microsoft.Bot.Connector/Authentication/ProactiveCredentialsResult.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ProactiveCredentialsResult.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Rest;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// The result from a call to create credentials for making a proactive Bot Framework Protocol request.
+    /// </summary>
+    public class ProactiveCredentialsResult
+    {
+        /// <summary>
+        /// Gets or sets a value for the Credentials.
+        /// </summary>
+        /// <value>
+        /// A value for the Credentials.
+        /// </value>
+        public ServiceClientCredentials Credentials { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value for the Scope.
+        /// </summary>
+        /// <value>
+        /// A value for the Scope.
+        /// </value>
+        public string Scope { get; set; }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <inheritdoc/>
-        public override Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
+        public override Task<ProactiveCredentialsResult> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
         {
             return _inner.GetProactiveCredentialsAsync(claimsIdentity, audience, cancellationToken);
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/ConfigurationBotFrameworkAuthentication.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/ConfigurationBotFrameworkAuthentication.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
         }
 
         /// <inheritdoc/>
-        public override Task<ServiceClientCredentials> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
+        public override Task<ProactiveCredentialsResult> GetProactiveCredentialsAsync(ClaimsIdentity claimsIdentity, string audience, CancellationToken cancellationToken)
         {
             return _inner.GetProactiveCredentialsAsync(claimsIdentity, audience, cancellationToken);
         }

--- a/tests/Microsoft.Bot.Builder.TestBot.Shared/Bots/ProactiveBot.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Shared/Bots/ProactiveBot.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.TestBot.Shared.Bots
+{
+    public class ProactiveBot : ActivityHandler
+    {
+        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            var claimsIdentity = turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) as ClaimsIdentity;
+
+            var botAppIdClaim = claimsIdentity.Claims?.SingleOrDefault(claim => claim.Type == AuthenticationConstants.AudienceClaim);
+
+            var appId = botAppIdClaim.Value;
+
+            var conversationReference = turnContext.Activity.GetConversationReference();
+
+            await turnContext.Adapter.ContinueConversationAsync(appId, conversationReference, BotCallback, cancellationToken);
+        }
+
+        private async Task BotCallback(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            await turnContext.SendActivityAsync("proactive hello");
+        }
+    }
+}


### PR DESCRIPTION
This adds proactive support to CloudAdapter.

One of the overloads of ContinueConversation doesn't provide an audience (actually the overloads that do were added for skills) in this case the audience is determined by the cloud environments settings. This is added to the turn context so for consistency this change also provides that value along with creating an appropriate credentials object.

As such this is a significant step towards Skills working with the CloudAdapter. Though there a number of other significant moving parts to Skills that would have to be implemented in a cloud agnostic manner before we have the whole Skills scenario running.