### PR TITLE
fix error caused by backtick in stringExpression and valueExpression

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionProperties/StringExpression.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/StringExpression.cs
@@ -119,7 +119,7 @@ namespace AdaptiveExpressions.Properties
                 }
 
                 // keep the string as quoted expression, which will be literal unless string interpolation is used.
-                this.ExpressionText = $"=`{stringOrExpression.Replace("\\", "\\\\")}`";
+                this.ExpressionText = $"=`{stringOrExpression.Replace("\\", "\\\\").Replace("`", "\\`")}`";
                 return;
             }
         }

--- a/libraries/AdaptiveExpressions/ExpressionProperties/ValueExpression.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/ValueExpression.cs
@@ -133,7 +133,7 @@ namespace AdaptiveExpressions.Properties
                 }
 
                 // keep the string as quoted expression, which will be literal unless string interpolation is used.
-                this.ExpressionText = $"=`{stringOrExpression.Replace("\\", "\\\\")}`";
+                this.ExpressionText = $"=`{stringOrExpression.Replace("\\", "\\\\").Replace("`", "\\`")}`";
                 return;
             }
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
@@ -305,13 +305,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             Assert.Equal(TestEnum.Three, test.Enm.TryGetValue(data).Value);
             Assert.True(test.Bool.TryGetValue(data).Value);
 
-            // test backtick in stringExpression
-            test.Str = new StringExpression(data => "test `name");
-            Assert.Equal("test `name", test.Str.TryGetValue(data).Value);
-
-            test.Str = new StringExpression(data => "test //`name");
-            Assert.Equal("test //`name", test.Str.TryGetValue(data).Value);
-
             // test null assignment
             var testNull = new ImplicitCastTest()
             {
@@ -372,6 +365,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             (result, error) = str.TryGetValue(data);
             Assert.Equal("c:\test\test\test", result);
             Assert.Null(error);
+
+            // test backtick in stringExpression
+            str = new StringExpression("test `name");
+            Assert.Equal("test `name", str.TryGetValue(data).Value);
+
+            str = new StringExpression("test //`name");
+            Assert.Equal("test //`name", str.TryGetValue(data).Value);
         }
 
         [Fact]

--- a/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionPropertyTests.cs
@@ -305,6 +305,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             Assert.Equal(TestEnum.Three, test.Enm.TryGetValue(data).Value);
             Assert.True(test.Bool.TryGetValue(data).Value);
 
+            // test backtick in stringExpression
+            test.Str = new StringExpression(data => "test `name");
+            Assert.Equal("test `name", test.Str.TryGetValue(data).Value);
+
+            test.Str = new StringExpression(data => "test //`name");
+            Assert.Equal("test //`name", test.Str.TryGetValue(data).Value);
+
             // test null assignment
             var testNull = new ImplicitCastTest()
             {
@@ -417,6 +424,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             val = new ValueExpression("c:\test\test\test");
             (result, error) = val.TryGetValue(data);
             Assert.Equal("c:\test\test\test", result);
+            Assert.Null(error);
+
+            // test backtick in valueExpression
+            val = new ValueExpression("name `backtick");
+            (result, error) = val.TryGetValue(data);
+            Assert.Equal("name `backtick", result);
+            Assert.Null(error);
+
+            val = new ValueExpression("name \\`backtick");
+            (result, error) = val.TryGetValue(data);
+            Assert.Equal("name \\`backtick", result);
             Assert.Null(error);
         }
 


### PR DESCRIPTION
closes: #4823 
```
str = new StringExpression("test `name");
str.TryGetValue(data).Value
```
The result is ```"test `name"```

```
str = new StringExpression("test //`name");
str.TryGetValue(data).Value
```

The result is ```"test //`name"```

```
val = new ValueExpression("test `name");
val.TryGetValue(data).Value
```
The result is ```"test `name"```

```
val = new ValueExpression("test //`name");
val.TryGetValue(data).Value
```

The result is ```"test //`name"```