### PR TITLE
Reduce concept count by making all entity recognizers to be simple Recognizer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new DeclarativeType<RegexEntityRecognizer>(RegexEntityRecognizer.Kind);
             yield return new DeclarativeType<TemperatureEntityRecognizer>(TemperatureEntityRecognizer.Kind);
             yield return new DeclarativeType<UrlEntityRecognizer>(UrlEntityRecognizer.Kind);
-            yield return new DeclarativeType<ClientMentionEntityRecognizer>(UrlEntityRecognizer.Kind);
+            yield return new DeclarativeType<ClientMentionEntityRecognizer>(ClientMentionEntityRecognizer.Kind);
 
             // selectors
             yield return new DeclarativeType<ConditionalSelector>(ConditionalSelector.Kind);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new DeclarativeType<RegexEntityRecognizer>(RegexEntityRecognizer.Kind);
             yield return new DeclarativeType<TemperatureEntityRecognizer>(TemperatureEntityRecognizer.Kind);
             yield return new DeclarativeType<UrlEntityRecognizer>(UrlEntityRecognizer.Kind);
+            yield return new DeclarativeType<ClientMentionEntityRecognizer>(UrlEntityRecognizer.Kind);
 
             // selectors
             yield return new DeclarativeType<ConditionalSelector>(ConditionalSelector.Kind);
@@ -197,7 +198,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new InterfaceConverter<EntityRecognizer>(resourceExplorer, sourceContext);
             yield return new InterfaceConverter<TriggerSelector>(resourceExplorer, sourceContext);
             yield return new ITemplateActivityConverter(resourceExplorer, sourceContext);
-            
+
             // yield return new ActivityTemplateConverter(resourceExplorer, sourceContext);
 
             yield return new IntExpressionConverter();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new DeclarativeType<RegexEntityRecognizer>(RegexEntityRecognizer.Kind);
             yield return new DeclarativeType<TemperatureEntityRecognizer>(TemperatureEntityRecognizer.Kind);
             yield return new DeclarativeType<UrlEntityRecognizer>(UrlEntityRecognizer.Kind);
-            yield return new DeclarativeType<ClientMentionEntityRecognizer>(ClientMentionEntityRecognizer.Kind);
+            yield return new DeclarativeType<ChannelMentionEntityRecognizer>(ChannelMentionEntityRecognizer.Kind);
 
             // selectors
             yield return new DeclarativeType<ConditionalSelector>(ConditionalSelector.Kind);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -40,10 +40,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Schemas\Recognizers\EntityRecognizers\Microsoft.ClientMentionEntityRecognizer.schema" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -40,6 +40,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Schemas\Recognizers\EntityRecognizers\Microsoft.ClientMentionEntityRecognizer.schema" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/AgeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/AgeEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/AgeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/AgeEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="AgeEntityRecognizer"/> class.
         /// </summary>
-        public AgeEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public AgeEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ChannelMentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ChannelMentionEntityRecognizer.cs
@@ -13,26 +13,26 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
     /// <summary>
-    /// Recognizer which maps entities passed from the client activity.Entities (@type=mention) into <see cref="RecognizerResult" /> format.
+    /// Recognizer which maps activity.Entities passed by a channel of @type=mention into <see cref="RecognizerResult" /> format.
     /// </summary>
     /// <remarks>
-    /// This makes it easy to pass explicit mentions from clients like Teams/Skype to LUIS models.
+    /// This makes it easy to pass explicit mentions from channels like Teams/Skype to LUIS models.
     /// </remarks>
-    public class ClientMentionEntityRecognizer : Recognizer
+    public class ChannelMentionEntityRecognizer : Recognizer
     {
         /// <summary>
         /// Class identifier.
         /// </summary>
         [JsonProperty("$kind")]
-        public const string Kind = "Microsoft.ClientMentionEntityRecognizer";
+        public const string Kind = "Microsoft.ChannelMentionEntityRecognizer";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ClientMentionEntityRecognizer"/> class.
+        /// Initializes a new instance of the <see cref="ChannelMentionEntityRecognizer"/> class.
         /// </summary>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
-        public ClientMentionEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public ChannelMentionEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(callerPath, callerLine)
         {
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ClientMentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ClientMentionEntityRecognizer.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Microsoft.Recognizers.Text;
+using Microsoft.Recognizers.Text.Sequence;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
+{
+    /// <summary>
+    /// Recognizer which maps entities passed from the client activity.Entities (@type=mention) into RecognizerResult format.
+    /// </summary>
+    /// <remarks>
+    /// This makes it easy to pass explicit mentions from clients like Teams/Skype to LUIS models.
+    /// </remarks>
+    public class ClientMentionEntityRecognizer : Recognizer
+    {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
+        [JsonProperty("$kind")]
+        public const string Kind = "Microsoft.ClientMentionEntityRecognizer";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClientMentionEntityRecognizer"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public ClientMentionEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+        {
+            var result = new RecognizerResult();
+
+            // promote external mention entities from the activity into recognizer result
+            if (activity.Entities != null)
+            {
+                if (result.Entities == null)
+                {
+                    result.Entities = new JObject();
+                }
+
+                dynamic entities = result.Entities;
+
+                // convert activity.entities entity that looks like this:
+                // {
+                //    "type": "mention",
+                //    "mentioned": {
+                //        "id": "28:0047c760-1f42-4a78-b1bd-9ecd95ec3615",
+                //        "name": "Tess"
+                //    },
+                //    "text": "<at>Tess</at>"
+                // },
+                int iStart = 0;
+                foreach (dynamic entity in activity.Entities.Where(e => e.Type == "mention").Select(e => JObject.FromObject(e)))
+                {
+                    // into recognizeresult that looks like this:
+                    // "entities": {
+                    //   "mention": [
+                    //      "28:0047c760-1f42-4a78-b1bd-9ecd95ec3615"
+                    //   ],
+                    //   "$instance": {
+                    //     "mention": [
+                    //        {
+                    //            "startIndex": 10,
+                    //            "endIndex": 13,
+                    //            "score": 1.0,
+                    //            "text": "@tom",
+                    //            "type": "mention",
+                    //            "resolution": {
+                    //              "value": "@tom"
+                    //            }
+                    //         }
+                    //      ]
+                    //   }
+                    // }
+                    if (entities.mention == null)
+                    {
+                        entities.mention = new JArray();
+                    }
+
+                    entities.mention.Add(entity.mentioned.id ?? entity.mentioned.name);
+
+                    dynamic instance = entities["$instance"];
+                    if (instance == null)
+                    {
+                        instance = new JObject();
+                        entities["$instance"] = instance;
+                    }
+
+                    if (instance.mention == null)
+                    {
+                        instance.mention = new JArray();
+                    }
+
+                    string mentionedText = (string)entity.text;
+                    iStart = activity.Text.IndexOf(mentionedText, iStart, System.StringComparison.InvariantCulture);
+                    if (iStart >= 0)
+                    {
+                        dynamic mentionData = new JObject();
+                        mentionData.type = "mention";
+                        mentionData.startIndex = iStart;
+                        mentionData.endIndex = iStart + mentionedText.Length - 1;
+                        mentionData.text = mentionedText;
+                        mentionData.score = 1.0;
+                        if (entity.mentioned.name != null)
+                        {
+                            mentionData.resolution = new JObject();
+                            mentionData.resolution.value = entity.mentioned.name;
+                        }
+
+                        instance.mention.Add(mentionData);
+
+                        // note, we increment so next pass through continues after the token we just processed.
+                        iStart++;
+                    }
+                }
+            }
+
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ClientMentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ClientMentionEntityRecognizer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         }
 
         /// <inheritdoc/>
-        public override Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+        public override Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             var result = new RecognizerResult();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ClientMentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ClientMentionEntityRecognizer.cs
@@ -1,18 +1,19 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
-using Microsoft.Recognizers.Text;
-using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
     /// <summary>
-    /// Recognizer which maps entities passed from the client activity.Entities (@type=mention) into RecognizerResult format.
+    /// Recognizer which maps entities passed from the client activity.Entities (@type=mention) into <see cref="RecognizerResult" /> format.
     /// </summary>
     /// <remarks>
     /// This makes it easy to pass explicit mentions from clients like Teams/Skype to LUIS models.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ConfirmationEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ConfirmationEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Choice;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ConfirmationEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/ConfirmationEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Choice;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfirmationEntityRecognizer"/> class.
         /// </summary>
-        public ConfirmationEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public ConfirmationEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/CurrencyEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/CurrencyEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="CurrencyEntityRecognizer"/> class.
         /// </summary>
-        public CurrencyEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public CurrencyEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/CurrencyEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/CurrencyEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DateTimeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DateTimeEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.DateTime;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="DateTimeEntityRecognizer"/> class.
         /// </summary>
-        public DateTimeEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public DateTimeEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DateTimeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DateTimeEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.DateTime;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DimensionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DimensionEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DimensionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/DimensionEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="DimensionEntityRecognizer"/> class.
         /// </summary>
-        public DimensionEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public DimensionEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EmailEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EmailEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EmailEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EmailEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="EmailEntityRecognizer"/> class.
         /// </summary>
-        public EmailEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public EmailEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
@@ -31,16 +31,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         {
         }
 
-        /// <summary>
-        /// Runs current DialogContext.TurnContext.Activity through a recognizer and returns a <see cref="RecognizerResult"/>.
-        /// </summary>
-        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
-        /// <param name="activity"><see cref="Activity"/> to recognize.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
-        /// <param name="telemetryProperties">Optional, additional properties to be logged to telemetry with the LuisResult event.</param>
-        /// <param name="telemetryMetrics">Optional, additional metrics to be logged to telemetry with the LuisResult event.</param>
-        /// <returns>Analysis of utterance.</returns>
-        public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+        /// <inheritdoc/>
+        public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             // Identify matched intents
             var text = activity.Text ?? string.Empty;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
@@ -1,25 +1,120 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.Recognizers.Text;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
     /// <summary>
     /// Entity recognizers base class.
     /// </summary>
-    public class EntityRecognizer
+    public class EntityRecognizer : Recognizer
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityRecognizer"/> class.
         /// </summary>
-        public EntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public EntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
+        }
+
+        /// <summary>
+        /// Runs current DialogContext.TurnContext.Activity through a recognizer and returns a <see cref="RecognizerResult"/>.
+        /// </summary>
+        /// <param name="dialogContext">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="activity"><see cref="Activity"/> to recognize.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/> of the task.</param>
+        /// <param name="telemetryProperties">Optional, additional properties to be logged to telemetry with the LuisResult event.</param>
+        /// <param name="telemetryMetrics">Optional, additional metrics to be logged to telemetry with the LuisResult event.</param>
+        /// <returns>Analysis of utterance.</returns>
+        public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+        {
+            // Identify matched intents
+            var text = activity.Text ?? string.Empty;
+            var locale = activity.Locale ?? "en-us";
+
+            var recognizerResult = new RecognizerResult()
+            {
+                Text = text,
+            };
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                // nothing to recognize, return empty recognizerResult
+                return recognizerResult;
+            }
+
+            // add entities from regexrecgonizer to the entities pool
+            var entityPool = new List<Entity>();
+
+            var textEntity = new TextEntity(text);
+            textEntity.Properties["start"] = 0;
+            textEntity.Properties["end"] = text.Length;
+            textEntity.Properties["score"] = 1.0;
+
+            entityPool.Add(textEntity);
+
+            // process entities using EntityRecognizerSet
+            var newEntities = await this.RecognizeEntitiesAsync(dialogContext, entityPool, cancellationToken).ConfigureAwait(false);
+            if (newEntities.Any())
+            {
+                entityPool.AddRange(newEntities);
+            }
+
+            // map entityPool of Entity objects => RecognizerResult entity format
+            recognizerResult.Entities = new JObject();
+
+            foreach (var entityResult in entityPool)
+            {
+                // add value
+                JToken values;
+                if (!recognizerResult.Entities.TryGetValue(entityResult.Type, StringComparison.OrdinalIgnoreCase, out values))
+                {
+                    values = new JArray();
+                    recognizerResult.Entities[entityResult.Type] = values;
+                }
+
+                // The Entity type names are not consistent, map everything to camelcase so we can process them cleaner.
+                dynamic entity = JObject.FromObject(entityResult);
+                ((JArray)values).Add(entity.text);
+
+                // get/create $instance
+                JToken instanceRoot;
+                if (!recognizerResult.Entities.TryGetValue("$instance", StringComparison.OrdinalIgnoreCase, out instanceRoot))
+                {
+                    instanceRoot = new JObject();
+                    recognizerResult.Entities["$instance"] = instanceRoot;
+                }
+
+                // add instanceData
+                JToken instanceData;
+                if (!((JObject)instanceRoot).TryGetValue(entityResult.Type, StringComparison.OrdinalIgnoreCase, out instanceData))
+                {
+                    instanceData = new JArray();
+                    instanceRoot[entityResult.Type] = instanceData;
+                }
+
+                dynamic instance = new JObject();
+                instance.startIndex = entity.start;
+                instance.endIndex = entity.end;
+                instance.score = (double)1.0;
+                instance.text = entity.text;
+                instance.type = entity.type;
+                instance.resolution = entity.resolution;
+                ((JArray)instanceData).Add(instance);
+            }
+
+            return recognizerResult;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
@@ -22,9 +22,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityRecognizerSet"/> class.
         /// </summary>
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EmailEntityRecognizer"/> class.
-        /// </summary>
         [JsonConstructor]
         public EntityRecognizerSet()
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/EntityRecognizerSet.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
@@ -21,6 +22,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityRecognizerSet"/> class.
         /// </summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailEntityRecognizer"/> class.
+        /// </summary>
+        [JsonConstructor]
         public EntityRecognizerSet()
         {
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/GuidEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/GuidEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/GuidEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/GuidEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="GuidEntityRecognizer"/> class.
         /// </summary>
-        public GuidEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public GuidEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/HashtagEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/HashtagEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/HashtagEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/HashtagEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="HashtagEntityRecognizer"/> class.
         /// </summary>
-        public HashtagEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public HashtagEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/IpEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/IpEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/IpEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/IpEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="IpEntityRecognizer"/> class.
         /// </summary>
-        public IpEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public IpEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="MentionEntityRecognizer"/> class.
         /// </summary>
-        public MentionEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public MentionEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/MentionEntityRecognizer.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
 {
     /// <summary>
-    /// Recognizes mention input.
+    /// Recognizes @mention input.
     /// </summary>
     public class MentionEntityRecognizer : TextEntityRecognizer
     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberEntityRecognizer"/> class.
         /// </summary>
-        public NumberEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public NumberEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberRangeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberRangeEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberRangeEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/NumberRangeEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberRangeEntityRecognizer"/> class.
         /// </summary>
-        public NumberRangeEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public NumberRangeEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/OrdinalEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/OrdinalEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/OrdinalEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/OrdinalEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="OrdinalEntityRecognizer"/> class.
         /// </summary>
-        public OrdinalEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public OrdinalEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PercentageEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PercentageEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PercentageEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PercentageEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Number;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="PercentageEntityRecognizer"/> class.
         /// </summary>
-        public PercentageEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public PercentageEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PhoneNumberEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PhoneNumberEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="PhoneNumberEntityRecognizer"/> class.
         /// </summary>
-        public PhoneNumberEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public PhoneNumberEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PhoneNumberEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/PhoneNumberEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/RegExEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/RegExEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/RegExEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/RegExEntityRecognizer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Microsoft.Recognizers.Text;
 using Newtonsoft.Json;
@@ -24,7 +25,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="RegexEntityRecognizer"/> class.
         /// </summary>
-        public RegexEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public RegexEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TemperatureEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TemperatureEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="TemperatureEntityRecognizer"/> class.
         /// </summary>
-        public TemperatureEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public TemperatureEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TemperatureEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TemperatureEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.NumberWithUnit;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntity.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Bot.Schema;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/TextEntityRecognizer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -20,7 +21,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="TextEntityRecognizer"/> class.
         /// </summary>
-        public TextEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public TextEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/UrlEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/UrlEntityRecognizer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;
 using Newtonsoft.Json;
@@ -19,7 +20,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// <summary>
         /// Initializes a new instance of the <see cref="UrlEntityRecognizer"/> class.
         /// </summary>
-        public UrlEntityRecognizer()
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public UrlEntityRecognizer([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(callerPath, callerLine)
         {
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/UrlEntityRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/EntityRecognizers/UrlEntityRecognizer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.Sequence;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.AgeEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.AgeEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Age entity recognizer",
     "description": "Recognizer which recognizes age.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.ChannelMentionEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.ChannelMentionEntityRecognizer.schema
@@ -1,8 +1,8 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.IRecognizer)" ],
-    "title": "Client mention entity recognizer",
-    "description": "Recognizes mention entities passed from the client (such as teams/skype).",
+    "title": "Channel mention entity recognizer",
+    "description": "Promotes mention entities passed by a channel via the activity.entities into recognizer result.",
     "type": "object",
     "properties": {}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.ClientMentionEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.ClientMentionEntityRecognizer.schema
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+    "$role": [ "implements(Microsoft.IRecognizer)" ],
+    "title": "Client mention entity recognizer",
+    "description": "Recognizes mention entities passed from the client (such as teams/skype).",
+    "type": "object",
+    "properties": {}
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.ConfirmationEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.ConfirmationEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Confirmation entity recognizer",
     "description": "Recognizer which recognizes confirmation choices (yes/no).",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.CurrencyEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.CurrencyEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Currency entity recognizer",
     "description": "Recognizer which recognizes currency.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.DateTimeEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.DateTimeEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Date and time entity recognizer",
     "description": "Recognizer which recognizes dates and time fragments.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.DimensionEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.DimensionEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Dimension entity recognizer",
     "description": "Recognizer which recognizes dimension.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.EmailEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.EmailEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Email entity recognizer",
     "description": "Recognizer which recognizes email.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.GuidEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.GuidEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Guid entity recognizer",
     "description": "Recognizer which recognizes guids.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.HashtagEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.HashtagEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Hashtag entity recognizer",
     "description": "Recognizer which recognizes Hashtags.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.IpEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.IpEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "IP entity recognizer",
     "description": "Recognizer which recognizes internet IP patterns (like 192.1.1.1).",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.MentionEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.MentionEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Mentions entity recognizer",
     "description": "Recognizer which recognizes @Mentions",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.NumberEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.NumberEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Number entity recognizer",
     "description": "Recognizer which recognizes numbers.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.NumberRangeEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.NumberRangeEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Number range entity recognizer",
     "description": "Recognizer which recognizes ranges of numbers (Example:2 to 5).",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.OrdinalEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.OrdinalEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Ordinal entity recognizer",
     "description": "Recognizer which recognizes ordinals (example: first, second, 3rd).",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.PercentageEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.PercentageEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Percentage entity recognizer",
     "description": "Recognizer which recognizes percentages.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.PhoneNumberEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.PhoneNumberEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Phone number entity recognizer",
     "description": "Recognizer which recognizes phone numbers.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.RegexEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.RegexEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Regex entity recognizer",
     "description": "Recognizer which recognizes patterns of input based on regex.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.TemperatureEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.TemperatureEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Temperature recognizer",
     "description": "Recognizer which recognizes temperatures.",
     "type": "object",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.UrlEntityRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Recognizers/EntityRecognizers/Microsoft.UrlEntityRecognizer.schema
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
-    "$role": "implements(Microsoft.IEntityRecognizer)",
+    "$role": [ "implements(Microsoft.IRecognizer)", "implements(Microsoft.IEntityRecognizer)" ],
     "title": "Url recognizer",
     "description": "Recognizer which recognizes urls.",
     "type": "object",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Bot.Builder.Adapters;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
+{
+    [CollectionDefinition("Dialogs.Adaptive.Recognizers")]
+    public class EntityRecognizerRecognizerTests
+    {
+        private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
+
+        private static Lazy<RecognizerSet> recognizers = new Lazy<RecognizerSet>(() =>
+        {
+            return new RecognizerSet()
+            {
+                Recognizers = new System.Collections.Generic.List<Recognizer>()
+                {
+                    new AgeEntityRecognizer(),
+                    new ConfirmationEntityRecognizer(),
+                    new CurrencyEntityRecognizer(),
+                    new DateTimeEntityRecognizer(),
+                    new DimensionEntityRecognizer(),
+                    new EmailEntityRecognizer(),
+                    new GuidEntityRecognizer(),
+                    new HashtagEntityRecognizer(),
+                    new IpEntityRecognizer(),
+                    new MentionEntityRecognizer(),
+                    new NumberEntityRecognizer(),
+                    new NumberRangeEntityRecognizer(),
+                    new OrdinalEntityRecognizer(),
+                    new PercentageEntityRecognizer(),
+                    new PhoneNumberEntityRecognizer(),
+                    new TemperatureEntityRecognizer(),
+                    new UrlEntityRecognizer(),
+                    new RegexEntityRecognizer() { Name = "color", Pattern = "(?i)(red|green|blue|purple|orange|violet|white|black)" },
+                    new RegexEntityRecognizer() { Name = "size", Pattern = "(?i)(small|medium|large)" },
+                }
+            };
+        });
+
+        [Fact]
+        public void TestAge()
+        {
+            var dialogContext = GetDialogContext(nameof(TestAge), "This is a test of one, 2, three years old");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.age);
+            Assert.NotNull(entities.number);
+            Assert.NotNull(entities["$instance"].age);
+            Assert.NotNull(entities["$instance"].number);
+        }
+
+        [Fact]
+        public void TestConfirmation()
+        {
+            var dialogContext = GetDialogContext(nameof(TestConfirmation), "yes, please");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.boolean);
+            Assert.Equal("yes", (string)entities.boolean[0]);
+            Assert.NotNull(entities["$instance"].boolean);
+        }
+
+        [Fact]
+        public void TestCurrency()
+        {
+            var dialogContext = GetDialogContext(nameof(TestCurrency), "I would pay four dollars for that.");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.currency);
+            Assert.Equal("four dollars", (string)entities.currency[0]);
+            Assert.NotNull(entities["$instance"].currency);
+        }
+
+        [Fact]
+        public void TestDateTime()
+        {
+            var dialogContext = GetDialogContext(nameof(TestDateTime), "Next thursday at 4pm.");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities["datetimeV2.datetime"]);
+            Assert.NotNull(entities["ordinal.relative"]);
+            Assert.NotNull(entities.dimension);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestDimension()
+        {
+            var dialogContext = GetDialogContext(nameof(TestDimension), "I think he's 5 foot ten");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.number);
+            Assert.NotNull(entities.dimension);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestEmail()
+        {
+            var dialogContext = GetDialogContext(nameof(TestEmail), "my email address is foo@att.uk.co");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.email);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestGuid()
+        {
+            var guid = Guid.Empty;
+            var dialogContext = GetDialogContext(nameof(TestGuid), $"my account number is {guid}...");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.guid);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestHashtag()
+        {
+            var dialogContext = GetDialogContext(nameof(TestHashtag), $"I'm so cool #cool #groovy...");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.hashtag);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestIp()
+        {
+            var dialogContext = GetDialogContext(nameof(TestIp), $"My address is 1.2.3.4");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.ip);
+            Assert.NotNull(entities.number);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestMention()
+        {
+            var dialogContext = GetDialogContext(nameof(TestMention), $"Tell @joesmith I'm coming...");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.mention);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestNumber()
+        {
+            var dialogContext = GetDialogContext(nameof(TestNumber), "This is a test of one, 2, three");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.number);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestNumberRange()
+        {
+            var dialogContext = GetDialogContext(nameof(TestNumberRange), "there are 3 to 5 of them");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.numberrange);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestOrdinal()
+        {
+            var dialogContext = GetDialogContext(nameof(TestOrdinal), "First, second or third");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.ordinal);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestPercentage()
+        {
+            var dialogContext = GetDialogContext(nameof(TestPercentage), "The population hit 33.3%");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.percentage);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestPhoneNumber()
+        {
+            var dialogContext = GetDialogContext(nameof(TestPhoneNumber), "Call 425-882-8080");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.phonenumber);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestTemperature()
+        {
+            var dialogContext = GetDialogContext(nameof(TestTemperature), "set the oven to 350 degrees");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.temperature);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestUrl()
+        {
+            var dialogContext = GetDialogContext(nameof(TestUrl), "go to http://about.me for more info");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.url);
+            Assert.Null(entities.boolean);
+        }
+
+        [Fact]
+        public void TestRegEx()
+        {
+            // I would like {order} 
+            var dialogContext = GetDialogContext(nameof(TestRegEx), "I would like a red or Blue cat");
+            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+
+            Assert.Equal(1, results.Intents.Count);
+            Assert.Equal("None", results.Intents.Single().Key);
+
+            dynamic entities = results.Entities;
+            Assert.NotNull(entities.color);
+            Assert.Null(entities.boolean);
+
+            Assert.Equal(2, entities.color.Count);
+            Assert.Equal("red", (string)entities.color[0]);
+            Assert.Equal("Blue", (string)entities.color[1]);
+        }
+
+        private DialogContext GetDialogContext(string testName, string text, string locale = "en-us")
+        {
+            return new DialogContext(
+                new DialogSet(),
+                new TurnContext(
+                    new TestAdapter(TestAdapter.CreateConversation(testName)),
+                    new Schema.Activity(type: Schema.ActivityTypes.Message, text: text, locale: locale)),
+                new DialogState());
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
@@ -228,18 +228,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 
             dynamic entities = results.Entities;
             dynamic instanceData = entities["$instance"];
-            Assert.NotNull(entities.mention);
-            Assert.Equal("15", (string)entities.mention[0]);
-            Assert.Equal("joelee", (string)instanceData.mention[0].text);
-            Assert.Equal("Joe Lee", (string)instanceData.mention[0].resolution.value);
-            Assert.Equal(0, (int)instanceData.mention[0].startIndex);
-            Assert.Equal(5, (int)instanceData.mention[0].endIndex);
 
-            Assert.Equal("30", (string)entities.mention[1]);
-            Assert.Equal("bobsm", (string)instanceData.mention[1].text);
-            Assert.Equal("Bob Smithson", (string)instanceData.mention[1].resolution.value);
-            Assert.Equal(7, (int)instanceData.mention[1].startIndex);
-            Assert.Equal(11, (int)instanceData.mention[1].endIndex);
+            // resolution [0]
+            Assert.NotNull(entities.channelMention);
+            Assert.Equal("15", (string)entities.channelMention[0].id);
+            Assert.Equal("Joe Lee", (string)entities.channelMention[0].name);
+
+            // instancedata[0]
+            Assert.Equal("joelee", (string)instanceData.channelMention[0].text);
+            Assert.Equal(0, (int)instanceData.channelMention[0].startIndex);
+            Assert.Equal(5, (int)instanceData.channelMention[0].endIndex);
+
+            // resolution [1]
+            Assert.Equal("30", (string)entities.channelMention[1].id);
+            Assert.Equal("Bob Smithson", (string)entities.channelMention[1].name);
+
+            // instanceData [1]
+            Assert.Equal("bobsm", (string)instanceData.channelMention[1].text);
+            Assert.Equal(7, (int)instanceData.channelMention[1].startIndex);
+            Assert.Equal(11, (int)instanceData.channelMention[1].endIndex);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
@@ -193,8 +193,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             Assert.NotNull(entities.mention);
             Assert.Equal("@joesmith", (string)entities.mention[0]);
             Assert.Equal("@joesmith", (string)instanceData.mention[0].text);
-            Assert.Equal(0, (int)instanceData.mention[0].startIndex);
-            Assert.Equal(8, (int)instanceData.mention[0].endIndex);
+            Assert.Equal(5, (int)instanceData.mention[0].startIndex);
+            Assert.Equal(13, (int)instanceData.mention[0].endIndex);
 
             Assert.Null(entities.boolean);
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
                     new GuidEntityRecognizer(),
                     new HashtagEntityRecognizer(),
                     new IpEntityRecognizer(),
-                    new ClientMentionEntityRecognizer(),
+                    new ChannelMentionEntityRecognizer(),
                     new MentionEntityRecognizer(),
                     new NumberEntityRecognizer(),
                     new NumberRangeEntityRecognizer(),
@@ -200,7 +200,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestClientMentionRecognizer()
+        public void TestChannelMentionEntityRecognizer()
         {
             var dialogContext = GetDialogContext(nameof(TestMention), $"joelee bobsm...");
             dialogContext.Context.Activity.Entities = new List<Entity>();

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -44,6 +44,9 @@
       "$ref": "#/definitions/Microsoft.ChoiceInput"
     },
     {
+      "$ref": "#/definitions/Microsoft.ClientMentionEntityRecognizer"
+    },
+    {
       "$ref": "#/definitions/Microsoft.ConditionalSelector"
     },
     {
@@ -1690,6 +1693,38 @@
           "type": "string",
           "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
           "const": "Microsoft.ChoiceInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ClientMentionEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)"
+      ],
+      "title": "Client mention entity recognizer",
+      "description": "Recognizes mention entities passed from the client (such as teams/skype).",
+      "type": "object",
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ClientMentionEntityRecognizer"
         },
         "$designer": {
           "title": "Designer information",
@@ -3632,30 +3667,6 @@
           "$ref": "#/definitions/Microsoft.Test.AssertCondition"
         },
         {
-          "$ref": "#/definitions/Microsoft.Ask"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.AttachmentInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ChoiceInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ConfirmInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.DateTimeInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.NumberInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.OAuthInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.TextInput"
-        },
-        {
           "$ref": "#/definitions/Microsoft.BeginDialog"
         },
         {
@@ -3759,6 +3770,30 @@
         },
         {
           "$ref": "#/definitions/Microsoft.UpdateActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.Ask"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AttachmentInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ChoiceInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OAuthInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TextInput"
         },
         {
           "$ref": "#/definitions/Teams.GetMeetingParticipant"
@@ -3891,6 +3926,9 @@
         },
         {
           "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ClientMentionEntityRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -41,10 +41,10 @@
       "$ref": "#/definitions/Microsoft.CancelDialog"
     },
     {
-      "$ref": "#/definitions/Microsoft.ChoiceInput"
+      "$ref": "#/definitions/Microsoft.ChannelMentionEntityRecognizer"
     },
     {
-      "$ref": "#/definitions/Microsoft.ClientMentionEntityRecognizer"
+      "$ref": "#/definitions/Microsoft.ChoiceInput"
     },
     {
       "$ref": "#/definitions/Microsoft.ConditionalSelector"
@@ -1354,6 +1354,38 @@
         }
       }
     },
+    "Microsoft.ChannelMentionEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)"
+      ],
+      "title": "Channel mention entity recognizer",
+      "description": "Promotes mention entities passed by a channel via the activity.entities into recognizer result.",
+      "type": "object",
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ChannelMentionEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
     "Microsoft.ChoiceInput": {
       "$role": [
         "implements(Microsoft.IDialog)",
@@ -1693,38 +1725,6 @@
           "type": "string",
           "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
           "const": "Microsoft.ChoiceInput"
-        },
-        "$designer": {
-          "title": "Designer information",
-          "type": "object",
-          "description": "Extra information for the Bot Framework Composer."
-        }
-      }
-    },
-    "Microsoft.ClientMentionEntityRecognizer": {
-      "$role": [
-        "implements(Microsoft.IRecognizer)"
-      ],
-      "title": "Client mention entity recognizer",
-      "description": "Recognizes mention entities passed from the client (such as teams/skype).",
-      "type": "object",
-      "required": [
-        "$kind"
-      ],
-      "additionalProperties": false,
-      "patternProperties": {
-        "^\\$": {
-          "title": "Tooling property",
-          "description": "Open ended property for tooling."
-        }
-      },
-      "properties": {
-        "$kind": {
-          "title": "Kind of dialog object",
-          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
-          "type": "string",
-          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
-          "const": "Microsoft.ClientMentionEntityRecognizer"
         },
         "$designer": {
           "title": "Designer information",
@@ -3667,6 +3667,30 @@
           "$ref": "#/definitions/Microsoft.Test.AssertCondition"
         },
         {
+          "$ref": "#/definitions/Microsoft.Ask"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AttachmentInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ChoiceInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OAuthInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TextInput"
+        },
+        {
           "$ref": "#/definitions/Microsoft.BeginDialog"
         },
         {
@@ -3770,30 +3794,6 @@
         },
         {
           "$ref": "#/definitions/Microsoft.UpdateActivity"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.Ask"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.AttachmentInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ChoiceInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ConfirmInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.DateTimeInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.NumberInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.OAuthInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.TextInput"
         },
         {
           "$ref": "#/definitions/Teams.GetMeetingParticipant"
@@ -3928,7 +3928,7 @@
           "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
         },
         {
-          "$ref": "#/definitions/Microsoft.ClientMentionEntityRecognizer"
+          "$ref": "#/definitions/Microsoft.ChannelMentionEntityRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -689,7 +689,10 @@
       }
     },
     "Microsoft.AgeEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Age entity recognizer",
       "description": "Recognizer which recognizes age.",
       "type": "object",
@@ -2035,7 +2038,10 @@
       }
     },
     "Microsoft.ConfirmationEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Confirmation entity recognizer",
       "description": "Recognizer which recognizes confirmation choices (yes/no).",
       "type": "object",
@@ -2211,7 +2217,10 @@
       }
     },
     "Microsoft.CurrencyEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Currency entity recognizer",
       "description": "Recognizer which recognizes currency.",
       "type": "object",
@@ -2241,7 +2250,10 @@
       }
     },
     "Microsoft.DateTimeEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Date and time entity recognizer",
       "description": "Recognizer which recognizes dates and time fragments.",
       "type": "object",
@@ -2639,7 +2651,10 @@
       }
     },
     "Microsoft.DimensionEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Dimension entity recognizer",
       "description": "Recognizer which recognizes dimension.",
       "type": "object",
@@ -2829,7 +2844,10 @@
       }
     },
     "Microsoft.EmailEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Email entity recognizer",
       "description": "Recognizer which recognizes email.",
       "type": "object",
@@ -3386,7 +3404,10 @@
       }
     },
     "Microsoft.GuidEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Guid entity recognizer",
       "description": "Recognizer which recognizes guids.",
       "type": "object",
@@ -3416,7 +3437,10 @@
       }
     },
     "Microsoft.HashtagEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Hashtag entity recognizer",
       "description": "Recognizer which recognizes Hashtags.",
       "type": "object",
@@ -3608,6 +3632,30 @@
           "$ref": "#/definitions/Microsoft.Test.AssertCondition"
         },
         {
+          "$ref": "#/definitions/Microsoft.Ask"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AttachmentInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ChoiceInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OAuthInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TextInput"
+        },
+        {
           "$ref": "#/definitions/Microsoft.BeginDialog"
         },
         {
@@ -3711,30 +3759,6 @@
         },
         {
           "$ref": "#/definitions/Microsoft.UpdateActivity"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.Ask"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.AttachmentInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ChoiceInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ConfirmInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.DateTimeInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.NumberInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.OAuthInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.TextInput"
         },
         {
           "$ref": "#/definitions/Teams.GetMeetingParticipant"
@@ -3845,10 +3869,10 @@
           "type": "string"
         },
         {
-          "$ref": "#/definitions/Microsoft.OrchestratorRecognizer"
+          "$ref": "#/definitions/Microsoft.LuisRecognizer"
         },
         {
-          "$ref": "#/definitions/Microsoft.LuisRecognizer"
+          "$ref": "#/definitions/Microsoft.OrchestratorRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
@@ -3864,6 +3888,60 @@
         },
         {
           "$ref": "#/definitions/Microsoft.RegexRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.CurrencyEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DimensionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EmailEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.GuidEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.HashtagEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.IpEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.MentionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberRangeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OrdinalEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.PercentageEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.PhoneNumberEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RegexEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TemperatureEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.UrlEntityRecognizer"
         }
       ]
     },
@@ -4274,7 +4352,10 @@
       }
     },
     "Microsoft.IpEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "IP entity recognizer",
       "description": "Recognizer which recognizes internet IP patterns (like 192.1.1.1).",
       "type": "object",
@@ -4542,7 +4623,10 @@
       }
     },
     "Microsoft.MentionEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Mentions entity recognizer",
       "description": "Recognizer which recognizes @Mentions",
       "type": "object",
@@ -4658,7 +4742,10 @@
       }
     },
     "Microsoft.NumberEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Number entity recognizer",
       "description": "Recognizer which recognizes numbers.",
       "type": "object",
@@ -4859,7 +4946,10 @@
       }
     },
     "Microsoft.NumberRangeEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Number range entity recognizer",
       "description": "Recognizer which recognizes ranges of numbers (Example:2 to 5).",
       "type": "object",
@@ -6941,7 +7031,10 @@
       }
     },
     "Microsoft.OrdinalEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Ordinal entity recognizer",
       "description": "Recognizer which recognizes ordinals (example: first, second, 3rd).",
       "type": "object",
@@ -6971,7 +7064,10 @@
       }
     },
     "Microsoft.PercentageEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Percentage entity recognizer",
       "description": "Recognizer which recognizes percentages.",
       "type": "object",
@@ -7001,7 +7097,10 @@
       }
     },
     "Microsoft.PhoneNumberEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Phone number entity recognizer",
       "description": "Recognizer which recognizes phone numbers.",
       "type": "object",
@@ -7457,7 +7556,10 @@
       }
     },
     "Microsoft.RegexEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Regex entity recognizer",
       "description": "Recognizer which recognizes patterns of input based on regex.",
       "type": "object",
@@ -8201,7 +8303,10 @@
       }
     },
     "Microsoft.TemperatureEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Temperature recognizer",
       "description": "Recognizer which recognizes temperatures.",
       "type": "object",
@@ -9738,7 +9843,10 @@
       }
     },
     "Microsoft.UrlEntityRecognizer": {
-      "$role": "implements(Microsoft.IEntityRecognizer)",
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
       "title": "Url recognizer",
       "description": "Recognizer which recognizes urls.",
       "type": "object",


### PR DESCRIPTION
## Description
EntityRecognizers are simple wrappers around TextAnalytics APIs, but currently are only usable from within RegExRecognizer via the EntityRecognizerSet.  
This delta makes all EntityRecognizers full blown recognizers, allowing them to be composed like any other recognizer in the system. 

This allows composition like this to feed external recgonizer results into LUIS recognizer:
```javascript
{
    "$schema": "../schemas/app.schema",
    "$kind": "Microsoft.LuisRecognizer",
    "id": "LUIS_msmeeting-actions",
 ...
    "externalEntityRecognizer": {
        "$kind": "Microsoft.RecognizerSet",
        "recognizers": [
            { $kind": "Microsoft.PartNumberRecognizer" },
            { $kind": "Iciclecreek.QuotedTextEntityRecognizer" },
..
        ]
    }
}
```

## Specific Changes
* Changed EntityRecognizer base class 
  * to derive from Recognizer, so it can be used as a recognizer. 
  * implement standard RecgonizeAsync() method to return RecognizerResult data structure.
* Added **ClientMentionEntityRecognizer** to map client passed mention entities => RecognizerResult entity structure, allowing that data to be passed to LuisRecognizer.

## Testing
* entity recognizer tests which use the RecognizeAsync() method and RecognizerResult data structure
