### PR TITLE
IDictionary to ConcurrentDictionary in StreamingRequestHandler

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -132,7 +132,6 @@ namespace Microsoft.Bot.Builder.Streaming
 
             Audience = audience;
             _conversations = new ConcurrentDictionary<string, DateTime>();
-            
             _userAgent = GetUserAgent();
             _server = new NamedPipeServer(pipeName, this);
             _serverIsConnected = true;

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -200,6 +200,7 @@ namespace Microsoft.Bot.Builder.Streaming
         /// <param name="conversationId">The ID of the conversation to remove.</param>
         public void ForgetConversation(string conversationId)
         {
+            // Ignore the result, since the goal is to simply remove the conversation.
             _conversations.TryRemove(conversationId, out _);
         }
 
@@ -252,6 +253,8 @@ namespace Microsoft.Bot.Builder.Streaming
                 // adapter is able to route requests to the correct handler.
                 if (!HasConversation(activity.Conversation.Id))
                 {
+                    // Ignore the result, since the goal is simply to ensure the Conversation.Id is in _conversations.
+                    // If some other thread added it already, does not matter.
                     _conversations.TryAdd(activity.Conversation.Id, DateTime.Now);
                 }
 

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Bot.Builder.Streaming
         private readonly ILogger _logger;
         private readonly IStreamingActivityProcessor _activityProcessor;
         private readonly string _userAgent;
-        private readonly IDictionary<string, DateTime> _conversations;
+        private readonly ConcurrentDictionary<string, DateTime> _conversations;
         private readonly IStreamingTransportServer _server;
 
         private bool _serverIsConnected;
@@ -132,6 +132,7 @@ namespace Microsoft.Bot.Builder.Streaming
 
             Audience = audience;
             _conversations = new ConcurrentDictionary<string, DateTime>();
+            
             _userAgent = GetUserAgent();
             _server = new NamedPipeServer(pipeName, this);
             _serverIsConnected = true;
@@ -200,7 +201,7 @@ namespace Microsoft.Bot.Builder.Streaming
         /// <param name="conversationId">The ID of the conversation to remove.</param>
         public void ForgetConversation(string conversationId)
         {
-            _conversations.Remove(conversationId);
+            _conversations.TryRemove(conversationId, out _);
         }
 
         /// <summary>
@@ -252,7 +253,7 @@ namespace Microsoft.Bot.Builder.Streaming
                 // adapter is able to route requests to the correct handler.
                 if (!HasConversation(activity.Conversation.Id))
                 {
-                    _conversations.Add(activity.Conversation.Id, DateTime.Now);
+                    _conversations.TryAdd(activity.Conversation.Id, DateTime.Now);
                 }
 
                 /*


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4837

Since this field is private and not injected for tests, I don't think there is any advantage to using IDictionary vs ConcurrentDictionary.