### PR TITLE
DialogContext: tactical change to decouple from TurnContext to remediate breaking changes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -659,8 +659,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A string representing the current locale.</returns>
         public string GetLocale()
         {
-            var locale = ((TurnContext)Context).Locale ?? null;
-            return locale;
+            return Context.TurnState.Get<string>(TurnContext.TurnLocaleProperty);
         }
 
         private async Task EndActiveDialogAsync(DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -659,7 +659,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A string representing the current locale.</returns>
         public string GetLocale()
         {
-            return Context.TurnState.Get<string>(TurnContext.TurnLocaleProperty);
+            return Context.TurnState.Get<string>("turn.locale");
         }
 
         private async Task EndActiveDialogAsync(DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))

--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -20,10 +20,7 @@ namespace Microsoft.Bot.Builder
     /// <seealso cref="IMiddleware"/>
     public class TurnContext : ITurnContext, IDisposable
     {
-        /// <summary>
-        /// State property for turn locale.
-        /// </summary>
-        public const string TurnLocaleProperty = "turn.locale";
+        private const string TurnLocale = "turn.locale";
 
         private readonly IList<SendActivitiesHandler> _onSendActivities = new List<SendActivitiesHandler>();
         private readonly IList<UpdateActivityHandler> _onUpdateActivity = new List<UpdateActivityHandler>();
@@ -96,8 +93,8 @@ namespace Microsoft.Bot.Builder
         /// <value>The string of locale on this context object.</value>
         public string Locale
         {
-            get => this.TurnState.Get<string>(TurnLocaleProperty);
-            set { this.TurnState.Set(TurnLocaleProperty, value); }
+            get => this.TurnState.Get<string>(TurnLocale);
+            set { this.TurnState.Set(TurnLocale, value); }
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Bot.Builder
     /// <seealso cref="IMiddleware"/>
     public class TurnContext : ITurnContext, IDisposable
     {
-        private const string TurnLocale = "turn.locale";
+        /// <summary>
+        /// State property for turn locale.
+        /// </summary>
+        public const string TurnLocaleProperty = "turn.locale";
 
         private readonly IList<SendActivitiesHandler> _onSendActivities = new List<SendActivitiesHandler>();
         private readonly IList<UpdateActivityHandler> _onUpdateActivity = new List<UpdateActivityHandler>();
@@ -93,8 +96,8 @@ namespace Microsoft.Bot.Builder
         /// <value>The string of locale on this context object.</value>
         public string Locale
         {
-            get => this.TurnState.Get<string>(TurnLocale);
-            set { this.TurnState.Set(TurnLocale, value); }
+            get => this.TurnState.Get<string>(TurnLocaleProperty);
+            set { this.TurnState.Set(TurnLocaleProperty, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4657

Unfortunately we broke developers who implemented their own `ITurnContext` when adding a cast to `TurnContext` in `DialogContext.GetLocale()`. Furthermore, the `GetLocale()` method is quite useless considering that whenever the `DialogContext` is available, a `ITurnContext` instance is available as well and we could get the locale from there.

I have some broader locale changes in another incoming PR (in which I mark `DialogContext.GetLocale()` as deprecated among other things), but this is the minimum bar, which is to un-break developers that have been broken because of this change.