### PR TITLE
[DO NOT MERGE] Update Binary Compatibility build verification

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -16,7 +16,7 @@ pr: none # pr trigger is set in ADO
 
 variables:
   ApiCompatVersion: 4.10.0
-  BotBuilderDll: Microsoft.Bot.Builder.AI.Luis,Microsoft.Bot.Builder.AI.QnA,Microsoft.Bot.Builder.ApplicationInsights,Microsoft.Bot.Builder.Azure,Microsoft.Bot.Builder.Dialogs,Microsoft.Bot.Builder.Integration.ApplicationInsights.Core,Microsoft.Bot.Builder.Integration.AspNet.Core,Microsoft.Bot.Builder.TemplateManager,Microsoft.Bot.Builder.Testing,Microsoft.Bot.Builder,Microsoft.Bot.Configuration,Microsoft.Bot.Connector,Microsoft.Bot.Schema,Microsoft.Bot.Streaming
+  BotBuilderDll: Microsoft.Bot.Builder.AI.Luis,Microsoft.Bot.Builder.AI.QnA,Microsoft.Bot.Builder.ApplicationInsights,Microsoft.Bot.Builder.Azure,Microsoft.Bot.Builder.Dialogs,Microsoft.Bot.Builder.Dialogs.Adaptive,Microsoft.Bot.Builder.Integration.ApplicationInsights.Core,Microsoft.Bot.Builder.Integration.AspNet.Core,Microsoft.Bot.Builder.TemplateManager,Microsoft.Bot.Builder.Testing,Microsoft.Bot.Builder,Microsoft.Bot.Configuration,Microsoft.Bot.Connector,Microsoft.Bot.Schema,Microsoft.Bot.Streaming
   BuildConfiguration: Debug-Windows
   BuildPlatform: any cpu
 #  DotNetCoverallsToken: define this in Azure

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -93,6 +93,7 @@ stages:
              '*/Microsoft.Bot.Builder.ApplicationInsights/*' { $changedLibrary = 'Microsoft.Bot.Builder.ApplicationInsights' }
              '*/Microsoft.Bot.Builder.Azure/*' { $changedLibrary = 'Microsoft.Bot.Builder.Azure' }
              '*/Microsoft.Bot.Builder.Dialogs/*' { $changedLibrary = 'Microsoft.Bot.Builder.Dialogs' }
+             '*/Microsoft.Bot.Builder.Dialogs.Adaptive/*' { $changedLibrary = 'Microsoft.Bot.Builder.Dialogs.Adaptive' }
              '*/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.ApplicationInsights.Core' }
              '*/Microsoft.Bot.Builder.Integration.AspNet.Core/*' { $changedLibrary = 'Microsoft.Bot.Builder.Integration.AspNet.Core' }
              '*/Microsoft.Bot.Builder.TemplateManager/*' { $changedLibrary = 'Microsoft.Bot.Builder.TemplateManager' }

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -15,7 +15,7 @@ trigger: none # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 variables:
-  ApiCompatVersion: 4.6.3
+  ApiCompatVersion: 4.10.0
   BotBuilderDll: Microsoft.Bot.Builder.AI.Luis,Microsoft.Bot.Builder.AI.QnA,Microsoft.Bot.Builder.ApplicationInsights,Microsoft.Bot.Builder.Azure,Microsoft.Bot.Builder.Dialogs,Microsoft.Bot.Builder.Integration.ApplicationInsights.Core,Microsoft.Bot.Builder.Integration.AspNet.Core,Microsoft.Bot.Builder.TemplateManager,Microsoft.Bot.Builder.Testing,Microsoft.Bot.Builder,Microsoft.Bot.Configuration,Microsoft.Bot.Connector,Microsoft.Bot.Schema,Microsoft.Bot.Streaming
   BuildConfiguration: Debug-Windows
   BuildPlatform: any cpu


### PR DESCRIPTION
## In this change:
- Binary Compatibility checks run against 4.6.3. This change modifies the verification to 4.10.0
- Add Adaptive Dialogs to the selection options