### PR TITLE
Remove the patch install from ExtractCompressNuGet.ps1

### DIFF
--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -10,8 +10,6 @@ param
 )
 pushd $path
 
-# Patch is ourmoded: Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
-
 [int]$itemsProcessed = 0
 if ($extract) {
     # Extract .nupkg packages in the path.

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -14,14 +14,16 @@ pushd $path
 #Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
 #Import-Module .\archive.psm1
 
+# This Powershell patch install now errors: FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
+# The patch is likely no longer necessary. Powershell probably has fixed the problem by now. 10/30/2020
 # Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
-$ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
-if ($ver -lt '1.2.3.0') { 
-    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"
-    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
-} else { 
-    Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
-}
+#$ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
+#if ($ver -lt '1.2.3.0') { 
+#    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"
+#    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
+#} else { 
+#    Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
+#}
 
 [int]$itemsProcessed = 0
 if ($extract) {

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -10,16 +10,7 @@ param
 )
 pushd $path
 
-# This Powershell patch install now errors: FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
-# The patch, put in place in June 2019, is likely no longer necessary. The fix is likely integrated into Powershell by now. 10/30/2020
-# Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
-#$ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
-#if ($ver -lt '1.2.3.0') { 
-#    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"
-#    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
-#} else { 
-#    Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
-#}
+# Patch is ourmoded: Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
 
 [int]$itemsProcessed = 0
 if ($extract) {

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -10,12 +10,8 @@ param
 )
 pushd $path
 
-# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
-#Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
-#Import-Module .\archive.psm1
-
 # This Powershell patch install now errors: FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
-# The patch is likely no longer necessary. Powershell probably has fixed the problem by now. 10/30/2020
+# The patch, put in place in June 2019, is likely no longer necessary. The fix is likely integrated into Powershell by now. 10/30/2020
 # Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
 #$ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
 #if ($ver -lt '1.2.3.0') { 


### PR DESCRIPTION
The patch install on line 19 gets a "not found" error, likely because it is no longer needed. It dates from June 2019 

This build shows this fix works: https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=180307&view=results