### PR TITLE
Revert PR 4898 for ExtractCompressNuGet.ps1 (4.11)

### DIFF
--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -15,6 +15,7 @@ pushd $path
 #Import-Module .\archive.psm1
 
 # Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
+# An "ObjectNotFound" error can result from a temporary Powershell module repository outage. 
 $ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
 if ($ver -lt '1.2.3.0') { 
     Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -10,6 +10,19 @@ param
 )
 pushd $path
 
+# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
+#Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
+#Import-Module .\archive.psm1
+
+# Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
+$ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
+if ($ver -lt '1.2.3.0') { 
+    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"
+    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
+} else { 
+    Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
+}
+
 [int]$itemsProcessed = 0
 if ($extract) {
     # Extract .nupkg packages in the path.

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -18,8 +18,8 @@ pushd $path
 # An "ObjectNotFound" error can result from a temporary Powershell module repository outage. 
 $ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
 if ($ver -lt '1.2.3.0') { 
-    Write-Host "Installing Microsoft.Powershell.Archive 1.2.3.0 (fix for Linux path separator bug)"
-    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.3.0' -AllowClobber -Force -AcceptLicense 
+    Write-Host "Installing Microsoft.Powershell.Archive 1.2.5 (fix for Linux path separator bug)"
+    Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.5' -AllowClobber -Force -AcceptLicense 
 } else { 
     Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
 }

--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -17,11 +17,10 @@ pushd $path
 # Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
 # An "ObjectNotFound" error can result from a temporary Powershell module repository outage. 
 $ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()
+Write-Host "Currently installed: Microsoft.Powershell.Archive $ver"
 if ($ver -lt '1.2.3.0') { 
     Write-Host "Installing Microsoft.Powershell.Archive 1.2.5 (fix for Linux path separator bug)"
     Install-Module -Name Microsoft.PowerShell.Archive -MinimumVersion '1.2.5' -AllowClobber -Force -AcceptLicense 
-} else { 
-    Write-Host "Already installed: Microsoft.Powershell.Archive $ver"
 }
 
 [int]$itemsProcessed = 0


### PR DESCRIPTION
This reverts PR "Remove the patch install from ExtractCompressNuGet.ps1 (4.11)" #4898.
Also, updated to install the current version of Microsoft.PowerShell.Archive, 1.2.5.

Turns out ExtractCompressNuGet.ps1 was likely broken by a module repository outage that was later resolved.

It may be desirable to make ExtractCompressNuGet.ps1 less vulnerable to this kind of outage.
