### PR TITLE
Fix broken help links in uischema files

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.uischema
@@ -3,6 +3,6 @@
     "form": {
         "label": "Log to console",
         "subtitle": "Log Action",
-        "helpLink": "https://aka.ms/bfc-debugging-bots"
+        "helpLink": "https://aka.ms/composer-telemetry"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TraceActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TraceActivity.uischema
@@ -3,6 +3,6 @@
     "form": {
         "label": "Emit a trace event",
         "subtitle": "Trace Activity",
-        "helpLink": "https://aka.ms/bfc-debugging-bots"
+        "helpLink": "https://aka.ms/composer-telemetry"
     }
 }


### PR DESCRIPTION
## Description
Fixing https://github.com/microsoft/BotFramework-Composer/issues/4623

## Specific Changes

Fix the broken link: https://aka.ms/bfc-debugging-bots in `Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.uischema` and `Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TraceActivity.uischema`files are broken.

Pointing to this article: https://aka.ms/composer-telemetry

