### PR TITLE
await async methods in Cosmos test fixture

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageFixture.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    public class CosmosDbPartitionStorageFixture : IDisposable
+    public class CosmosDbPartitionStorageFixture : IAsyncLifetime
     {
         private const string CosmosServiceEndpoint = "https://localhost:8081";
         private const string CosmosAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
@@ -40,7 +42,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             return false;
         });
 
-        public CosmosDbPartitionStorageFixture()
+        public async Task InitializeAsync()
         {
             if (HasEmulator.Value)
             {
@@ -49,11 +51,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     CosmosAuthKey,
                     new CosmosClientOptions());
 
-                client.CreateDatabaseIfNotExistsAsync(CosmosDatabaseName);
+                await client.CreateDatabaseIfNotExistsAsync(CosmosDatabaseName);
             }
         }
 
-        public async void Dispose()
+        public async Task DisposeAsync()
         {
             if (HasEmulator.Value)
             {


### PR DESCRIPTION
## Description
Prior to this fix, there were some issues when running Cosmos tests individually.

## Specific Changes

- change the fixture from IDisposable to [IAsyncLifetime](https://github.com/xunit/xunit/blob/master/src/xunit.core/IAsyncLifetime.cs)

## Testing

Tests were failing when run individually. Now:

![image](https://user-images.githubusercontent.com/40401643/98048969-a6506380-1de3-11eb-8a87-820c014c0afe.png)
