### PR TITLE
[Debugger] add injectable transport, with unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ActiveObject.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Base/ActiveObject.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Base
+{
+    /// <summary>
+    /// Implementation of the active object pattern.
+    /// https://en.wikipedia.org/wiki/Active_object
+    /// Invokes a task with a cooperative cancellation token that runs until disposable.
+    /// Most useful for running a task during a using-block scope.
+    /// </summary>
+    internal sealed class ActiveObject : IDisposable
+    {
+        private readonly Task _task;
+        private readonly CancellationTokenSource _cancellationToken = new CancellationTokenSource();
+
+        public ActiveObject(Func<CancellationToken, Task> invokeAsync)
+        {
+            if (invokeAsync == null)
+            {
+                throw new ArgumentNullException(nameof(invokeAsync));
+            }
+
+            _task = invokeAsync(_cancellationToken.Token);
+        }
+
+        public void Dispose()
+        {
+            DisposeAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task DisposeAsync()
+        {
+            // initiate the cancellation
+            _cancellationToken.Cancel();
+
+            // dispose all owned objects
+            using (_cancellationToken)
+            using (_task)
+            {
+                try
+                {
+                    // wait for the completion of the task
+                    await _task.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException error) when (error.CancellationToken == _cancellationToken.Token)
+                {
+                    // swallow exceptions expected from cancellation
+                }
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/DebuggingBotAdapterExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Transport;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging
@@ -33,7 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging
             return botAdapter.Use(
 #pragma warning disable CA2000 // Dispose objects before losing scope (excluding, the object ownership is transferred to the adapter and the adapter should dispose it)
                 new DialogDebugAdapter(
-                    port,
+                    new DebugTransport(port, logger),
                     DebugSupport.SourceMap,
                     DebugSupport.SourceMap as IBreakpoints,
                     terminate,

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events/Events.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Events/Events.cs
@@ -35,12 +35,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Events
         }
 
         ExceptionBreakpointFilter[] IEvents.Filters =>
-            _stateByFilter.Select(kv => new ExceptionBreakpointFilter
+            _stateByFilter
+            .Select(kv => new ExceptionBreakpointFilter
             {
                 Label = kv.Key,
                 Filter = kv.Key,
                 Default = kv.Value
-            }).ToArray();
+            })
+
+            // ensure consistency for UI and trace oracle tests
+            .OrderBy(f => f.Filter)
+            .ToArray();
 
         bool IEvents.this[string filter]
         {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/HasRest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/HasRest.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Protocol
 {
-    internal abstract class Message : HasRest
+    internal abstract class HasRest
     {
-        public int Seq { get; set; }
-
-        public string Type { get; set; }
+        [JsonExtensionData]
+        public JObject Rest { get; } = new JObject();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/ProtocolMessage.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Protocol/ProtocolMessage.cs
@@ -2,13 +2,27 @@
 // Licensed under the MIT License.
 
 using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Protocol
 {
     // https://github.com/Microsoft/debug-adapter-protocol/blob/gh-pages/debugAdapterProtocol.json
     internal static class ProtocolMessage
     {
+        private static readonly JsonSerializer Serializer = new JsonSerializer
+        {
+            NullValueHandling = NullValueHandling.Include,
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        };
+
+        public static JToken ToToken(Message message)
+        {
+            var token = JToken.FromObject(message, Serializer);
+            return token;
+        }
+
         public static Request Parse(JToken token)
         {
             switch ((string)token["type"])

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Transport/IDebugTransport.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/Transport/IDebugTransport.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Transport
+{
+    /// <summary>
+    /// Encapsulate the transport between Debug Client (e.g. Visual Studio Code)
+    /// and Debug Adapter (i.e. running within the bot code).
+    /// </summary>
+    internal interface IDebugTransport
+    {
+        /// <summary>
+        /// Gets or sets the callback for accepting a new connection.
+        /// Single subscriber event, required to break circular dependency.
+        /// </summary>
+        /// <value>
+        /// The accept callback.
+        /// </value>
+        Func<CancellationToken, Task> Accept { get; set; }
+
+        /// <summary>
+        /// Reads the next token from the transport.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing completion of the wait for the next token.</returns>
+        Task<JToken> ReadAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sends the next token to the transport.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task representing completion of the send.</returns>
+        Task SendAsync(JToken token, CancellationToken cancellationToken);
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracle.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracle.cs
@@ -8,6 +8,7 @@ using Microsoft.Bot.Builder.Dialogs.Choices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 {
@@ -29,7 +30,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
         public static string MakePath(params string[] names)
             => Path.ChangeExtension(Path.Combine(GetProjectPath(), "TraceOracles", Path.Combine(names)), "json");
 
-        public static async Task ValidateAsync(string pathFile, IReadOnlyList<JToken> listNew)
+        public static async Task ValidateAsync(string pathFile, IReadOnlyList<JToken> listNew, ITestOutputHelper output)
         {
             // ensure the trace oracles directory exists
             var pathRoot = Path.GetDirectoryName(pathFile);
@@ -71,7 +72,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 
                     // and updated the saved trace oracle for review
                     var jsonNew = JsonConvert.SerializeObject(items, Settings);
-                    await File.WriteAllTextAsync(pathFile, jsonNew);
+                    await File.WriteAllTextAsync(pathFile, jsonNew).ConfigureAwait(false);
+
+                    output.WriteLine(jsonNew);
 
                     throw;
                 }
@@ -82,7 +85,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
                 // 1. establishing a new trace
                 // 2. the developer deleted the older one after code updates with expected changes
                 var jsonNew = JsonConvert.SerializeObject(listNew, Settings);
-                await File.WriteAllTextAsync(pathFile, jsonNew);
+                await File.WriteAllTextAsync(pathFile, jsonNew).ConfigureAwait(false);
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracle.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracle.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Choices;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+{
+    /// <summary>
+    /// An alternative to hand writing test assertions for complicated protocols.
+    /// https://en.wikipedia.org/wiki/Test_oracle
+    /// .
+    /// </summary>
+    public static class TraceOracle
+    {
+        private static readonly JToken FailureMarker = new JValue("FAILFAIL");
+        private static readonly IEqualityComparer<JToken> Comparer = new JTokenEqualityComparer();
+
+        private static readonly JsonSerializerSettings Settings = new JsonSerializerSettings()
+        {
+            Formatting = Formatting.Indented,
+        };
+
+        public static string MakePath(params string[] names)
+            => Path.ChangeExtension(Path.Combine(GetProjectPath(), "TraceOracles", Path.Combine(names)), "json");
+
+        public static async Task ValidateAsync(string pathFile, IReadOnlyList<JToken> listNew)
+        {
+            // ensure the trace oracles directory exists
+            var pathRoot = Path.GetDirectoryName(pathFile);
+            if (!Directory.Exists(pathRoot))
+            {
+                Directory.CreateDirectory(pathRoot);
+            }
+
+            // if the trace oracle exists
+            if (File.Exists(pathFile))
+            {
+                // then load the existing trace
+                var jsonOld = await File.ReadAllTextAsync(pathFile).ConfigureAwait(false);
+                var listOld = JsonConvert.DeserializeObject<IReadOnlyList<JToken>>(jsonOld);
+
+                // and verify that the previous test has not failed
+                Assert.DoesNotContain<JToken>(FailureMarker, listOld, Comparer);
+
+                try
+                {
+                    // now verify that the trace has not changed
+                    Assert.Equal(listOld, listNew, Comparer);
+                }
+                catch
+                {
+                    // if it has changed, then add a failure marker for diagnosis
+                    var count = Math.Min(listOld.Count, listNew.Count);
+                    int index;
+                    for (index = 0; index < count; ++index)
+                    {
+                        if (!Comparer.Equals(listOld[index], listNew[index]))
+                        {
+                            break;
+                        }
+                    }
+
+                    var items = new List<JToken>(listNew);
+                    items.Insert(index, FailureMarker);
+
+                    // and updated the saved trace oracle for review
+                    var jsonNew = JsonConvert.SerializeObject(items, Settings);
+                    await File.WriteAllTextAsync(pathFile, jsonNew);
+
+                    throw;
+                }
+            }
+            else
+            {
+                // if the trace oracle does not exist, then assume we are either
+                // 1. establishing a new trace
+                // 2. the developer deleted the older one after code updates with expected changes
+                var jsonNew = JsonConvert.SerializeObject(listNew, Settings);
+                await File.WriteAllTextAsync(pathFile, jsonNew);
+            }
+        }
+
+        private static string GetProjectPath()
+        {
+            var parent = Directory.GetCurrentDirectory();
+            while (!string.IsNullOrEmpty(parent))
+            {
+                if (Directory.EnumerateFiles(parent, "*proj").Any())
+                {
+                    break;
+                }
+                else
+                {
+                    parent = Path.GetDirectoryName(parent);
+                }
+            }
+
+            return parent;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracles/ProtocolMessages_AreConsistent.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracles/ProtocolMessages_AreConsistent.json
@@ -1,0 +1,356 @@
+[
+  {
+    "arguments": {
+      "clientID": null,
+      "clientName": null,
+      "adapterID": null,
+      "pathFormat": null,
+      "linesStartAt1": false,
+      "columnsStartAt1": false,
+      "supportsVariableType": false,
+      "supportsVariablePaging": false,
+      "supportsRunInTerminalRequest": false,
+      "locale": null
+    },
+    "command": "initialize",
+    "seq": 1,
+    "type": "request"
+  },
+  {
+    "body": {
+      "supportsConfigurationDoneRequest": true,
+      "supportsSetVariable": true,
+      "supportsEvaluateForHovers": true,
+      "supportsFunctionBreakpoints": true,
+      "exceptionBreakpointFilters": [
+        {
+          "filter": "activityReceived",
+          "label": "activityReceived",
+          "default": true
+        },
+        {
+          "filter": "beginDialog",
+          "label": "beginDialog",
+          "default": true
+        },
+        {
+          "filter": "cancelDialog",
+          "label": "cancelDialog",
+          "default": true
+        },
+        {
+          "filter": "custom",
+          "label": "custom",
+          "default": true
+        },
+        {
+          "filter": "EndDialog",
+          "label": "EndDialog",
+          "default": false
+        },
+        {
+          "filter": "error",
+          "label": "error",
+          "default": true
+        },
+        {
+          "filter": "repromptDialog",
+          "label": "repromptDialog",
+          "default": true
+        },
+        {
+          "filter": "versionChanged",
+          "label": "versionChanged",
+          "default": true
+        }
+      ],
+      "supportTerminateDebuggee": true,
+      "supportsTerminateRequest": true
+    },
+    "request_seq": 1,
+    "success": true,
+    "message": null,
+    "command": "initialize",
+    "seq": 1,
+    "type": "response"
+  },
+  {
+    "body": {},
+    "event": "initialized",
+    "seq": 2,
+    "type": "event"
+  },
+  {
+    "arguments": {
+      "breakOnStart": true
+    },
+    "command": "attach",
+    "seq": 2,
+    "type": "request"
+  },
+  {
+    "arguments": {},
+    "command": "configurationdone",
+    "seq": 3,
+    "type": "request"
+  },
+  {
+    "arguments": {},
+    "command": "threads",
+    "seq": 4,
+    "type": "request"
+  },
+  {
+    "body": {},
+    "request_seq": 2,
+    "success": true,
+    "message": null,
+    "command": "attach",
+    "seq": 3,
+    "type": "response"
+  },
+  {
+    "body": {},
+    "request_seq": 3,
+    "success": true,
+    "message": null,
+    "command": "configurationdone",
+    "seq": 4,
+    "type": "response"
+  },
+  {
+    "body": {
+      "threads": []
+    },
+    "request_seq": 4,
+    "success": true,
+    "message": null,
+    "command": "threads",
+    "seq": 5,
+    "type": "response"
+  },
+  {
+    "body": {
+      "output": "one ==> Started         \r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 6,
+    "type": "event"
+  },
+  {
+    "body": {
+      "threadId": 1,
+      "reason": "started"
+    },
+    "event": "thread",
+    "seq": 7,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "'one' ==> beginDialog      ==> ProtocolMessages_AreConsistent \r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 8,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent\r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 9,
+    "type": "event"
+  },
+  {
+    "body": {
+      "reason": "breakpoint",
+      "description": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+      "threadId": 1,
+      "text": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+      "preserveFocusHint": false,
+      "allThreadsStopped": false
+    },
+    "event": "stopped",
+    "seq": 10,
+    "type": "event"
+  },
+  {
+    "arguments": {
+      "threadId": 1
+    },
+    "command": "next",
+    "seq": 5,
+    "type": "request"
+  },
+  {
+    "body": {},
+    "request_seq": 5,
+    "success": true,
+    "message": null,
+    "command": "next",
+    "seq": 11,
+    "type": "response"
+  },
+  {
+    "body": {
+      "output": "one ==> Next             ==> ProtocolMessages_AreConsistent\r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 12,
+    "type": "event"
+  },
+  {
+    "body": {
+      "threadId": 1,
+      "allThreadsContinued": false
+    },
+    "event": "continued",
+    "seq": 13,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "one ==> Exited          \r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 14,
+    "type": "event"
+  },
+  {
+    "body": {
+      "threadId": 1,
+      "reason": "exited"
+    },
+    "event": "thread",
+    "seq": 15,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "two ==> Started         \r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 16,
+    "type": "event"
+  },
+  {
+    "body": {
+      "threadId": 2,
+      "reason": "started"
+    },
+    "event": "thread",
+    "seq": 17,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "'two' ==> activityReceived ==> ProtocolMessages_AreConsistent \r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 18,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent\r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 19,
+    "type": "event"
+  },
+  {
+    "body": {
+      "reason": "breakpoint",
+      "description": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+      "threadId": 2,
+      "text": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+      "preserveFocusHint": false,
+      "allThreadsStopped": false
+    },
+    "event": "stopped",
+    "seq": 20,
+    "type": "event"
+  },
+  {
+    "arguments": {
+      "threadId": 2
+    },
+    "command": "next",
+    "seq": 6,
+    "type": "request"
+  },
+  {
+    "body": {},
+    "request_seq": 6,
+    "success": true,
+    "message": null,
+    "command": "next",
+    "seq": 21,
+    "type": "response"
+  },
+  {
+    "body": {
+      "output": "two ==> Next             ==> ProtocolMessages_AreConsistent\r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 22,
+    "type": "event"
+  },
+  {
+    "body": {
+      "threadId": 2,
+      "allThreadsContinued": false
+    },
+    "event": "continued",
+    "seq": 23,
+    "type": "event"
+  },
+  {
+    "body": {
+      "output": "two ==> Exited          \r\n",
+      "source": null,
+      "line": null,
+      "variablesReference": 0
+    },
+    "event": "output",
+    "seq": 24,
+    "type": "event"
+  },
+  {
+    "body": {
+      "threadId": 2,
+      "reason": "exited"
+    },
+    "event": "thread",
+    "seq": 25,
+    "type": "event"
+  }
+]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracles/ProtocolMessages_AreConsistent.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracles/ProtocolMessages_AreConsistent.json
@@ -102,24 +102,6 @@
   },
   {
     "Token": {
-      "arguments": {},
-      "command": "configurationdone",
-      "seq": 3,
-      "type": "request"
-    },
-    "Client": true
-  },
-  {
-    "Token": {
-      "arguments": {},
-      "command": "threads",
-      "seq": 4,
-      "type": "request"
-    },
-    "Client": true
-  },
-  {
-    "Token": {
       "body": {},
       "request_seq": 2,
       "success": true,
@@ -132,6 +114,15 @@
   },
   {
     "Token": {
+      "arguments": {},
+      "command": "configurationdone",
+      "seq": 3,
+      "type": "request"
+    },
+    "Client": true
+  },
+  {
+    "Token": {
       "body": {},
       "request_seq": 3,
       "success": true,
@@ -141,6 +132,15 @@
       "type": "response"
     },
     "Client": false
+  },
+  {
+    "Token": {
+      "arguments": {},
+      "command": "threads",
+      "seq": 4,
+      "type": "request"
+    },
+    "Client": true
   },
   {
     "Token": {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracles/ProtocolMessages_AreConsistent.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceOracles/ProtocolMessages_AreConsistent.json
@@ -1,356 +1,449 @@
 [
   {
-    "arguments": {
-      "clientID": null,
-      "clientName": null,
-      "adapterID": null,
-      "pathFormat": null,
-      "linesStartAt1": false,
-      "columnsStartAt1": false,
-      "supportsVariableType": false,
-      "supportsVariablePaging": false,
-      "supportsRunInTerminalRequest": false,
-      "locale": null
+    "Token": {
+      "arguments": {
+        "clientID": null,
+        "clientName": null,
+        "adapterID": null,
+        "pathFormat": null,
+        "linesStartAt1": false,
+        "columnsStartAt1": false,
+        "supportsVariableType": false,
+        "supportsVariablePaging": false,
+        "supportsRunInTerminalRequest": false,
+        "locale": null
+      },
+      "command": "initialize",
+      "seq": 1,
+      "type": "request"
     },
-    "command": "initialize",
-    "seq": 1,
-    "type": "request"
+    "Client": true
   },
   {
-    "body": {
-      "supportsConfigurationDoneRequest": true,
-      "supportsSetVariable": true,
-      "supportsEvaluateForHovers": true,
-      "supportsFunctionBreakpoints": true,
-      "exceptionBreakpointFilters": [
-        {
-          "filter": "activityReceived",
-          "label": "activityReceived",
-          "default": true
-        },
-        {
-          "filter": "beginDialog",
-          "label": "beginDialog",
-          "default": true
-        },
-        {
-          "filter": "cancelDialog",
-          "label": "cancelDialog",
-          "default": true
-        },
-        {
-          "filter": "custom",
-          "label": "custom",
-          "default": true
-        },
-        {
-          "filter": "EndDialog",
-          "label": "EndDialog",
-          "default": false
-        },
-        {
-          "filter": "error",
-          "label": "error",
-          "default": true
-        },
-        {
-          "filter": "repromptDialog",
-          "label": "repromptDialog",
-          "default": true
-        },
-        {
-          "filter": "versionChanged",
-          "label": "versionChanged",
-          "default": true
-        }
-      ],
-      "supportTerminateDebuggee": true,
-      "supportsTerminateRequest": true
+    "Token": {
+      "body": {
+        "supportsConfigurationDoneRequest": true,
+        "supportsSetVariable": true,
+        "supportsEvaluateForHovers": true,
+        "supportsFunctionBreakpoints": true,
+        "exceptionBreakpointFilters": [
+          {
+            "filter": "activityReceived",
+            "label": "activityReceived",
+            "default": true
+          },
+          {
+            "filter": "beginDialog",
+            "label": "beginDialog",
+            "default": true
+          },
+          {
+            "filter": "cancelDialog",
+            "label": "cancelDialog",
+            "default": true
+          },
+          {
+            "filter": "custom",
+            "label": "custom",
+            "default": true
+          },
+          {
+            "filter": "EndDialog",
+            "label": "EndDialog",
+            "default": false
+          },
+          {
+            "filter": "error",
+            "label": "error",
+            "default": true
+          },
+          {
+            "filter": "repromptDialog",
+            "label": "repromptDialog",
+            "default": true
+          },
+          {
+            "filter": "versionChanged",
+            "label": "versionChanged",
+            "default": true
+          }
+        ],
+        "supportTerminateDebuggee": true,
+        "supportsTerminateRequest": true
+      },
+      "request_seq": 1,
+      "success": true,
+      "message": null,
+      "command": "initialize",
+      "seq": 1,
+      "type": "response"
     },
-    "request_seq": 1,
-    "success": true,
-    "message": null,
-    "command": "initialize",
-    "seq": 1,
-    "type": "response"
+    "Client": false
   },
   {
-    "body": {},
-    "event": "initialized",
-    "seq": 2,
-    "type": "event"
-  },
-  {
-    "arguments": {
-      "breakOnStart": true
+    "Token": {
+      "body": {},
+      "event": "initialized",
+      "seq": 2,
+      "type": "event"
     },
-    "command": "attach",
-    "seq": 2,
-    "type": "request"
+    "Client": false
   },
   {
-    "arguments": {},
-    "command": "configurationdone",
-    "seq": 3,
-    "type": "request"
-  },
-  {
-    "arguments": {},
-    "command": "threads",
-    "seq": 4,
-    "type": "request"
-  },
-  {
-    "body": {},
-    "request_seq": 2,
-    "success": true,
-    "message": null,
-    "command": "attach",
-    "seq": 3,
-    "type": "response"
-  },
-  {
-    "body": {},
-    "request_seq": 3,
-    "success": true,
-    "message": null,
-    "command": "configurationdone",
-    "seq": 4,
-    "type": "response"
-  },
-  {
-    "body": {
-      "threads": []
+    "Token": {
+      "arguments": {
+        "breakOnStart": true
+      },
+      "command": "attach",
+      "seq": 2,
+      "type": "request"
     },
-    "request_seq": 4,
-    "success": true,
-    "message": null,
-    "command": "threads",
-    "seq": 5,
-    "type": "response"
+    "Client": true
   },
   {
-    "body": {
-      "output": "one ==> Started         \r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "arguments": {},
+      "command": "configurationdone",
+      "seq": 3,
+      "type": "request"
     },
-    "event": "output",
-    "seq": 6,
-    "type": "event"
+    "Client": true
   },
   {
-    "body": {
-      "threadId": 1,
-      "reason": "started"
+    "Token": {
+      "arguments": {},
+      "command": "threads",
+      "seq": 4,
+      "type": "request"
     },
-    "event": "thread",
-    "seq": 7,
-    "type": "event"
+    "Client": true
   },
   {
-    "body": {
-      "output": "'one' ==> beginDialog      ==> ProtocolMessages_AreConsistent \r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {},
+      "request_seq": 2,
+      "success": true,
+      "message": null,
+      "command": "attach",
+      "seq": 3,
+      "type": "response"
     },
-    "event": "output",
-    "seq": 8,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "output": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent\r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {},
+      "request_seq": 3,
+      "success": true,
+      "message": null,
+      "command": "configurationdone",
+      "seq": 4,
+      "type": "response"
     },
-    "event": "output",
-    "seq": 9,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "reason": "breakpoint",
-      "description": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
-      "threadId": 1,
-      "text": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
-      "preserveFocusHint": false,
-      "allThreadsStopped": false
+    "Token": {
+      "body": {
+        "threads": []
+      },
+      "request_seq": 4,
+      "success": true,
+      "message": null,
+      "command": "threads",
+      "seq": 5,
+      "type": "response"
     },
-    "event": "stopped",
-    "seq": 10,
-    "type": "event"
+    "Client": false
   },
   {
-    "arguments": {
-      "threadId": 1
+    "Token": {
+      "body": {
+        "output": "one ==> Started         \r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 6,
+      "type": "event"
     },
-    "command": "next",
-    "seq": 5,
-    "type": "request"
+    "Client": false
   },
   {
-    "body": {},
-    "request_seq": 5,
-    "success": true,
-    "message": null,
-    "command": "next",
-    "seq": 11,
-    "type": "response"
-  },
-  {
-    "body": {
-      "output": "one ==> Next             ==> ProtocolMessages_AreConsistent\r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {
+        "threadId": 1,
+        "reason": "started"
+      },
+      "event": "thread",
+      "seq": 7,
+      "type": "event"
     },
-    "event": "output",
-    "seq": 12,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "threadId": 1,
-      "allThreadsContinued": false
+    "Token": {
+      "body": {
+        "output": "'one' ==> beginDialog      ==> ProtocolMessages_AreConsistent \r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 8,
+      "type": "event"
     },
-    "event": "continued",
-    "seq": 13,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "output": "one ==> Exited          \r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {
+        "output": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent\r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 9,
+      "type": "event"
     },
-    "event": "output",
-    "seq": 14,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "threadId": 1,
-      "reason": "exited"
+    "Token": {
+      "body": {
+        "reason": "breakpoint",
+        "description": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+        "threadId": 1,
+        "text": "one ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+        "preserveFocusHint": false,
+        "allThreadsStopped": false
+      },
+      "event": "stopped",
+      "seq": 10,
+      "type": "event"
     },
-    "event": "thread",
-    "seq": 15,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "output": "two ==> Started         \r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "arguments": {
+        "threadId": 1
+      },
+      "command": "next",
+      "seq": 5,
+      "type": "request"
     },
-    "event": "output",
-    "seq": 16,
-    "type": "event"
+    "Client": true
   },
   {
-    "body": {
-      "threadId": 2,
-      "reason": "started"
+    "Token": {
+      "body": {},
+      "request_seq": 5,
+      "success": true,
+      "message": null,
+      "command": "next",
+      "seq": 11,
+      "type": "response"
     },
-    "event": "thread",
-    "seq": 17,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "output": "'two' ==> activityReceived ==> ProtocolMessages_AreConsistent \r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {
+        "output": "one ==> Next             ==> ProtocolMessages_AreConsistent\r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 12,
+      "type": "event"
     },
-    "event": "output",
-    "seq": 18,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "output": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent\r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {
+        "threadId": 1,
+        "allThreadsContinued": false
+      },
+      "event": "continued",
+      "seq": 13,
+      "type": "event"
     },
-    "event": "output",
-    "seq": 19,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "reason": "breakpoint",
-      "description": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
-      "threadId": 2,
-      "text": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
-      "preserveFocusHint": false,
-      "allThreadsStopped": false
+    "Token": {
+      "body": {
+        "output": "one ==> Exited          \r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 14,
+      "type": "event"
     },
-    "event": "stopped",
-    "seq": 20,
-    "type": "event"
+    "Client": false
   },
   {
-    "arguments": {
-      "threadId": 2
+    "Token": {
+      "body": {
+        "threadId": 1,
+        "reason": "exited"
+      },
+      "event": "thread",
+      "seq": 15,
+      "type": "event"
     },
-    "command": "next",
-    "seq": 6,
-    "type": "request"
+    "Client": false
   },
   {
-    "body": {},
-    "request_seq": 6,
-    "success": true,
-    "message": null,
-    "command": "next",
-    "seq": 21,
-    "type": "response"
-  },
-  {
-    "body": {
-      "output": "two ==> Next             ==> ProtocolMessages_AreConsistent\r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {
+        "output": "two ==> Started         \r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 16,
+      "type": "event"
     },
-    "event": "output",
-    "seq": 22,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "threadId": 2,
-      "allThreadsContinued": false
+    "Token": {
+      "body": {
+        "threadId": 2,
+        "reason": "started"
+      },
+      "event": "thread",
+      "seq": 17,
+      "type": "event"
     },
-    "event": "continued",
-    "seq": 23,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "output": "two ==> Exited          \r\n",
-      "source": null,
-      "line": null,
-      "variablesReference": 0
+    "Token": {
+      "body": {
+        "output": "'two' ==> activityReceived ==> ProtocolMessages_AreConsistent \r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 18,
+      "type": "event"
     },
-    "event": "output",
-    "seq": 24,
-    "type": "event"
+    "Client": false
   },
   {
-    "body": {
-      "threadId": 2,
-      "reason": "exited"
+    "Token": {
+      "body": {
+        "output": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent\r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 19,
+      "type": "event"
     },
-    "event": "thread",
-    "seq": 25,
-    "type": "event"
+    "Client": false
+  },
+  {
+    "Token": {
+      "body": {
+        "reason": "breakpoint",
+        "description": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+        "threadId": 2,
+        "text": "two ==> Breakpoint       ==> ProtocolMessages_AreConsistent",
+        "preserveFocusHint": false,
+        "allThreadsStopped": false
+      },
+      "event": "stopped",
+      "seq": 20,
+      "type": "event"
+    },
+    "Client": false
+  },
+  {
+    "Token": {
+      "arguments": {
+        "threadId": 2
+      },
+      "command": "next",
+      "seq": 6,
+      "type": "request"
+    },
+    "Client": true
+  },
+  {
+    "Token": {
+      "body": {},
+      "request_seq": 6,
+      "success": true,
+      "message": null,
+      "command": "next",
+      "seq": 21,
+      "type": "response"
+    },
+    "Client": false
+  },
+  {
+    "Token": {
+      "body": {
+        "output": "two ==> Next             ==> ProtocolMessages_AreConsistent\r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 22,
+      "type": "event"
+    },
+    "Client": false
+  },
+  {
+    "Token": {
+      "body": {
+        "threadId": 2,
+        "allThreadsContinued": false
+      },
+      "event": "continued",
+      "seq": 23,
+      "type": "event"
+    },
+    "Client": false
+  },
+  {
+    "Token": {
+      "body": {
+        "output": "two ==> Exited          \r\n",
+        "source": null,
+        "line": null,
+        "variablesReference": 0
+      },
+      "event": "output",
+      "seq": 24,
+      "type": "event"
+    },
+    "Client": false
+  },
+  {
+    "Token": {
+      "body": {
+        "threadId": 2,
+        "reason": "exited"
+      },
+      "event": "thread",
+      "seq": 25,
+      "type": "event"
+    },
+    "Client": false
   }
 ]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Debugging;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Base;
+using Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels;
+using Microsoft.Bot.Builder.Dialogs.Debugging.DataModels;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Events;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Protocol;
+using Microsoft.Bot.Builder.Dialogs.Debugging.Transport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
+{
+    public sealed class TraceTests
+    {
+        [Fact]
+        public async Task ProtocolMessages_AreConsistent()
+        {
+            WaterfallStep MakeStep(string text, DialogTurnResult result = null)
+                => async (stepContext, cancellationToken) =>
+                {
+                    await stepContext.Context.SendActivityAsync(MessageFactory.Text(text), cancellationToken);
+                    return result ?? Dialog.EndOfTurn;
+                };
+
+            var dialog = new WaterfallDialog(
+                nameof(ProtocolMessages_AreConsistent),
+                new[] { MakeStep("hello"), MakeStep("world") });
+
+            var trace = new List<JToken>();
+            var transport = new MockTransport(trace);
+            var debugger = MakeDebugger(transport);
+
+            using (new ActiveObject(((IDebugTransport)transport).Accept))
+            {
+                var storage = new MemoryStorage();
+                var userState = new UserState(storage);
+                var conversationState = new ConversationState(storage);
+                var adapter = new TestAdapter()
+                    .Use(debugger)
+                    .UseStorage(storage)
+                    .UseBotState(userState, conversationState);
+
+                var dialogManager = new DialogManager(dialog);
+
+                await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
+                {
+                    await dialogManager.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+                })
+                .Send("one")
+                .AssertReply("hello")
+                .Send("two")
+                .AssertReply("world")
+                .StartTestAsync();
+            }
+
+            var pathJson = TraceOracle.MakePath(nameof(ProtocolMessages_AreConsistent));
+            await TraceOracle.ValidateAsync(pathJson, trace);
+        }
+
+        internal static DialogDebugAdapter MakeDebugger(IDebugTransport transport)
+        {
+            var codeModel = new CodeModel();
+            var sourceMap = new DebuggerSourceMap(codeModel);
+            var events = new Events<DialogEvents>();
+            var coercion = new Coercion();
+            var dataModel = new DataModel(coercion);
+            var debugger = new DialogDebugAdapter(transport, sourceMap, sourceMap, () => { }, events, codeModel, dataModel, NullLogger.Instance, coercion);
+            return debugger;
+        }
+
+        internal sealed class MockTransport : IDebugTransport
+        {
+            private readonly List<JToken> _trace;
+            private readonly Queue<JToken> _queue = new Queue<JToken>();
+            private readonly SemaphoreSlim _count = new SemaphoreSlim(0, int.MaxValue);
+            private readonly object _gate = new object();
+            private int _seq = 0;
+
+            public MockTransport(List<JToken> trace)
+            {
+                _trace = trace;
+
+                Request(new Initialize() { });
+            }
+
+            Func<CancellationToken, Task> IDebugTransport.Accept { get; set; }
+
+            async Task<JToken> IDebugTransport.ReadAsync(CancellationToken cancellationToken)
+            {
+                await _count.WaitAsync(cancellationToken).ConfigureAwait(false);
+                lock (_gate)
+                {
+                    return _queue.Dequeue();
+                }
+            }
+
+            Task IDebugTransport.SendAsync(JToken token, CancellationToken cancellationToken)
+            {
+                try
+                {
+                    lock (_gate)
+                    {
+                        _trace.Add(token);
+                    }
+
+                    var incoming = token.ToObject<Incoming>();
+                    if (incoming.Type == "event")
+                    {
+                        switch (incoming.Event)
+                        {
+                            case "initialized":
+                                Request(new Attach() { BreakOnStart = true });
+                                Request(new ConfigurationDone());
+
+                                Request(new Threads());
+                                break;
+                            case "stopped":
+                                Request(new Next() { ThreadId = incoming.Body.ThreadId });
+                                break;
+                        }
+                    }
+
+                    return Task.CompletedTask;
+                }
+                catch (OperationCanceledException error)
+                {
+                    return Task.FromCanceled(error.CancellationToken);
+                }
+                catch (Exception error)
+                {
+                    return Task.FromException(error);
+                }
+            }
+
+            private void Request<TBody>(TBody arguments)
+            {
+                var request = new Request<TBody>()
+                {
+                    Type = nameof(Request).ToLowerInvariant(),
+                    Command = arguments.GetType().Name.ToLowerInvariant(),
+                    Arguments = arguments,
+                };
+
+                Enqueue(request);
+            }
+
+            private void Enqueue(Message message)
+            {
+                lock (_gate)
+                {
+                    message.Seq = ++_seq;
+                    var token = ProtocolMessage.ToToken(message);
+                    _trace.Add(token);
+                    _queue.Enqueue(token);
+                }
+
+                _count.Release();
+            }
+
+            private sealed class Incoming
+            {
+                public string Type { get; set; }
+
+                public string Command { get; set; }
+
+                public string Event { get; set; }
+
+                public BodyType Body { get; set; }
+
+                public sealed class BodyType
+                {
+                    public ulong ThreadId { get; set; }
+                }
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
@@ -15,11 +15,19 @@ using Microsoft.Bot.Builder.Dialogs.Debugging.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 {
     public sealed class TraceTests
     {
+        private readonly ITestOutputHelper _output;
+
+        public TraceTests(ITestOutputHelper output)
+        {
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+        }
+
         [Fact]
         public async Task ProtocolMessages_AreConsistent()
         {
@@ -62,7 +70,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
             }
 
             var pathJson = TraceOracle.MakePath(nameof(ProtocolMessages_AreConsistent));
-            await TraceOracle.ValidateAsync(pathJson, trace);
+            await TraceOracle.ValidateAsync(pathJson, trace, _output);
         }
 
         internal static DialogDebugAdapter MakeDebugger(IDebugTransport transport)
@@ -119,7 +127,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
                             case "initialized":
                                 Request(new Attach() { BreakOnStart = true });
                                 Request(new ConfigurationDone());
-
                                 Request(new Threads());
                                 break;
                             case "stopped":

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -93,7 +94,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
                 return targets.ToArray();
             });
 
-            var tokens = sorted.Select(JToken.FromObject).ToArray();
+            var tokens = sorted.Select(JToken.FromObject).Select(TraceOracle.Normalize).ToArray();
             await TraceOracle.ValidateAsync(pathJson, tokens, _output).ConfigureAwait(false);
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 
                 public BodyType Body { get; set; }
 
-                public sealed class BodyType
+                public sealed class BodyType : HasRest
                 {
                     public ulong ThreadId { get; set; }
                 }


### PR DESCRIPTION
## Description
This PR allows the debugger transport to be injectable to
1. simplify the debug adapter code
2. remove implementation inheritance
3. allow unit tests (with mocked transports) for the debug adapter code

## Specific Changes
  - create new IDebugTransport interface
  - move code to use IDebugTransport interface
  - add first substantial unit test for debug adapter

## Testing
Yep.