### PR TITLE
Update disabled property to booleanExpression in Microsoft.SendActivity.schema

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendActivity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendActivity.schema
@@ -11,12 +11,9 @@
             "description": "Optional id for the dialog"
         },
         "disabled": {
-            "$ref": "schema:#/definitions/stringExpression",
+            "$ref": "schema:#/definitions/booleanExpression",
             "title": "Disabled",
-            "description": "Optional condition which if true will disable this action.",
-            "examples": [
-                "user.age > 3"
-            ]
+            "description": "Optional condition which if true will disable this action."
         },
         "activity": {
             "$kind": "Microsoft.IActivityTemplate",


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotFramework-Composer/issues/4651
<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

Composer is assuming disable property to be booleanExpression across all the kinds.
But currently in sdk, in SendActivity and Ask action, the disable property is defined as a StringExpression which breaks composer's assumption and the disable feature for SendActivity and Ask action is not working now.
Disabling the two actions will get an validation error.  


## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Update disable property in SendActivity from StringExpression to booleanExpression.

## Testing

Tested in composer UX, update the schema will fix this issue. 
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->