### PR TITLE
Cherry-Pick to 4.11: OnCondition is not correctly caching expressions 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsAppBasedLinkQuery.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsAppBasedLinkQuery.cs
@@ -23,10 +23,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/queryLink'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.name == 'composeExtension/queryLink'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.name == 'composeExtension/queryLink'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsCardAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsCardAction.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is null
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == null"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == null"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelCreated.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelCreated.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'channelCreated'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelCreated'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelCreated'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelDeleted.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelDeleted.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'channelDeleted'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelDeleted'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelDeleted'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelRenamed.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelRenamed.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'channelRenamed'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelRenamed'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelRenamed'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelRestored.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsChannelRestored.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'channelRestored'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelRestored'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'channelRestored'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsFileConsent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsFileConsent.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'fileConsent/invoke'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'fileConsent/invoke'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'fileConsent/invoke'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionCardButtonClicked.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionCardButtonClicked.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/onCardButtonClicked'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/onCardButtonClicked'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/onCardButtonClicked'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionConfigurationQuerySettingUrl.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionConfigurationQuerySettingUrl.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/querySettingUrl'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/querySettingUrl'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/querySettingUrl'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionConfigurationSetting.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionConfigurationSetting.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/setting'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/setting'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/setting'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionFetchTask.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionFetchTask.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/fetchTask'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/fetchTask'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/fetchTask'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionQuery.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionQuery.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/query'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/query'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/query'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionSelectItem.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionSelectItem.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/selectItem'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/selectItem'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/selectItem'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionSubmitAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsMessagingExtensionSubmitAction.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'composeExtension/submitAction'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/submitAction'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'composeExtension/submitAction'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsO365ConnectorCardAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsO365ConnectorCardAction.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'actionableMessage/executeAction'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'actionableMessage/executeAction'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'actionableMessage/executeAction'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTaskModuleFetch.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTaskModuleFetch.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'task/fetch'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'task/fetch'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'task/fetch'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTaskModuleSubmit.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTaskModuleSubmit.cs
@@ -24,10 +24,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if name is 'task/submit'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'task/submit'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'task/submit'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamArchived.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamArchived.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'teamArchived'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamArchived'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamArchived'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamDeleted.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamDeleted.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'teamDeleted'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamDeleted'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamDeleted'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamHardDeleted.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamHardDeleted.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'teamHardDeleted'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamHardDeleted'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamHardDeleted'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamRenamed.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamRenamed.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'teamRenamed'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamRenamed'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamRenamed'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamRestored.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamRestored.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'teamRestored'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamRestored'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamRestored'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamUnarchived.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/TriggerConditions/OnTeamsTeamUnarchived.cs
@@ -27,10 +27,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Teams
         {
         }
 
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // if teams channel and eventType == 'teamUnarchived'
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamUnarchived'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.ChannelId == '{Channels.Msteams}' && {TurnPath.Activity}.channelData.eventType == 'teamUnarchived'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/Activities/OnActivity.cs
@@ -58,14 +58,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return $"{this.GetType().Name}[{this.Condition}]";
         }
 
-        /// <summary>
-        /// Gets this activity's representing expresion.
-        /// </summary>
-        /// <returns>An <see cref="Expression"/> representing the activity.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // add constraints for activity type
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.type == '{this.Type}'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.type == '{this.Type}'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnAssignEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnAssignEntity.cs
@@ -70,13 +70,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public override string GetIdentity()
             => $"{this.GetType().Name}({this.Property}, {this.Entity})";
 
-        /// <summary>
-        /// Get the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
-            var expressions = new List<Expression> { base.GetExpression() };
+            var expressions = new List<Expression> { base.CreateExpression() };
             if (this.Property != null)
             {
                 expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.property == '{this.Property}'"));

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
@@ -61,13 +61,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public override string GetIdentity()
             => $"{this.GetType().Name}({this.Property}, {this.Entity})";
 
-        /// <summary>
-        /// Get the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
-            var expressions = new List<Expression> { base.GetExpression() };
+            var expressions = new List<Expression> { base.CreateExpression() };
             if (this.Property != null)
             {
                 expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.property == '{this.Property}'"));

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseIntent.cs
@@ -46,20 +46,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public List<string> Intents { get; set; } = new List<string>();
 #pragma warning restore CA2227 // Collection properties should be read only
 
-        /// <summary>
-        /// Get the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // add constraints for the intents property if set
             if (this.Intents?.Any() == true)
             {
                 var constraints = this.Intents.Select(subIntent => Expression.Parse($"contains(jPath({TurnPath.Recognized}, '$.candidates[*].intent'), '{subIntent}')"));
-                return Expression.AndExpression(base.GetExpression(), Expression.AndExpression(constraints.ToArray()));
+                return Expression.AndExpression(base.CreateExpression(), Expression.AndExpression(constraints.ToArray()));
             }
 
-            return base.GetExpression();
+            return base.CreateExpression();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseProperty.cs
@@ -65,13 +65,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public override string GetIdentity()
             => $"{this.GetType().Name}([{string.Join(",", this.Properties)}], {this.Entities})";
 
-        /// <summary>
-        /// Get the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
-            var expressions = new List<Expression> { base.GetExpression() };
+            var expressions = new List<Expression> { base.CreateExpression() };
             foreach (var property in this.Properties)
             {
                 expressions.Add(Expression.Parse($"contains(foreach({TurnPath.DialogEvent}.value, mapping, mapping.property), '{property}')"));

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnContinueConversation.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnContinueConversation.cs
@@ -30,17 +30,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public OnContinueConversation(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(actions, condition, callerPath, callerLine)
         {
-            this.RegisterSourceLocation(callerPath, callerLine);
         }
 
-        /// <summary>
-        /// Gets the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // add constraints for activity type
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.name == 'ContinueConversation'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.name == 'ContinueConversation'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnDialogEvent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnDialogEvent.cs
@@ -52,13 +52,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return $"{this.GetType().Name}({this.Event})";
         }
 
-        /// <summary>
-        /// Gets the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
-            return Expression.AndExpression(Expression.Parse($"{TurnPath.DialogEvent}.name == '{this.Event}'"), base.GetExpression());
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.DialogEvent}.name == '{this.Event}'"), base.CreateExpression());
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnIntent.cs
@@ -73,11 +73,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             return $"{this.GetType().Name}({this.Intent})[{string.Join(",", this.Entities)}]";
         }
 
-        /// <summary>
-        /// Gets the expression for this rule.
-        /// </summary>
-        /// <returns>Expression which will be cached and used to evaluate this rule.</returns>
-        public override Expression GetExpression()
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
         {
             // add constraints for the intents property
             if (string.IsNullOrEmpty(this.Intent))
@@ -103,7 +100,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                     }).ToArray()));
             }
 
-            return Expression.AndExpression(intentExpression, base.GetExpression());
+            return Expression.AndExpression(intentExpression, base.CreateExpression());
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Schema;
@@ -19,7 +23,46 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(ConditionalsTests));
         }
-        
+
+        [Fact]
+        public void ConditionalsTests_VerifyGetExpression()
+        {
+            var conditions = new List<OnCondition>()
+            {
+                new OnActivity(),
+                new OnConversationUpdateActivity(),
+                new OnEndOfConversationActivity(),
+                new OnEventActivity(),
+                new OnHandoffActivity(),
+                new OnInstallationUpdateActivity(),
+                new OnInvokeActivity(),
+                new OnMessageActivity(),
+                new OnMessageDeleteActivity(),
+                new OnMessageReactionActivity(),
+                new OnMessageUpdateActivity(),
+                new OnTypingActivity(),
+                new OnAssignEntity(),
+                new OnBeginDialog(),
+                new OnCancelDialog(),
+                new OnChooseEntity(),
+                new OnChooseIntent(),
+                new OnChooseProperty(),
+                new OnCondition(),
+                new OnContinueConversation(),
+                new OnDialogEvent(),
+                new OnEndOfActions(),
+                new OnError(),
+                new OnIntent() { Intent = "test" },
+                new OnQnAMatch(),
+                new OnRepromptDialog(),
+                new OnUnknownIntent(),
+            };
+            foreach (var condition in conditions)
+            {
+                Assert.Equal(condition.GetExpression(), condition.GetExpression());
+            }
+        }
+
         [Fact]
         public async Task ConditionalsTests_OnIntent()
         {


### PR DESCRIPTION
From: https://github.com/microsoft/botbuilder-dotnet/pull/4935

causing constant expression.Parse calls (#4935)

* GetExpression() was only caching the root expresion parsing, all child conditions which overrode GetExpression() were callin Expression.Parse() on EVERY call, causing us to parse and allocate Expression obejcts every time someone asked for the expression.  This creates a  huge overhead for evaluating triggers.  This was an architectural regression introduced in refactoring in 2019 via commit fe543724, and fixes the problem by having GetExpression() clearly documented as returning a CACHED expression, and moving all creation logic to protected virtual method CreateExpression().  This should be backward compatible with classes which do override this method but there shouldn't be because custom triggers is not something our community has been active in.

* add unit test

* double registerSourceLocation causes exception in OnContinueConversation

* Fix unit test