### PR TITLE
[#4022] Throwing Generic Exceptions - LanguageGeneration

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels
             var result = exp.TryEvaluate(DialogContext.State);
             if (!string.IsNullOrEmpty(result.error))
             {
-                throw new ArgumentException(result.error);
+                throw new InvalidOperationException(result.error);
             }
 
             return result.value;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/CodeModels/CodePoint.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.CodeModels
             var result = exp.TryEvaluate(DialogContext.State);
             if (!string.IsNullOrEmpty(result.error))
             {
-                throw new Exception(result.error);
+                throw new ArgumentException(result.error);
             }
 
             return result.value;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                     };
                 }
 
-                throw new Exception($"{id} error: {err.Message}\n{err.InnerException?.Message}", err);
+                throw new InvalidOperationException($"{id} error: {err.Message}\n{err.InnerException?.Message}", err);
             }
         }
 
@@ -336,7 +336,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
 
             if (result == null)
             {
-                throw new Exception($"Factory registration for name {kind} resulted in type {built.GetType()}, but expected assignable to {typeof(T)}");
+                throw new ArgumentException($"Factory registration for name {kind} resulted in type {built.GetType()}, but expected assignable to {typeof(T)}");
             }
 
             return result;

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Analyzer.cs
@@ -53,12 +53,12 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             if (!_templateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             if (_evaluationTargetStack.Any(e => e.TemplateName == templateName))
             {
-                throw new Exception($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
+                throw new InvalidOperationException($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
             }
 
             // Using a stack to track the evaluation trace

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (!TemplateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             var templateTarget = new EvaluationTarget(templateName, memory);
@@ -92,7 +92,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (_evaluationTargetStack.Any(e => e.GetId() == currentEvaluateId))
             {
-                throw new Exception($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
+                throw new InvalidOperationException($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
             }
 
             object result = null;
@@ -329,7 +329,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (!TemplateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             var parameters = TemplateMap[templateName].Parameters;
@@ -347,7 +347,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var memory = currentScope as CustomizedMemory;
             if (memory == null)
             {
-                throw new Exception(TemplateErrors.InvalidMemory);
+                throw new InvalidOperationException(TemplateErrors.InvalidMemory);
             }
 
             // inherit current memory's global scope
@@ -392,7 +392,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 errorMsg = ConcatErrorMsg(errorMsg, TemplateErrors.ErrorExpression(lineContent, templateName, errorPrefix));
             }
 
-            throw new Exception(ConcatErrorMsg(childErrorMsg, errorMsg));
+            throw new InvalidOperationException(ConcatErrorMsg(childErrorMsg, errorMsg));
         }
 
         private object VisitStructureValue(LGTemplateParser.KeyValueStructureLineContext context)
@@ -692,7 +692,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
             {
-                throw new Exception(TemplateErrors.InvalidTemplateNameType);
+                throw new InvalidOperationException(TemplateErrors.InvalidTemplateNameType);
             }
 
             // Validate more if the name is string constant
@@ -719,7 +719,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             if (!this.TemplateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count;
@@ -727,7 +727,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (actualArgsCount != 0 && expectedArgsCount != actualArgsCount)
             {
-                throw new Exception(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
+                throw new ArgumentException(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Events/ExpressionRef.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Events/ExpressionRef.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             if (SourceRange == null)
             {
-                throw new Exception("Source range is empty.");
+                throw new InvalidOperationException("Source range is empty.");
             }
 
             return SourceRange.Source + ":" + SourceRange.Range + ":" + Expression;

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (!TemplateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             var templateTarget = new EvaluationTarget(templateName, memory);
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (_evaluationTargetStack.Any(e => e.GetId() == currentEvaluateId))
             {
-                throw new Exception($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
+                throw new InvalidOperationException($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
             }
 
             // Using a stack to track the evaluation trace
@@ -613,7 +613,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if ((children0.ReturnType & ReturnType.Object) == 0 && (children0.ReturnType & ReturnType.String) == 0)
             {
-                throw new Exception(TemplateErrors.InvalidTemplateNameType);
+                throw new InvalidOperationException(TemplateErrors.InvalidTemplateNameType);
             }
 
             // Validate more if the name is string constant
@@ -630,7 +630,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (!this.TemplateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count;
@@ -638,7 +638,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (expectedArgsCount != actualArgsCount)
             {
-                throw new Exception(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
+                throw new ArgumentException(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
             }
         }
 
@@ -668,7 +668,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         {
             if (!this.TemplateMap.ContainsKey(templateName))
             {
-                throw new Exception(TemplateErrors.TemplateNotExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateNotExist(templateName));
             }
 
             var expectedArgsCount = this.TemplateMap[templateName].Parameters.Count;
@@ -676,7 +676,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (actualArgsCount != 0 && expectedArgsCount != actualArgsCount)
             {
-                throw new Exception(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
+                throw new ArgumentException(TemplateErrors.ArgumentMismatch(templateName, expectedArgsCount, actualArgsCount));
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/MultiLanguageLG.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (fallbackLocales.Count == 0)
             {
-                throw new Exception($"No supported language found for {locale}");
+                throw new ArgumentException($"No supported language found for {locale}");
             }
 
             foreach (var fallbackLocale in fallbackLocales)
@@ -98,7 +98,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 }
             }
 
-            throw new Exception($"No LG responses found for locale: {locale}");
+            throw new ArgumentException($"No LG responses found for locale: {locale}");
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Templates.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
             var template = this.FirstOrDefault(u => u.Name == templateName);
             if (template != null)
             {
-                throw new Exception(TemplateErrors.TemplateExist(templateName));
+                throw new ArgumentException(TemplateErrors.TemplateExist(templateName));
             }
 
             ClearDiagnostics();
@@ -563,7 +563,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             if (startLine < 0 || startLine > stopLine || stopLine >= originList.Length)
             {
-                throw new Exception("index out of range.");
+                throw new ArgumentException("index out of range.");
             }
 
             var destList = new List<string>();
@@ -620,7 +620,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var errors = AllDiagnostics.Where(u => u.Severity == DiagnosticSeverity.Error);
                 if (errors.Any())
                 {
-                    throw new Exception(string.Join(_newLine, errors));
+                    throw new InvalidOperationException(string.Join(_newLine, errors));
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
+++ b/libraries/Microsoft.Bot.Configuration/BotConfiguration.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Bot.Configuration
             }
             else if (this.Services.Where(s => s.Type == newService.Type && s.Id == newService.Id).Any())
             {
-                throw new Exception($"service with {newService.Id} is already connected");
+                throw new InvalidOperationException($"service with {newService.Id} is already connected");
             }
 
             this.Services.Add(newService);
@@ -388,7 +388,7 @@ namespace Microsoft.Bot.Configuration
             var service = this.FindServiceByNameOrId(nameOrId);
             if (service == null)
             {
-                throw new Exception($"a service with id or name of[{nameOrId}] was not found");
+                throw new ArgumentException($"a service with id or name of[{nameOrId}] was not found");
             }
 
             this.Services.Remove(service);
@@ -413,7 +413,7 @@ namespace Microsoft.Bot.Configuration
             var service = this.FindServiceByNameOrId<T>(nameOrId);
             if (service == null)
             {
-                throw new Exception($"a service with id or name of[{nameOrId}] was not found");
+                throw new ArgumentException($"a service with id or name of[{nameOrId}] was not found");
             }
 
             this.Services.Remove(service);
@@ -446,7 +446,7 @@ namespace Microsoft.Bot.Configuration
         {
             if (secret?.Length == null)
             {
-                throw new Exception("You are attempting to perform an operation which needs access to the secret and --secret is missing");
+                throw new InvalidOperationException("You are attempting to perform an operation which needs access to the secret and --secret is missing");
             }
 
             try
@@ -464,7 +464,7 @@ namespace Microsoft.Bot.Configuration
             }
             catch
             {
-                throw new Exception("You are attempting to perform an operation which needs access to the secret and --secret is incorrect.");
+                throw new InvalidOperationException("You are attempting to perform an operation which needs access to the secret and --secret is incorrect.");
             }
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 }
                 else
                 {
-                    throw new Exception($"Invalid channel auth tenant: {value}");
+                    throw new ArgumentException($"Invalid channel auth tenant: {value}");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Bot.Connector.Authentication
             {
                 if (!documentResponse.IsSuccessStatusCode)
                 {
-                    throw new Exception($"An non-success status code of {documentResponse.StatusCode} was received while fetching the endorsements document.");
+                    throw new InvalidOperationException($"An non-success status code of {documentResponse.StatusCode} was received while fetching the endorsements document.");
                 }
 
                 var json = await documentResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -147,7 +147,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 {
                     if (!keysResponse.IsSuccessStatusCode)
                     {
-                        throw new Exception($"An non-success status code of {keysResponse.StatusCode} was received while fetching the web key set document.");
+                        throw new InvalidOperationException($"An non-success status code of {keysResponse.StatusCode} was received while fetching the web key set document.");
                     }
 
                     return await keysResponse.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/LUResource.cs
+++ b/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/LUResource.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Bot.Builder.Parsers.LU
                     return SectionType.QnaSection;
             }
 
-            throw new Exception("Cannot unmarshal type SectionType");
+            throw new InvalidOperationException("Cannot unmarshal type SectionType");
         }
 
         public override void WriteJson(JsonWriter writer, object untypedValue, JsonSerializer serializer)
@@ -309,7 +309,7 @@ namespace Microsoft.Bot.Builder.Parsers.LU
                     return;
             }
 
-            throw new Exception("Cannot marshal type EntitySectionType");
+            throw new InvalidOperationException("Cannot marshal type EntitySectionType");
         }
     }
 
@@ -351,7 +351,7 @@ namespace Microsoft.Bot.Builder.Parsers.LU
                     return TypeEnum.MachineLearned;
             }
 
-            throw new Exception("Cannot unmarshal type TypeEnum");
+            throw new InvalidOperationException("Cannot unmarshal type TypeEnum");
         }
 
         public override void WriteJson(JsonWriter writer, object untypedValue, JsonSerializer serializer)
@@ -397,7 +397,7 @@ namespace Microsoft.Bot.Builder.Parsers.LU
                     return;
             }
 
-            throw new Exception("Cannot marshal type TypeEnum");
+            throw new InvalidOperationException("Cannot marshal type TypeEnum");
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var context = GetDialogContext(string.Empty);
             var lg = new TemplateEngineLanguageGenerator();
-            await Assert.ThrowsAsync<Exception>(() => lg.GenerateAsync(context, "${tesdfdfsst()}", null));
+            await Assert.ThrowsAsync<InvalidOperationException>(() => lg.GenerateAsync(context, "${tesdfdfsst()}", null));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -267,13 +267,13 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestLoopDetected()
         {
             var lgFile = GetTemplates("LoopDetected.lg");
-            var exception = Assert.Throws<Exception>(() => lgFile.Evaluate("wPhrase"));
+            var exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("wPhrase"));
             Assert.Contains(TemplateErrors.LoopDetected, exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.AnalyzeTemplate("wPhrase"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.AnalyzeTemplate("wPhrase"));
             Assert.Contains(TemplateErrors.LoopDetected, exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.AnalyzeTemplate("shouldFail"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.AnalyzeTemplate("shouldFail"));
             Assert.Contains(TemplateErrors.LoopDetected, exception.Message);
         }
 
@@ -289,7 +289,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestErrorExpression()
         {
             var lgFile = GetTemplates("ErrorExpression.lg");
-            var exception = Assert.Throws<Exception>(() => lgFile.Evaluate("template1"));
+            var exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("template1"));
             Assert.Contains("Error occurred when evaluating", exception.Message);
         }
 
@@ -298,34 +298,34 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var lgFile = GetTemplates("RunTimeErrors.lg");
 
-            var exception = Assert.Throws<Exception>(() => lgFile.Evaluate("template1"));
+            var exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("template1"));
             Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("prebuilt1"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("prebuilt1"));
             Assert.Equal("'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("template2"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("template2"));
             Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("conditionalTemplate1", new { dialog = true }));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("conditionalTemplate1", new { dialog = true }));
             Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("conditionalTemplate2"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("conditionalTemplate2"));
             Assert.Equal("'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("structured1"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("structured1"));
             Assert.Equal("'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("structured2"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("structured2"));
             Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("structured3"));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("structured3"));
             Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("switchcase1", new { turn = new { testValue = 1 } }));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("switchcase1", new { turn = new { testValue = 1 } }));
             Assert.Equal("'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
 
-            exception = Assert.Throws<Exception>(() => lgFile.Evaluate("switchcase2", new { turn = new { testValue = 0 } }));
+            exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("switchcase2", new { turn = new { testValue = 0 } }));
             Assert.Equal("'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
         }
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -1475,7 +1475,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var options = new List<string> { "Hi", "Hello", "Hiya" };
             Assert.True(options.Contains(evaled), $"The result `{evaled}` is not in those options [{string.Join(",", options)}]");
 
-            var exception = Assert.Throws<Exception>(() => templates.EvaluateText("${ErrrorTemplate()}"));
+            var exception = Assert.Throws<InvalidOperationException>(() => templates.EvaluateText("${ErrrorTemplate()}"));
             Assert.Contains("it's not a built-in function or a custom function", exception.Message);
         }
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -766,7 +766,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             templates = Templates.ParseFile(GetExampleFilePath("EvaluationOptions/StrictModeTrue.lg"));
 
-            var exception = Assert.Throws<Exception>(() => templates.ExpandTemplate("StrictTrue"));
+            var exception = Assert.Throws<InvalidOperationException>(() => templates.ExpandTemplate("StrictTrue"));
             Assert.Contains("'variable_not_defined' evaluated to null. [StrictTrue]  Error occurred when evaluating '-${variable_not_defined}'", exception.Message);
         }
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -941,7 +941,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal(17, newTemplate.SourceRange.Range.End.Line);
 
             // add an exist template
-            var exception = Assert.Throws<Exception>(() => templates.AddTemplate("newtemplate", null, "- hi2 "));
+            var exception = Assert.Throws<ArgumentException>(() => templates.AddTemplate("newtemplate", null, "- hi2 "));
             Assert.Equal(TemplateErrors.TemplateExist("newtemplate"), exception.Message);
         }
 

--- a/tests/Microsoft.Bot.Configuration.Tests/ConfigurationLoadAndSaveTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ConfigurationLoadAndSaveTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Configuration.Tests
         [Fact]
         public async Task FailLoadFromFolderWithNoSecret()
         {
-            await Assert.ThrowsAsync<Exception>(async () =>
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 var secret = BotConfiguration.GenerateKey();
                 var config = await BotConfiguration.LoadAsync(testBotFileName);


### PR DESCRIPTION
Addresses #4022

## Description

This PR replaces all 39 generic exceptions found within the libraries `Dialogs.Debugging`, `Dialogs.Declarative`, `LanguageGeneration`, `Configuration`, `Connector`, and `Parsers.LU` with proper exceptions according to the [Standard Exception Types](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/using-standard-exception-types).

## Specific Changes

- Replaces all 39 generic exceptions within:
  - libraries\Microsoft.Bot.Builder.Dialogs.Debugging\
  - libraries\Microsoft.Bot.Builder.Dialogs.Declarative\
  - libraries\Microsoft.Bot.Builder.LanguageGeneration\
  - libraries\Microsoft.Bot.Configuration\
  - libraries\Microsoft.Bot.Connector\
  - libraries\Parsers\Microsoft.Bot.Builder.Parsers.LU\
- Updates test `ConfigurationLoadAndSaveTests`, `TemplatesTest`, `TemplateDiagnosticTest`, and `LGGeneratorTests` to comply with the changes

## Testing
Here's a screenshot of the tests for these files working correctly with the changes applied:
![image](https://user-images.githubusercontent.com/64803884/98715509-06f21a00-2369-11eb-9ade-14af651a5ffa.png)