### PR TITLE
[#4022] Throwing Generic Exceptions - Dialogs Adaptive Testing

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertNoActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertNoActivity.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         {
             if (adapter.ActiveQueue.Count > 0)
             {
-                throw new InvalidOperationException($"{GetConditionDescription()}");
+                throw new ArgumentException($"{GetConditionDescription()}");
             }
 
             return Task.CompletedTask;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertNoActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertNoActivity.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         {
             if (adapter.ActiveQueue.Count > 0)
             {
-                throw new Exception($"{GetConditionDescription()}");
+                throw new InvalidOperationException($"{GetConditionDescription()}");
             }
 
             return Task.CompletedTask;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReply.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReply.cs
@@ -58,21 +58,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 var error = $"{description}Text '{text}' didn't match expected text: '{Text}'";
                 if (text == null)
                 {
-                    throw new Exception(error);
+                    throw new InvalidOperationException(error);
                 }
                 else if (Exact)
                 {
                     // Normalize line endings to work on windows and mac
                     if (text.Replace("\r", string.Empty) != Text.Replace("\r", string.Empty))
                     {
-                        throw new Exception(error);
+                        throw new InvalidOperationException(error);
                     }
                 }
                 else
                 {
                     if (text.ToLowerInvariant().Trim().Contains(Text.ToLowerInvariant().Trim()) == false)
                     {
-                        throw new Exception(error);
+                        throw new InvalidOperationException(error);
                     }
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyActivity.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 var (result, error) = Expression.Parse(assertion).TryEvaluate<bool>(activity);
                 if (result != true)
                 {
-                    throw new Exception($"{Description} {assertion}\n{JsonConvert.SerializeObject(activity, Formatting.Indented)}");
+                    throw new InvalidOperationException($"{Description} {assertion}\n{JsonConvert.SerializeObject(activity, Formatting.Indented)}");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyOneOf.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyOneOf.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 
             if (!found)
             {
-                throw new Exception(Description ?? $"Text {activity.Text} didn't match one of expected text: {string.Join("\n", Text)}");
+                throw new InvalidOperationException(Description ?? $"Text {activity.Text} didn't match one of expected text: {string.Join("\n", Text)}");
             }
 
             base.ValidateReply(activity);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/CustomEvent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/CustomEvent.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         {
             if (Name == null)
             {
-                throw new Exception("You must define the event name.");
+                throw new InvalidOperationException("You must define the event name.");
             }
 
             var eventActivity = adapter.MakeActivity();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/MemoryAssertions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/MemoryAssertions.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                             var (val, error) = Expression.Parse(assertion).TryEvaluate<bool>(dc.State);
                             if (error != null || !val)
                             {
-                                throw new Exception($"{Description} {assertion} failed");
+                                throw new InvalidOperationException($"{Description} {assertion} failed");
                             }
                         }
                     }).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/SetProperties.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
             }
             else
             {
-                throw new Exception("No inspector to use for setting properties");
+                throw new InvalidOperationException("No inspector to use for setting properties");
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         {
             if (Activity == null)
             {
-                throw new Exception("You must define one of Text or Activity properties");
+                throw new InvalidOperationException("You must define one of Text or Activity properties");
             }
 
             var activity = ObjectPath.Clone(Activity);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserSays.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserSays.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         {
             if (Text == null)
             {
-                throw new Exception("You must define the Text property");
+                throw new InvalidOperationException("You must define the Text property");
             }
 
             var activity = adapter.MakeActivity(Text);


### PR DESCRIPTION
Fixes #4022

## Description
This PR replaces all generic exceptions found within `Dialogs.Adaptive.Testing\TestActions`.

## Specific Changes

- Replaces all generic exceptions within:
  - libraries\Microsoft.Bot.Builder.Dialogs.Adaptive.Testing\TestActions

## Testing
No test coverage for these files.