### PR TITLE
Streaming fixes

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
@@ -324,6 +324,11 @@ namespace Microsoft.Bot.Builder.Streaming
         /// <param name="activity">The incoming activity to be processed by a <see cref="StreamingRequestHandler"/>.</param>
         private string GetAudienceFromCallerId(Activity activity)
         {
+            if (string.IsNullOrEmpty(activity.CallerId))
+            {
+                return null;
+            }
+
             switch (activity.CallerId)
             {
                 case CallerIdConstants.PublicAzureChannel:

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -241,6 +241,14 @@ namespace Microsoft.Bot.Builder.Streaming
             try
             {
                 var activity = JsonConvert.DeserializeObject<Activity>(body, SerializationSettings.DefaultDeserializationSettings);
+                var conversationId = activity?.Conversation?.Id;
+
+                // An Activity with Conversation.Id is required.
+                if (activity == null || string.IsNullOrEmpty(conversationId))
+                {
+                    response.StatusCode = (int)HttpStatusCode.BadRequest;
+                    return response;
+                }
 
                 // All activities received by this StreamingRequestHandler will originate from the same channel, but we won't
                 // know what that channel is until we've received the first request.
@@ -251,11 +259,11 @@ namespace Microsoft.Bot.Builder.Streaming
 
                 // If this is the first time the handler has seen this conversation it needs to be added to the dictionary so the
                 // adapter is able to route requests to the correct handler.
-                if (!HasConversation(activity.Conversation.Id))
+                if (!HasConversation(conversationId))
                 {
                     // Ignore the result, since the goal is simply to ensure the Conversation.Id is in _conversations.
                     // If some other thread added it already, does not matter.
-                    _conversations.TryAdd(activity.Conversation.Id, DateTime.Now);
+                    _conversations.TryAdd(conversationId, DateTime.Now);
                 }
 
                 /*

--- a/libraries/Microsoft.Bot.Streaming/ReceiveRequestExtensions.cs
+++ b/libraries/Microsoft.Bot.Streaming/ReceiveRequestExtensions.cs
@@ -76,18 +76,18 @@ namespace Microsoft.Bot.Streaming
         /// <returns>On success, a string populated with data read from the <see cref="ReceiveRequest"/> body.
         /// Otherwise null.
         /// </returns>
-        public static Task<string> ReadBodyAsStringAsync(this ReceiveRequest request)
+        public static async Task<string> ReadBodyAsStringAsync(this ReceiveRequest request)
         {
             var contentStream = request.Streams.FirstOrDefault();
 
             if (contentStream == null)
             {
-                return Task.FromResult(string.Empty);
+                return string.Empty;
             }
 
             using (var reader = new StreamReader(contentStream.Stream, Encoding.UTF8))
             {
-                return reader.ReadToEndAsync();
+                return await reader.ReadToEndAsync().ConfigureAwait(false);
             }
         }
     }

--- a/tests/Microsoft.Bot.Streaming.Tests/StreamingRequestHandlerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/StreamingRequestHandlerTests.cs
@@ -156,6 +156,28 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
+        public async void DoesNotThrowExceptionIfReceiveRequestHasNoActivity()
+        {
+            // Arrange
+            var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
+            
+            var payload = new MemoryStream();
+            var fakeContentStreamId = Guid.NewGuid();
+            var fakeContentStream = new FakeContentStream(fakeContentStreamId, "application/json", payload);
+            var testRequest = new ReceiveRequest
+            {
+                Verb = "POST",
+            };
+            testRequest.Streams.Add(fakeContentStream);
+
+            // Act
+            var response = await handler.ProcessRequestAsync(testRequest);
+
+            // Assert
+            Assert.Equal(400, response.StatusCode);
+        }
+
+        [Fact]
         public async void RequestHandlerRemembersConversations()
         {
             // Arrange
@@ -302,7 +324,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
             // Assert
             Assert.Matches(expectation, response.Streams[0].Content.ReadAsStringAsync().Result);
         }
-
+        
         public class FauxSock : WebSocket
         {
             public override WebSocketCloseStatus? CloseStatus => throw new NotImplementedException();


### PR DESCRIPTION
Fixes: Return BadRequest if an Activity is not present https://github.com/microsoft/botbuilder-dotnet/issues/4958

Do not throw if callerid is null

await ReadToEndAsync within ReadBotyAsStringAsync