### PR TITLE
Return unrecognized state instead of throwing exceptions for non-string input of TextInput action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -47,8 +47,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
         protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var input = dc.State.GetValue<string>(VALUE_PROPERTY);
-
+            var input = dc.State.GetValue<object>(VALUE_PROPERTY);
+            if (!(input is string strInput))
+            {
+                return Task.FromResult(InputState.Unrecognized);
+            }
+            
             if (this.OutputFormat != null)
             {
                 var (outputValue, error) = this.OutputFormat.TryGetValue(dc.State);
@@ -57,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     if (!string.IsNullOrWhiteSpace(outputValue))
                     {
                         // if the result is null or empty string, ignore it.
-                        input = outputValue.ToString();
+                        strInput = outputValue.ToString();
                     }
                 }
                 else
@@ -66,8 +70,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 }
             }
 
-            dc.State.SetValue(VALUE_PROPERTY, input);
-            return input.Length > 0 ? Task.FromResult(InputState.Valid) : Task.FromResult(InputState.Unrecognized);
+            dc.State.SetValue(VALUE_PROPERTY, strInput);
+            return strInput.Length > 0 ? Task.FromResult(InputState.Valid) : Task.FromResult(InputState.Unrecognized);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/TextInput.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             var input = dc.State.GetValue<object>(VALUE_PROPERTY);
             if (!(input is string strInput))
             {
-                return Task.FromResult(InputState.Unrecognized);
+                return Task.FromResult(InputState.Invalid);
             }
             
             if (this.OutputFormat != null)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -336,6 +336,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_TextInputWithNonStringInput()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_TextInputWithValueExpression()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInputWithNonStringInput.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInputWithNonStringInput.test.dialog
@@ -27,6 +27,7 @@
                                 "property": "user.name",
                                 "prompt": "Hello, what is your name?",
                                 "unrecognizedPrompt": "How should I call you?",
+                                "invalidPrompt": "That does not soud like a name",
                                 "value": "=json(`{'foo': '$firstName','item': '$lastName'}`)"
                             }
                         ]
@@ -44,7 +45,7 @@
         },
         {
             "$kind": "Microsoft.Test.AssertReply",
-            "text": "How should I call you?"
+            "text": "That does not soud like a name"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInputWithNonStringInput.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInputWithNonStringInput.test.dialog
@@ -1,0 +1,50 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.firstName",
+                        "value": "lu"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.lastName",
+                        "value": "han"
+                    },
+                    {
+                        "$kind": "Microsoft.IfCondition",
+                        "condition": "(user.name == null)",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.TextInput",
+                                "property": "user.name",
+                                "prompt": "Hello, what is your name?",
+                                "unrecognizedPrompt": "How should I call you?",
+                                "value": "=json(`{'foo': '$firstName','item': '$lastName'}`)"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "How should I call you?"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #4948 
## Description
In adaptive dialog, TextInput action only accept string values, but in some cases, non-string values such as objects will be passed into TextInput action, in such cases, it will throw exceptions instead of throw invalid prompt to users for a valid input. This is not friendly. In this fix, we added the validation of string format for all values and if it's value is not string, it will go into invalid state instead of throwing exceptions. 

## Specific Changes
  - TextInput.cs

## Testing
Test cases added