### PR TITLE
Added GetConversationReference/ContinueConversation actions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversation.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversation.cs
@@ -1,0 +1,99 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
+{
+    /// <summary>
+    /// Action which continues a conversation using a Conversation reference.
+    /// </summary>
+    /// <remarks>
+    /// This action works by writing an EventActivity(Name=ContinueConversation) to an StorageQueue stamped with the 
+    /// routing information from the provided ConversationReference. 
+    /// 
+    /// The queue needs a process (such as a webjob/azure function) pulling activites from the StorageQueue and processing them by 
+    /// calling adapter.ProcessActivity(activity, ...); 
+    /// 
+    /// NOTE: In the case of multiple adapters this webjob/function should inspect the activity.channelId 
+    /// to properly route the activity to the appropriate adapter. 
+    /// 
+    /// This dialog returns the receipt information for the queued activity as the result of the dialog.
+    /// <seealso cref="ContinueConversationLater"/>
+    /// </remarks>
+    public class ContinueConversation : Dialog
+    {
+        /// <summary>
+        /// The Kind name for this dialog.
+        /// </summary>
+        [JsonProperty("$kind")]
+        public const string Kind = "Microsoft.ContinueConversation";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContinueConversation"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        public ContinueConversation([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        {
+            this.RegisterSourceLocation(callerPath, callerLine);
+        }
+
+        /// <summary>
+        /// Gets or sets an optional expression which if is true will disable this action.
+        /// </summary>
+        /// <value>
+        /// A boolean expression. 
+        /// </value>
+        [JsonProperty("disabled")]
+        public BoolExpression Disabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the conversationReference for the target conversation.
+        /// </summary>
+        /// <value>
+        /// The conversation reference data structure which is needed to switch to a conversation.
+        /// </value>
+        [JsonProperty("conversationReference")]
+        public ObjectExpression<ConversationReference> ConversationReference { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional value to use for EventActivity.Value.
+        /// </summary>
+        /// <value>
+        /// The value to use for the EventActivity.Value payload.
+        /// </value>
+        [JsonProperty("value")]
+        public ValueExpression Value { get; set; }
+
+        /// <inheritdoc/>
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object opts = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (opts != null)
+            {
+                throw new NotSupportedException($"{nameof(opts)} is not supported by this action.");
+            }
+
+            if (this.Disabled != null && this.Disabled.GetValue(dc.State) == true)
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            var conversationReference = this.ConversationReference.GetValue(dc.State);
+            var continuationActivity = conversationReference.GetContinuationActivity();
+            continuationActivity.Value = Value.GetValue(dc.State);
+
+            var queueStorage = dc.Context.TurnState.Get<QueueStorage>() ?? throw new NullReferenceException("Unable to locate QueueStorage in HostContext");
+            var receipt = await queueStorage.QueueActivityAsync(continuationActivity, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            // return the receipt as the result.
+            return await dc.EndDialogAsync(result: receipt, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversation.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversation.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// Action which continues a conversation using a Conversation reference.
     /// </summary>
     /// <remarks>
-    /// This action works by writing an EventActivity(Name=ContinueConversation) to an StorageQueue stamped with the 
+    /// This action works by writing an EventActivity(Name=ContinueConversation) to a StorageQueue stamped with the 
     /// routing information from the provided ConversationReference. 
     /// 
     /// The queue needs a process (such as a webjob/azure function) pulling activites from the StorageQueue and processing them by 
@@ -40,13 +40,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// </summary>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
         public ContinueConversation([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
             this.RegisterSourceLocation(callerPath, callerLine);
         }
 
         /// <summary>
-        /// Gets or sets an optional expression which if is true will disable this action.
+        /// Gets or sets an optional expression which if true will disable this action.
         /// </summary>
         /// <value>
         /// A boolean expression. 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversationLater.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversationLater.cs
@@ -11,19 +11,20 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
     /// <summary>
-    /// Action which schedules a conversation to be continued later by writing an EventActivity(Name=ContinueConversation) to a queue.
+    /// Action which schedules the current conversation to be continued at a later time..
     /// </summary>
     /// <remarks>
-    /// This class works by writing an EventActivity(Name=ConversationUpdate) to an azure storage queue with visibility policy to 
-    /// make it visible at a future point in time. 
+    /// This action works by writing an EventActivity(Name=ContinueConversation) to an StorageQueue with same routing information 
+    /// as the current conversation reference, and with a visibility policy to make it visible at a future point in time. 
     /// 
-    /// The queue needs a process (such as a webjob/azure function) monitoring incoming activities and processing them by either:
-    ///   - posting the activity back to the bot itself via BotFrameworkHttpClient.PostActivityAsync(botId, botEndpoint, activity).
-    /// OR
-    ///   - processing the activity directly via adapter.ProcessActivity(activity, ...); 
-    ///     NOTE: adapter.ProcessActivity() understands that EventActivity(Name=ConversationUpdate) should be processed as ContinueConversation() pipeline.
+    /// The queue needs a process (such as a webjob/azure function) pulling activites from the StorageQueue and processing them by 
+    /// calling adapter.ProcessActivity(activity, ...); 
+    /// 
+    /// NOTE: In the case of multiple adapters this webjob/function should inspect the activity.channelId 
+    /// to properly route the activity to the appropriate adapter. 
     /// 
     /// This dialog returns the receipt information for the queued activity as the result of the dialog.
+    /// <seealso cref="ContinueConversation"/>
     /// </remarks>
     public class ContinueConversationLater : Dialog
     {
@@ -65,7 +66,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public StringExpression Date { get; set; }
 
         /// <summary>
-        /// Gets or sets the value to pass in the EventActivity.Value payload. 
+        /// Gets or sets an optional value to use for EventActivity.Value.
         /// </summary>
         /// <value>
         /// The value to use for the EventActivity.Value payload.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversationLater.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ContinueConversationLater.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
     /// Action which schedules the current conversation to be continued at a later time..
     /// </summary>
     /// <remarks>
-    /// This action works by writing an EventActivity(Name=ContinueConversation) to an StorageQueue with same routing information 
+    /// This action works by writing an EventActivity(Name=ContinueConversation) to a StorageQueue with same routing information 
     /// as the current conversation reference, and with a visibility policy to make it visible at a future point in time. 
     /// 
     /// The queue needs a process (such as a webjob/azure function) pulling activites from the StorageQueue and processing them by 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationReference.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationReference.cs
@@ -1,0 +1,95 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
+{
+    /// <summary>
+    /// Gets the current conversation reference and saves it to a memory property suitable to use in ContinueConversation action.
+    /// </summary>
+    public class GetConversationReference : Dialog
+    {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
+        [JsonProperty("$kind")]
+        public const string Kind = "Microsoft.GetConversationReference";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetConversationReference"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public GetConversationReference([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base()
+        {
+            this.RegisterSourceLocation(callerPath, callerLine);
+        }
+
+        /// <summary>
+        /// Gets or sets an optional expression which if is true will disable this action.
+        /// </summary>
+        /// <example>
+        /// "user.age > 18".
+        /// </example>
+        /// <value>
+        /// A boolean expression. 
+        /// </value>
+        [JsonProperty("disabled")]
+        public BoolExpression Disabled { get; set; } 
+
+        /// <summary>
+        /// Gets or sets property path to put the value in.
+        /// </summary>
+        /// <value>
+        /// Property path to put the value in.
+        /// </value>
+        [JsonProperty("property")]
+        public StringExpression Property { get; set; }
+
+        /// <summary>
+        /// Called when the dialog is started and pushed onto the dialog stack.
+        /// </summary>
+        /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
+        /// <param name="options">Optional, initial information to pass to the dialog.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (options is CancellationToken)
+            {
+                throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
+            }
+
+            if (this.Disabled != null && this.Disabled.GetValue(dc.State) == true)
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            var cr = dc.Context.Activity.GetConversationReference();
+            if (this.Property != null)
+            {
+                dc.State.SetValue(this.Property.GetValue(dc.State), cr);
+            }
+
+            return await dc.EndDialogAsync(result: cr, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Builds the compute Id for the dialog.
+        /// </summary>
+        /// <returns>A string representing the compute Id.</returns>
+        protected override string OnComputeId()
+        {
+            return $"{this.GetType().Name}[{this.Property?.ToString() ?? string.Empty}]";
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationReference.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationReference.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         }
 
         /// <summary>
-        /// Gets or sets an optional expression which if is true will disable this action.
+        /// Gets or sets an optional expression which if true will disable this action.
         /// </summary>
         /// <example>
-        /// "user.age > 18".
+        /// "user.age = 18".
         /// </example>
         /// <value>
         /// A boolean expression. 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new DeclarativeType<DeleteActivity>(DeleteActivity.Kind);
             yield return new DeclarativeType<GetActivityMembers>(GetActivityMembers.Kind);
             yield return new DeclarativeType<GetConversationMembers>(GetConversationMembers.Kind);
+            yield return new DeclarativeType<GetConversationReference>(GetConversationReference.Kind);
             yield return new DeclarativeType<SignOutUser>(SignOutUser.Kind);
             yield return new DeclarativeType<TelemetryTrackEventAction>(TelemetryTrackEventAction.Kind);
             yield return new DeclarativeType<ContinueConversation>(ContinueConversation.Kind);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -20,6 +20,7 @@ using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Converters;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Functions;
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
@@ -114,6 +115,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new DeclarativeType<GetConversationMembers>(GetConversationMembers.Kind);
             yield return new DeclarativeType<SignOutUser>(SignOutUser.Kind);
             yield return new DeclarativeType<TelemetryTrackEventAction>(TelemetryTrackEventAction.Kind);
+            yield return new DeclarativeType<ContinueConversation>(ContinueConversation.Kind);
+            yield return new DeclarativeType<ContinueConversationLater>(ContinueConversationLater.Kind);
 
             // Inputs
             yield return new DeclarativeType<AttachmentInput>(AttachmentInput.Kind);
@@ -211,6 +214,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new ObjectExpressionConverter<ChoiceSet>();
             yield return new ObjectExpressionConverter<ChoiceFactoryOptions>();
             yield return new ObjectExpressionConverter<FindChoicesOptions>();
+            yield return new ObjectExpressionConverter<ConversationReference>();
 
             yield return new ArrayExpressionConverter<string>();
             yield return new ArrayExpressionConverter<Choice>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -39,11 +39,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Schemas\Actions\Microsoft.ContinueConversation.schema" />
-    <None Remove="Schemas\Actions\Microsoft.GetConversationReference.schema" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -39,6 +39,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Schemas\Actions\Microsoft.ContinueConversation.schema" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.LanguageGeneration" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <None Remove="Schemas\Actions\Microsoft.ContinueConversation.schema" />
+    <None Remove="Schemas\Actions\Microsoft.GetConversationReference.schema" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueConversation.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueConversation.schema
@@ -1,11 +1,11 @@
 ﻿{
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": "implements(Microsoft.IDialog)",
-    "title": "Continue conversation later (Queue)",
-    "description": "Continue conversation at later time (via StorageQueue implementation).",
+    "title": "Continue conversation (Queue)",
+    "description": "Continue a specific conversation (via StorageQueue implementation).",
     "type": "object",
     "required": [
-        "date"
+        "conversationReference"
     ],
     "properties": {
         "id": {
@@ -21,12 +21,25 @@
                 "user.age > 3"
             ]
         },
-        "date": {
-            "$ref": "schema:#/definitions/stringExpression",
-            "title": "Date",
-            "description": "Date in the future as a ISO string when the conversation should continue.",
+        "conversationReference": {
+            "$ref": "schema:#/definitions/objectExpression",
+            "title": "Conversation Reference",
+            "description": "A conversation reference. (NOTE: Minimum required values or channelId, conversation).",
             "examples": [
-                "=addHours(utcNow(), 1)"
+                {
+                    "channelId": "skype",
+                    "serviceUrl": "http://smba.skype.com",
+                    "conversation": {
+                        "id": "11111"
+                    },
+                    "bot": {
+                        "id": "22222"
+                    },
+                    "user": {
+                        "id": "33333"
+                    },
+                    "locale": "en-us"
+                }
             ]
         },
         "value": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationReference.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationReference.schema
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+    "$role": "implements(Microsoft.IDialog)",
+    "title": "Get ConversationReference for current activity context.",
+    "description": "Gets the ConversationReference from current context and stores in property so it can be used to with ContinueConversation action.",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Optional id for the dialog"
+        },
+        "property": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "Property",
+            "description": "Property (named location to store information).",
+            "examples": [
+                "user.age"
+            ]
+        },
+        "disabled": {
+            "$ref": "schema:#/definitions/booleanExpression",
+            "title": "Disabled",
+            "description": "Optional condition which if true will disable this action.",
+            "examples": [
+                "user.age > 3"
+            ]
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationReference.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationReference.schema
@@ -1,8 +1,8 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": "implements(Microsoft.IDialog)",
-    "title": "Get ConversationReference for current activity context.",
-    "description": "Gets the ConversationReference from current context and stores in property so it can be used to with ContinueConversation action.",
+    "title": "Get ConversationReference",
+    "description": "Gets the ConversationReference from current context and stores it in property so it can be used to with ContinueConversation action.",
     "type": "object",
     "properties": {
         "id": {

--- a/libraries/Microsoft.Bot.Builder/QueueStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/QueueStorage.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder
     {
         /// <summary>
         /// Enqueues an Activity for later processing. The visibility timeout specifies how long the message should be invisible
-        /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
+        /// to Dequeue and Peek operations. 
         /// </summary>
         /// <param name="activity">The <see cref="Activity"/> to be queued for later processing.</param>
         /// <param name="visibilityTimeout"> Visibility timeout.  Optional with a default value of 0.  Cannot be larger than 7 days. </param>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ContinuationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ContinuationTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    public class ContinuationTests
+    {
+        [Fact]
+        public async Task ContinueConversationLaterTests()
+        {
+            var queueName = nameof(ContinueConversationLaterTests).ToLower();
+
+            var cr = TestAdapter.CreateConversation(nameof(ContinueConversationLaterTests));
+            var adapter = new TestAdapter(cr)
+                   .UseStorage(new MemoryStorage())
+                   .UseBotState(new ConversationState(new MemoryStorage()), new UserState(new MemoryStorage()));
+
+            var queueStorage = new MockQueue();
+            var dm = new DialogManager(new ContinueConversationLater()
+            {
+                Date = "=addSeconds(utcNow(), 2)",
+                Value = "foo"
+            });
+
+            dm.InitialTurnState.Set<QueueStorage>(queueStorage);
+
+            await new TestFlow((TestAdapter)adapter, dm.OnTurnAsync)
+                .Send("hi")
+                .StartTestAsync();
+            await Task.Delay(2000);
+            var activity = await queueStorage.ReceiveActivity();
+            Assert.Equal(ActivityTypes.Event, activity.Type);
+            Assert.Equal(ActivityEventNames.ContinueConversation, activity.Name);
+            Assert.Equal("foo", activity.Value);
+            Assert.NotNull(activity.RelatesTo);
+            var cr2 = activity.GetConversationReference();
+            cr.ActivityId = null;
+            cr2.ActivityId = null;
+            Assert.Equal(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
+        }
+
+        [Fact]
+        public async Task ContinueConversationTests()
+        {
+            var conv1 = $"{nameof(ContinueConversationTests)}1";
+            var conv2 = $"{nameof(ContinueConversationTests)}2";
+            var cr1 = TestAdapter.CreateConversation(conv1);
+            var cr2 = TestAdapter.CreateConversation(conv2);
+            var adapter = new TestAdapter(cr1)
+                   .UseStorage(new MemoryStorage())
+                   .UseBotState(new ConversationState(new MemoryStorage()), new UserState(new MemoryStorage()));
+
+            var queueStorage = new MockQueue();
+            var dm = new DialogManager(new AdaptiveDialog()
+            {
+                Triggers = new List<OnCondition>()
+                    {
+                        new OnMessageActivity()
+                        {
+                            Actions = new List<Dialog>()
+                            {
+                                new ContinueConversation()
+                                {
+                                    ConversationReference = cr2,
+                                    Value = "foo"
+                                },
+                                new SendActivity() { Activity = new ActivityTemplate("ContinueConversation Sent") }
+                            }
+                        }
+                    }
+            });
+
+            dm.InitialTurnState.Set<QueueStorage>(queueStorage);
+
+            await new TestFlow((TestAdapter)adapter, dm.OnTurnAsync)
+                .Send("hi")
+                    .AssertReply("ContinueConversation Sent")
+                .StartTestAsync();
+            var activity = await queueStorage.ReceiveActivity();
+            Assert.Equal(ActivityTypes.Event, activity.Type);
+            Assert.Equal(ActivityEventNames.ContinueConversation, activity.Name);
+            Assert.Equal("foo", activity.Value);
+            Assert.NotNull(activity.RelatesTo);
+            var crReceived = activity.GetConversationReference();
+            cr2.ActivityId = null;
+            crReceived.ActivityId = null;
+            Assert.Equal(JsonConvert.SerializeObject(cr2), JsonConvert.SerializeObject(crReceived));
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MockQueue.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MockQueue.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
+{
+    public class MockQueue : QueueStorage
+    {
+        private int receipt = 1;
+
+        private Queue<Activity> queue = new Queue<Activity>();
+
+        public override Task<string> QueueActivityAsync(Activity activity, TimeSpan? visibilityTimeout = null, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default)
+        {
+            if (visibilityTimeout != null)
+            {
+                Task.Delay(visibilityTimeout.Value).ContinueWith(t =>
+                {
+                    lock (queue)
+                    {
+                        queue.Enqueue(activity);
+                    }
+                });
+            }
+            else
+            {
+                lock (this.queue)
+                {
+                    queue.Enqueue(activity);
+                }
+            }
+
+            return Task.FromResult($"{receipt++}");
+        }
+
+        public async Task<Activity> ReceiveActivity()
+        {
+            while (true)
+            {
+                lock (queue)
+                {
+                    if (queue.Any())
+                    {
+                        return queue.Dequeue();
+                    }
+                }
+
+                await Task.Delay(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
We have **ContinueConversationLater** action which allows you to take the current conversation and schedule it for later, but we don't have the ability to continue a specific conversation later.  This delta adds that, and fixes comments and bugs discovered in the process of adding that 

If you want to have the current conversation continue an hour from now you use **ContinueConversationLater**.  This writes to an azure queue a message which will be processed in an hour, and when that happens **OnContinueConversation** trigger will fire.

This PR enables switching conversations.  Say you have 2 conversations, A and B.

A -> **GetConversationReference** captures a **ConversationReference(A)** that you can store in some shared state
B -> wants to continue that conversation, so gets the **ConversationReference(A)** from shared state and calls **ContinueConversation(ConversationReference(A)).**

Under the hood it uses the same mechanism, which is writing to the azure queue that then is processsed in the context of conversation A.

## Specific Changes
- added **ContinueConversation** action
- Added **GetConversationReference** action so you can capture the ConversationReference and save for later.
- Fixed missing registrations for ContinueConversationLater
- cleaned up comments


## Testing
- added mock StorageQueue
- changed ContinueConversationLater tests to use mock storageQueue
- added ContinueConversation test
- added GetConversationReference test

