### PR TITLE
Update branch 4.8 ESRP signing with new SHA 

### DIFF
--- a/build/yaml/sign-steps.yml
+++ b/build/yaml/sign-steps.yml
@@ -51,37 +51,41 @@ steps:
     signConfigType: inlineSignParams
     inlineOperation: |
      [
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolSign",
-             "parameters": [
-             {
-                 "parameterName": "OpusName",
-                 "parameterValue": "Microsoft"
-             },
-             {
-                 "parameterName": "OpusInfo",
-                 "parameterValue": "http://www.microsoft.com"
-             },
-             {
-                 "parameterName": "PageHash",
-                 "parameterValue": "/NPH"
-             },
-             {
-                 "parameterName": "TimeStamp",
-                 "parameterValue": "/t \"http://ts4096.gtm.microsoft.com/TSS/AuthenticodeTS\""
-             }
-             ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolVerify",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
+        {
+            "keyCode": "CP-230012",
+            "operationSetCode": "SigntoolSign",
+            "parameters": [
+            {
+                "parameterName": "OpusName",
+                "parameterValue": "Microsoft"
+            },
+            {
+                "parameterName": "OpusInfo",
+                "parameterValue": "http://www.microsoft.com"
+            },
+            {
+                "parameterName": "PageHash",
+                "parameterValue": "/NPH"
+            },
+            {
+                "parameterName": "FileDigest",
+                "parameterValue": "/fd \"SHA256\""
+            },
+            {
+                "parameterName": "TimeStamp",
+                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            }
+            ],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+        },
+        {
+            "keyCode": "CP-230012",
+            "operationSetCode": "SigntoolVerify",
+            "parameters": [ ],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+        }
      ]
     SessionTimeout: 20
 
@@ -144,32 +148,38 @@ steps:
    
    [int] $packageCount = $outvar.Length;
    $PackagesDescription = "$packageCount packages";
-   Write-Host $PackagesDescription
+   $PackagesDescription;
+   $outvar;
+
    "##vso[task.setvariable variable=PackagesDescription;]$PackagesDescription";
-   
-   ## Log the package names
-   for ($i = 0; $i -lt $packageCount; $i++ ) {
-       Write-Host $outvar[$i];
-   }
-   
-   if ($packageCount -gt 30) {
-       ## Too many packages for tags. Show this message instead
-       $message = "See the 'Get package names' log output for their names";
-       Write-Host "##vso[task.setvariable variable=pkg0;]$message";
-       $packageCount = 1;
+   [int] $maxTags = 5;
+
+   if ($packageCount -gt $maxTags) {
+       # Too many packages for tags.
+
+       # Set a few package name variables for tags
+       for ($i = 0; $i -lt $maxTags; $i++ ) {
+           $p = $outvar[$i];
+           "##vso[task.setvariable variable=pkg$i;]$p";
+       }
+
+       $message = "(See 'Package names' task log for full list)";
+       Write-Host "##vso[task.setvariable variable=pkg$i;]$message";
+       Write-Host $message;
+       $packageCount = ++$i;
    } else {
-       ## Set package name variables for tags
+       # Set package name variables for tags
        for ($i = 0; $i -lt $packageCount; $i++ ) {
            $p = $outvar[$i];
            "##vso[task.setvariable variable=pkg$i;]$p";
        }
    }
-   
+
    for ($i = $packageCount; $i -le 30; $i++ ) {
-       ## Set remaining variables to an empty string
+       # Set remaining variables to an empty string
        "##vso[task.setvariable variable=pkg$i;]";
    }
-  displayName: 'Get package names'
+  displayName: 'Package names'
   continueOnError: true
 
 - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0


### PR DESCRIPTION
SHA was not updated for this legacy branch a few months ago when ESRP required it for all signing.

This updated file is merely a copy of the one from the main branch.