### PR TITLE
simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,123 +12,16 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global rule:
-* @microsoft/bb-dotnet
-
-# Various C# Libraries
-/FunctionalTests/**                                                                 @gabog @mrivera-ms
-/tests/Microsoft.Bot.Builder.TestBot*/**                                            @gabog @mrivera-ms
-/build/**                                                                           @microsoft/bb-dotnet
-
-# Specific Test Projects
-/tests/Microsoft.Bot.Builder.TestBot.Json/**                                        @chrimc62 @tomlm @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-/tests/Microsoft.Bot.Builder.TestProtocol/**                                        @gabog @microsoft/bf-skills
-
-# Adapters
-/libraries/Adapters/**                                                              @EricDahlvang @garypretty @mrivera-ms
-/tests/Adapters/**                                                                  @EricDahlvang @garypretty @mrivera-ms
-
-# Platform Integration Libaries (.NET Core and WebApi)
-/libraries/integration/**                                                           @microsoft/bb-dotnet-integration
-/tests/integration/**                                                               @microsoft/bb-dotnet-integration
-
-# Application Insights/Telemetry
-/libraries/Microsoft.Bot.Builder.ApplicationInsights/**                             @EricDahlvang @johnataylor @mrivera-ms
-/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/**                           @EricDahlvang @johnataylor @mrivera-ms
-
-# AI: LUIS + Orchestrator
-/libraries/Microsoft.Bot.Builder.AI*/**                                             @microsoft/bf-cog-services
-/tests/Microsoft.Bot.Builder.AI*/**                                                 @microsoft/bf-cog-services
-
-# AI: QnA Maker
-/libraries/Microsoft.Bot.Builder.AI.QnA/**					                        @mrivera-ms @microsoft/bf-cog-services
-/tests/Microsoft.Bot.Builder.AI.QnA.Tests/**					                    @mrivera-ms @microsoft/bf-cog-services
-
-# Azure (Storage)
-/libraries/Microsoft.Bot.Builder.Azure/**                                           @EricDahlvang @mrivera-ms
-/tests/Microsoft.Bot.Builder.Azure.Tests/**                                         @EricDahlvang @mrivera-ms
-
-# Adaptive Dialogs
-/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/**                                @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/**                          @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/**                        @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-#   Adaptive Dialogs' tests
-/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling/**                          @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams.Tests/**                        @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/**                    @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/**                              @microsoft/bf-adaptive @EricDahlvang @mrivera-ms @ccastro
-
-# AdaptiveExpressions & LanguageGeneration libraries
-/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/**                             @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/**                           @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-/libraries/Microsoft.Bot.Builder.LanguageGeneration/**                              @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/**                            @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-/libraries/AdaptiveExpressions/**                                                   @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-/tests/AdaptiveExpressions.Tests/**                                                 @microsoft/bf-adaptive @EricDahlvang @mrivera-ms
-
-# BotBuilder Dialogs Debugging
-/libraries/Microsoft.Bot.Builder.Dialogs.Debugging/**                               @mrivera-ms @tomlm @gabog @ccastro
-/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/**                             @mrivera-ms @tomlm @gabog @ccastro
-
-# TemplateManager
-/libraries/Microsoft.Bot.Builder.TemplateManager/**                                 @mrivera-ms @tomlm
-/tests/Microsoft.Bot.Builder.TemplateManager/**                                     @mrivera-ms @tomlm
-
-# BotBuilder Testing
-/libraries/Microsoft.Bot.Builder.Testing/**                                         @gabog @EricDahlvang
-/tests/Microsoft.Bot.Builder.Testing.Tests/**                                       @gabog @EricDahlvang
-
-# Bot Framework Schema
-/libraries/Microsoft.Bot.Schema/**                                                  @microsoft/bb-core
-/tests/Microsoft.Bot.Schema.Tests/**                                                @microsoft/bb-core
+* @microsoft/botframework-sdk
 
 # Streaming library
-/libraries/Microsoft.Bot.Builder/Streaming/**                                       @microsoft/bf-streaming
-/libraries/Microsoft.Bot.Streaming/**                                               @microsoft/bf-streaming
-/tests/Microsoft.Bot.Builder.Streaming.Tests/**                                     @microsoft/bf-streaming
-/tests/Microsoft.Bot.Streaming.Tests/**                                             @microsoft/bf-streaming
+**/*Streaming*/**                                                                   @stevengum @carlosscastro @microsoft/botframework-sdk
 
-# BotBuilder library
-/libraries/Microsoft.Bot.Builder/**                                                 @microsoft/bb-core
-/tests/Microsoft.Bot.Builder.Tests/**                                               @microsoft/bb-core
-
-# BotBuilder Dialogs
-/libraries/Microsoft.Bot.Builder.Dialogs/**                                         @microsoft/bf-dialogs
-/tests/Microsoft.Bot.Builder.Dialogs/**                                             @microsoft/bf-dialogs
-
-# Bot Framework Connector
-/libraries/Microsoft.Bot.Connector/**                                               @microsoft/bb-core
-/tests/Microsoft.Bot.Connector.Tests/**                                             @microsoft/bb-core
-
-# Bot Framework Authentication
-/libraries/Microsoft.Bot.Builder/OAuth/**                                           @microsoft/bf-auth
-/libraries/Microsoft.Bot.Connector/Authentication/**                                @microsoft/bf-auth
-/tests/Microsoft.Bot.Connector.Tests/Authentication/**                              @microsoft/bf-auth
-
-# Bot Configuration
-/libraries/Microsoft.Bot.Configuration/**                                           @tomlm
-/libraries/Microsoft.Bot.Configuration.Tests/**                                     @tomlm
-
-# Bot Framework Skills
-/libraries/Microsoft.Bot.Builder/Skills/**                                          @microsoft/bf-skills
-/tests/Microsoft.Bot.Builder.Tests/Skills/**                                        @microsoft/bf-skills
-
-/libraries/Microsoft.Bot.Builder.Integration.AspNet.Core/Skills/**                  @microsoft/bf-skills
-/libraries/Microsoft.Bot.Builder.Integration.AspNet.Core/**/*HttpClient.cs          @microsoft/bf-skills
-
-/tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Skills/**                @microsoft/bf-skills
-/tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/**/*HttpClientTests.cs   @microsoft/bf-skills
-
-/FunctionalTests/Skills/**                                                          @microsoft/bf-skills
-/tests/Skills/**                                                                    @microsoft/bf-skills
-
-# Bot Framework & Microsoft Teams
-/libraries/Microsoft.Bot.Builder/Teams/**                                           @microsoft/bf-teams
-/tests/Microsoft.Bot.Builder.Tests/Teams/**                                         @microsoft/bf-teams
-/tests/Teams/**                                                                     @microsoft/bf-teams
-
-# Ownership by specific files or file types
-# This section MUST stay at the bottom of the CODEOWNERS file. For more information, see
-# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file
+**/Microsoft.Bot.Builder.Dialogs.Adaptive*/**                                       @microsoft/bf-adaptive @microsoft/botframework-sdk
+**/Microsoft.Bot.Builder.Dialogs.Declarative*/**                                    @microsoft/bf-adaptive @microsoft/botframework-sdk
+**/Microsoft.Bot.Builder.LanguageGeneration*/**                                     @microsoft/bf-adaptive @microsoft/botframework-sdk
+**/AdaptiveExpressions*/**                                                          @microsoft/bf-adaptive @microsoft/botframework-sdk
 
 # .schema files
-/**/*.schema                                                                        @chrimc62 @tomlm
+/**/*.schema                                                                        @chrimc62 @tomlm @microsoft/botframework-sdk
+/tests/Microsoft.Bot.Builder.TestBot.Json/**                                        @chrimc62 @tomlm @microsoft/botframework-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,5 @@
 **/Microsoft.Bot.Builder.Dialogs.Declarative*/**                                    @microsoft/bf-adaptive @microsoft/botframework-sdk
 **/Microsoft.Bot.Builder.LanguageGeneration*/**                                     @microsoft/bf-adaptive @microsoft/botframework-sdk
 **/AdaptiveExpressions*/**                                                          @microsoft/bf-adaptive @microsoft/botframework-sdk
-
-# .schema files
-/**/*.schema                                                                        @chrimc62 @tomlm @microsoft/botframework-sdk
-/tests/Microsoft.Bot.Builder.TestBot.Json/**                                        @chrimc62 @tomlm @microsoft/botframework-sdk
+**/*.schema                                                                        @chrimc62 @tomlm @microsoft/botframework-sdk
+tests/Microsoft.Bot.Builder.TestBot.Json/**                                        @chrimc62 @tomlm @microsoft/botframework-sdk


### PR DESCRIPTION
Testing out simplified codeowners.

The global rule now requests reviews from the **microsoft/botframework-sdk** team.

Select glob patterns also trigger reviews from other teams or individuals in addition to the **microsoft/botframework-sdk**.