### PR TITLE
Fix InvalidOperationException text in oauth input and oauth prompt

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             // Attempt to get the users token
             if (!(dc.Context.Adapter is IUserTokenProvider adapter))
             {
-                throw new InvalidOperationException("OAuthPrompt.Recognize(): not supported by the current adapter");
+                throw new InvalidOperationException("OAuthInput.BeginDialog(): not supported by the current adapter");
             }
 
             var output = await adapter.GetUserTokenAsync(dc.Context, ConnectionName.GetValue(dc.State), null, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Attempt to get the users token
             if (!(dc.Context.Adapter is IExtendedUserTokenProvider adapter))
             {
-                throw new InvalidOperationException("OAuthPrompt.Recognize(): not supported by the current adapter");
+                throw new InvalidOperationException("OAuthPrompt.BeginDialog(): not supported by the current adapter");
             }
 
             var output = await adapter.GetUserTokenAsync(dc.Context, _settings.OAuthAppCredentials, _settings.ConnectionName, null, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/4918