### PR TITLE
Add constructor that allows AuthenticationConfiguration to BotFrameworkHttpAdapter and BotFrameworkHttpAdapterAdapterBase

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -404,5 +404,23 @@ namespace Microsoft.Bot.Builder
         {
             return Task.CompletedTask;
         }
+
+        /// <summary>
+        /// Override this in a derived class to provide logic specific to
+        /// <see cref="ActivityTypes.EndOfConversation"/> activities, such as the conversational logic.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>
+        /// When the <see cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
+        /// method receives a message activity, it calls this method.
+        /// </remarks>
+        /// <seealso cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
+        protected virtual Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -76,6 +76,9 @@ namespace Microsoft.Bot.Builder
                 case ActivityTypes.Event:
                     return OnEventActivityAsync(new DelegatingTurnContext<IEventActivity>(turnContext), cancellationToken);
 
+                case ActivityTypes.EndOfConversation:
+                    return OnEndOfConversationActivityAsync(new DelegatingTurnContext<IEndOfConversationActivity>(turnContext), cancellationToken);
+
                 default:
                     return OnUnrecognizedActivityTypeAsync(turnContext, cancellationToken);
             }

--- a/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
@@ -6,25 +6,47 @@ using System.Net.Http;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Security.Principal;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
+using Microsoft.Rest.TransientFaultHandling;
 
 namespace Microsoft.Bot.Builder.Streaming
 {
     public class BotFrameworkHttpAdapterBase : BotFrameworkAdapter, IStreamingActivityProcessor
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapterBase"/> class.
+        /// </summary>
+        /// <param name="credentialProvider">The credential provider.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <param name="channelProvider">The channel provider.</param>
+        /// <param name="connectorClientRetryPolicy">Retry policy for retyring HTTP operations.</param>
+        /// <param name="customHttpClient">The HTTP client.</param>
+        /// <param name="middleware">The middleware to initially add to the adapter.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        public BotFrameworkHttpAdapterBase(
+            ICredentialProvider credentialProvider,
+            AuthenticationConfiguration authConfig,
+            IChannelProvider channelProvider = null,
+            RetryPolicy connectorClientRetryPolicy = null,
+            HttpClient customHttpClient = null,
+            IMiddleware middleware = null,
+            ILogger logger = null)
+            : base(credentialProvider, authConfig, channelProvider, connectorClientRetryPolicy, customHttpClient, middleware, logger)
+        {
+        }
+
         public BotFrameworkHttpAdapterBase(ICredentialProvider credentialProvider = null, IChannelProvider channelProvider = null, ILogger<BotFrameworkHttpAdapterBase> logger = null)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, null, null, logger)
+        : this(credentialProvider ?? new SimpleCredentialProvider(), new AuthenticationConfiguration(), channelProvider, null, null, null, logger)
         {
         }
 
         public BotFrameworkHttpAdapterBase(ICredentialProvider credentialProvider, IChannelProvider channelProvider, HttpClient httpClient, ILogger<BotFrameworkHttpAdapterBase> logger)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, null, httpClient, null, logger)
+         : this(credentialProvider ?? new SimpleCredentialProvider(), new AuthenticationConfiguration(), channelProvider, null, httpClient, null, logger)
         {
         }
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -14,6 +14,7 @@ using Microsoft.Bot.Builder.Streaming;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Rest.TransientFaultHandling;
 
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 {
@@ -25,18 +26,81 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         private const string AuthHeaderName = "authorization";
         private const string ChannelIdHeaderName = "channelid";
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapter"/> class,
+        /// using a credential provider.
+        /// </summary>
+        /// <param name="credentialProvider">The credential provider.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <param name="channelProvider">The channel provider.</param>
+        /// <param name="connectorClientRetryPolicy">Retry policy for retrying HTTP operations.</param>
+        /// <param name="customHttpClient">The HTTP client.</param>
+        /// <param name="middleware">The middleware to initially add to the adapter.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="credentialProvider"/> is <c>null</c>.</exception>
+        /// <remarks>Use a <see cref="MiddlewareSet"/> object to add multiple middleware
+        /// components in the constructor. Use the IMiddleware method to
+        /// add additional middleware to the adapter after construction.
+        /// </remarks>
+        public BotFrameworkHttpAdapter(
+            ICredentialProvider credentialProvider,
+            AuthenticationConfiguration authConfig,
+            IChannelProvider channelProvider = null,
+            RetryPolicy connectorClientRetryPolicy = null,
+            HttpClient customHttpClient = null,
+            IMiddleware middleware = null,
+            ILogger logger = null)
+            : base(credentialProvider, authConfig ?? new AuthenticationConfiguration(), channelProvider, connectorClientRetryPolicy, customHttpClient, middleware, logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapter"/> class,
+        /// using a credential provider.
+        /// </summary>
+        /// <param name="credentialProvider">The credential provider.</param>
+        /// <param name="channelProvider">The channel provider.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
         public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider = null, IChannelProvider channelProvider = null, ILogger<BotFrameworkHttpAdapter> logger = null)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, logger)
+            : this(credentialProvider ?? new SimpleCredentialProvider(), new AuthenticationConfiguration(), channelProvider, null, null, null, logger)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapter"/> class,
+        /// using a credential provider.
+        /// </summary>
+        /// <param name="credentialProvider">The credential provider.</param>
+        /// <param name="channelProvider">The channel provider.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> used.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
         public BotFrameworkHttpAdapter(ICredentialProvider credentialProvider, IChannelProvider channelProvider, HttpClient httpClient, ILogger<BotFrameworkHttpAdapter> logger)
-            : base(credentialProvider ?? new SimpleCredentialProvider(), channelProvider, httpClient, logger)
+            : this(credentialProvider ?? new SimpleCredentialProvider(), new AuthenticationConfiguration(), channelProvider, null, httpClient, null, logger)
         {
         }
 
-        protected BotFrameworkHttpAdapter(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger = null)
-            : base(new ConfigurationCredentialProvider(configuration), new ConfigurationChannelProvider(configuration), logger: logger)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapter"/> class.
+        /// </summary>
+        /// <param name="configuration">An <see cref="IConfiguration"/> instance.</param>
+        /// <param name="credentialProvider">The credential provider.</param>
+        /// <param name="authConfig">The authentication configuration.</param>
+        /// <param name="channelProvider">The channel provider.</param>
+        /// <param name="connectorClientRetryPolicy">Retry policy for retrying HTTP operations.</param>
+        /// <param name="customHttpClient">The HTTP client.</param>
+        /// <param name="middleware">The middleware to initially add to the adapter.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        protected BotFrameworkHttpAdapter(
+            IConfiguration configuration,
+            ICredentialProvider credentialProvider,
+            AuthenticationConfiguration authConfig = null,
+            IChannelProvider channelProvider = null,
+            RetryPolicy connectorClientRetryPolicy = null,
+            HttpClient customHttpClient = null,
+            IMiddleware middleware = null,
+            ILogger logger = null)
+            : this(credentialProvider ?? new ConfigurationCredentialProvider(configuration), authConfig ?? new AuthenticationConfiguration(), channelProvider ?? new ConfigurationChannelProvider(configuration), connectorClientRetryPolicy, customHttpClient, middleware, logger)
         {
             var openIdEndpoint = configuration.GetSection(AuthenticationConstants.BotOpenIdMetadataKey)?.Value;
 
@@ -46,6 +110,16 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 ChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
                 GovernmentChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapter"/> class.
+        /// </summary>
+        /// <param name="configuration">An <see cref="IConfiguration"/> instance.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        protected BotFrameworkHttpAdapter(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger = null)
+            : this(configuration, new ConfigurationCredentialProvider(configuration), new AuthenticationConfiguration(), new ConfigurationChannelProvider(configuration), logger: logger)
+        {
         }
 
         public async Task ProcessAsync(HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default)

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        public async Task TestOnEndOfConversationActivityType()
+        public async Task TestEndOfConversationActivity()
         {
             // Arrange
             var activity = new Activity

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -350,6 +350,26 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
+        public async Task TestOnEndOfConversationActivityType()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.EndOfConversation,
+                Value = "some value"
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.AreEqual(1, bot.Record.Count);
+            Assert.AreEqual("OnEndOfConversationActivityAsync", bot.Record[0]);
+        }
+
+        [TestMethod]
         public async Task TestDelegatingTurnContext()
         {
             // Arrange
@@ -481,6 +501,12 @@ namespace Microsoft.Bot.Builder.Tests
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return base.OnUnrecognizedActivityTypeAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnEndOfConversationActivityAsync(ITurnContext<IEndOfConversationActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnEndOfConversationActivityAsync(turnContext, cancellationToken);
             }
         }
 

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -8,6 +8,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Bot.Connector.Tests.Authentication
@@ -484,6 +485,29 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             // v2 version with azp
             v2Claims.Add(new Claim(AuthenticationConstants.AuthorizedParty, appId));
             Assert.Equal(appId, JwtTokenValidation.GetAppIdFromClaims(v2Claims));
+        }
+
+        [Fact]
+        public async Task ValidateClaimsTest()
+        {
+            var claims = new List<Claim>();
+            var defaultAuthConfig = new AuthenticationConfiguration();
+
+            // No validator should pass.
+            await JwtTokenValidation.ValidateClaimsAsync(defaultAuthConfig, claims);
+
+            var mockValidator = new Mock<ClaimsValidator>();
+            var authConfigWithClaimsValidator = new AuthenticationConfiguration() { ClaimsValidator = mockValidator.Object };
+
+            // ClaimsValidator configured but no exception should pass.
+            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Returns(Task.CompletedTask);
+            await JwtTokenValidation.ValidateClaimsAsync(authConfigWithClaimsValidator, claims);
+
+            // Configure IClaimsValidator to fail
+            mockValidator.Setup(x => x.ValidateClaimsAsync(It.IsAny<List<Claim>>())).Throws(new UnauthorizedAccessException("Invalid claims."));
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () => await JwtTokenValidation.ValidateClaimsAsync(authConfigWithClaimsValidator, claims));
+            Assert.Equal("Invalid claims.", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #4992 

## Description
Allow `AuthenticationConfiguration` as a parameter in `BotFrameworkHttpAdapter` and `BotFrameworkHttpAdapterBase`, as currently only `BotFrameworkAdapter` allows it.