### PR TITLE
Fix creating InvokeResponse activities in LG

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
@@ -90,6 +90,12 @@ namespace Microsoft.Bot.Builder
             else if (type == nameof(Activity).ToLowerInvariant())
             {
                 activity = BuildActivity(lgJObj);
+
+                // InvokeResponse requires value to be a InvokeResponse typed object. 
+                if (activity.Type == ActivityTypesEx.InvokeResponse && activity.Value != null)
+                {
+                    activity.Value = JObject.FromObject(activity.Value).ToObject<InvokeResponse>();
+                }
             }
             else
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -80,6 +80,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
+        public void TestInvokeResponse()
+        {
+            dynamic data = new JObject();
+            data.text = "textContent";
+            var lgResult = templates.Evaluate("InvokeResponseExample", data);
+            var activity = (Activity)ActivityFactory.FromObject(lgResult);
+            
+            Assert.Equal(ActivityTypesEx.InvokeResponse, activity.Type);
+            Assert.NotNull(activity.Value);
+            Assert.IsType<InvokeResponse>(activity.Value);
+            var invokeResponse = (InvokeResponse)activity.Value;
+            dynamic body = invokeResponse.Body;
+            Assert.Equal(200, invokeResponse.Status);
+            Assert.True((bool)body.test);
+        }
+
+        [Fact]
         public void TestExternalAdaptiveCardActivity()
         {
             dynamic data = new JObject();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/lg/NormalStructuredLG.lg
@@ -235,6 +235,21 @@
     SuggestedActions = Add todo | View Todo | Remove Todo | Cancel | Help
 ]
 
+# InvokeResponseExample
+[ Activity
+  Type = invokeResponse
+  Value = ${json(InvokeResponseTemplate())}
+]
+
+# InvokeResponseTemplate
+- ```
+{
+    "status": 200,
+    "body": {
+        "test": true
+    }
+}
+```
 
 > --------------internal cardaction templates----------------------
 # cardActionTemplate(type, title, value)


### PR DESCRIPTION

Fixes #4991 

## Description
To create invoke response using composer and LG requires that the untyped activity.Value has a typed object InvokeResponse in in it.

## Specific Changes
- Changed ActivityFactory to coerce value to InvokeResponse when the activity Type is a InvokeResponse

## Testing
- Added unit test to verify coercion.