### PR TITLE
Align OrchestratorRecognizer with LuisRecognizer ExternalEntityRecognizer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -51,15 +51,12 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         public string SnapshotPath { get; set; }
 
         /// <summary>
-        /// Gets or sets the entity recognizers.
+        /// Gets or sets an external entity recognizer.
         /// </summary>
-        /// <value>
-        /// The entity recognizers.
-        /// </value>
-        [JsonProperty("entityRecognizers")]
-#pragma warning disable CA2227 // Collection properties should be read only (keeping this consistent with RegexRecognizer)
-        public List<EntityRecognizer> EntityRecognizers { get; set; } = new List<EntityRecognizer>();
-#pragma warning restore CA2227 // Collection properties should be read only
+        /// <remarks>This recognizer is run before calling Orchestrator and the entities are merged with Orchestrator results.</remarks>
+        /// <value>Recognizer.</value>
+        [JsonProperty("externalEntityRecognizer")]
+        public Recognizer ExternalEntityRecognizer { get; set; }
 
         /// <summary>
         /// Gets or sets the disambiguation score threshold.
@@ -89,7 +86,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
                 ModelPath = this.ModelPath,
                 SnapshotPath = this.SnapshotPath,
                 DisambiguationScoreThreshold = this.DisambiguationScoreThreshold,
-                EntityRecognizers = this.EntityRecognizers,
+                ExternalEntityRecognizer = this.ExternalEntityRecognizer,
             };
 
             var dc = new DialogContext(new DialogSet(), turnContext, new DialogState());

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Schemas/Microsoft.OrchestratorRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Schemas/Microsoft.OrchestratorRecognizer.schema
@@ -22,13 +22,10 @@
             "description": "SnapShot file path.",
             "default": "=settings.orchestrator.shapshotpath"
         },
-        "entityRecognizers": {
-            "type": "array",
-            "items": {
-                "$kind": "Microsoft.IEntityRecognizer"
-            },
-            "title": "Entity recognizers",
-            "description": "Collection of entity recognizers to use."
+        "externalEntityRecognizer": {
+            "$kind": "Microsoft.IRecognizer",
+            "title": "External entity recognizer",
+            "description": "Entities recognized by this recognizer will be merged with Orchestrator results."
         },
         "disambiguationScoreThreshold": {
             "$ref": "schema:#/definitions/numberExpression",

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorTests.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
             var recognizer = new OrchestratorAdaptiveRecognizer(string.Empty, string.Empty, mockResolver)
             {
                 ModelPath = new StringExpression("fakePath"),
-                SnapshotPath = new StringExpression("fakePath")
+                SnapshotPath = new StringExpression("fakePath"),
+                ExternalEntityRecognizer = new NumberEntityRecognizer()
             };
-            recognizer.EntityRecognizers.Add(new NumberEntityRecognizer());
 
             var adapter = new TestAdapter(TestAdapter.CreateConversation("ds"));
             var activity = MessageFactory.Text("12");


### PR DESCRIPTION
## Description
In 4.11 we deprecated the specific EntityRecognizer concept and instead only have Recognizer (EntityRecognizer base class is now Recognizer).  LuisRecognizer has property **ExternalEntityRecognizer** which is of type Recognizer.  This delta aligns with LUIS, so that you can a recognizer which is run and the results passed into orchestrator for orchestrator to use.

## Specific Changes
- Replaced **List<EntityRecognizer> EntityRecognizers** property with **Recognizer ExternalEntityRecognizer**
- updated schema

## Testing
- updated unit tests
