### PR TITLE
Fix ApiCompat issue causing pipeline failures

### DIFF
--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -39,14 +39,14 @@ steps:
       $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
         
       if ($FileContent.Length -eq 1) {
-        [system.io.file]::WriteAllText($fileName,$FileContent)
+        [system.io.file]::WriteAllText($FileName,$FileContent)
       } else {
-        Set-Content $fileName $FileContent
+        Set-Content $FileName $FileContent
       }
 
       Write-Host "The updated line 1: `n$FileContent[0]"
     } else {
-      $FileContent = The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue.
+      $FileContent = "The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue."
       New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt' -ItemType "file" -Value $FileContent
     }
   displayName: 'Insert nuget link into ApiCompat results file.'


### PR DESCRIPTION
## Description
This PR fixes an issue that was causing the pipelines to fail in the "Insert nuget link into ApiCompat results file." task for the Api Compatibility check.

## Specific Changes
- Add missing double quotes in the "Insert nuget link into ApiCompat results file." task for the `ci-api-validation-steps.yml` file.

## Testing
![image](https://user-images.githubusercontent.com/62260472/99849077-a24d7100-2b59-11eb-87d0-b3d7afe1f2b4.png)

