### PR TITLE
feat: create parity issues via github workflow

### DIFF
--- a/.github/workflows/create-botbuilder-js-parity-issue.yml
+++ b/.github/workflows/create-botbuilder-js-parity-issue.yml
@@ -1,0 +1,28 @@
+name: create-botbuilder-js-parity-issue.yml
+
+on:
+  pull_request:
+    branches:
+    - main
+    types: [closed]
+
+jobs:
+  triggerWorkflow:
+    name: create parity issue for botbuilder-js
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: joshgummersall/dispatch-workflow@main
+        if: github.event.pull_request.merged == true
+        with:
+          inputs: |
+            {
+              "prDescription": "${{ github.event.pull_request.body }}",
+              "prNumber": "${{ github.event.pull_request.number }}",
+              "prTitle": "${{ github.event.pull_request.title }}",
+              "sourceRepo": "${{ github.repository }}"
+            }
+          ref: main
+          repo: microsoft/botbuilder-js
+          token: "${{ secrets.BOTBUILDER_JS_ACCESS_TOKEN }}"
+          workflow: create-parity-issue.yml


### PR DESCRIPTION
This will remotely trigger the workflow introduced via https://github.com/microsoft/botbuilder-js/pull/3080

This will reintroduce the "Tom Bot" functionality of creating parity issues automatically when pull requests are merged in this repo.

We could certainly add globs to limit the sets of things that trigger parity issues, but I think this will be a good start.

The full source code for the action is available via [joshgummersall/dispatch-workflow](https://github.com/joshgummersall/dispatch-workflow).