### PR TITLE
Fix locale determination in confirm/choice inputs

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Builder.Dialogs.Prompts;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 using static Microsoft.Recognizers.Text.Culture;
@@ -60,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="callerLine">Optional, line number in source file.</param>
         public ChoiceInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
-            this.RegisterSourceLocation(callerPath, callerLine);
+            RegisterSourceLocation(callerPath, callerLine);
         }
 
         /// <summary>
@@ -127,10 +128,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="cancellationToken">Optional, a <see cref="CancellationToken"/> that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<DialogTurnResult> ResumeDialogAsync(DialogContext dc, DialogReason reason, object result = null, CancellationToken cancellationToken = default)
         {
-            FoundChoice foundChoice = result as FoundChoice;
-            if (foundChoice != null)
+            if (result is FoundChoice foundChoice)
             {
                 // return value insted of FoundChoice object
                 return base.ResumeDialogAsync(dc, reason, foundChoice.Value, cancellationToken);
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     op = new ChoiceInputOptions();
                 }
 
-                var (choices, error) = this.Choices.TryGetValue(dc.State);
+                var (choices, error) = Choices.TryGetValue(dc.State);
                 if (error != null)
                 {
                     throw new InvalidOperationException(error);
@@ -173,7 +173,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>InputState which reflects whether input was recognized as valid or not.</returns>
-        protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             var input = dc.State.GetValue<object>(VALUE_PROPERTY);
             var options = dc.State.GetValue<ChoiceInputOptions>(ThisPath.Options);
@@ -182,8 +182,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
             if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
-                var opt = this.RecognizerOptions?.GetValue(dc.State) ?? new FindChoicesOptions();
-                opt.Locale = GetCulture(dc);
+                var opt = RecognizerOptions?.GetValue(dc.State) ?? new FindChoicesOptions();
+                opt.Locale = DetermineCulture(dc, opt);
                 var results = ChoiceRecognizers.RecognizeChoices(input.ToString(), choices, opt);
                 if (results == null || results.Count == 0)
                 {
@@ -191,7 +191,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 }
 
                 var foundChoice = results[0].Resolution;
-                switch (this.OutputFormat.GetValue(dc.State))
+                switch (OutputFormat.GetValue(dc.State))
                 {
                     case ChoiceOutputFormat.Value:
                     default:
@@ -213,36 +213,32 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="state">Dialog <see cref="InputState"/>.</param>
         /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Activity to send to the user.</returns>
-        protected override async Task<IActivity> OnRenderPromptAsync(DialogContext dc, InputState state, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task<IActivity> OnRenderPromptAsync(DialogContext dc, InputState state, CancellationToken cancellationToken = default)
         {
-            var locale = GetCulture(dc);
+            var locale = DetermineCulture(dc);
             var prompt = await base.OnRenderPromptAsync(dc, state, cancellationToken).ConfigureAwait(false);
             var channelId = dc.Context.Activity.ChannelId;
-            var choicePrompt = new ChoicePrompt(this.Id);
-            var choiceOptions = this.ChoiceOptions?.GetValue(dc.State) ?? ChoiceInput.DefaultChoiceOptions[locale];
+            var choiceOptions = ChoiceOptions?.GetValue(dc.State) ?? DefaultChoiceOptions[locale];
 
-            var (choices, error) = this.Choices.TryGetValue(dc.State);
+            var (choices, error) = Choices.TryGetValue(dc.State);
             if (error != null)
             {
                 throw new InvalidOperationException(error);
             }
 
-            return this.AppendChoices(prompt.AsMessageActivity(), channelId, choices, this.Style.GetValue(dc.State), choiceOptions);
+            return AppendChoices(prompt.AsMessageActivity(), channelId, choices, Style.GetValue(dc.State), choiceOptions);
         }
 
-        private string GetCulture(DialogContext dc)
+        private string DetermineCulture(DialogContext dc, FindChoicesOptions opt = null)
         {
-            if (!string.IsNullOrWhiteSpace(dc.Context.Activity.Locale))
+            var culture = PromptCultureModels.MapToNearestLanguage(dc.Context.Activity.Locale ?? opt?.Locale ?? DefaultLocale?.GetValue(dc.State));
+
+            if (string.IsNullOrEmpty(culture) || !DefaultChoiceOptions.ContainsKey(culture))
             {
-                return dc.Context.Activity.Locale;
+                culture = English;
             }
 
-            if (this.DefaultLocale != null)
-            {
-                return this.DefaultLocale.GetValue(dc.State);
-            }
-
-            return English;
+            return culture;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Gets or sets list of choices to present to user.
         /// </summary>
         /// <value>
-        /// ChoiceSet or expression which evalutes to a ChoiceSet.
+        /// ChoiceSet or expression which evaluates to a ChoiceSet.
         /// </value>
         [JsonProperty("choices")]
         public ObjectExpression<ChoiceSet> Choices { get; set; }
@@ -104,7 +104,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Gets or sets choiceOptions controls display options for customizing language.
         /// </summary>
         /// <value>
-        /// ChoiceOptions or expression which evluates to ChoiceOptions.
+        /// ChoiceOptions or expression which evaluates to ChoiceOptions.
         /// </value>
         [JsonProperty("choiceOptions")]
         public ObjectExpression<ChoiceFactoryOptions> ChoiceOptions { get; set; }
@@ -116,10 +116,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// FindChoicesOptions or expression which evaluates to FindChoicesOptions.
         /// </value>
         [JsonProperty("recognizerOptions")]
-        public ObjectExpression<FindChoicesOptions> RecognizerOptions { get; set; } = null;
+        public ObjectExpression<FindChoicesOptions> RecognizerOptions { get; set; }
 
         /// <summary>
-        /// Replaces the result with the FoundChoice value if possible, then proceedes to <see cref="Dialog.ResumeDialogAsync(DialogContext, DialogReason, object, CancellationToken)"/>.
+        /// Replaces the result with the FoundChoice value if possible, then proceeds to <see cref="Dialog.ResumeDialogAsync(DialogContext, DialogReason, object, CancellationToken)"/>.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="reason">Reason why the dialog resumed.</param>
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         {
             if (result is FoundChoice foundChoice)
             {
-                // return value insted of FoundChoice object
+                // return value instead of FoundChoice object
                 return base.ResumeDialogAsync(dc, reason, foundChoice.Value, cancellationToken);
             }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         }
 
         /// <summary>
-        /// Called when input has been received, recognices choice.
+        /// Called when input has been received, recognizes choice.
         /// </summary>
         /// <param name="dc">The <see cref="DialogContext"/> for the current turn of conversation.</param>
         /// <param name="cancellationToken">Optional, the <see cref="CancellationToken"/> that can be used by other objects or threads to receive notice of cancellation.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Choices;
+using Microsoft.Bot.Builder.Dialogs.Prompts;
 using Microsoft.Bot.Schema;
 using Microsoft.Recognizers.Text.Choice;
 using Newtonsoft.Json;
@@ -26,7 +27,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.ConfirmInput";
 
-        private static readonly Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)> ChoiceDefaults = new Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)> DefaultChoiceOptions = new Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)>(StringComparer.OrdinalIgnoreCase)
         {
             { Spanish, (new Choice("Sí"), new Choice("No"), new ChoiceFactoryOptions(", ", " o ", ", o ", true)) },
             { Dutch, (new Choice("Ja"), new Choice("Nee"), new ChoiceFactoryOptions(", ", " of ", ", of ", true)) },
@@ -45,7 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="callerLine">Optional, line number in source file.</param>
         public ConfirmInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
         {
-            this.RegisterSourceLocation(callerPath, callerLine);
+            RegisterSourceLocation(callerPath, callerLine);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             if (dc.Context.Activity.Type == ActivityTypes.Message)
             {
                 // Recognize utterance
-                var culture = GetCulture(dc);
+                var culture = DetermineCulture(dc);
                 var results = ChoiceRecognizer.RecognizeBoolean(input.ToString(), culture);
                 if (results.Count > 0)
                 {
@@ -115,7 +116,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                             }
                             else
                             {
-                                throw new InvalidOperationException($"OutputFormat Expression evaluation resulted in an error. Expression: {OutputFormat.ToString()}. Error: {error}");
+                                throw new InvalidOperationException($"OutputFormat Expression evaluation resulted in an error. Expression: {OutputFormat}. Error: {error}");
                             }
                         }
 
@@ -129,7 +130,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 else
                 {
                     // First check whether the prompt was sent to the user with numbers - if it was we should recognize numbers
-                    var defaults = ChoiceDefaults[culture];
+                    var defaults = DefaultChoiceOptions[culture];
                     var choiceOptions = ChoiceOptions?.GetValue(dc.State) ?? defaults.Item3;
 
                     // This logic reflects the fact that IncludeNumbers is nullable and True is the default set in Inline style
@@ -165,29 +166,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         {
             // Format prompt to send
             var channelId = dc.Context.Activity.ChannelId;
-            var culture = GetCulture(dc);
-            var defaults = ChoiceDefaults[culture];
+            var culture = DetermineCulture(dc);
+            var defaults = DefaultChoiceOptions[culture];
             var choiceOptions = ChoiceOptions?.GetValue(dc.State) ?? defaults.Item3;
             var confirmChoices = ConfirmChoices?.GetValue(dc.State) ?? new List<Choice>() { defaults.Item1, defaults.Item2 };
 
             var prompt = await base.OnRenderPromptAsync(dc, state, cancellationToken).ConfigureAwait(false);
-            var (style, error) = this.Style.TryGetValue(dc.State);
-            return this.AppendChoices(prompt.AsMessageActivity(), channelId, confirmChoices, style, choiceOptions);
+            var (style, _) = Style.TryGetValue(dc.State);
+            return AppendChoices(prompt.AsMessageActivity(), channelId, confirmChoices, style, choiceOptions);
         }
 
-        private string GetCulture(DialogContext dc)
+        private string DetermineCulture(DialogContext dc)
         {
-            if (!string.IsNullOrEmpty(dc.Context.Activity.Locale))
+            var culture = PromptCultureModels.MapToNearestLanguage(dc.Context.Activity.Locale ?? DefaultLocale?.GetValue(dc.State));
+
+            if (string.IsNullOrEmpty(culture) || !DefaultChoiceOptions.ContainsKey(culture))
             {
-                return dc.Context.Activity.Locale;
+                culture = English;
             }
 
-            if (this.DefaultLocale != null)
-            {
-                return this.DefaultLocale.GetValue(dc.State);
-            }
-
-            return English;
+            return culture;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// Gets or sets the DefaultLocale to use to parse confirmation choices if there is not one passed by the caller.
         /// </summary>
         /// <value>
-        /// The locale (en-us, nl-nl, etc) or expression which evluates to locale.
+        /// The locale (en-us, nl-nl, etc) or expression which evaluates to locale.
         /// </value>
         [JsonProperty("defaultLocale")]
         public StringExpression DefaultLocale { get; set; }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -21,11 +21,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// A dictionary of Default Choices based on <seealso cref="GetSupportedCultures"/>.
         /// Can be replaced by user using the constructor that contains choiceDefaults.
         /// </summary>
-        private readonly Dictionary<string, ChoiceFactoryOptions> _choiceDefaults =
-            new Dictionary<string, ChoiceFactoryOptions>(
-            GetSupportedCultures().ToDictionary(
-                culture => culture.Locale, culture =>
-                new ChoiceFactoryOptions { InlineSeparator = culture.Separator, InlineOr = culture.InlineOr, InlineOrMore = culture.InlineOrMore, IncludeNumbers = true }));
+        private readonly Dictionary<string, ChoiceFactoryOptions> _choiceDefaults;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ChoicePrompt"/> class.
@@ -43,10 +39,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// the <paramref name="defaultLocale"/> is used. US-English is the used if no language or
         /// default locale is available, or if the language or locale is not otherwise supported.</para></remarks>
         public ChoicePrompt(string dialogId, PromptValidator<FoundChoice> validator = null, string defaultLocale = null)
-            : base(dialogId, validator)
+            : this(
+                dialogId,
+                new Dictionary<string, ChoiceFactoryOptions>(
+                    GetSupportedCultures().ToDictionary(
+                        culture => culture.Locale, culture =>
+                        new ChoiceFactoryOptions(culture.Separator, culture.InlineOr, culture.InlineOrMore, true))),
+                validator,
+                defaultLocale)
         {
-            Style = ListStyle.Auto;
-            DefaultLocale = defaultLocale;
         }
 
         /// <summary>
@@ -67,8 +68,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// the <paramref name="defaultLocale"/> is used. US-English is the used if no language or
         /// default locale is available, or if the language or locale is not otherwise supported.</para></remarks>
         public ChoicePrompt(string dialogId, Dictionary<string, ChoiceFactoryOptions> choiceDefaults, PromptValidator<FoundChoice> validator = null, string defaultLocale = null)
-            : this(dialogId, validator, defaultLocale)
+            : base(dialogId, validator)
         {
+            Style = ListStyle.Auto;
+            DefaultLocale = defaultLocale;
             _choiceDefaults = choiceDefaults;
         }
 
@@ -110,7 +113,12 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected override async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task OnPromptAsync(
+            ITurnContext turnContext,
+            IDictionary<string, object> state,
+            PromptOptions options,
+            bool isRetry,
+            CancellationToken cancellationToken = default)
         {
             if (turnContext == null)
             {
@@ -154,7 +162,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result describes the result of the recognition attempt.</remarks>
-        protected override Task<PromptRecognizerResult<FoundChoice>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        protected override Task<PromptRecognizerResult<FoundChoice>> OnRecognizeAsync(
+            ITurnContext turnContext,
+            IDictionary<string, object> state,
+            PromptOptions options,
+            CancellationToken cancellationToken = default)
         {
             if (turnContext == null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -22,13 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// A dictionary of Default Choices based on <seealso cref="GetSupportedCultures"/>.
         /// Can be replaced by user using the constructor that contains choiceDefaults.
         /// </summary>
-        private readonly Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)> _choiceDefaults =
-            new Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)>(
-            GetSupportedCultures().ToDictionary(
-                culture => culture.Locale, culture =>
-                (new Choice(culture.YesInLanguage),
-                    new Choice(culture.NoInLanguage),
-                    new ChoiceFactoryOptions(culture.Separator, culture.InlineOr, culture.InlineOrMore, true))));
+        private readonly Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)> _choiceDefaults;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfirmPrompt"/> class.
@@ -46,10 +40,17 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// the <paramref name="defaultLocale"/> is used. US-English is the used if no language or
         /// default locale is available, or if the language or locale is not otherwise supported.</para></remarks>
         public ConfirmPrompt(string dialogId, PromptValidator<bool> validator = null, string defaultLocale = null)
-            : base(dialogId, validator)
+            : this(
+                dialogId,
+                new Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)>(
+                    GetSupportedCultures().ToDictionary(
+                        culture => culture.Locale, culture =>
+                        (new Choice(culture.YesInLanguage),
+                            new Choice(culture.NoInLanguage),
+                            new ChoiceFactoryOptions(culture.Separator, culture.InlineOr, culture.InlineOrMore, true)))),
+                validator,
+                defaultLocale)
         {
-            Style = ListStyle.Auto;
-            DefaultLocale = defaultLocale;
         }
 
         /// <summary>
@@ -70,8 +71,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// the <paramref name="defaultLocale"/> is used. US-English is the used if no language or
         /// default locale is available, or if the language or locale is not otherwise supported.</para></remarks>
         public ConfirmPrompt(string dialogId, Dictionary<string, (Choice, Choice, ChoiceFactoryOptions)> choiceDefaults, PromptValidator<bool> validator = null, string defaultLocale = null)
-            : this(dialogId, validator, defaultLocale)
+            : base(dialogId, validator)
         {
+            Style = ListStyle.Auto;
+            DefaultLocale = defaultLocale;
             _choiceDefaults = choiceDefaults;
         }
 
@@ -114,7 +117,12 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected override async Task OnPromptAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, bool isRetry, CancellationToken cancellationToken = default(CancellationToken))
+        protected override async Task OnPromptAsync(
+            ITurnContext turnContext,
+            IDictionary<string, object> state,
+            PromptOptions options,
+            bool isRetry,
+            CancellationToken cancellationToken = default)
         {
             if (turnContext == null)
             {
@@ -159,7 +167,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result describes the result of the recognition attempt.</remarks>
-        protected override Task<PromptRecognizerResult<bool>> OnRecognizeAsync(ITurnContext turnContext, IDictionary<string, object> state, PromptOptions options, CancellationToken cancellationToken = default(CancellationToken))
+        protected override Task<PromptRecognizerResult<bool>> OnRecognizeAsync(
+            ITurnContext turnContext,
+            IDictionary<string, object> state,
+            PromptOptions options,
+            CancellationToken cancellationToken = default)
         {
             if (turnContext == null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
                 if (!SupportedLocales.Contains(cultureCode))
                 {
                     var culturePrefix = cultureCode.Split('-').First();
-                    var fallbackLocales = SupportedLocales.Where(locale => locale.StartsWith(culturePrefix, StringComparison.Ordinal));
+                    var fallbackLocales = SupportedLocales.Where(locale => locale.StartsWith(culturePrefix, StringComparison.Ordinal)).ToList();
 
                     if (fallbackLocales.Any())
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptCultureModels.cs
@@ -235,28 +235,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Prompts
         /// <returns>Normalized locale.</returns>
         public static string MapToNearestLanguage(string cultureCode)
         {
-            cultureCode = cultureCode.ToLowerInvariant();
-
-            if (SupportedLocales.All(o => o != cultureCode))
+            if (!string.IsNullOrWhiteSpace(cultureCode))
             {
-                // Handle cases like EnglishOthers with cultureCode "en-*"
-                var fallbackCultureCodes = SupportedLocales
-                    .Where(o => o.EndsWith("*", StringComparison.Ordinal) &&
-                                cultureCode.StartsWith(o.Split('-').First(), StringComparison.Ordinal)).ToList();
+                cultureCode = cultureCode.ToLowerInvariant();
 
-                if (fallbackCultureCodes.Count == 1)
+                if (!SupportedLocales.Contains(cultureCode))
                 {
-                    return fallbackCultureCodes.First();
-                }
+                    var culturePrefix = cultureCode.Split('-').First();
+                    var fallbackLocales = SupportedLocales.Where(locale => locale.StartsWith(culturePrefix, StringComparison.Ordinal));
 
-                // If there is no cultureCode like "-*", map only the prefix
-                // For example, "es-mx" will be mapped to "es-es"
-                fallbackCultureCodes = SupportedLocales
-                    .Where(o => cultureCode.StartsWith(o.Split('-').First(), StringComparison.Ordinal)).ToList();
+                    if (fallbackLocales.Any())
+                    {
+                        // Handle cases like EnglishOthers with cultureCode "en-*"
+                        if (fallbackLocales.FirstOrDefault(locale => locale.EndsWith("*", StringComparison.Ordinal)) is string genericLocale)
+                        {
+                            return genericLocale;
+                        }
 
-                if (fallbackCultureCodes.Any())
-                {
-                    return fallbackCultureCodes.First();
+                        // If there is no cultureCode like "-*", map only the prefix
+                        // For example, "es-mx" will be mapped to "es-es"
+                        return fallbackLocales.First();
+                    }
                 }
             }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptCultureModelsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/PromptCultureModelsTests.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
+        public void ShouldNotThrowWhenLocaleIsNull() => MapToNearestLanguage(null);
+
+        [Fact]
         public void ShouldReturnAllSupportedCultures()
         {
             var expected = new PromptCultureModel[]


### PR DESCRIPTION
Fixes #4981

## Description

This is a port of https://github.com/microsoft/botbuilder-js/pull/2534, and it should help adaptive dialogs handle unexpected locales better in Composer

## Specific Changes

- Implement `PromptCultureModelsTests.ShouldNotThrowWhenLocaleIsNull`
- Fix `MapToNearestLanguage` so that it doesn't throw when the locale is null and so it's more efficient and easier to read and closer to the TypeScript implementation
- Rename `GetCulture` to `DetermineCulture` in `ConfirmInput` and `ChoiceInput` to align with other classes
- Fix `DetermineCulture` in `ConfirmInput` and `ChoiceInput` so that it uses `MapToNearestLanguage`
- Have `DetermineCulture` accept a second parameter in `ChoiceInput` to align with `ChoicePrompt`
- Rework `ConfirmPrompt` and `ChoicePrompt` constructors so that the default choice options are only generated when needed, aligning with best practices and the TypeScript implementations
- Clean up `ConfirmPrompt`, `ChoicePrompt`, `ConfirmInput`, and `ChoiceInput` according to Visual Studio suggestions

## Testing
`PromptCultureModelsTests.ShouldNotThrowWhenLocaleIsNull`