### PR TITLE
Remove offset in default format in ConvertFromUtc pre-built function

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
@@ -17,6 +17,8 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// </summary>
     internal class ConvertFromUtc : ExpressionEvaluator
     {
+        private const string DefaultFormat = "yyyy-MM-ddTHH:mm:ss:fffffffK";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConvertFromUtc"/> class.
         /// </summary>
@@ -31,7 +33,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
             string error = null;
             IReadOnlyList<object> args;
             var locale = options.Locale != null ? new CultureInfo(options.Locale) : Thread.CurrentThread.CurrentCulture;
-            var format = FunctionUtils.DefaultDateTimeFormat;
+            var format = DefaultFormat;
             (args, error) = FunctionUtils.EvaluateChildren(expression, state, options);
             if (error == null)
             {

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
@@ -17,7 +17,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// </summary>
     internal class ConvertFromUtc : ExpressionEvaluator
     {
-        private const string DefaultFormat = "yyyy-MM-ddTHH:mm:ss:fffffffK";
+        private const string DefaultFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConvertFromUtc"/> class.

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -885,6 +885,7 @@ namespace AdaptiveExpressions.Tests
             Test("getFutureTime(1,'Month','MM-dd-yy')", DateTime.UtcNow.AddMonths(1).ToString("MM-dd-yy")),
             Test("getFutureTime(1,'Week','MM-dd-yy')", DateTime.UtcNow.AddDays(7).ToString("MM-dd-yy")),
             Test("getFutureTime(1,'Day','MM-dd-yy')", DateTime.UtcNow.AddDays(1).ToString("MM-dd-yy")),
+            Test("convertFromUTC('2018-01-02T02:00:00.000Z', 'Pacific Standard Time')", "2018-01-01T18:00:00.0000000"),
             Test("convertFromUTC('2018-01-02T02:00:00.000Z', 'Pacific Standard Time', 'D', 'en-US')", "Monday, January 1, 2018"),
             Test("convertFromUTC(timestampObj2, 'Pacific Standard Time', 'D', 'en-US')", "Monday, January 1, 2018"),
             Test("convertFromUTC('2018-01-02T01:00:00.000Z', 'America/Los_Angeles', 'D', 'en-US')", "Monday, January 1, 2018"),


### PR DESCRIPTION
closes: #5003 
Now the default format of ConvertFromUtc are the same as it in WDL, which compiles "yyyy-MM-ddTHH:mm:ss.fffffffK".
See Ref:
https://docs.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference#convertFromUtc