### PR TITLE
fix Issue#3568 utterance smaller than entity indexes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisUtil.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisUtil.cs
@@ -165,13 +165,13 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
         internal static JObject ExtractEntityMetadata(EntityModel entity, string utterance)
         {
-            var start = (int)entity.StartIndex;
-            var end = (int)entity.EndIndex + 1;
+            var start = entity.StartIndex;
+            var end = entity.EndIndex + 1;
             dynamic obj = JObject.FromObject(new
             {
                 startIndex = start,
                 endIndex = end,
-                text = entity.Entity.Length == end - start ? entity.Entity : utterance.Substring(start, end - start),
+                text = GetEntityText(entity, utterance, start, end),
                 type = entity.Type,
             });
 
@@ -191,6 +191,27 @@ namespace Microsoft.Bot.Builder.AI.Luis
             }
 
             return obj;
+        }
+
+        internal static string GetEntityText(EntityModel entity, string utterance, int start, int end)
+        {
+            string result;
+            var entitySize = end - start;
+
+            if (entity.Entity.Length == entitySize)
+            {
+                result = entity.Entity;
+            }
+            else if (utterance.Length <= entitySize)
+            {
+                result = utterance;
+            }
+            else
+            {
+                result = utterance.Substring(start, entitySize);
+            }
+
+            return result;
         }
 
         internal static string ExtractNormalizedEntityName(EntityModel entity)

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisUtilTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisUtilTests.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.Models;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.AI.Luis.Tests
+{
+    public class LuisUtilTests
+    {
+        private const string _ENTITY = "testEntity";
+
+        [Fact]
+        public void GetEntityTextShouldReturnTheEntityItself()
+        {
+            //Arrange
+            var mockEntity = new EntityModel { Entity = _ENTITY, StartIndex = 0, EndIndex = _ENTITY.Length };
+
+            //Act
+            var actualEntityText = LuisUtil.GetEntityText(mockEntity, _ENTITY, mockEntity.StartIndex, mockEntity.EndIndex + 1);
+
+            //Assert
+            Assert.Equal(_ENTITY, actualEntityText);
+        }
+
+        [Fact]
+        public void GetEntityTextShouldReturnUtterance()
+        {
+            //Arrange
+            const string UTTERANCE = "entity";
+            var mockEntity = new EntityModel { Entity = _ENTITY, StartIndex = 0, EndIndex = _ENTITY.Length };
+
+            //Act
+            var actualEntityText = LuisUtil.GetEntityText(mockEntity, UTTERANCE, mockEntity.StartIndex, mockEntity.EndIndex + 1);
+
+            //Assert
+            Assert.Equal(UTTERANCE, actualEntityText);
+        }
+
+        [Theory]
+        [InlineData("testEntity with utterance", 0, 9)]
+        [InlineData("utterance with testEntity", 15, 24)]
+        [InlineData("utterance, testEntity and other things", 12, 21)]
+        public void GetEntityTextShouldReturnUtteranceSubstring(string utterance, int start, int end)
+        {
+            //Arrange
+            var mockEntity = new EntityModel { Entity = _ENTITY, StartIndex = start, EndIndex = end };
+
+            //Act
+            var actualEntityText = LuisUtil.GetEntityText(mockEntity, utterance, mockEntity.StartIndex, mockEntity.EndIndex + 1);
+
+            //Assert
+            Assert.Equal(_ENTITY, actualEntityText);
+        }
+
+        [Theory]
+        [InlineData("utterance with entity", 15, 20)]
+        [InlineData("entity with utterance", 0, 5)]
+        [InlineData("utterance, entity and other things", 11, 16)]
+        public void GetEntityTextShouldReturnUtteranceSubstringWithEntityTextSmallerThanTheEntity(string utterance, int start, int end)
+        {
+            //Arrange
+            const string SMALL_ENTITY = "entity";
+            var mockEntity = new EntityModel { Entity = _ENTITY, StartIndex = start, EndIndex = end };
+
+            //Act
+            var actualEntityText = LuisUtil.GetEntityText(mockEntity, utterance, mockEntity.StartIndex, mockEntity.EndIndex + 1);
+
+            //Assert
+            Assert.Equal(SMALL_ENTITY, actualEntityText);
+        }
+    }
+}


### PR DESCRIPTION
Fixes Issue#3568 utterance smaller than entity indexes

## Description
This pull request is a follow up on a [previous pull request](https://github.com/microsoft/botbuilder-dotnet/pull/4456) that was closed due to inactivity.

It fixes the [issue #3568](https://github.com/microsoft/botframework-solutions/issues/3568), adding the requested unit tests.

## Specific Changes
Adds a verification on the utterance length when setting the Entity text in the class LuisUtil. The current behavior is only modified for utterance with a length smaller than the entity. We followed the suggestion made on the previous pull request where the utterance is returned when it is shorter than the entity.

## Testing
We added tests for both current and new behaviors.