### PR TITLE
fix: use base64 encoded JSON values

### DIFF
--- a/.github/workflows/create-botbuilder-js-parity-issue.yml
+++ b/.github/workflows/create-botbuilder-js-parity-issue.yml
@@ -7,20 +7,57 @@ on:
     types: [closed]
 
 jobs:
-  triggerWorkflow:
+  encode:
+    name: encode inputs
+    runs-on: ubuntu-latest
+
+    outputs:
+      pr-body: ${{ steps.pr-body.outputs.value }}
+      pr-number: ${{ steps.pr-number.outputs.value }}
+      pr-title: ${{ steps.pr-title.outputs.value }}
+      repository: ${{ steps.repository.outputs.value }}
+
+    steps:
+      - id: pr-body
+        if: github.event.pull_request.merged == true
+        uses: joshgummersall/base64-encode@main
+        with:
+          value: ${{ github.event.pull_request.body }}
+
+      - id: pr-number
+        if: github.event.pull_request.merged == true
+        uses: joshgummersall/base64-encode@main
+        with:
+          value: ${{ github.event.pull_request.number }}
+
+      - id: pr-title
+        if: github.event.pull_request.merged == true
+        uses: joshgummersall/base64-encode@main
+        with:
+          value: ${{ github.event.pull_request.title }}
+
+      - id: repository
+        if: github.event.pull_request.merged == true
+        uses: joshgummersall/base64-encode@main
+        with:
+          value: ${{ github.repository }}
+
+  dispatchWorkflow:
     name: create parity issue for botbuilder-js
     runs-on: ubuntu-latest
+    needs: encode
 
     steps:
       - uses: joshgummersall/dispatch-workflow@main
         if: github.event.pull_request.merged == true
         with:
+          encoded: "true"
           inputs: |
             {
-              "prDescription": "${{ github.event.pull_request.body }}",
-              "prNumber": "${{ github.event.pull_request.number }}",
-              "prTitle": "${{ github.event.pull_request.title }}",
-              "sourceRepo": "${{ github.repository }}"
+              "prDescription": "${{ needs.encode.outputs.pr-body }}",
+              "prNumber": "${{ needs.encode.outputs.pr-number }}",
+              "prTitle": "${{ needs.encode.outputs.pr-title }}",
+              "sourceRepo": "${{ needs.encode.outputs.repository }}"
             }
           ref: main
           repo: microsoft/botbuilder-js


### PR DESCRIPTION
Github actions don't have a lot of rich operators or functions to, for
example, construct JSON.

The `dispatch-workflow` action expects a JSON string that includes some
PR metadata (which may include single or double quotes).

In order to make this as simple as possible, but also as flexible as
possible, base64 encode all JSON values before jamming them in the JSON
string.

The `dispatch-workflow` action, then, knows how to decode these values.