### PR TITLE
Update Channel.cs to make it clear that Telegram supports card actions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                     return buttonCnt <= 99;
 
                 case Connector.Channels.Slack:
+                case Connector.Channels.Telegram:
                 case Connector.Channels.Emulator:
                 case Connector.Channels.Directline:
                 case Connector.Channels.DirectlineSpeech:


### PR DESCRIPTION
`Channel.SupportsCardActions` returns false for Telegram when it should return true. This makes no difference when you call `ChoiceFactory.ForChannel` because that prefers suggested actions anyway, but it's important to have `Channel.SupportsCardActions` contain accurate information anyway.