### PR TITLE
Support Skip() as an operation for form generation

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -1582,8 +1582,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 if (candidate.Operation == AdaptiveEvents.ChooseEntity)
                 {
                     // Property has resolution so remove entity ambiguity
-                    existing.Dequeue(actionContext);
-                    candidate.Operation = DefaultOperation(candidate, askDefaultOp, defaultOp);
+                    var entityChoices = existing.Dequeue(actionContext);
+                    candidate.Operation = entityChoices.Operation;
+                    if (candidate.Entity.Value is JArray values && values.Count > 1)
+                    {
+                        // Resolve ambiguous response to one of the original choices
+                        var originalChoices = entityChoices.Entity.Value as JArray;
+                        var intersection = values.Intersect(originalChoices);
+                        if (intersection.Any())
+                        {
+                            candidate.Entity.Value = intersection;
+                        }
+                    }
                 }
                 else if (candidate.Operation == AdaptiveEvents.ChooseProperty)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
@@ -62,6 +62,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public uint RaisedCount { get; set; } = 0;
 
         /// <summary>
+        /// Gets or sets the expected properties when assignment was made.
+        /// </summary>
+        /// <value>
+        /// Expected properties.
+        /// </value>
+        [JsonProperty("expectedProperties")]
+        public IReadOnlyCollection<string> ExpectedProperties { get; set; }
+
+        /// <summary>
         /// Gets the alternative entity assignments.
         /// </summary>
         /// <value>
@@ -77,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 {
                     yield return current;
                     current = current.Alternative;
-                } 
+                }
                 while (current != null);
             }
         }

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -7002,14 +7002,11 @@
           "description": "SnapShot file path.",
           "default": "=settings.orchestrator.shapshotpath"
         },
-        "entityRecognizers": {
-          "type": "array",
-          "title": "Entity recognizers",
-          "description": "Collection of entity recognizers to use.",
-          "items": {
-            "$kind": "Microsoft.IEntityRecognizer",
-            "$ref": "#/definitions/Microsoft.IEntityRecognizer"
-          }
+        "externalEntityRecognizer": {
+          "$kind": "Microsoft.IRecognizer",
+          "title": "External entity recognizer",
+          "description": "Entities recognized by this recognizer will be merged with Orchestrator results.",
+          "$ref": "#/definitions/Microsoft.IRecognizer"
         },
         "disambiguationScoreThreshold": {
           "$ref": "#/definitions/numberExpression",


### PR DESCRIPTION
Fix bug where an operation without properties would get dropped as an assignment.
Preserve expectedEntities for assignments without a property.
Preserve operation when choosing an entity.
Both of these were to support skip as an entity in generation.

