### PR TITLE
Switch to list to be consistent with other properties.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -1416,7 +1416,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 if (assignment.Property == null)
                 {
-                    assignment.ExpectedProperties = expected;
+                    assignment.ExpectedProperties = expected.ToList();
                 }
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
@@ -68,7 +68,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// Expected properties.
         /// </value>
         [JsonProperty("expectedProperties")]
-        public IReadOnlyCollection<string> ExpectedProperties { get; set; }
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
+        public List<string> ExpectedProperties { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only 
 
         /// <summary>
         /// Gets the alternative entity assignments.


### PR DESCRIPTION
Tom asked for this to be changed from a readonly collection to a list to be consistent with the API.