### PR TITLE
add resource tags to FB adapter CI

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -60,6 +60,13 @@ steps:
   displayName: 'Display env vars'
 
 - powershell: |
+   # Create DateTimeTag for Resource Group
+   $DateTimeTag=Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+   "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
+  displayName: 'Create DateTimeTag for Resource Group'
+  # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
+
+- powershell: |
     $InvalidVariables = $FALSE
     $Message = "Required variable 'REPLACE_VARIABLE' either null, empty or whitespaced. Please set up this variable in the pipeline configuration."
 
@@ -109,7 +116,7 @@ steps:
      Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
      Write-Host "************************************************************************";
      Set-PSDebug -Trace 1;
-     az group create --location westus --name $(BotGroup);
+     az group create --location westus --name $(BotGroup) --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)";
      
      # set up bot channels registration, app service, app service plan
      az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" facebookVerifyToken="$(FacebookTestBotFacebookVerifyToken)" facebookAppSecret="$(FacebookTestBotFaceBookAppSecret)"  facebookAccessToken="$(FacebookTestBotFacebookAccessToken)" --name "$(BotName)";
@@ -129,7 +136,7 @@ steps:
      Set-PSDebug -Trace 1;
      
      # set up resource group, bot channels registration, app service, app service plan
-     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" facebookVerifyToken="$(FacebookTestBotFacebookVerifyToken)" facebookAppSecret="$(FacebookTestBotFaceBookAppSecret)"  facebookAccessToken="$(FacebookTestBotFacebookAccessToken)";
+     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" facebookVerifyToken="$(FacebookTestBotFacebookVerifyToken)" facebookAppSecret="$(FacebookTestBotFaceBookAppSecret)"  facebookAccessToken="$(FacebookTestBotFacebookAccessToken)" groupTags='{\"buildName\":\"$(Build.DefinitionName)\", \"cause\":\"automation\", \"date\":\"$(DateTimeTag)\", \"product\":\"$(Build.Repository.Name)\", \"sourceBranch\":\"$(Build.SourceBranch)\"}';
      Set-PSDebug -Trace 0;
   condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/DeploymentTemplates/template-with-new-rg.json
@@ -90,7 +90,16 @@
       "metadata": {
         "description": "The Facebook page access token."
       }
-    }
+    },
+    "groupTags": {
+      "type": "object",
+      "defaultValue": {
+          "cause": "automation"
+      },
+      "metadata": {
+        "description": "Populated with DevOps Pipeline values at runtime."
+      }
+  }
   },
   "variables": {
     "appServicePlanName": "[parameters('newAppServicePlanName')]",
@@ -106,8 +115,8 @@
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2018-05-01",
       "location": "[parameters('groupLocation')]",
-      "properties": {
-      }
+      "properties": {},
+      "tags": "[parameters('groupTags')]"
     },
     {
       "type": "Microsoft.Resources/deployments",


### PR DESCRIPTION
## Description
Adds tags to the provisioned Azure Resource Group for automated management of RGs for the **Facebook adapter tests**.

These tags indicate when and why the Resource Group was created. They also provide pointers to the repository, the source branch and name of the pipeline that was run to better assist other team members with figuring out who to contact.

## Specific Changes
- Add tags to `az group create` step
- Create `$DateTimeTag` runtime variable in Azure DevOps
  - A REST call is required to get the actual pipeline queue time, which didn't seem necessary for the goals of this PR.
- Creating an RG via ARM template also sets the appropriate tags

___

### Azure screencap of changes in action

![nightlyFB-tags](https://user-images.githubusercontent.com/14935595/101407239-720f0d80-388f-11eb-9fa5-cdddee1aabf8.png)

