### PR TITLE
Change LogAction.Text from stringExpression to IActivityTemplate

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.schema
@@ -23,7 +23,7 @@
             ]
         },
         "text": {
-            "$ref": "schema:#/definitions/stringExpression",
+            "$kind": "Microsoft.IActivityTemplate",
             "title": "Text",
             "description": "Information to log."
         },


### PR DESCRIPTION
Fixes #4988 
## Description
The schema definition of field Text is in conflict with the field type in LogAction.cs

## Specific Changes
Updating the schema definition to IActivityTemplate.
