### PR TITLE
Fix FileTranscriptLogger

### DIFF
--- a/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
@@ -287,6 +287,18 @@ namespace Microsoft.Bot.Builder
             }
         }
 
+        private static string SanitizeString(string str, char[] invalidChars)
+        {
+            var sb = new StringBuilder(str);
+
+            foreach (var invalidChar in invalidChars)
+            {
+                sb.Replace(invalidChar.ToString(), string.Empty);
+            }
+
+            return sb.ToString();
+        }
+
         private string GetTranscriptFile(string channelId, string conversationId)
         {
             if (channelId == null)
@@ -300,9 +312,10 @@ namespace Microsoft.Bot.Builder
             }
 
             var channelFolder = GetChannelFolder(channelId);
-            var fileName = SanitizeFileName(conversationId);
-            var transcriptFile = Path.Combine(channelFolder, fileName + ".transcript");
-            return transcriptFile;
+
+            var fileName = SanitizeString(conversationId, Path.GetInvalidFileNameChars());
+
+            return Path.Combine(channelFolder, fileName + ".transcript");
         }
 
         private string GetChannelFolder(string channelId)
@@ -312,25 +325,15 @@ namespace Microsoft.Bot.Builder
                 throw new ArgumentNullException(channelId);
             }
 
-            var channelFolder = Path.Combine(_folder, channelId);
+            var folderName = SanitizeString(channelId, Path.GetInvalidPathChars());
+
+            var channelFolder = Path.Combine(_folder, folderName);
             if (!Directory.Exists(channelFolder))
             {
                 Directory.CreateDirectory(channelFolder);
             }
 
             return channelFolder;
-        }
-
-        private string SanitizeFileName(string fileName)
-        {
-            var sb = new StringBuilder(fileName);
-
-            foreach (var invalidFilNameChar in Path.GetInvalidFileNameChars())
-            {
-                sb.Replace(invalidFilNameChar.ToString(), string.Empty);
-            }
-
-            return sb.ToString();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
@@ -299,7 +300,8 @@ namespace Microsoft.Bot.Builder
             }
 
             var channelFolder = GetChannelFolder(channelId);
-            string transcriptFile = Path.Combine(channelFolder, conversationId + ".transcript");
+            var fileName = SanitizeFileName(conversationId);
+            var transcriptFile = Path.Combine(channelFolder, fileName + ".transcript");
             return transcriptFile;
         }
 
@@ -317,6 +319,18 @@ namespace Microsoft.Bot.Builder
             }
 
             return channelFolder;
+        }
+
+        private string SanitizeFileName(string fileName)
+        {
+            var sb = new StringBuilder(fileName);
+
+            foreach (var invalidFilNameChar in Path.GetInvalidFileNameChars())
+            {
+                sb.Replace(invalidFilNameChar.ToString(), string.Empty);
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
@@ -113,10 +113,11 @@ namespace Microsoft.Bot.Builder
                     }
                 }
 #pragma warning disable CA1031 // Do not catch general exception types (we ignore the exception and we retry)
-                catch (Exception)
+                catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
                 {
                     // try again
+                    Trace.TraceError($"Try {i + 1} - Failed to log activity because: {e.GetType()} : {e.Message}");
                 }
             }
         }

--- a/tests/Microsoft.Bot.Builder.Tests/FileTranscriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/FileTranscriptTests.cs
@@ -38,6 +38,12 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [Fact]
+        public async Task FileTranscript_LogActivityWithInvalidIds()
+        {
+            await LogActivityWithInvalidIds();
+        }
+
+        [Fact]
         public async Task FileTranscript_LogMultipleActivities()
         {
             await LogMultipleActivities();

--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptBaseTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptBaseTests.cs
@@ -43,6 +43,32 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.Equal(JsonConvert.SerializeObject(activity), JsonConvert.SerializeObject(results.Items[0]));
         }
 
+        public async Task LogActivityWithInvalidIds()
+        {
+            var channelId = "channelWith|invalidChars";
+            var emulatorConversationId = "8b6e9a80-3c94-11eb-83c4-83172d04969b|livechat";
+
+            var activity = new Activity()
+            {
+                Type = ActivityTypes.Message,
+                Timestamp = DateTime.UtcNow,
+                Id = Guid.NewGuid().ToString(),
+                Text = "text",
+                ChannelId = channelId,
+                From = new ChannelAccount($"User"),
+                Conversation = new ConversationAccount(id: emulatorConversationId),
+                Recipient = new ChannelAccount("Bot1", "2"),
+                ServiceUrl = "http://foo.com/api/messages",
+            };
+
+            await Store.LogActivityAsync(activity);
+
+            var results = await Store.GetTranscriptActivitiesAsync(channelId, emulatorConversationId);
+            Assert.Single(results.Items);
+
+            Assert.Equal(JsonConvert.SerializeObject(activity), JsonConvert.SerializeObject(results.Items[0]));
+        }
+
         public async Task LogMultipleActivities()
         {
             string conversationId = "LogMultipleActivities";


### PR DESCRIPTION
## Description

The `FileTranscriptLogger` has a bug when it's being used in a bot that is being tested locally from the Bot Framework Emulator.

The problem is that the logger is trying to create a transcript file with the following name format: `<conversationId>.transcript`. But when you are talking to the from the Emulator, the conversation ID is set by the Emulator to strings like this: `8b6e9a80-3c94-11eb-83c4-83172d04969b|livechat`.

I have no idea about Linux/Mac (and a bit lazy right now to check :)), but I am 100% sure that on Windows, the `|` character is not a valid character in a filename (it's before the `livechat` part in the above example), thus the `FileTranscriptLogger` will fail to log any activities to the filesystem. Worst of all, it does this silently, leaving almost zero traces of the issue in the bot's logs.

This PR intends to fix both of these issues: the usage of incorrect filenames and the lack of logging.

## Specific Changes
  - Add error logging when we fail to log an Activty to the filesystem.
  - Make sure we use valid filenames for saving the transcript file - regardless of host OS - by removing invalid characters from the conversation ID.
  - Also take care of possibly invalid folder names based on the channel ID by removing invalid characters from those as well before creating folders for the transcript files. (By default none of the channel ID-s contain any special characters - like `emulator` - but in practice a client can send any arbitrary string as the channel ID to the bot, even one that contains invalid characters.)