### PR TITLE
Fix dialog id is not default set to resource id issue when LoadType = AdaptiveDialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
 
                 var (token, range) = SourceScope.ReadTokenRange(readerJson, sourceContext);
 
-                AutoAssignId(resource, token, sourceContext);
+                AutoAssignId(resource, token, sourceContext, range);
                 range.Path = resource.FullName ?? resource.Id;
                 return (token, range);
             }
@@ -679,13 +679,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             }
         }
 
-        private void AutoAssignId(Resource resource, JToken jToken, SourceContext sourceContext)
+        private void AutoAssignId(Resource resource, JToken jToken, SourceContext sourceContext, SourceRange range)
         {
             if (sourceContext is ResourceSourceContext resourceSourceContext)
             {
-                if (jToken is JObject jObj && !jObj.ContainsKey("id") && !resourceSourceContext.DefaultIdMap.ContainsKey(jToken))
+                if (jToken is JObject jObj && !jObj.ContainsKey("id"))
                 {
-                    resourceSourceContext.DefaultIdMap.Add(jToken, resource.Id);
+                    jObj["id"] = resource.Id;
+                    range.EndPoint.LineIndex += 1;
+
+                    if (!resourceSourceContext.DefaultIdMap.ContainsKey(jToken))
+                    {
+                        resourceSourceContext.DefaultIdMap.Add(jToken, resource.Id);
+                    }
                 }
             }
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -328,6 +328,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             }
         }
 
+        [Fact]
+        public async Task ResourceExplorer_LoadType_VerifyAdaptiveDialogIdAssigned()
+        {
+            var path = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, PathUtils.NormalizePath(@"..\..\..")));
+            const string resourceId = "test.dialog";
+
+            using (var explorer = new ResourceExplorer())
+            {
+                explorer.AddResourceProvider(new FolderResourceProvider(explorer, path));
+
+                // Load file using resource explorer
+                var resource = explorer.GetResource(resourceId);
+                var dialog = await explorer.LoadTypeAsync<AdaptiveDialog>(resource).ConfigureAwait(false);
+
+                // Verify that the correct id was assigned
+                Assert.Equal(resourceId, dialog.Id);
+            }
+        }
+
         private static void AssertResourceFound(ResourceExplorer explorer, string id)
         {
             var dialog = explorer.GetResource(id);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(0, 0),
-                    EndPoint = new SourcePoint(13, 1),
+                    EndPoint = new SourcePoint(14, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 
@@ -257,7 +257,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(1, 1),
-                    EndPoint = new SourcePoint(13, 1),
+                    EndPoint = new SourcePoint(14, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 
@@ -287,7 +287,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var expectedRange = new SourceRange
                 {
                     StartPoint = new SourcePoint(1, 1),
-                    EndPoint = new SourcePoint(13, 1),
+                    EndPoint = new SourcePoint(14, 1),
                     Path = Path.Join(Path.Join(path, resourcesFolder), resourceId)
                 };
 

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -4496,10 +4496,9 @@
           ]
         },
         "text": {
-          "$kind": "Microsoft.IActivityTemplate",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate",
           "title": "Text",
-          "description": "Information to log.",
-          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+          "description": "Information to log."
         },
         "label": {
           "$ref": "#/definitions/stringExpression",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -4496,9 +4496,10 @@
           ]
         },
         "text": {
-          "$ref": "#/definitions/stringExpression",
+          "$kind": "Microsoft.IActivityTemplate",
           "title": "Text",
-          "description": "Information to log."
+          "description": "Information to log.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
         },
         "label": {
           "$ref": "#/definitions/stringExpression",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -4496,7 +4496,7 @@
           ]
         },
         "text": {
-          "$ref": "#/definitions/Microsoft.IActivityTemplate",
+          "$ref": "#/definitions/stringExpression",
           "title": "Text",
           "description": "Information to log."
         },


### PR DESCRIPTION
Fixes #4821

## Description
Set resource id as the default dialog id in loaded dialog memory when the id is not specified in dialog definition

## Specific Changes
- Change AutoAssignId function in ResourceExplorer.cs to assign id to loaded dialog json token

## Testing
Unit test is added in ResourceTests.cs