### PR TITLE
Enable skill authentication and default behaviors on core runtime

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Runtime/Authentication/AllowedCallersClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Builder.Runtime/Authentication/AllowedCallersClaimsValidator.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Bot.Builder.Runtime.Authentication
         /// <returns>True if the validation is successful, false if not.</returns>
         public override Task ValidateClaimsAsync(IList<Claim> claims)
         {
+            if (claims == null)
+            {
+                throw new ArgumentNullException(nameof(claims));
+            }
+
             // If _allowedCallers contains an "*", allow all callers.
             if (SkillValidation.IsSkillClaim(claims) &&
                 !_allowedCallers.Contains("*"))

--- a/libraries/Microsoft.Bot.Builder.Runtime/Authentication/AllowedCallersClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Builder.Runtime/Authentication/AllowedCallersClaimsValidator.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Bot.Builder.Runtime.Authentication
+{
+    public class AllowedCallersClaimsValidator : ClaimsValidator
+    {
+        public const string DefaultAllowedCallersKey = "skillConfiguration:allowedCallers";
+
+        private readonly List<string> _allowedCallers = new List<string>();
+
+        public AllowedCallersClaimsValidator(IConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            // AllowedCallers is the setting in the appsettings.json file
+            // that consists of the list of consumer bot application ids that are allowed to access the skill.
+            var allowedCallersList = configuration.GetSection(DefaultAllowedCallersKey).Get<string[]>();
+            if (allowedCallersList != null)
+            {
+                _allowedCallers = new List<string>(allowedCallersList);
+            }
+        }
+
+        /// <summary>
+        /// Validate a list of claims and throw an exception if it fails.
+        /// </summary>
+        /// <param name="claims">The list of claims to validate.</param>
+        /// <returns>True if the validation is successful, false if not.</returns>
+        public override Task ValidateClaimsAsync(IList<Claim> claims)
+        {
+            // If _allowedCallers contains an "*", allow all callers.
+            if (SkillValidation.IsSkillClaim(claims) &&
+                !_allowedCallers.Contains("*"))
+            {
+                // Check that the appId claim in the skill request is in the list of callers configured for this bot.
+                var applicationId = JwtTokenValidation.GetAppIdFromClaims(claims);
+                if (!_allowedCallers.Contains(applicationId))
+                {
+                    throw new UnauthorizedAccessException(
+                        $"Received a request from a bot with an app ID of \"{applicationId}\". To enable requests from this caller, add the app ID to your ${DefaultAllowedCallersKey} configuration.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Runtime/CoreBot.cs
+++ b/libraries/Microsoft.Bot.Builder.Runtime/CoreBot.cs
@@ -69,13 +69,6 @@ namespace Microsoft.Bot.Builder.Runtime
         /// <seealso cref="ActivityTypes"/>
         public virtual async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var rootDialog = (AdaptiveDialog)this._dialogManager.RootDialog;
-            if (turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity claimIdentity &&
-                SkillValidation.IsSkillClaim(claimIdentity.Claims))
-            {
-                rootDialog.AutoEndDialog = true;
-            }
-
             await this._dialogManager.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
             await this._conversationState.SaveChangesAsync(turnContext, false, cancellationToken).ConfigureAwait(false);
             await this._userState.SaveChangesAsync(turnContext, false, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder.Runtime/Providers/RuntimeConfigurationProvider.cs
+++ b/libraries/Microsoft.Bot.Builder.Runtime/Providers/RuntimeConfigurationProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Skills;
+using Microsoft.Bot.Builder.Runtime.Authentication;
 using Microsoft.Bot.Builder.Runtime.Extensions;
 using Microsoft.Bot.Builder.Runtime.Providers.Adapter;
 using Microsoft.Bot.Builder.Runtime.Providers.Storage;
@@ -126,13 +127,13 @@ namespace Microsoft.Bot.Builder.Runtime.Providers
 
             ConfigureSkillServices(services);
             ConfigureBotStateServices(services);
-            ConfigureAuthenticationConfigurationServices(services);
+            ConfigureAuthenticationConfigurationServices(services, configuration);
             ConfigureCoreBotServices(services, configuration);
         }
 
-        private static void ConfigureAuthenticationConfigurationServices(IServiceCollection services)
+        private static void ConfigureAuthenticationConfigurationServices(IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton<AuthenticationConfiguration>();
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(configuration) });
         }
 
         private static void ConfigureBotStateServices(IServiceCollection services)

--- a/tests/Microsoft.Bot.Builder.Runtime.Tests/Authentication/AllowedCallersClaimsValidationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Runtime.Tests/Authentication/AllowedCallersClaimsValidationTests.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Runtime.Authentication;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Runtime.Tests.Authentication
+{
+    public class AllowedCallersClaimsValidationTests
+    {
+        private string version = "1.0";
+
+        private string audienceClaim = Guid.NewGuid().ToString();
+
+        public static IEnumerable<object[]> GetConfigureServicesSucceedsData()
+        {
+            string primaryAppId = Guid.NewGuid().ToString();
+            string secondaryAppId = Guid.NewGuid().ToString();
+
+            // Null allowed callers
+            yield return new object[]
+            {
+                (string)null,
+                (IConfiguration)TestDataGenerator.BuildConfigurationRoot()
+            };
+
+            // Empty allowed callers array
+            yield return new object[]
+            {
+                (string)null,
+                (IConfiguration)TestDataGenerator.BuildConfigurationRoot(new JObject
+                {
+                    { AllowedCallersClaimsValidator.DefaultAllowedCallersKey, JToken.FromObject(new string[0]) }
+                })
+            };
+
+            // Allow any caller
+            yield return new object[]
+            {
+                primaryAppId,
+                (IConfiguration)TestDataGenerator.BuildConfigurationRoot(new JObject
+                {
+                    { AllowedCallersClaimsValidator.DefaultAllowedCallersKey, JToken.FromObject(new string[] { "*" }) }
+                })
+            };
+
+            // Specify allowed caller
+            yield return new object[]
+            {
+                primaryAppId,
+                (IConfiguration)TestDataGenerator.BuildConfigurationRoot(new JObject
+                {
+                    { AllowedCallersClaimsValidator.DefaultAllowedCallersKey, JToken.FromObject(new string[] { $"{primaryAppId}" }) }
+                })
+            };
+
+            // Specify multiple callers
+            yield return new object[]
+            {
+                primaryAppId,
+                (IConfiguration)TestDataGenerator.BuildConfigurationRoot(new JObject
+                {
+                    { AllowedCallersClaimsValidator.DefaultAllowedCallersKey, JToken.FromObject(new string[] { $"{primaryAppId}", $"{secondaryAppId}" }) }
+                })
+            };
+
+            // Blocked caller throws exception
+            yield return new object[]
+            {
+                primaryAppId,
+                (IConfiguration)TestDataGenerator.BuildConfigurationRoot(new JObject
+                {
+                    { AllowedCallersClaimsValidator.DefaultAllowedCallersKey, JToken.FromObject(new string[] { $"{secondaryAppId}" }) }
+                })
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetConfigureServicesSucceedsData))]
+
+        public async Task AcceptAllowedCallersArray(string allowedCallerClaimId, IConfiguration configuration)
+        {
+            var validator = new AllowedCallersClaimsValidator(configuration);
+
+            var allowedCallersList = configuration.GetSection(AllowedCallersClaimsValidator.DefaultAllowedCallersKey).Get<string[]>();
+
+            if (allowedCallersList != null)
+            {
+                var claims = CreateCallerClaims(allowedCallerClaimId);
+
+                if (allowedCallersList.Contains(allowedCallerClaimId) || allowedCallersList.Contains("*"))
+                {
+                    await validator.ValidateClaimsAsync(claims);
+                }
+                else
+                {
+                    Exception ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => validator.ValidateClaimsAsync(claims));
+
+                    Assert.Equal(
+                        $"Received a request from a bot with an app ID of \"{allowedCallerClaimId}\". To enable requests from this caller," +
+                        $" add the app ID to your ${AllowedCallersClaimsValidator.DefaultAllowedCallersKey} configuration.", ex.Message);
+                }
+            }
+        }
+
+        private List<Claim> CreateCallerClaims(string appId)
+        {
+            return new List<Claim>()
+            {
+                new Claim(AuthenticationConstants.AppIdClaim, appId),
+                new Claim(AuthenticationConstants.VersionClaim, version),
+                new Claim(AuthenticationConstants.AudienceClaim, audienceClaim),
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixes microsoft/botframework-core#24
Fixes microsoft/botframework-core#31
Fixes microsoft/botframework-core#44

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
- Remove autoEndDialog enforcement for skill bots.
- Instantiate allowed callers claims validation for all bots (host and skill), this is used to validate identity [Claim](https://docs.microsoft.com/en-us/dotnet/api/system.security.claims.claim?view=net-5.0).

## Specific Changes
#### AutoEndDialog
The current implementation enforces the runtime to auto end the root dialog when it is consumed as a skill, but this restricts the bot author from making that decision themselves (setting the autoEndDialog property in the root dialog using Composer). There are two scenarios where the skill dialog needs to end.

1. The skill dialog ends automatically when there are no more actions available in the stack. This will be supported with something like `turn.activity.isSkill` and is on the backlog.
1. The skill dialog ends when the parent bot sends the signal. This is supported by the value `true`.

#### Allowed callers claims validation
Composer bots use the following settings for authentication configuration. This restricts which skill consumers (core bot) can access the skill.
```
  "skillConfiguration": {
    "isSkill": true,
    "allowedCallers": [comma separated list of app ids with access to the skill]
  }
```
Read [Implement a skill](https://docs.microsoft.com/en-us/azure/bot-service/skill-implement-skill?view=azure-bot-service-4.0&tabs=cs#application-configuration) for supporting documentation.

## Testing
- Added tests for allowed callers claims validation.
- Validated in Composer with:

|Description|Core `allowedCallers`|Skill `allowedCallers`|Expected|
|-|-|-|-|
|Core calls local skill|[ ]|[ ]|Success|
|Core calls remote skill with empty array|["*"]|[ ] |401 error|
|Core calls remote skill with any allowed caller|["*"]|["*"]|Success|
|Core calls remote skill with coreAppId|["*"]|["coreAppId"]|Success|