### PR TITLE
Remove comment only ProductInfoHeaderValue

### DIFF
--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -209,9 +209,9 @@ namespace Microsoft.Bot.Connector
                     // .NETCoreAppVersion/v3.1
 
                     // from:
-                    // Microsoft Windows 10.0.19042
+                    // .NET Framework 4.8.4250.0
                     // to:
-                    // MicrosoftWindows/10.0.19042
+                    // .NETFramework/4.8.4250.0
 
                     var splitFramework = framework.Replace(",", string.Empty).Replace(" ", string.Empty).Split('=');
                     if (splitFramework.Length > 1)

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Rest;
 using Newtonsoft.Json.Serialization;
@@ -199,12 +200,53 @@ namespace Microsoft.Bot.Connector
 
                 // Additional Info.
                 // https://github.com/Microsoft/botbuilder-dotnet/blob/d342cd66d159a023ac435aec0fdf791f93118f5f/doc/UserAgents.md
-                var userAgent = $"({GetASPNetVersion()}; {GetOsVersion()}; {GetArchitecture()})";
-                if (ProductInfoHeaderValue.TryParse(userAgent, out var additionalProductInfo))
+                var framework = GetASPNetVersion();
+                if (!string.IsNullOrWhiteSpace(framework) && framework.Length > 0)
                 {
-                    if (!httpClient.DefaultRequestHeaders.UserAgent.Contains(additionalProductInfo))
+                    // from:
+                    // .NETCoreApp,Version=v3.1
+                    // to:
+                    // .NETCoreAppVersion/v3.1
+
+                    // from:
+                    // Microsoft Windows 10.0.19042
+                    // to:
+                    // MicrosoftWindows/10.0.19042
+
+                    var splitFramework = framework.Replace(",", string.Empty).Replace(" ", string.Empty).Split('=');
+                    if (splitFramework.Length > 1)
                     {
-                        httpClient.DefaultRequestHeaders.UserAgent.Add(additionalProductInfo);
+                        ProductInfoHeaderValue aspProductInfo = null;
+
+                        if (ProductInfoHeaderValue.TryParse($"{splitFramework[0]}/{splitFramework[1]}", out aspProductInfo))
+                        {
+                            if (!httpClient.DefaultRequestHeaders.UserAgent.Contains(aspProductInfo))
+                            {
+                                httpClient.DefaultRequestHeaders.UserAgent.Add(aspProductInfo);
+                            }
+                        }
+                    }
+                    else if (splitFramework.Length > 0)
+                    {
+                        framework = splitFramework[0];
+
+                        // Parse the version from the framework string.
+                        Regex regEx = new Regex(@"(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.\d+)", RegexOptions.Compiled);
+                        var version = regEx.Match(framework);
+
+                        if (version.Success)
+                        {
+                            framework = framework.Replace(version.Value, string.Empty).Trim();
+
+                            ProductInfoHeaderValue aspProductInfo = null;
+                            if (ProductInfoHeaderValue.TryParse($"{framework}/{version.Value}", out aspProductInfo))
+                            {
+                                if (!httpClient.DefaultRequestHeaders.UserAgent.Contains(aspProductInfo))
+                                {
+                                    httpClient.DefaultRequestHeaders.UserAgent.Add(aspProductInfo);
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/tests/Microsoft.Bot.Connector.Tests/ConnectorClientTest.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConnectorClientTest.cs
@@ -13,6 +13,18 @@ namespace Microsoft.Bot.Connector.Tests
     public class ConnectorClientTest : BaseTest
     {
         [Fact]
+        public void ConnectorClient_CustomHttpClient_UserAgentContainsAspNetVersion()
+        {
+            var customHttpClient = new HttpClient();   
+            ConnectorClient.AddDefaultRequestHeaders(customHttpClient);
+
+            // The AspNetVersion string is modified, to be used in a ProductInfoHeaderValue.
+            // This test replaces the same characters as what are required to construct a valid ProductInfoHeaderValue
+            var aspNetVersion = ConnectorClient.GetASPNetVersion().Replace(",", string.Empty).Replace(" ", string.Empty).Replace("=", string.Empty);
+            Assert.Contains(aspNetVersion, customHttpClient.DefaultRequestHeaders.UserAgent.ToString().Replace("/", string.Empty));
+        }
+
+        [Fact]
         public void ConnectorClient_CustomHttpClient_AndMicrosoftCredentials()
         {
             var baseUri = new Uri("https://test.coffee");


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botbuilder-dotnet/issues/4867

Fixes: https://github.com/microsoft/botbuilder-dotnet/issues/5042

Fixes: https://github.com/microsoft/BotFramework-Composer/issues/4828

Fixes: 
https://github.com/microsoft/botbuilder-dotnet/issues/5026

UserAgent:


Currently WITH comment only (web api):
Microsoft-BotFramework/3.1 
BotBuilder/4.0.0.0 
(.NET Framework 4.8.4250.0; Microsoft Windows 10.0.19042 ; X64)

Currently WITH comment ONLY (netcore):
Microsoft-BotFramework/3.1 
BotBuilder/4.0.0.0 
(.NETCoreApp,Version=v3.1; Microsoft Windows 10.0.19042; X64)

Currently WITHOUT comment only (netcore):
Microsoft-BotFramework/3.1 
BotBuilder/4.0.0.0 
FxVersion/4.700.20.41105 
OSName/Windows 
OSVersion/Microsoft.Windows.10.0.19042 
Microsoft.Bot.Connector.ConnectorClient/4.11.0.0

Removed comment only ProductInfoHeaderValue, and modified code to still include .net version, converted to Product and Version string. Accounting for

 .NET Framework 4.8.4250.0 
and
 .NETCoreApp,Version=v3.1


-example:
Microsoft-BotFramework/3.1 
BotBuilder/4.0.0.0 
.NETCoreAppVersion/v3.1 
FxVersion/4.700.20.41105 
OSName/Windows 
OSVersion/Microsoft.Windows.10.0.19042 
Microsoft.Bot.Connector.ConnectorClient/4.11.0.0