### PR TITLE
Throw a meaningful exception if InputDialog.Prompt is missing

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
             if (msg == null)
             {
-                template = this.Prompt;
+                template = this.Prompt ?? throw new InvalidOperationException($"InputDialog is missing Prompt.");
                 msg = await this.Prompt.BindAsync(dc, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/5060