### PR TITLE
fix: request scoped headers for LUIS v3 api calls

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
@@ -167,13 +167,16 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
                 using (var request = new HttpRequestMessage(HttpMethod.Post, uri.Uri))
                 {
-                    request.Content = new StringContent(content.ToString(), Encoding.UTF8, "application/json");
-                    request.Headers.Add("Ocp-Apim-Subscription-Key", Application.EndpointKey);
+                    using (var stringContent = new StringContent(content.ToString(), Encoding.UTF8, "application/json"))
+                    {
+                        request.Content = stringContent;
+                        request.Headers.Add("Ocp-Apim-Subscription-Key", Application.EndpointKey);
 
-                    var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                    response.EnsureSuccessStatusCode();
+                        var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                        response.EnsureSuccessStatusCode();
 
-                    luisResponse = (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+                        luisResponse = (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+                    }
                 }
 
                 var prediction = (JObject)luisResponse["prediction"];

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptionsV3.cs
@@ -164,12 +164,15 @@ namespace Microsoft.Bot.Builder.AI.Luis
             {
                 var uri = BuildUri(options);
                 var content = BuildRequestBody(utterance, options);
-                httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", Application.EndpointKey);
-                using (var stringContent = new StringContent(content.ToString(), System.Text.Encoding.UTF8, "application/json"))
+
+                using (var request = new HttpRequestMessage(HttpMethod.Post, uri.Uri))
                 {
-                    var response = await httpClient.PostAsync(uri.Uri, stringContent, cancellationToken).ConfigureAwait(false);
+                    request.Content = new StringContent(content.ToString(), Encoding.UTF8, "application/json");
+                    request.Headers.Add("Ocp-Apim-Subscription-Key", Application.EndpointKey);
+
+                    var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
                     response.EnsureSuccessStatusCode();
-                    httpClient.DefaultRequestHeaders.Remove("Ocp-Apim-Subscription-Key");
+
                     luisResponse = (JObject)JsonConvert.DeserializeObject(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
                 }
 


### PR DESCRIPTION
Modifying the `httpClient` default request headers seems a bit more prone to errors and/or side effects than simply constructing a scoped request with its own headers.