### PR TITLE
DialogManager should implement IBot.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <summary>
     /// Class which runs the dialog system.
     /// </summary>
-    public class DialogManager
+    public class DialogManager : IBot
     {
         private const string LastAccess = "_lastAccess";
         private string _rootDialogId;
@@ -249,6 +249,18 @@ namespace Microsoft.Bot.Builder.Dialogs
             await botStateSet.SaveAllChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
 
             return new DialogManagerResult { TurnResult = turnResult };
+        }
+
+        /// <summary>
+        /// IBot OnTurnAsync => OnTurnAsync.
+        /// </summary>
+        /// <remarks>This allows the DialogManager to be used directly as an IBot implementation with adapters.</remarks>
+        /// <param name="turnContext">turn context.</param>
+        /// <param name="cancellationToken">cancellation token.</param>
+        /// <returns>task.</returns>
+        async Task IBot.OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            await this.OnTurnAsync(turnContext, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
@@ -78,6 +78,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
+        public async Task DialogManager_IBot()
+        {
+            var storage = new MemoryStorage();
+            var convoState = new ConversationState(storage);
+            var userState = new UserState(storage);
+
+            var adapter = (TestAdapter)new TestAdapter()
+                .UseStorage(storage)
+                .UseBotState(userState, convoState)
+                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            await new TestFlow((TestAdapter)adapter, (IBot)new DialogManager(new SimpleDialog()))
+                .Send("hi")
+                    .AssertReply("simple")
+            .StartTestAsync();
+        }
+
+        [Fact]
         public async Task DialogManager_AlternateProperty()
         {
             var firstConversationId = Guid.NewGuid().ToString();
@@ -247,7 +265,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         Actions = new List<Dialog> { new AdaptiveDialog("inner") }
                     }
-                } 
+                }
             };
 
             var storage = new MemoryStorage();
@@ -261,7 +279,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
             // The inner adaptive dialog should be registered on the DialogManager after OnTurn
             var dm = new DialogManager(root);
-            
+
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
             {
                 await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -283,8 +301,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     new OnBeginDialog()
                     {
-                        Actions = new List<Dialog> 
-                        { 
+                        Actions = new List<Dialog>
+                        {
                             new AdaptiveDialog("inner")
                             {
                                 Triggers = new List<OnCondition>
@@ -294,13 +312,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                                         Actions = new List<Dialog>
                                         {
                                             new AdaptiveDialog("innerinner")
-                                            { 
+                                            {
                                                 Triggers = new List<OnCondition>()
-                                                { 
+                                                {
                                                     new OnBeginDialog()
-                                                    { 
+                                                    {
                                                         Actions = new List<Dialog>()
-                                                        { 
+                                                        {
                                                             new SendActivity("helloworld")
                                                         }
                                                     }


### PR DESCRIPTION
## Description
DialogManager is a full implementation of IBot.  If you want to use it as an IBot via dependency injection, etc. you have to 
create a class like
```cs
    public class Bot : DialogManager, IBot
    {
        async Task IBot.OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken) => await base.OnTurnAsync(turnContext, cancellationToken).ConfigureAwait(False);
    }
```
That is silly. We should just have DialogManager implement the IBot method signature.

## Specific Changes
Changed DialogManager to implement IBot.OnTurnAsync()


## Testing
Added unit test to verify it works.