### PR TITLE
Cyclical dialog graphs: Bug fixes and improvements in DialogSet, DialogManager and Type Loading

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
     /// </summary>
     public class DialogExpressionConverter : JsonConverter<DialogExpression>, IObservableConverter, IObservableJsonConverter
     {
+        private readonly Dictionary<string, DialogExpression> cache = new Dictionary<string, DialogExpression>();
         private readonly InterfaceConverter<Dialog> converter;
         private readonly ResourceExplorer resourceExplorer;
 
@@ -60,7 +61,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
                 var id = (string)reader.Value;
                 if (id.StartsWith("=", StringComparison.Ordinal))
                 {
-                    result = new DialogExpression(id);
+                    result = UpdateOrCreateExpression(id);
                 }
                 else
                 {
@@ -68,7 +69,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
                     {
                         using (var jsonTextReader = new JsonTextReader(new StringReader($"\"{id}\"")))
                         {
-                            result = new DialogExpression((Dialog)converter.ReadJson(jsonTextReader, objectType, existingValue, serializer));
+                            var dialog = (Dialog)converter.ReadJson(jsonTextReader, objectType, existingValue, serializer);
+                            result = UpdateOrCreateExpression(id, dialog);
                         }
                     }
                     catch (InvalidOperationException)
@@ -79,7 +81,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
                     catch (Exception)
 #pragma warning restore CA1031 // Do not catch general exception types
                     {
-                        result = new DialogExpression($"='{id}'");
+                        result = UpdateOrCreateExpression($"='{id}'");
                     }
                 }
             }
@@ -87,7 +89,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
             {
                 using (var jTokenReader = new JTokenReader(jToken))
                 {
-                    result = new DialogExpression((Dialog)this.converter.ReadJson(jTokenReader, objectType, existingValue, serializer));
+                    var dialog = (Dialog)this.converter.ReadJson(jTokenReader, objectType, existingValue, serializer);
+                    result = UpdateOrCreateExpression(dialog?.Id, dialog);
                 }
             }
 
@@ -138,6 +141,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
             }
 
             this.converter.RegisterObserver(observer);
+        }
+
+        private DialogExpression UpdateOrCreateExpression(string id, Dialog dialog = null)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentException("Expected non-empty dialog id in expression.", nameof(id));
+            }
+
+            if (cache.ContainsKey(id))
+            {
+                cache[id].SetValue(dialog);
+                return cache[id];
+            }
+            else
+            {
+                var result = new DialogExpression((Dialog)dialog);
+                cache.Add(id, result);
+                return result;
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
     /// </summary>
     public class DialogExpressionConverter : JsonConverter<DialogExpression>, IObservableConverter, IObservableJsonConverter
     {
-        private readonly Dictionary<string, DialogExpression> cache = new Dictionary<string, DialogExpression>();
+        private readonly Dictionary<string, DialogExpression> cache = new Dictionary<string, DialogExpression>(StringComparer.OrdinalIgnoreCase);
         private readonly InterfaceConverter<Dialog> converter;
         private readonly ResourceExplorer resourceExplorer;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -50,7 +50,15 @@ namespace Microsoft.Bot.Builder.Dialogs
             set
             {
                 base.TelemetryClient = value ?? NullBotTelemetryClient.Instance;
-                Dialogs.TelemetryClient = base.TelemetryClient;
+
+                // Care! Dialogs.TelemetryClient assigment internally assigns the 
+                // TelemetryClient for each dialog which could lead to an eventual stack
+                // overflow in cyclical dialg structures. 
+                // Don't set the telemetry client if the candidate instance is the same as the currently set one.
+                if (Dialogs.TelemetryClient != value)
+                {
+                    Dialogs.TelemetryClient = base.TelemetryClient;
+                }
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
@@ -382,7 +383,12 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                 foreach (var inner in container.Dialogs.GetDialogs())
                 {
-                    RegisterContainerDialogs(inner);
+                    // Only continue recursive registration if we have not seen and registered 
+                    // the current dialog.
+                    if (!Dialogs.GetDialogs().Any(d => d.Id == inner.Id))
+                    {
+                        RegisterContainerDialogs(inner);
+                    }
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -385,7 +385,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 {
                     // Only continue recursive registration if we have not seen and registered 
                     // the current dialog.
-                    if (!Dialogs.GetDialogs().Any(d => d.Id == inner.Id))
+                    if (!Dialogs.GetDialogs().Any(d => d.Id.Equals(inner.Id, StringComparison.Ordinal)))
                     {
                         RegisterContainerDialogs(inner);
                     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -58,6 +58,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
         }
 
         [Fact]
+        public async Task JsonDialogLoad_CycleDetection_AdaptiveDialogType()
+        {
+            await BuildTestFlow<AdaptiveDialog>(@"Root.dialog", nameof(JsonDialogLoad_CycleDetection))
+                .SendConversationUpdate()
+                .AssertReply("Hello")
+                .Send("Hello what?")
+                .AssertReply("World")
+                .Send("World what?")
+                .AssertReply("Hello")
+                .Send("Hello what?")
+                .AssertReply("World")
+                .Send("World what?")
+                .AssertReply("Hello")
+                .Send("Hello what?")
+                .AssertReply("World")
+                .Send("World what?")
+                .AssertReply("Hello")
+            .StartTestAsync();
+        }
+
+        [Fact]
         public void JsonDialogLoad_CycleDetectionWithNoCycleMode()
         {
             Assert.Throws<InvalidOperationException>(() => BuildNoCycleTestFlow(@"Root.dialog", nameof(JsonDialogLoad_CycleDetectionWithNoCycleMode)));
@@ -458,8 +479,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
 
         private TestFlow BuildTestFlow(string resourceName, string testName, bool sendTrace = false)
         {
+            return BuildTestFlow<Dialog>(resourceName, testName, sendTrace);
+        }
+
+        private TestFlow BuildTestFlow<T>(string resourceName, string testName, bool sendTrace = false)
+            where T : Dialog
+        {
             var adapter = InitializeAdapter(testName, sendTrace);
-            var dialog = _resourceExplorer.LoadType<Dialog>(resourceName);
+            var dialog = _resourceExplorer.LoadType<T>(resourceName);
             return GetTestFlow(dialog, adapter);
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -46,6 +46,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                 .AssertReply("World")
                 .Send("World what?")
                 .AssertReply("Hello")
+                .Send("Hello what?")
+                .AssertReply("World")
+                .Send("World what?")
+                .AssertReply("Hello")
+                .Send("Hello what?")
+                .AssertReply("World")
+                .Send("World what?")
+                .AssertReply("Hello")
             .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -139,6 +139,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
+        public async Task DialogSet_AddTelemetrySet_OnCyclicalDialogStructures()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
+
+            var component1 = new ComponentDialog("component1");
+            var component2 = new ComponentDialog("component2");
+
+            component1.Dialogs.Add(component2);
+            component2.Dialogs.Add(component1);
+
+            // Without the check in DialogSet setter, this test throws StackOverflowException.
+            component1.Dialogs.TelemetryClient = new MyBotTelemetryClient();
+            await Task.CompletedTask;
+        }
+
+        [Fact]
         public async Task DialogSet_HeterogeneousLoggers()
         {
             var convoState = new ConversationState(new MemoryStorage());


### PR DESCRIPTION
## Changes

- **DialogSet:** Telemetry client setter leading to StackOverflowExceptions on any cyclical dialog structure. Affects traditional component dialogs, coded adaptive dialgs and could affect declarative dialogs
- **DialogManager:** Recursive registration of dependencies, on cyclical dialog structures could lead to stackOverflowException
- **Type loading:** Cache DialogExpression instances to improve performance, fix debugger which requires a single instance for an id, and catch special cases that can break type loading of cyclical dialog structures (fixes https://github.com/microsoft/botframework-sdk/issues/6094). In a future change for debugging we'll enforce all instances to be unique during type loading, but that will be part of a larger change to also support richer debugging semantics.
- **Type Loading**: Now cycle detection is independent on the type that is requested, for example LoadType<Dialog> is the same as LoadType<AdaptiveDialog>. (fixes https://github.com/microsoft/botbuilder-dotnet/issues/5021) (fixes https://github.com/microsoft/botframework-core/issues/69)

## Testing

Unit tests provided. All 3 fail without the fix.