### PR TITLE
Update Cosmos, fix Azure tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDBKeyEscape.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Converts the key into a DocumentID that can be used safely with Cosmos DB.
         /// The following characters are restricted and cannot be used in the Id property: '/', '\', '?', and '#'.
-        /// More information at <see cref="Microsoft.Azure.Documents.Resource.Id"/>.
+        /// More information at <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet"/>.
         /// </summary>
         /// <param name="key">The key to escape.</param>
         /// <returns>An escaped key that can be used safely with CosmosDB.</returns>
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Converts the key into a DocumentID that can be used safely with Cosmos DB.
         /// The following characters are restricted and cannot be used in the Id property: '/', '\', '?', and '#'.
-        /// More information at <see cref="Microsoft.Azure.Documents.Resource.Id"/>.
+        /// More information at <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet"/>.
         /// </summary>
         /// <param name="key">The key to escape.</param>
         /// <param name="suffix">The string to add at the end of all row keys.</param>

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbCustomClientOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbCustomClientOptions.cs
@@ -24,22 +24,22 @@ namespace Microsoft.Bot.Builder.Azure
         public string CollectionId { get; set; }
 
         /// <summary>
-        /// Gets or sets the CosmosDB <see cref="Microsoft.Azure.Documents.Client.RequestOptions"/> that
+        /// Gets or sets the CosmosDB <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.requestoptions?view=azure-dotnet"/> that
         /// are passed when the document collection is created. Null is the default.
         /// </summary>
         /// <value>
         /// The set of options passed into
-        /// <see cref="Microsoft.Azure.Documents.Client.DocumentClient.CreateDocumentCollectionIfNotExistsAsync(string, Microsoft.Azure.Documents.DocumentCollection, RequestOptions)"/>.
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.idocumentclient.createdocumentcollectionifnotexistsasync?view=azure-dotnet"/>.
         /// </value>
         public RequestOptions DocumentCollectionRequestOptions { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the CosmosDB <see cref="Microsoft.Azure.Documents.Client.RequestOptions"/>
+        /// Gets or sets the CosmosDB <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.requestoptions?view=azure-dotnet"/>
         /// that are passed when the database is created. Null is the default.
         /// </summary>
         /// <value>
         /// The set of options passed into
-        /// <see cref="Microsoft.Azure.Documents.Client.DocumentClient.CreateDatabaseIfNotExistsAsync(Microsoft.Azure.Documents.Database, RequestOptions)"/>.
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.documentclient.createdatabaseifnotexistsasync?view=azure-dotnet"/>.
         /// </value>
         public RequestOptions DatabaseCreationRequestOptions { get; set; } = null;
     }

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbStorageOptions.cs
@@ -67,22 +67,22 @@ namespace Microsoft.Bot.Builder.Azure
         public Action<ConnectionPolicy> ConnectionPolicyConfigurator { get; set; } = (options) => { };
 
         /// <summary>
-        /// Gets or sets the CosmosDB <see cref="Microsoft.Azure.Documents.Client.RequestOptions"/> that
+        /// Gets or sets the CosmosDB <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.requestoptions?view=azure-dotnet"/> that
         /// are passed when the document collection is created. Null is the default.
         /// </summary>
         /// <value>
         /// The set of options passed into
-        /// <see cref="Microsoft.Azure.Documents.Client.DocumentClient.CreateDocumentCollectionIfNotExistsAsync(string, DocumentCollection, RequestOptions)"/>.
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.idocumentclient.createdocumentcollectionifnotexistsasync?view=azure-dotnet"/>.
         /// </value>
         public RequestOptions DocumentCollectionRequestOptions { get; set; } = null;
 
         /// <summary>
-        /// Gets or sets the CosmosDB <see cref="Microsoft.Azure.Documents.Client.RequestOptions"/> that
+        /// Gets or sets the CosmosDB <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.requestoptions?view=azure-dotnet"/> that
         /// are passed when the database is created. Null is the default.
         /// </summary>
         /// <value>
         /// The set of options passed into
-        /// <see cref="Microsoft.Azure.Documents.Client.DocumentClient.CreateDatabaseIfNotExistsAsync(Database, RequestOptions)"/>.
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.requestoptions?view=azure-dotnet"/>.
         /// </value>
         public RequestOptions DatabaseCreationRequestOptions { get; set; } = null;
     }

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.1" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.13.1" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.21" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.14.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
@@ -12,7 +13,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    public class AzureBlobStorageTests : BlobStorageBaseTests, IDisposable
+    public class AzureBlobStorageTests : BlobStorageBaseTests, IAsyncLifetime
     {
         private readonly string _testName;
 
@@ -44,7 +45,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public async void Dispose()
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -45,9 +45,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public async Task InitializeAsync()
+        public Task InitializeAsync()
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task DisposeAsync()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 {
     [Trait("TestCategory", "Storage")]
     [Trait("TestCategory", "Storage - BlobTranscripts")]
-    public class AzureBlobTranscriptStoreTests : TranscriptStoreBaseTests, IDisposable
+    public class AzureBlobTranscriptStoreTests : TranscriptStoreBaseTests, IAsyncLifetime
     {
         private readonly string _testName;
 
@@ -43,7 +43,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected override ITranscriptStore TranscriptStore => new AzureBlobTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
 
-        public async void Dispose()
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobTranscriptStoreTests.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected override ITranscriptStore TranscriptStore => new AzureBlobTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
 
-        public async Task InitializeAsync()
+        public Task InitializeAsync()
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task DisposeAsync()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
@@ -35,9 +35,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected override string ContainerName => $"blobs{_testName.ToLower().Replace("_", string.Empty)}";
 
-        public async Task InitializeAsync()
+        public Task InitializeAsync()
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task DisposeAsync()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Microsoft.Bot.Builder.Azure.Blobs;
 using Newtonsoft.Json;
@@ -12,7 +13,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
 {
-    public class BlobsStorageTests : BlobStorageBaseTests, IDisposable
+    public class BlobsStorageTests : BlobStorageBaseTests, IAsyncLifetime
     {
         private readonly string _testName;
 
@@ -34,7 +35,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected override string ContainerName => $"blobs{_testName.ToLower().Replace("_", string.Empty)}";
 
-        public async void Dispose()
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 {
     [Trait("TestCategory", "Storage")]
     [Trait("TestCategory", "Storage - BlobsTranscriptStore")]
-    public class BlobsTranscriptStoreTests : TranscriptStoreBaseTests, IDisposable
+    public class BlobsTranscriptStoreTests : TranscriptStoreBaseTests, IAsyncLifetime
     {
         private readonly string _testName;
 
@@ -41,7 +41,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected override ITranscriptStore TranscriptStore => new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
 
-        public async void Dispose()
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             if (StorageEmulatorHelper.CheckEmulator())
             {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
         protected override ITranscriptStore TranscriptStore => new BlobsTranscriptStore(BlobStorageEmulatorConnectionString, ContainerName);
 
-        public async Task InitializeAsync()
+        public Task InitializeAsync()
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task DisposeAsync()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 {
     [Trait("TestCategory", "Storage")]
     [Trait("TestCategory", "Storage - CosmosDB Partitioned")]
-    public class CosmosDbPartitionStorageTests : StorageBaseTests, IDisposable, IClassFixture<CosmosDbPartitionStorageFixture>
+    public class CosmosDbPartitionStorageTests : StorageBaseTests, IAsyncLifetime, IClassFixture<CosmosDbPartitionStorageFixture>
     {
         // Endpoint and Authkey for the CosmosDB Emulator running locally
         private const string CosmosServiceEndpoint = "https://localhost:8081";
@@ -38,7 +38,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 });
         }
 
-        public async void Dispose()
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             _storage = null;
         }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionStorageTests.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 });
         }
 
-        public async Task InitializeAsync()
+        public Task InitializeAsync()
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task DisposeAsync()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public async Task InitializeAsync() 
+        public Task InitializeAsync() 
         {
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         public async Task DisposeAsync()

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 {
     [Trait("TestCategory", "Storage")]
     [Trait("TestCategory", "Storage - CosmosDB")]
-    public class CosmosDbStorageTests : StorageBaseTests, IDisposable
+    public class CosmosDbStorageTests : StorageBaseTests, IAsyncLifetime
     {
         // Endpoint and Authkey for the CosmosDB Emulator running locally
         private const string CosmosServiceEndpoint = "https://localhost:8081";
@@ -94,7 +94,12 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public async void Dispose()
+        public async Task InitializeAsync()
+        {
+            await Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             if (_storage != null)
             {

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbStorageTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             }
         }
 
-        public async Task InitializeAsync()
+        public async Task InitializeAsync() 
         {
             await Task.CompletedTask;
         }


### PR DESCRIPTION
Fixes an issue brought up by @mrivera-ms and @dandriscoll, similar to #4909 

## Description

`Microsoft.Azure.Cosmos` could not be used alongside `Microsoft.Bot.Builder.Azure` without updating the `...Cosmos` package. In fixing this, I also found few other issues, noted below.

## Specific Changes

  - Update `Microsoft.Azure.Cosmos` package used in `Microsoft.Bot.Builder.Azure` library from 3.14.0 (has since been de-listed) to 3.15.1
  - Update `Microsoft.Azure.DocumentDB` from 2.1.2 to 2.13.1 since there were no breaking changes and [the changelog](https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/changelog.md) noted quite a few performance improvements.
  - Change from `cref:<packageReference>` to `href:<urlReference>`
    - This was a weird one that I couldn't seem to fix. The `cref` correctly addressed the appropriate class by the full name, but would still throw "ambiguous reference..." errors.
    - Very open to changing this if there's a better way.
  - Change tests that inherit from `IDisposable` to inherit from `IAsyncLifetime`. There were a few tests that I had issues running until I did this. Similar to [this PR](https://github.com/microsoft/botbuilder-dotnet/pull/4913). Not all tests seemed to need it, but none of them fail with the change, so this may prevent future failures.
  - Adjusted how delays work in `TranscriptStoreBaseTests.cs`. There's some async oddities with `TranscriptLoggerMiddleware` that only seem to be exposed in these tests with a fast CPU. Not sure why.

## Testing

All tests pass. Regarding #4909, I added the `Microsoft.Azure.Cosmos` package to a sample that already had `Microsoft.Bot.Builder.Azure` and it threw errors, as in the linked issue. After importing the `Microsoft.Bot.Builder.Azure` package as updated in this PR, it works:

![image](https://user-images.githubusercontent.com/40401643/103836424-e29b7c80-503d-11eb-95a2-4bc6ee030449.png)


