### PR TITLE
Fix MemoryAssertions test

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_PropertyMock.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_PropertyMock.test.dialog
@@ -5,15 +5,24 @@
     "dialog": {
         "$kind": "Microsoft.AdaptiveDialog",
         "triggers": [
-            {
-                "$kind": "Microsoft.OnBeginDialog",
-                "actions": [
-                    {
-                        "$kind": "Microsoft.SendActivity",
-                        "activity": "hi"
-                    }
-                ]
-            }
+          {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+              {
+                "$kind": "Microsoft.SendActivity",
+                "activity": "hi"
+              }
+            ]
+          },
+          {
+            "$kind": "Microsoft.OnError",
+            "actions": [
+              {
+                "$kind": "Microsoft.SendActivity",
+                "activity": "${turn.dialogEvent.value.message}"
+              }
+            ]
+          }
         ]
     },
     "script": [


### PR DESCRIPTION
## Description

The MemoryAssertions tests were silently failing. They'll now pass and also elicit errors if they fail. You can see it in the original code if you throw a breakpoint [here](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/MemoryAssertions.cs#L64).

## Specific Changes

- Removed `new KeyValuePair<string, string>("fileoverwrite", "this is overwritten")`. `settings` is an `ImmutableDictionary` and cannot be overwritten. 
  - --->>>>	**This may be an error in ObjectPath.cs**, but I don't know enough about this to say for sure. <<<<----
- Added an `OnError` trigger for the PropertyMock test script. It would otherwise silently swallow errors.
- Adjusted what memory properties get written and overwritten.

**Note: There's a similar issue in JS that I'll fix.**