### PR TITLE
Tag Resource Groups in DevOps Pipelines

### DIFF
--- a/FunctionalTests/ExportedTemplate/template-with-new-rg.json
+++ b/FunctionalTests/ExportedTemplate/template-with-new-rg.json
@@ -69,6 +69,15 @@
       "metadata": {
         "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
       }
+    },
+    "groupTags": {
+      "type": "object",
+      "defaultValue": {
+        "cause": "automation"
+      },
+      "metadata": {
+        "description": "Populated with DevOps Pipeline values at runtime."
+      }
     }
   },
   "variables": {
@@ -85,8 +94,8 @@
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2018-05-01",
       "location": "[parameters('groupLocation')]",
-      "properties": {
-      }
+      "properties": {},
+      "tags": "[parameters('groupTags')]"
     },
     {
       "type": "Microsoft.Resources/deployments",

--- a/build/yaml/botbuilder-dotnet-ci-slack-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slack-test.yml
@@ -56,11 +56,18 @@ variables:
 #  SlackTestBotSlackBotToken: define this in Azure
 #  SlackTestBotSlackChannel: define this in Azure
 #  SlackTestBotSlackClientSigningSecret: define this in Azure
-    #  SlackTestBotSlackVerificationToken: define this in Azure
+#  SlackTestBotSlackVerificationToken: define this in Azure
 
 steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
   displayName: 'Display env vars'
+
+- powershell: |
+   # Create DateTimeTag for Resource Group
+   $DateTimeTag=Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+   "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
+  displayName: 'Create DateTimeTag for Resource Group'
+  # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'
@@ -82,7 +89,7 @@ steps:
      Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
      Write-Host "************************************************************************";
      Set-PSDebug -Trace 1;
-     az group create --location westus --name $(BotGroup);
+     az group create --location westus --name $(BotGroup) --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)";;
      
      # set up bot channels registration, app service, app service plan
      az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" slackVerificationToken="$(SlackVerificationToken)" slackBotToken="$(SlackBotToken)"  slackClientSigningSecret="$(SlackClientSigningSecret)" --name "$(BotName)"
@@ -102,7 +109,7 @@ steps:
      Set-PSDebug -Trace 1;
      
      # set up resource group, bot channels registration, app service, app service plan
-     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" slackVerificationToken="$(SlackVerificationToken)" slackBotToken="$(SlackBotToken)"  slackClientSigningSecret="$(SlackClientSigningSecret)"
+     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Slack.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" newAppServicePlanLocation="westus" slackVerificationToken="$(SlackVerificationToken)" slackBotToken="$(SlackBotToken)"  slackClientSigningSecret="$(SlackClientSigningSecret)" groupTags='{\"buildName\":\"$(Build.DefinitionName)\", \"cause\":\"automation\", \"date\":\"$(DateTimeTag)\", \"product\":\"$(Build.Repository.Name)\", \"sourceBranch\":\"$(Build.SourceBranch)\"}';
      Set-PSDebug -Trace 0;
   condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
 

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -65,6 +65,13 @@ steps:
   displayName: 'Display env vars'
 
 - powershell: |
+   # Create DateTimeTag for Resource Group
+   $DateTimeTag=Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+   "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
+  displayName: 'Create DateTimeTag for Resource Group'
+  # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
+
+- powershell: |
     $InvalidVariables = $FALSE
     $Message = "Required variable 'REPLACE_VARIABLE' either null, empty or whitespaced. Please set up this variable in the pipeline configuration."
 
@@ -108,7 +115,7 @@ steps:
      Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
      Write-Host "************************************************************************";
      Set-PSDebug -Trace 1;
-     az group create --location westus --name $(BotGroup);
+     az group create --location westus --name $(BotGroup) --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)";
      
      # set up bot channels registration, app service, app service plan
      az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-preexisting-rg.json" --parameters appId="$(AppId)" appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexTestBotWebexBotAccessToken)" webexSecret="$(WebexTestBotWebexWebhookSecret)" webexWebhookName="$(WebexTestBotWebexWebhookName)" --name "$(BotName)"
@@ -128,7 +135,7 @@ steps:
      Set-PSDebug -Trace 1;
      
      # set up resource group, bot channels registration, app service, app service plan
-     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newAppServicePlanLocation="westus" newWebAppName="$(BotName)" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexTestBotWebexBotAccessToken)" webexSecret="$(WebexTestBotWebexWebhookSecret)" webexWebhookName="$(WebexTestBotWebexWebhookName)" groupName="$(BotGroup)" groupLocation="westus"
+     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\tests\Adapters\Microsoft.Bot.Builder.Adapters.Webex.TestBot\DeploymentTemplates\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newAppServicePlanLocation="westus" newWebAppName="$(BotName)" webexPublicAddress="$(WebexPublicAddress)" webexAccessToken="$(WebexTestBotWebexBotAccessToken)" webexSecret="$(WebexTestBotWebexWebhookSecret)" webexWebhookName="$(WebexTestBotWebexWebhookName)" groupName="$(BotGroup)" groupLocation="westus" groupTags='{\"buildName\":\"$(Build.DefinitionName)\", \"cause\":\"automation\", \"date\":\"$(DateTimeTag)\", \"product\":\"$(Build.Repository.Name)\", \"sourceBranch\":\"$(Build.SourceBranch)\"}';
      Set-PSDebug -Trace 0;
   condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
 

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -55,6 +55,13 @@ steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
   displayName: 'Display env vars'
 
+- powershell: |
+   # Create DateTimeTag for Resource Group
+   $DateTimeTag=Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+   "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
+  displayName: 'Create DateTimeTag for Resource Group'
+  # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
+
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'
   inputs:
@@ -75,7 +82,7 @@ steps:
      Write-Host "This task runs for even-numbered builds. Build ID = $(Build.BuildId)";
      Write-Host "************************************************************************";
      Set-PSDebug -Trace 1;
-     az group create --location westus --name $(BotGroup);
+     az group create --location westus --name $(BotGroup) --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)";
      
      # set up bot channels registration, app service, app service plan
      az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template-with-preexisting-rg.json" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)"
@@ -95,7 +102,7 @@ steps:
      Set-PSDebug -Trace 1;
      
      # set up resource group, bot channels registration, app service, app service plan
-     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newAppServicePlanLocation="westus" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus"
+     az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newAppServicePlanLocation="westus" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus" groupTags='{\"buildName\":\"$(Build.DefinitionName)\", \"cause\":\"automation\", \"date\":\"$(DateTimeTag)\", \"product\":\"$(Build.Repository.Name)\", \"sourceBranch\":\"$(Build.SourceBranch)\"}';
      Set-PSDebug -Trace 0;
   condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
 
@@ -111,7 +118,7 @@ steps:
      call az deployment sub create --name "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template-with-new-rg.json" --location "westus" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newAppServicePlanLocation="westus" newWebAppName="$(BotName)" groupName="$(BotGroup)" groupLocation="westus"
      
      :: Option 2: Use the "preexisting-rg" template:
-     ::call az group create --location westus --name $(BotGroup)
+     ::call az group create --location westus --name $(BotGroup) --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)"
      ::call az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template-with-preexisting-rg.json" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)"
 
 - task: AzureCLI@1

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/DeploymentTemplates/template-with-new-rg.json
@@ -90,6 +90,15 @@
       "metadata": {
         "description": "The slack client signing secret, taken from the Slack page after create an app"
       }
+    },
+    "groupTags": {
+      "type": "object",
+      "defaultValue": {
+          "cause": "automation"
+      },
+      "metadata": {
+        "description": "Populated with DevOps Pipeline values at runtime."
+      }
     }
   },
   "variables": {
@@ -106,8 +115,8 @@
       "type": "Microsoft.Resources/resourceGroups",
       "apiVersion": "2018-05-01",
       "location": "[parameters('groupLocation')]",
-      "properties": {
-      }
+      "properties": {},
+      "tags": "[parameters('groupTags')]"
     },
     {
       "type": "Microsoft.Resources/deployments",

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/DeploymentTemplates/template-with-new-rg.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/DeploymentTemplates/template-with-new-rg.json
@@ -97,6 +97,15 @@
       "metadata": {
         "description": "The name of the webhook created for communicating with Webex."
       }
+    },
+    "groupTags": {
+      "type": "object",
+      "defaultValue": {
+          "cause": "automation"
+      },
+      "metadata": {
+        "description": "Populated with DevOps Pipeline values at runtime."
+      }
     }
   },
     "variables": {
@@ -113,8 +122,8 @@
             "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2018-05-01",
             "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
+            "properties": {},
+            "tags": "[parameters('groupTags')]"
         },
         {
             "type": "Microsoft.Resources/deployments",


### PR DESCRIPTION
Fixes #5032 

Add tags to Azure resource groups with metadata that's handy for debugging.

## Description

*Azure Portal View of Resource Group with Tags*
![image](https://user-images.githubusercontent.com/35248895/104485987-03a12780-5580-11eb-9d89-434360137aa9.png)



<details>
<summary>AZ CLI View</summary>

```json
{
  "id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/NightlyWinTestBotRG",
  "location": "westus",
  "managedBy": null,
  "name": "NightlyWinTestBotRG",
  "properties": {
    "provisioningState": "Succeeded"
  },
  "tags": {
    "buildName": "BotBuilder-DotNet-Functional-Tests-Windows-yaml",
    "cause": "automation",
    "date": "2021-01-12T07:19:18Z",
    "product": "microsoft/botbuilder-dotnet",
    "sourceBranch": "refs/heads/Zerryth/azg-tagging"
  },
  "type": "Microsoft.Resources/resourceGroups"
}
```

</details>

Added to following dotnet functional test pipelines:
- Slack 
- Webex 
- Windows 
