### PR TITLE
added disposed

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -188,10 +188,9 @@ namespace Microsoft.Bot.Builder.Adapters
                 activity.LocalTimestamp = DateTimeOffset.Now;
             }
 
-            using (var context = CreateTurnContext(activity))
-            {
-                await RunPipelineAsync(context, callback, cancellationToken).ConfigureAwait(false);
-            }
+            // note here Dispose is NOT called on the TurnContext because we want to use it later in the test code
+            var context = CreateTurnContext(activity);
+            await RunPipelineAsync(context, callback, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Bot.Builder
         private readonly IList<UpdateActivityHandler> _onUpdateActivity = new List<UpdateActivityHandler>();
         private readonly IList<DeleteActivityHandler> _onDeleteActivity = new List<DeleteActivityHandler>();
 
+        private bool _disposed;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TurnContext"/> class.
         /// </summary>
@@ -159,6 +161,11 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         public ITurnContext OnSendActivities(SendActivitiesHandler handler)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(OnSendActivities));
+            }
+
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
@@ -180,6 +187,11 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         public ITurnContext OnUpdateActivity(UpdateActivityHandler handler)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(OnUpdateActivity));
+            }
+
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
@@ -202,6 +214,11 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         public ITurnContext OnDeleteActivity(DeleteActivityHandler handler)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(OnDeleteActivity));
+            }
+
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
@@ -236,6 +253,11 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         public async Task<ResourceResponse> SendActivityAsync(string textReplyToSend, string speak = null, string inputHint = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SendActivityAsync));
+            }
+
             if (string.IsNullOrWhiteSpace(textReplyToSend))
             {
                 throw new ArgumentNullException(nameof(textReplyToSend));
@@ -268,6 +290,11 @@ namespace Microsoft.Bot.Builder
         /// channel assigned to the activity.</remarks>
         public async Task<ResourceResponse> SendActivityAsync(IActivity activity, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SendActivityAsync));
+            }
+
             BotAssert.ActivityNotNull(activity);
 
             ResourceResponse[] responses = await SendActivitiesAsync(new[] { activity }, cancellationToken).ConfigureAwait(false);
@@ -294,6 +321,11 @@ namespace Microsoft.Bot.Builder
         /// the receiving channel assigned to the activities.</remarks>
         public Task<ResourceResponse[]> SendActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SendActivitiesAsync));
+            }
+
             if (activities == null)
             {
                 throw new ArgumentNullException(nameof(activities));
@@ -411,6 +443,11 @@ namespace Microsoft.Bot.Builder
         /// of the activity to replace.</para></remarks>
         public async Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(UpdateActivityAsync));
+            }
+
             BotAssert.ActivityNotNull(activity);
 
             var conversationReference = Activity.GetConversationReference();
@@ -434,6 +471,11 @@ namespace Microsoft.Bot.Builder
         /// The HTTP operation failed and the response contained additional information.</exception>
         public async Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(DeleteActivityAsync));
+            }
+
             if (string.IsNullOrWhiteSpace(activityId))
             {
                 throw new ArgumentNullException(nameof(activityId));
@@ -462,6 +504,11 @@ namespace Microsoft.Bot.Builder
         /// indicates the activity in the conversation to delete.</remarks>
         public async Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(DeleteActivityAsync));
+            }
+
             if (conversationReference == null)
             {
                 throw new ArgumentNullException(nameof(conversationReference));
@@ -490,10 +537,17 @@ namespace Microsoft.Bot.Builder
         /// <param name="disposing">Boolean value that determines whether to free resources or not.</param>
         protected virtual void Dispose(bool disposing)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             if (disposing)
             {
-                // Dispose any disposable objects owned by the class here.
+                TurnState.Dispose();
             }
+
+            _disposed = true;
         }
 
         private async Task<ResourceResponse> UpdateActivityInternalAsync(

--- a/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContextStateCollection.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Bot.Builder
 {
@@ -16,6 +15,8 @@ namespace Microsoft.Bot.Builder
     /// </remarks>
     public class TurnContextStateCollection : Dictionary<string, object>, IDisposable
     {
+        private bool _disposed;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TurnContextStateCollection"/> class.
         /// </summary>
@@ -35,6 +36,11 @@ namespace Microsoft.Bot.Builder
         public T Get<T>(string key)
             where T : class
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(Get));
+            }
+
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
@@ -74,6 +80,11 @@ namespace Microsoft.Bot.Builder
         public void Add<T>(string key, T value)
             where T : class
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(Add));
+            }
+
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
@@ -111,6 +122,11 @@ namespace Microsoft.Bot.Builder
         public void Set<T>(string key, T value)
             where T : class
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(Set));
+            }
+
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
@@ -146,10 +162,7 @@ namespace Microsoft.Bot.Builder
         /// <param name="disposing">Boolean value that indicates if freeing resources should be performed.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                // Dispose any disposable objects owned by the class here.
-            }
+            _disposed = true;
         }
     }
 }


### PR DESCRIPTION
turn context and turn state dispose

Rather than relying on turnContext.TurnState.Set(null); to detect later errors, the correct behavior is to to directly detect the later invalid access.