### PR TITLE
Add UserActivity test

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestScriptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestScriptTests.cs
@@ -140,6 +140,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task TestScriptTests_UserActivity()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task TestScriptTests_UserConversationUpdate()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserActivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserActivity.test.dialog
@@ -1,0 +1,32 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test AssertReply",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnTypingActivity",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "[received typing]"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hello"
+        },
+        {
+            "$kind": "Microsoft.Test.UserTyping"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "[received typing]"
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserActivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserActivity.test.dialog
@@ -1,32 +1,75 @@
 {
-    "$schema": "../../../tests.schema",
-    "$kind": "Microsoft.Test.Script",
-    "description": "Test AssertReply",
-    "dialog": {
-        "$kind": "Microsoft.AdaptiveDialog",
-        "triggers": [
-            {
-                "$kind": "Microsoft.OnTypingActivity",
-                "actions": [
-                    {
-                        "$kind": "Microsoft.SendActivity",
-                        "activity": "[received typing]"
-                    }
-                ]
-            }
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "description": "Test AssertReply",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "test",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "conversation.activity",
+            "value": "=turn.activity"
+          }
         ]
-    },
-    "script": [
-        {
-            "$kind": "Microsoft.Test.UserSays",
-            "text": "hello"
-        },
-        {
-            "$kind": "Microsoft.Test.UserTyping"
-        },
-        {
-            "$kind": "Microsoft.Test.AssertReply",
-            "text": "[received typing]"
-        }
+      }
     ]
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "text": "some text"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "conversation.activity.channelId == 'test'",
+        "conversation.activity.serviceUrl == 'https://test.com'",
+        "conversation.activity.conversation.id == 'TestScriptTests_UserActivity'",
+        "conversation.activity.conversation.isGroup == false",
+        "conversation.activity.conversation.name == 'TestScriptTests_UserActivity'",
+        "conversation.activity.from.id == 'user1'",
+        "conversation.activity.from.name == 'User1'",
+        "conversation.activity.recipient.id == 'bot'",
+        "conversation.activity.recipient.name == 'Bot'",
+        "conversation.activity.locale == 'en-us'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "text": "some text",
+        "from": {
+          "id": "from id",
+          "name": "from name"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "conversation.activity.from.id == 'from id'",
+        "conversation.activity.from.name == 'from name'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "text": "some text"
+      },
+      "user": "user id"
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "conversation.activity.from.id == 'user id'",
+        "conversation.activity.from.name == 'user id'"
+      ]
+    }
+  ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserTyping.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserTyping.test.dialog
@@ -1,75 +1,32 @@
 {
-  "$schema": "../../../schemas/sdk.schema",
-  "$kind": "Microsoft.Test.Script",
-  "description": "Test AssertReply",
-  "dialog": {
-    "$kind": "Microsoft.AdaptiveDialog",
-    "id": "test",
-    "triggers": [
-      {
-        "$kind": "Microsoft.OnBeginDialog",
-        "actions": [
-          {
-            "$kind": "Microsoft.SetProperty",
-            "property": "conversation.activity",
-            "value": "=turn.activity"
-          }
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test AssertReply",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnTypingActivity",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "[received typing]"
+                    }
+                ]
+            }
         ]
-      }
-    ]
-  },
-  "script": [
-    {
-      "$kind": "Microsoft.Test.UserActivity",
-      "activity": {
-        "text": "some text"
-      }
     },
-    {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "conversation.activity.channelId == 'test'",
-        "conversation.activity.serviceUrl == 'https://test.com'",
-        "conversation.activity.conversation.id == 'TestScriptTests_UserActivity'",
-        "conversation.activity.conversation.isGroup == false",
-        "conversation.activity.conversation.name == 'TestScriptTests_UserActivity'",
-        "conversation.activity.from.id == 'user1'",
-        "conversation.activity.from.name == 'User1'",
-        "conversation.activity.recipient.id == 'bot'",
-        "conversation.activity.recipient.name == 'Bot'",
-        "conversation.activity.locale == 'en-us'"
-      ]
-    },
-    {
-      "$kind": "Microsoft.Test.UserActivity",
-      "activity": {
-        "text": "some text",
-        "from": {
-          "id": "from id",
-          "name": "from name"
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hello"
+        },
+        {
+            "$kind": "Microsoft.Test.UserTyping"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "[received typing]"
         }
-      }
-    },
-    {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "conversation.activity.from.id == 'from id'",
-        "conversation.activity.from.name == 'from name'"
-      ]
-    },
-    {
-      "$kind": "Microsoft.Test.UserActivity",
-      "activity": {
-        "text": "some text"
-      },
-      "user": "user id"
-    },
-    {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "conversation.activity.from.id == 'user id'",
-        "conversation.activity.from.name == 'user id'"
-      ]
-    }
-  ]
+    ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserTyping.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_UserTyping.test.dialog
@@ -1,32 +1,75 @@
 {
-    "$schema": "../../../tests.schema",
-    "$kind": "Microsoft.Test.Script",
-    "description": "Test AssertReply",
-    "dialog": {
-        "$kind": "Microsoft.AdaptiveDialog",
-        "triggers": [
-            {
-                "$kind": "Microsoft.OnTypingActivity",
-                "actions": [
-                    {
-                        "$kind": "Microsoft.SendActivity",
-                        "activity": "[received typing]"
-                    }
-                ]
-            }
+  "$schema": "../../../schemas/sdk.schema",
+  "$kind": "Microsoft.Test.Script",
+  "description": "Test AssertReply",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "test",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.SetProperty",
+            "property": "conversation.activity",
+            "value": "=turn.activity"
+          }
         ]
-    },
-    "script": [
-        {
-            "$kind": "Microsoft.Test.UserSays",
-            "text": "hello"
-        },
-        {
-            "$kind": "Microsoft.Test.UserTyping"
-        },
-        {
-            "$kind": "Microsoft.Test.AssertReply",
-            "text": "[received typing]"
-        }
+      }
     ]
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "text": "some text"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "conversation.activity.channelId == 'test'",
+        "conversation.activity.serviceUrl == 'https://test.com'",
+        "conversation.activity.conversation.id == 'TestScriptTests_UserActivity'",
+        "conversation.activity.conversation.isGroup == false",
+        "conversation.activity.conversation.name == 'TestScriptTests_UserActivity'",
+        "conversation.activity.from.id == 'user1'",
+        "conversation.activity.from.name == 'User1'",
+        "conversation.activity.recipient.id == 'bot'",
+        "conversation.activity.recipient.name == 'Bot'",
+        "conversation.activity.locale == 'en-us'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "text": "some text",
+        "from": {
+          "id": "from id",
+          "name": "from name"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "conversation.activity.from.id == 'from id'",
+        "conversation.activity.from.name == 'from name'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "text": "some text"
+      },
+      "user": "user id"
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "conversation.activity.from.id == 'user id'",
+        "conversation.activity.from.name == 'user id'"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
There wasn't an existing test for UserActivity. Since I add one [in this JS PR](https://github.com/microsoft/botbuilder-js/pull/3187), I figured I should add it here, as well.