### PR TITLE
uischema: port composer ui schema 'flow' part to component schema files

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "flow": {
+    "widget": "ActionCard",
+    "body": "=action.hostname"
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.uischema
@@ -17,5 +17,18 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "DialogRef",
+            "dialog": "=action.dialog"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Return value"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.uischema
@@ -11,5 +11,26 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "colors": {
+            "theme": "#004578",
+            "color": "#FFFFFF",
+            "icon": "#FFFFFF"
+        },
+        "icon": "Library",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "Host",
+            "resource": "=coalesce(action.skillEndpoint, \"?\")",
+            "singleline": true
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Result"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.CancelAllDialogs.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.CancelAllDialogs.uischema
@@ -4,5 +4,13 @@
         "label": "Cancel all active dialogs",
         "subtitle": "Cancel All Dialogs",
         "helpLink": "https://aka.ms/bfc-understanding-dialogs"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.eventName, \"?\")",
+            "description": "(Event)"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperties.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperties.uischema
@@ -11,5 +11,12 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ListOverview",
+            "items": "=action.properties"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperty.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperty.uischema
@@ -11,5 +11,9 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": "=action.property"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditActions.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditActions.uischema
@@ -3,5 +3,9 @@
     "form": {
         "label": "Modify active dialog",
         "subtitle": "Edit Actions"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": "=action.changeType"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.uischema
@@ -16,5 +16,19 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "=coalesce(action.changeType, \"?\")",
+            "resource": "=coalesce(action.itemsProperty, \"?\")"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Result"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EmitEvent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EmitEvent.uischema
@@ -4,5 +4,13 @@
         "label": "Emit a custom event",
         "subtitle": "Emit Event",
         "helpLink": "https://aka.ms/bfc-custom-events"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.eventName, \"?\")",
+            "description": "(Event)"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.uischema
@@ -28,5 +28,13 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ForeachWidget",
+        "nowrap": true,
+        "loop": {
+            "widget": "ActionCard",
+            "body": "=concat(\"Each value in \", coalesce(action.itemsProperty, \"?\"))"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ForeachPage.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ForeachPage.uischema
@@ -29,5 +29,13 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ForeachWidget",
+        "nowrap": true,
+        "loop": {
+            "widget": "ActionCard",
+            "body": "=concat(\"Each page of \", coalesce(action.pageSize, \"?\"), \" in \", coalesce(action.page, \"?\"))"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetActivityMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetActivityMembers.uischema
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.activityId, \"?\")",
+            "description": "= ActivityId"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.property, \"?\")",
+            "description": "= Result property"
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationMembers.uischema
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "flow": {
+        "widget": "ActionCard",
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.property",
+            "description": "= Result property"
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.uischema
@@ -18,5 +18,20 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "=action.method",
+            "resource": "=action.url",
+            "singleline": true
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Result property"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.IfCondition.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.IfCondition.uischema
@@ -8,5 +8,13 @@
             "elseActions"
         ],
         "helpLink": "https://aka.ms/bfc-controlling-conversation-flow"
+    },
+    "flow": {
+        "widget": "IfConditionWidget",
+        "nowrap": true,
+        "judgement": {
+            "widget": "ActionCard",
+            "body": "=coalesce(action.condition, \"<condition>\")"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.uischema
@@ -9,5 +9,12 @@
             "options",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "DialogRef",
+            "dialog": "=action.dialog"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendActivity.uischema
@@ -8,5 +8,20 @@
             "activity",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "LgWidget",
+            "field": "activity"
+        },
+        "header": {
+            "widget": "ActionHeader",
+            "icon": "MessageBot",
+            "colors": {
+                "theme": "#EEEAF4",
+                "icon": "#5C2E91"
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperties.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperties.uischema
@@ -15,5 +15,12 @@
                 }
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ListOverview",
+            "items": "=foreach(action.assignments, x => concat(coalesce(x.property, \"?\"), \" : \", coalesce(x.value, \"?\")))"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperty.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperty.uischema
@@ -11,5 +11,9 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": "${coalesce(action.property, \"?\")} : ${coalesce(action.value, \"?\")}"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.uischema
@@ -19,5 +19,13 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "SwitchConditionWidget",
+        "nowrap": true,
+        "judgement": {
+            "widget": "ActionCard",
+            "body": "=coalesce(action.condition, \"<condition>\")"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ThrowException.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ThrowException.uischema
@@ -3,5 +3,13 @@
     "form": {
         "label": "Throw an exception",
         "subtitle": "Throw an exception"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.errorValue, \"?\")",
+            "description": "= ErrorValue"
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.UpdateActivity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.UpdateActivity.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": "implements(Microsoft.IDialog)",
-    "title": "Send an activity",
+    "title": "Update an activity",
     "description": "Respond with an activity.",
     "type": "object",
     "properties": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.UpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.UpdateActivity.uischema
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "form": {
+        "label": "Update an activity",
+        "subtitle": "Update Activity"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "header": {
+            "widget": "ActionHeader",
+            "title": "Update activity",
+            "icon": "MessageBot",
+            "colors": {
+                "theme": "#D7D7D7",
+                "icon": "#656565"
+            }
+        },
+        "body": {
+            "widget": "LgWidget",
+            "field": "activity"
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.uischema
@@ -8,5 +8,26 @@
             "activity",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "header": {
+            "widget": "ActionHeader",
+            "icon": "MessageBot",
+            "colors": {
+                "theme": "#EEEAF4",
+                "icon": "#5C2E91"
+            }
+        },
+        "body": {
+            "widget": "LgWidget",
+            "field": "activity"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.defaultOperation",
+            "description": "= Default operation"
+        },
+        "hideFooter": "=!action.defaultOperation"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.AttachmentInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.AttachmentInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.DateTimeInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.DateTimeInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.NumberInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.NumberInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.OAuthInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.OAuthInput.uischema
@@ -8,5 +8,20 @@
             "connectionName",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "Connection",
+            "resource": "=coalesce(action.connectionName, \"?\")",
+            "singleline": true
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.property",
+            "description": "= Token property"
+        },
+        "hideFooter": "=!action.property"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.TextInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.TextInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -2561,9 +2561,9 @@
           "$ref": "#/definitions/stringExpression",
           "title": "ActivityId",
           "description": "expression to an activityId to delete",
-            "examples": [
-                "=turn.lastresult.id"
-            ]
+          "examples": [
+            "=turn.lastresult.id"
+          ]
         },
         "disabled": {
           "$ref": "#/definitions/booleanExpression",
@@ -3315,9 +3315,9 @@
           "$ref": "#/definitions/stringExpression",
           "title": "Activity Id",
           "description": "Activity ID or expression to an activityId to use to get the members. If none is defined then the current activity id will be used.",
-            "examples": [
-                "turn.lastresult.id"
-            ]
+          "examples": [
+            "turn.lastresult.id"
+          ]
         },
         "disabled": {
           "$ref": "#/definitions/booleanExpression",
@@ -4496,9 +4496,10 @@
           ]
         },
         "text": {
-          "$ref": "#/definitions/stringExpression",
+          "$kind": "Microsoft.IActivityTemplate",
           "title": "Text",
-          "description": "Information to log."
+          "description": "Information to log.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
         },
         "label": {
           "$ref": "#/definitions/stringExpression",
@@ -9798,7 +9799,7 @@
     },
     "Microsoft.UpdateActivity": {
       "$role": "implements(Microsoft.IDialog)",
-      "title": "Send an activity",
+      "title": "Update an activity",
       "description": "Respond with an activity.",
       "type": "object",
       "required": [
@@ -9830,9 +9831,9 @@
           "$ref": "#/definitions/stringExpression",
           "title": "Activity Id",
           "description": "An string expression with the activity id to update.",
-            "examples": [
-                "=turn.lastresult.id"
-            ]
+          "examples": [
+            "=turn.lastresult.id"
+          ]
         },
         "activity": {
           "$kind": "Microsoft.IActivityTemplate",

--- a/tests/tests.uischema
+++ b/tests/tests.uischema
@@ -24,6 +24,27 @@
     }
   },
   "Microsoft.Ask": {
+    "flow": {
+      "body": {
+        "field": "activity",
+        "widget": "LgWidget"
+      },
+      "footer": {
+        "description": "= Default operation",
+        "property": "=action.defaultOperation",
+        "widget": "PropertyDescription"
+      },
+      "header": {
+        "colors": {
+          "icon": "#5C2E91",
+          "theme": "#EEEAF4"
+        },
+        "icon": "MessageBot",
+        "widget": "ActionHeader"
+      },
+      "hideFooter": "=!action.defaultOperation",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-send-activity",
       "label": "Send a response to ask a question",
@@ -35,6 +56,40 @@
     }
   },
   "Microsoft.AttachmentInput": {
+    "flow": {
+      "body": "=action.prompt",
+      "botAsks": {
+        "body": {
+          "defaultContent": "<prompt>",
+          "field": "prompt",
+          "widget": "LgWidget"
+        },
+        "header": {
+          "colors": {
+            "icon": "#5C2E91",
+            "theme": "#EEEAF4"
+          },
+          "icon": "MessageBot",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "userInput": {
+        "header": {
+          "colors": {
+            "icon": "#0078D4",
+            "theme": "#E5F0FF"
+          },
+          "disableSDKTitle": true,
+          "icon": "User",
+          "menu": "none",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "widget": "PromptWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for a file or an attachment",
@@ -49,6 +104,19 @@
     }
   },
   "Microsoft.BeginDialog": {
+    "flow": {
+      "body": {
+        "dialog": "=action.dialog",
+        "widget": "DialogRef"
+      },
+      "footer": {
+        "description": "= Return value",
+        "property": "=action.resultProperty",
+        "widget": "PropertyDescription"
+      },
+      "hideFooter": "=!action.resultProperty",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
       "label": "Begin a new dialog",
@@ -69,6 +137,27 @@
     }
   },
   "Microsoft.BeginSkill": {
+    "flow": {
+      "body": {
+        "operation": "Host",
+        "resource": "=coalesce(action.skillEndpoint, \"?\")",
+        "singleline": true,
+        "widget": "ResourceOperation"
+      },
+      "colors": {
+        "color": "#FFFFFF",
+        "icon": "#FFFFFF",
+        "theme": "#004578"
+      },
+      "footer": {
+        "description": "= Result",
+        "property": "=action.resultProperty",
+        "widget": "PropertyDescription"
+      },
+      "hideFooter": "=!action.resultProperty",
+      "icon": "Library",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bf-composer-docs-connect-skill",
       "label": "Connect to a skill",
@@ -89,6 +178,14 @@
     }
   },
   "Microsoft.CancelAllDialogs": {
+    "flow": {
+      "body": {
+        "description": "(Event)",
+        "property": "=coalesce(action.eventName, \"?\")",
+        "widget": "PropertyDescription"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
       "label": "Cancel all active dialogs",
@@ -96,6 +193,40 @@
     }
   },
   "Microsoft.ChoiceInput": {
+    "flow": {
+      "body": "=action.prompt",
+      "botAsks": {
+        "body": {
+          "defaultContent": "<prompt>",
+          "field": "prompt",
+          "widget": "LgWidget"
+        },
+        "header": {
+          "colors": {
+            "icon": "#5C2E91",
+            "theme": "#EEEAF4"
+          },
+          "icon": "MessageBot",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "userInput": {
+        "header": {
+          "colors": {
+            "icon": "#0078D4",
+            "theme": "#E5F0FF"
+          },
+          "disableSDKTitle": true,
+          "icon": "User",
+          "menu": "none",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "widget": "PromptWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt with multi-choice",
@@ -110,6 +241,40 @@
     }
   },
   "Microsoft.ConfirmInput": {
+    "flow": {
+      "body": "=action.prompt",
+      "botAsks": {
+        "body": {
+          "defaultContent": "<prompt>",
+          "field": "prompt",
+          "widget": "LgWidget"
+        },
+        "header": {
+          "colors": {
+            "icon": "#5C2E91",
+            "theme": "#EEEAF4"
+          },
+          "icon": "MessageBot",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "userInput": {
+        "header": {
+          "colors": {
+            "icon": "#0078D4",
+            "theme": "#E5F0FF"
+          },
+          "disableSDKTitle": true,
+          "icon": "User",
+          "menu": "none",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "widget": "PromptWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for confirmation",
@@ -130,6 +295,40 @@
     }
   },
   "Microsoft.DateTimeInput": {
+    "flow": {
+      "body": "=action.prompt",
+      "botAsks": {
+        "body": {
+          "defaultContent": "<prompt>",
+          "field": "prompt",
+          "widget": "LgWidget"
+        },
+        "header": {
+          "colors": {
+            "icon": "#5C2E91",
+            "theme": "#EEEAF4"
+          },
+          "icon": "MessageBot",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "userInput": {
+        "header": {
+          "colors": {
+            "icon": "#0078D4",
+            "theme": "#E5F0FF"
+          },
+          "disableSDKTitle": true,
+          "icon": "User",
+          "menu": "none",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "widget": "PromptWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for a date or a time",
@@ -149,6 +348,13 @@
     }
   },
   "Microsoft.DeleteProperties": {
+    "flow": {
+      "body": {
+        "items": "=action.properties",
+        "widget": "ListOverview"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Delete properties",
@@ -163,6 +369,10 @@
     }
   },
   "Microsoft.DeleteProperty": {
+    "flow": {
+      "body": "=action.property",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Delete a property",
@@ -177,12 +387,30 @@
     }
   },
   "Microsoft.EditActions": {
+    "flow": {
+      "body": "=action.changeType",
+      "widget": "ActionCard"
+    },
     "form": {
       "label": "Modify active dialog",
       "subtitle": "Edit Actions"
     }
   },
   "Microsoft.EditArray": {
+    "flow": {
+      "body": {
+        "operation": "=coalesce(action.changeType, \"?\")",
+        "resource": "=coalesce(action.itemsProperty, \"?\")",
+        "widget": "ResourceOperation"
+      },
+      "footer": {
+        "description": "= Result",
+        "property": "=action.resultProperty",
+        "widget": "PropertyDescription"
+      },
+      "hideFooter": "=!action.resultProperty",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Edit an array property",
@@ -202,6 +430,14 @@
     }
   },
   "Microsoft.EmitEvent": {
+    "flow": {
+      "body": {
+        "description": "(Event)",
+        "property": "=coalesce(action.eventName, \"?\")",
+        "widget": "PropertyDescription"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-custom-events",
       "label": "Emit a custom event",
@@ -223,6 +459,14 @@
     }
   },
   "Microsoft.Foreach": {
+    "flow": {
+      "loop": {
+        "body": "=concat(\"Each value in \", coalesce(action.itemsProperty, \"?\"))",
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "widget": "ForeachWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
       "hidden": [
@@ -254,6 +498,14 @@
     }
   },
   "Microsoft.ForeachPage": {
+    "flow": {
+      "loop": {
+        "body": "=concat(\"Each page of \", coalesce(action.pageSize, \"?\"), \" in \", coalesce(action.page, \"?\"))",
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "widget": "ForeachWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
       "hidden": [
@@ -285,7 +537,47 @@
       "subtitle": "For Each Page"
     }
   },
+  "Microsoft.GetActivityMembers": {
+    "flow": {
+      "body": {
+        "description": "= ActivityId",
+        "property": "=coalesce(action.activityId, \"?\")",
+        "widget": "PropertyDescription"
+      },
+      "footer": {
+        "description": "= Result property",
+        "property": "=coalesce(action.property, \"?\")",
+        "widget": "PropertyDescription"
+      },
+      "widget": "ActionCard"
+    }
+  },
+  "Microsoft.GetConversationMembers": {
+    "flow": {
+      "footer": {
+        "description": "= Result property",
+        "property": "=action.property",
+        "widget": "PropertyDescription"
+      },
+      "widget": "ActionCard"
+    }
+  },
   "Microsoft.HttpRequest": {
+    "flow": {
+      "body": {
+        "operation": "=action.method",
+        "resource": "=action.url",
+        "singleline": true,
+        "widget": "ResourceOperation"
+      },
+      "footer": {
+        "description": "= Result property",
+        "property": "=action.resultProperty",
+        "widget": "PropertyDescription"
+      },
+      "hideFooter": "=!action.resultProperty",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-http",
       "label": "Send an HTTP request",
@@ -307,6 +599,14 @@
     }
   },
   "Microsoft.IfCondition": {
+    "flow": {
+      "judgement": {
+        "body": "=coalesce(action.condition, \"<condition>\")",
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "widget": "IfConditionWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
       "hidden": [
@@ -325,6 +625,40 @@
     }
   },
   "Microsoft.NumberInput": {
+    "flow": {
+      "body": "=action.prompt",
+      "botAsks": {
+        "body": {
+          "defaultContent": "<prompt>",
+          "field": "prompt",
+          "widget": "LgWidget"
+        },
+        "header": {
+          "colors": {
+            "icon": "#5C2E91",
+            "theme": "#EEEAF4"
+          },
+          "icon": "MessageBot",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "userInput": {
+        "header": {
+          "colors": {
+            "icon": "#0078D4",
+            "theme": "#E5F0FF"
+          },
+          "disableSDKTitle": true,
+          "icon": "User",
+          "menu": "none",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "widget": "PromptWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for a number",
@@ -339,6 +673,21 @@
     }
   },
   "Microsoft.OAuthInput": {
+    "flow": {
+      "body": {
+        "operation": "Connection",
+        "resource": "=coalesce(action.connectionName, \"?\")",
+        "singleline": true,
+        "widget": "ResourceOperation"
+      },
+      "footer": {
+        "description": "= Token property",
+        "property": "=action.property",
+        "widget": "PropertyDescription"
+      },
+      "hideFooter": "=!action.property",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-oauth",
       "label": "OAuth login",
@@ -661,6 +1010,12 @@
       "subtitle": "Unknown intent recognized"
     }
   },
+  "Microsoft.QnAMakerDialog": {
+    "flow": {
+      "body": "=action.hostname",
+      "widget": "ActionCard"
+    }
+  },
   "Microsoft.RegexRecognizer": {
     "form": {
       "hidden": [
@@ -680,6 +1035,13 @@
     }
   },
   "Microsoft.ReplaceDialog": {
+    "flow": {
+      "body": {
+        "dialog": "=action.dialog",
+        "widget": "DialogRef"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
       "label": "Replace this dialog",
@@ -692,6 +1054,21 @@
     }
   },
   "Microsoft.SendActivity": {
+    "flow": {
+      "body": {
+        "field": "activity",
+        "widget": "LgWidget"
+      },
+      "header": {
+        "colors": {
+          "icon": "#5C2E91",
+          "theme": "#EEEAF4"
+        },
+        "icon": "MessageBot",
+        "widget": "ActionHeader"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-send-activity",
       "label": "Send a response",
@@ -703,6 +1080,13 @@
     }
   },
   "Microsoft.SetProperties": {
+    "flow": {
+      "body": {
+        "items": "=foreach(action.assignments, x => concat(coalesce(x.property, \"?\"), \" : \", coalesce(x.value, \"?\")))",
+        "widget": "ListOverview"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Set properties",
@@ -721,6 +1105,10 @@
     }
   },
   "Microsoft.SetProperty": {
+    "flow": {
+      "body": "${coalesce(action.property, \"?\")} : ${coalesce(action.value, \"?\")}",
+      "widget": "ActionCard"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-using-memory",
       "label": "Set a property",
@@ -741,6 +1129,14 @@
     }
   },
   "Microsoft.SwitchCondition": {
+    "flow": {
+      "judgement": {
+        "body": "=coalesce(action.condition, \"<condition>\")",
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "widget": "SwitchConditionWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
       "hidden": [
@@ -763,6 +1159,40 @@
     }
   },
   "Microsoft.TextInput": {
+    "flow": {
+      "body": "=action.prompt",
+      "botAsks": {
+        "body": {
+          "defaultContent": "<prompt>",
+          "field": "prompt",
+          "widget": "LgWidget"
+        },
+        "header": {
+          "colors": {
+            "icon": "#5C2E91",
+            "theme": "#EEEAF4"
+          },
+          "icon": "MessageBot",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "nowrap": true,
+      "userInput": {
+        "header": {
+          "colors": {
+            "icon": "#0078D4",
+            "theme": "#E5F0FF"
+          },
+          "disableSDKTitle": true,
+          "icon": "User",
+          "menu": "none",
+          "widget": "ActionHeader"
+        },
+        "widget": "ActionCard"
+      },
+      "widget": "PromptWidget"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-ask-for-user-input",
       "label": "Prompt for text",
@@ -777,6 +1207,14 @@
     }
   },
   "Microsoft.ThrowException": {
+    "flow": {
+      "body": {
+        "description": "= ErrorValue",
+        "property": "=coalesce(action.errorValue, \"?\")",
+        "widget": "PropertyDescription"
+      },
+      "widget": "ActionCard"
+    },
     "form": {
       "label": "Throw an exception",
       "subtitle": "Throw an exception"
@@ -787,6 +1225,28 @@
       "helpLink": "https://aka.ms/composer-telemetry",
       "label": "Emit a trace event",
       "subtitle": "Trace Activity"
+    }
+  },
+  "Microsoft.UpdateActivity": {
+    "flow": {
+      "body": {
+        "field": "activity",
+        "widget": "LgWidget"
+      },
+      "header": {
+        "colors": {
+          "icon": "#656565",
+          "theme": "#D7D7D7"
+        },
+        "icon": "MessageBot",
+        "title": "Update activity",
+        "widget": "ActionHeader"
+      },
+      "widget": "ActionCard"
+    },
+    "form": {
+      "label": "Update an activity",
+      "subtitle": "Update Activity"
     }
   }
 }


### PR DESCRIPTION
follows #4341 

## Description
In #4341, we port the ui schema `form` part to runtime in order to support the customization of Composer Form Editor;
in this PR, the `flow` part is added to runtime as well to support the customization of Composer Flow Editor.

Refs ui.schema definition change in SDK repo: https://github.com/microsoft/botframework-sdk/pull/6163

## Affected SDK $kinds
- QnAMakerDialog
- BeginDialog
- BeginSkill
- CancelAllDialog
- DeleteProperty, DeleteProperties
- EditActions
- EditArray
- EmitEvent
- Foreach, ForeachPage
- GetActivityMembers, GetConversationMembers
- HttpRequest
- IfCondition
- ReplaceDialog
- SendActivity
- SetProperties, SetProperty
- SwitchCondition
- ThrowException
- UpdateActivity
- Ask
- AttachmentInput, ChoiceInput, ConfirmInput, DateTimeInput, NumberInput, TextInput
- OAuthInput

## Example
Below is an example of the `flow` schema:
```
{
    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
    "form": {...},
    "flow": {
        "widget": "ActionCard",
        "body": {
            "widget": "ResourceOperation",
            "operation": "=coalesce(action.changeType, \"?\")",
            "resource": "=coalesce(action.itemsProperty, \"?\")"
        },
        "footer": {
            "widget": "PropertyDescription",
            "property": "=action.resultProperty",
            "description": "= Result"
        },
        "hideFooter": "=!action.resultProperty"
    }
}

```
which describes the `Microsoft.EditArray` type in Composer as
![image](https://user-images.githubusercontent.com/8528761/104685778-ccc14200-5736-11eb-8526-ff7a17f7b6f8.png)
