### PR TITLE
When input is invalid, only send responses to message types in OAuthInput 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -235,11 +235,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     { 
                         // increase the turnCount as last step
                         dc.State.SetValue(TURN_COUNT_PROPERTY, turnCount + 1);
-                        var prompt = await this.OnRenderPromptAsync(dc, inputState, cancellationToken).ConfigureAwait(false);
-                        await dc.Context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+
+                        if (isMessage)
+                        {
+                            var prompt = await this.OnRenderPromptAsync(dc, inputState, cancellationToken).ConfigureAwait(false);
+                            await dc.Context.SendActivityAsync(prompt, cancellationToken).ConfigureAwait(false);
+                        }
                     }
 
-                    await SendOAuthCardAsync(dc, promptOptions?.Prompt, cancellationToken).ConfigureAwait(false);
+                    // Only send the card in response to a message.
+                    if (isMessage)
+                    {
+                        await SendOAuthCardAsync(dc, promptOptions?.Prompt, cancellationToken).ConfigureAwait(false);
+                    }
+
                     return Dialog.EndOfTurn;
                 }
                 else


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/5103