### PR TITLE
[DO NOT MERGE] Allow TextInput action to set non string property

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInputWithNonStringInput.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_TextInputWithNonStringInput.test.dialog
@@ -28,9 +28,13 @@
                                 "prompt": "Hello, what is your name?",
                                 "unrecognizedPrompt": "How should I call you?",
                                 "invalidPrompt": "That does not soud like a name",
-                                "value": "=json(`{'foo': '$firstName','item': '$lastName'}`)"
+                                "value": "=createArray(dialog.firstName, dialog.lastName)"
                             }
                         ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Hello ${concat(toUpper(user.name[0]),toUpper(user.name[1]))}, nice to meet you!"
                     }
                 ]
             }
@@ -45,7 +49,7 @@
         },
         {
             "$kind": "Microsoft.Test.AssertReply",
-            "text": "That does not soud like a name"
+            "text": "Hello LUHAN, nice to meet you!"
         }
     ]
 }


### PR DESCRIPTION
Fixes #5088 

## Description
Remove the limitation that TextInput can only set string value to property. A more friendly solution is that TextInput only limits string format for raw user input from activity but no longer limits string format to property setting after post processing of user input. For example, users can set a luis recognized result like entity array generated from a text input to a dialog memory property. 

## Specific Changes
  - Change the input recognition and validation logic in InputDialog to allow non-string input set to property
  - Adjust the test case to test such changes

## Testing
Test case adjusted.