### PR TITLE
Allow customize inputHint via prompt property

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -473,7 +473,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 msg = await this.Prompt.BindAsync(dc, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            msg.InputHint = InputHints.ExpectingInput;
+            if (string.IsNullOrEmpty(msg?.InputHint))
+            {
+                msg.InputHint = InputHints.ExpectingInput;
+            }
 
             var properties = new Dictionary<string, string>()
             {


### PR DESCRIPTION

## Description
Using `expectingInput` while `inputHint` property is not assigned of prompt property in InputDialog. Otherwise, keep it as it is.

Original issue links:
https://github.com/microsoft/botbuilder-js/issues/3195
https://github.com/microsoft/botbuilder-js/issues/1776#issuecomment-733418246

Original j pr:https://github.com/microsoft/botbuilder-js/pull/3196