### PR TITLE
[Expression]Add abs and sqrt built- in function

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Abs.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Abs.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace AdaptiveExpressions.BuiltinFunctions
+{
+    /// <summary>
+    /// Returns the absolute value of the specified number.
+    /// </summary>
+    internal class Abs : NumberTransformEvaluator
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Abs"/> class.
+        /// </summary>
+        public Abs()
+                : base(ExpressionType.Abs, Function)
+        {
+        }
+
+        private static object Function(IReadOnlyList<object> args)
+        {
+            return Math.Abs(Convert.ToDouble(args[0], CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Sqrt.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Sqrt.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+
+namespace AdaptiveExpressions.BuiltinFunctions
+{
+    /// <summary>
+    /// Returns the logarithm of a specified number.
+    /// </summary>
+    internal class Sqrt : ExpressionEvaluator
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Sqrt"/> class.
+        /// </summary>
+        public Sqrt()
+            : base(ExpressionType.Sqrt, Evaluator(), ReturnType.Number, FunctionUtils.ValidateUnaryNumber)
+        {
+        }
+
+        private static EvaluateExpressionDelegate Evaluator()
+        {
+            return FunctionUtils.ApplyWithError(
+                        args =>
+                        {
+                            string error = null;
+                            object result = null;
+                            var originalNumber = Convert.ToDouble(args[0], CultureInfo.InvariantCulture);
+                            if (originalNumber < 0)
+                            {
+                                error = "Do not support square root extraction of negative numbers currently.";
+                            }
+                            else
+                            {
+                                result = Math.Sqrt(originalNumber);
+                            }
+
+                            return (result, error);
+                        }, FunctionUtils.VerifyNumber);
+        }
+    }
+}

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Sqrt.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Sqrt.cs
@@ -29,7 +29,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             var originalNumber = Convert.ToDouble(args[0], CultureInfo.InvariantCulture);
                             if (originalNumber < 0)
                             {
-                                error = "Do not support square root extraction of negative numbers currently.";
+                                error = "Do not support square root extraction of negative numbers.";
                             }
                             else
                             {

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -30,6 +30,7 @@ namespace AdaptiveExpressions
         {
             var functions = new List<ExpressionEvaluator>
             {
+                new BuiltinFunctions.Abs(),
                 new BuiltinFunctions.Accessor(),
                 new BuiltinFunctions.Add(),
                 new BuiltinFunctions.AddDays(),
@@ -147,6 +148,7 @@ namespace AdaptiveExpressions
                 new BuiltinFunctions.SortBy(),
                 new BuiltinFunctions.SortByDescending(),
                 new BuiltinFunctions.Split(),
+                new BuiltinFunctions.Sqrt(),
                 new BuiltinFunctions.StartOfDay(),
                 new BuiltinFunctions.StartOfHour(),
                 new BuiltinFunctions.StartOfMonth(),

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -24,6 +24,8 @@ namespace AdaptiveExpressions
         public const string Floor = "floor";
         public const string Ceiling = "ceiling";
         public const string Round = "round";
+        public const string Abs = "abs";
+        public const string Sqrt = "sqrt";
 
         // Comparisons
         public const string LessThan = "<";

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -195,6 +195,11 @@ namespace AdaptiveExpressions.Tests
             Test("round(1.2, 16)"), // the 2nd parameter should not greater than 15
             Test("round(1.2, 2, 3)"), // should have one or two number parameters
             Test("round(1.2, 21232123123123123)"), // the second parameter should be a 32-bit signed integer
+            Test("abs()"), // should have one parameters
+            Test("abs(hello)"), // should have one number parameters
+            Test("sqrt()"), // should have one parameters
+            Test("sqrt(hello)"), // should have one number parameters
+            Test("sqrt(-1)"), // should have one non-nagitive number parameters
             #endregion
             
             #region Date and time function test

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -803,6 +803,11 @@ namespace AdaptiveExpressions.Tests
             Test("round(3.51)", 4),
             Test("round(3.55, 1)", 3.6),
             Test("round(3.12134, 3)", 3.121),
+            Test("abs(3.12134)", 3.12134),
+            Test("abs(-3.12134)", 3.12134),
+            Test("abs(0)", 0),
+            Test("sqrt(9)", 3),
+            Test("sqrt(0)", 0),
             #endregion
 
             #region  Date and time function test


### PR DESCRIPTION
Fixes #5114

## Description
Add `abs` and `sqrt` prebuilt function.
Example:
```
abs(3.12134)  -> 3.12134
abs(-3.12134) -> 3.12134
abs(0) -> 0
sqrt(9) -> 3
sqrt(-1)  -> throw error
sqrt(0) ->  0
```