### PR TITLE
[Api Compat] Add support for excluding classes in compatibility check

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -27,6 +27,7 @@ variables:
   runCodesignValidationInjection: false # Disables unnecessary CodeSign Validation step
 #  DotNetCoverallsToken: define this in Azure
 #  GitHubCommentApiKey: define this in Azure
+#  ApiCompatExcludeClasses: (optional) define this in Azure
 #  DisableApiCompatibityValidation: (optional) define this in Azure
 
 # The following 2 stages run multi-configuration, multi-agent parallel jobs.
@@ -130,7 +131,7 @@ stages:
     - template: ci-api-validation-steps.yml
 
   - job: post_results_to_gitHub
-    dependsOn: generate_multiconfig_var
+    dependsOn: check_api_for
     condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
     variables:
       BuildConfiguration: Release-Windows

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -24,38 +24,99 @@ steps:
     contractsRootFolder: 'DownloadedNuGet\$(BotBuilderDll).$(ApiCompatVersion)\lib\netstandard2.0'
     contractsFileName: '$(BotBuilderDll).dll'
     implFolder: '$(System.ArtifactsDirectory)/Artifacts'
-    failOnIssue: true
+    failOnIssue: false
     resolveFx: false
     generateLog: true
     outputFilename: '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt'
     outputFolder: '$(Build.ArtifactStagingDirectory)'
-    useBaseline: false
 
 - powershell: |
-    $FileName = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"
-    if (Test-Path $FileName) {
-      $FileContent = @(Get-Content $FileName)
+    $filePath = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"
+    $nugetLink = "compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion)).";
+    Write-Host "Compatibility Check:"; 
 
-      $FileContent[0] = $FileContent[0] + " compared against [version $(ApiCompatVersion)](https://www.nuget.org/packages/$(BotBuilderDll)/$(ApiCompatVersion))"
+    if (-not (Test-Path $filePath)) {
+      $content = "The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue."
+      New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt' -ItemType "file" -Value $content
+      $content;
+      return;
+    }
+
+    $baseline = Get-Content $filePath -Raw;
+    Write-Host "`n[Compare binaries task]"; 
+    Write-Host "`nOriginal result:"; 
+    $baseline;
+
+    # When the Api Compat task has Binary compatibility issues, this process will filter out the Classes
+    # and then validates if still exists remaining issues.
+    if ($baseline.ToString().Trim().StartsWith(':x:')) {
+      Write-Host "`n[Class exclusion]"; 
+      $excludeClasses = "$($env:ApiCompatExcludeClasses)".Trim().Split(',') | Where-Object { ($_.Trim().Length -gt 0) } | ForEach-Object { $_.Trim() };
+      
+      if ($excludeClasses) {
+        Write-Host "`nList of classes to exclude:"; 
+        $excludeClasses | ForEach-Object { "  - " + $_ }
+      }
+      else {
+        Write-Host "`nThere are no classes to exclude."; 
+      }
+      
+      $content = ($baseline -split '<details\>|<\/details\>');
+      $header = $content[0].SubString($content[0].IndexOf('Binary') - 1).Trim();
+      $issues = $content[1].Trim();
+      $issues = ($issues -replace '```', '').Split([Environment]::NewLine);
+
+      # Filter out issues based on Class name.
+      $issues = @(
+        $issues | Where-Object {
+          $line = $_;
+          if (-not $line.Trim()) {
+            return $false;
+          }
+          if ($excludeClasses) {
+            foreach ($class in $excludeClasses) {
+              $pattern = "'$class";
+              if ($line -match $pattern) { 
+                return $false;
+              }
+            }
+          }
+          return $true;
+        } | ForEach-Object { $_.Trim() }
+      )
+
+      # Creates new file content.
+      if ($issues) {
+        $newFile = @();
+        $newfile += ":x: $($issues.Length) $header $nugetLink";
+        $newFile += '<details>';
+        $newFile += "";
+        $newFile += '```';
+        $newfile += $issues;
+        $newFile += '```';
+        $newFile += "";
+        $newFile += '</details>';
         
-      if ($FileContent.Length -eq 1) {
-        [system.io.file]::WriteAllText($FileName,$FileContent)
-      } else {
-        Set-Content $FileName $FileContent
+        $newFile = $newFile -join [Environment]::NewLine;
+        Write-Host "##vso[task.complete result=Failed;]";
+      }
+      else {
+        $newFile = ":heavy_check_mark: No Binary Compatibility issues for **$(BotBuilderDll)** $nugetLink";
       }
 
-      Write-Host "The updated line 1: `n$FileContent[0]"
-    } else {
-      $FileContent = "The binary compatibility report for library '$(BotBuilderDll)' wasn't generated. This may have happened because the NuGet library '$(BotBuilderDll)' for version '$(ApiCompatVersion)' was unavailable or a connectivity issue."
-      New-Item -Path '$(Build.ArtifactStagingDirectory)' -Name '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt' -ItemType "file" -Value $FileContent
+      $baseline = $newFile;
+      [system.io.file]::WriteAllText($filePath, $baseline);
+      Write-Host "`nProcessed result:"; 
+      $baseline;
     }
-  displayName: 'Insert nuget link into ApiCompat results file.'
+  displayName: 'Compatibility Check'
   condition: succeededOrFailed()
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Compat Results artifact'
   inputs:
     ArtifactName: '$(BotBuilderDll).$(ApiCompatVersion).CompatResults'
+  condition: succeededOrFailed()
 
 - script: |
    cd ..

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -29,6 +29,7 @@ steps:
     generateLog: true
     outputFilename: '$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt'
     outputFolder: '$(Build.ArtifactStagingDirectory)'
+    useBaseline: false
 
 - powershell: |
     $filePath = "$(Build.ArtifactStagingDirectory)\$(BotBuilderDll).$(ApiCompatVersion).CompatResults.txt"


### PR DESCRIPTION
## Description
This PR adds support for excluding classes from the API Compatibility checks.
We introduced a new pipeline variable (`ApiCompatExcludeClasses`) that will let you define a comma separated list of excluded classes. Each class has to be defined as **[Package]+[Class]**, e.g. `Microsoft.Bot.Builder.AdapterExtensions, ...`
Then, the Compare Binaries task has been modified to not fail on issue leaving the pipeline with a **SuccessWithIssues** state when it founds compatibility issues.
Finally, a new PowerShell task will compare the compatibility issues found on the previous step with the list of excluded classes. If all issues have been excluded, the task will set the status as **Success**, otherwise it will be set as **Failed**.

## Specific Changes
- Updated `Compare Binaries` task on `ci-api-validation-steps.yml` to `failOnIssue: false`.
- Updated `post_results_to_gitHub` job to depend on `check_api_for` instead of `generate_multiconfig_var`, occasionally it executes the GitHub PR Comment task before the Api Compat ones.
- Added `Compatibility Check` PowerShell script after the `Compare Binaries` task, that will evaluate the result of `Compare Binaries` and process the output based on the excluded classes.
  - Filter out wanted classes from the found issues in `Compare Binaries`.
  - Updates Api Compat result file with the remaining issues from the exclusion or with a `No Binary Compatibility issues`.
- Added `succeededOrFailed()` on `PublishBuildArtifacts` task to upload the previous task result, either `succeed` or `failed`.
- Removed `Insert nuget link into ApiCompat results file.` task in favor of `Compatibility Check` and included some code from this task to maintain current functionality.

## Testing
In the following image there is a sneak peek for the pipeline output and the GitHub Pr Comments.
![image](https://user-images.githubusercontent.com/62260472/105506829-3c8c7b00-5ca9-11eb-98b6-a2e1661b3c17.png)