### PR TITLE
[Expression]Add stringOrValue built-in function

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StringOrValue.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StringOrValue.cs
@@ -27,7 +27,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
             if (!(stringInput is string))
             {
-                error = "Parameter should be string.";
+                error = "Parameter should be a string.";
             }
 
             if (error == null)
@@ -36,7 +36,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 var firstChildren = expr.Children[0];
                 var secondChildren = expr.Children[1];
 
-                // If the Expression is follow this format:
+                // If the Expression follows this format:
                 // concat('', childExpression)
                 // return the childExpression result directly.
                 if ((firstChildren is Constant child)

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StringOrValue.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StringOrValue.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Linq;
-
 namespace AdaptiveExpressions.BuiltinFunctions
 {
     /// <summary>
-    /// TODO.
+    /// Wrap string interpolation to get real value.
+    /// For example: stringOrValue('${1}'), would get number 1
+    /// stringOrValue('${1} item'), would get string "1 item".
     /// </summary>
     internal class StringOrValue : ExpressionEvaluator
     {
@@ -26,16 +25,30 @@ namespace AdaptiveExpressions.BuiltinFunctions
             object stringInput;
             (stringInput, error) = expression.Children[0].TryEvaluate(state, options);
 
-            // TODO
-            // verify string
+            if (!(stringInput is string))
+            {
+                error = "Parameter should be string.";
+            }
+
             if (error == null)
             {
                 var expr = Expression.Parse("`" + stringInput + "`");
                 var firstChildren = expr.Children[0];
                 var secondChildren = expr.Children[1];
-                if ((firstChildren is Constant child) && (child.Value.ToString().Length == 0) && !(secondChildren is Constant))
+
+                // If the Expression is follow this format:
+                // concat('', childExpression)
+                // return the childExpression result directly.
+                if ((firstChildren is Constant child)
+                    && (child.Value.ToString().Length == 0)
+                    && !(secondChildren is Constant)
+                    && expr.Children.Length == 2)
                 {
-                    
+                    (result, error) = secondChildren.TryEvaluate(state, options);
+                }
+                else
+                {
+                    (result, error) = expr.TryEvaluate(state, options);
                 }
             }
 

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/StringOrValue.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/StringOrValue.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+
+namespace AdaptiveExpressions.BuiltinFunctions
+{
+    /// <summary>
+    /// TODO.
+    /// </summary>
+    internal class StringOrValue : ExpressionEvaluator
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringOrValue"/> class.
+        /// </summary>
+        public StringOrValue()
+            : base(ExpressionType.StringOrValue, Evaluator, ReturnType.Object, FunctionUtils.ValidateUnaryString)
+        {
+        }
+
+        private static (object, string) Evaluator(Expression expression, object state, Options options)
+        {
+            object result = null;
+            string error;
+            object stringInput;
+            (stringInput, error) = expression.Children[0].TryEvaluate(state, options);
+
+            // TODO
+            // verify string
+            if (error == null)
+            {
+                var expr = Expression.Parse("`" + stringInput + "`");
+                var firstChildren = expr.Children[0];
+                var secondChildren = expr.Children[1];
+                if ((firstChildren is Constant child) && (child.Value.ToString().Length == 0) && !(secondChildren is Constant))
+                {
+                    
+                }
+            }
+
+            return (result, error);
+        }
+    }
+}

--- a/libraries/AdaptiveExpressions/ExpressionFunctions.cs
+++ b/libraries/AdaptiveExpressions/ExpressionFunctions.cs
@@ -152,6 +152,7 @@ namespace AdaptiveExpressions
                 new BuiltinFunctions.StartOfMonth(),
                 new BuiltinFunctions.StartsWith(),
                 new BuiltinFunctions.String(),
+                new BuiltinFunctions.StringOrValue(),
                 new BuiltinFunctions.SubArray(),
                 new BuiltinFunctions.Substring(),
                 new BuiltinFunctions.Subtract(),

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -195,6 +195,9 @@ namespace AdaptiveExpressions
         public const string IsBoolean = "isBoolean";
         public const string IsDateTime = "isDateTime";
 
+        // TODO
+        public const string StringOrValue = "stringOrValue";
+
         // trigger tree 
 
         /// <summary>

--- a/libraries/AdaptiveExpressions/ExpressionType.cs
+++ b/libraries/AdaptiveExpressions/ExpressionType.cs
@@ -195,7 +195,7 @@ namespace AdaptiveExpressions
         public const string IsBoolean = "isBoolean";
         public const string IsDateTime = "isDateTime";
 
-        // TODO
+        // StringOrValue
         public const string StringOrValue = "stringOrValue";
 
         // trigger tree 

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -461,6 +461,12 @@ namespace AdaptiveExpressions.Tests
             // optional throws because it's a placeholder only interpreted by trigger tree and is removed before evaluation
             Test("optional(true)"), 
             #endregion
+
+            #region StringOrValue
+            Test("stringOrValue()"), // should have 1 parameter
+            Test("stringOrValue(1)"), // should have string parameter
+            Test("stringOrValue('${1/0} item')"), // throw error in evaluation stage
+            #endregion
         };
 
         /// <summary>

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1149,6 +1149,11 @@ namespace AdaptiveExpressions.Tests
             #region TriggerTree Tests
             Test("ignore(true)", true),
             #endregion
+
+            #region StringOrValue
+            Test("stringOrValue('${one}')", 1.0),
+            Test("stringOrValue('${one} item')", "1 item"),
+            #endregion
         };
 
         public static IEnumerable<object[]> DataForThreadLocale => new[]


### PR DESCRIPTION
Fixes #5009

## Description
Introduce a new built-in function that refers to smart interpolation.

The original requirements are:
- when user input is a simple variable, like `${name}` or `${age}`, it should evaluate as a single variable and the return type is the variable type (int\float\string, it could vary)
- when user input is text + variables, like `${age} is too big`, it should evaluate as a string intepolation, and always return a string type 

Samples:
`stringOrValue('${2+3}')` -> 5
`stringOrValue('woof is ${3+5}')` would produce 'woof is 8'.

## Changes
Create a new function that can evaluate the value expression smartly.