### PR TITLE
Fix deliveryMode.ExpectReplies for skills.

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     using (var response = await HttpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
                     {
                         var content = response.Content != null ? await response.Content.ReadAsStringAsync().ConfigureAwait(false) : null;
-                        var invokeResponse = JsonConvert.DeserializeObject<InvokeResponse<T>>(content ?? "{}");
+                        var invokeResponse = string.IsNullOrEmpty(content) ? new InvokeResponse<T>() : JsonConvert.DeserializeObject<InvokeResponse<T>>(content);
                         invokeResponse.Status = (int)response.StatusCode;
                         return invokeResponse;
                     }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -210,19 +210,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
         }
 
-        private static T GetBodyContent<T>(string content)
-        {
-            try
-            {
-                return JsonConvert.DeserializeObject<T>(content);
-            }
-            catch (JsonException)
-            {
-                // This will only happen when the skill didn't return valid json in the content (e.g. when the status code is 500 or there's a bug in the skill)
-                return default;
-            }
-        }
-
         private async Task<InvokeResponse<T>> SecurePostActivityAsync<T>(Uri toUrl, Activity activity, string token, CancellationToken cancellationToken)
         {
             using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
@@ -240,11 +227,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     using (var response = await HttpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
                     {
                         var content = response.Content != null ? await response.Content.ReadAsStringAsync().ConfigureAwait(false) : null;
-                        return new InvokeResponse<T>
-                        {
-                            Status = (int)response.StatusCode,
-                            Body = content?.Length > 0 ? GetBodyContent<T>(content) : default
-                        };
+                        var invokeResponse = JsonConvert.DeserializeObject<InvokeResponse<T>>(content ?? "{}");
+                        invokeResponse.Status = (int)response.StatusCode;
+                        return invokeResponse;
                     }
                 }
             }

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpClientTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpClientTests.cs
@@ -56,9 +56,14 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 Assert.Equal(RoleTypes.Skill, sentActivity.Recipient.Role);
 
                 // Create mock response.
+                var body = (expectedResponseBodyJson != null) ? JsonConvert.DeserializeObject(expectedResponseBodyJson) : null;
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = expectedResponseBodyJson == null ? null : new StringContent(expectedResponseBodyJson)
+                    Content = new StringContent(JsonConvert.SerializeObject(new InvokeResponse()
+                    {
+                        Status = (int)HttpStatusCode.OK,
+                        Body = body
+                    }))
                 };
                 return Task.FromResult(response);
             });
@@ -142,7 +147,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 // Create mock response.
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(JObject.FromObject(new TestContentBody("someId", "theProp")).ToString())
+                    Content = new StringContent(JObject.FromObject(new InvokeResponse<TestContentBody>()
+                    {
+                        Status = (int)HttpStatusCode.OK,
+                        Body = new TestContentBody("someId", "theProp")
+                    }).ToString())
                 };
                 return Task.FromResult(response);
             });
@@ -155,14 +164,13 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             Assert.IsType<InvokeResponse<TestContentBody>>(result);
             Assert.NotNull(result.Body);
 
-            var typedContent = JsonConvert.DeserializeObject<TestContentBody>(JsonConvert.SerializeObject(result.Body));
-            Assert.Equal("someId", typedContent.Id);
-            Assert.Equal("theProp", typedContent.SomeProp);
+            Assert.Equal("someId", result.Body.Id);
+            Assert.Equal("theProp", result.Body.SomeProp);
         }
 
         [Fact]
         public async Task PostActivityUsingInvokeResponseToSelf()
-        {      
+        {
             var activity = new Activity { Conversation = new ConversationAccount(id: Guid.NewGuid().ToString()) };
             var httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
             {
@@ -178,7 +186,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 };
                 return Task.FromResult(response);
             });
-            
+
             var client = new BotFrameworkHttpClient(httpClient, new Mock<ICredentialProvider>().Object);
             var result = await client.PostActivityAsync(string.Empty, new Uri("https://skillbot.com/api/messages"), activity);
 
@@ -189,7 +197,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
         [Fact]
         public async Task PostActivityUsingInvokeResponseOfTToSelf()
-        {      
+        {
             var activity = new Activity { Conversation = new ConversationAccount(id: Guid.NewGuid().ToString()) };
             var httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
             {
@@ -201,11 +209,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 // Create mock response.
                 var response = new HttpResponseMessage(HttpStatusCode.OK)
                 {
-                    Content = new StringContent(JObject.FromObject(new TestContentBody("someId", "theProp")).ToString())
-                };
+                    Content = new StringContent(JObject.FromObject(new InvokeResponse<TestContentBody>()
+                    {
+                        Status = (int)HttpStatusCode.OK,
+                        Body = new TestContentBody("someId", "theProp")
+                    }).ToString())
+                }; 
                 return Task.FromResult(response);
             });
-            
+
             var client = new BotFrameworkHttpClient(httpClient, new Mock<ICredentialProvider>().Object);
             var result = await client.PostActivityAsync<TestContentBody>(string.Empty, new Uri("https://skillbot.com/api/messages"), activity);
 


### PR DESCRIPTION
## Description
When callling /api/messages the return type is always a **InvokeResponse&lt;T&gt;** data structure.

When a skill receives an activity with **deliveryMode=expectReplies**, the **botframeworkAdapter** caches all outbound activities and returns them as a **InvokeReponse&lt;ExpectedReplies&gt;** :
```
{
   "status": status code
   "body": { // type expectedReplies
      "activities": [... ]
    }
}
```
This is the correct speced behavior.

The bug is that the **BotFrameworkHttpClient** code is interpreting the body of the response as **ExpectedReplies** instead of **InvokeResponse&lt;ExpectedReplies&gt;**

The properties don't align and hence the activities are dropped on the floor.

The unit tests test both sides independently but with mismatched assumptions, so only when e2e is used it doesn't work. (classic metric vs english measurement situation).

This changes client to do correc thing and aligns unit tests to same assumptions as the bot framework adapter class.

## Specific Changes
* The response from the skill is already **InvokeResponse&lt;ExpectedReplies&gt;**, there is no need for special code to other then deserializing it as such.

## Testing
* Updated the unit tests to correctly mock returning **InvokeResponse&lt;ExpectedReplies&gt;**

## NOTE
We should make sure this bug was not ported to other platforms