### PR TITLE
Add DeliveryMode to SkillDialog/BeginSkill

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.schema
@@ -76,6 +76,27 @@
             "title": "Activity",
             "description": "The activity to send to the skill."
         },
+        "deliveryMode": {
+            "title": "Delivery mode",
+            "description": "Delivery Mode to use to communicate with skill.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "title": "Delivery Modes",
+                    "description": "Delivery Modes.",
+                    "default": "expectReplies",
+                    "enum": [
+                        "normal",
+                        "expectReplies",
+                        "notification",
+                        "ephemeral"
+                    ]
+                },
+                {
+                    "$ref": "schema:#/definitions/equalsExpression"
+                }
+            ]
+        },
         "allowInterruptions": {
             "$ref": "schema:#/definitions/booleanExpression",
             "title": "Allow interruptions",

--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialogOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialogOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Bot.Builder.Skills;
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
@@ -74,5 +75,17 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </value>
         [JsonProperty("connectionName")]
         public string ConnectionName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default delivery mode to use for communication with the skill.
+        /// </summary>
+        /// <remarks>
+        /// This value will be used for activities that do not explicitly set deliveryMode.
+        /// </remarks>
+        /// <value>
+        /// A deliveryMode constant [normal|expectReplies].
+        /// </value>
+        [JsonProperty("deliveryMode")]
+        public string DeliveryMode { get; set; } = DeliveryModes.Normal;
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkill.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkill.test.dialog
@@ -20,17 +20,17 @@
                 "actions": [
                     {
                         "$kind": "Microsoft.BeginSkill",
-                        "BotId": "test-bot-id",
-                        "SkillHostEndpoint": "http://localhost:3978/api/skills/",
-                        "SkillEndpoint": "http://localhost:39782/api/messages",
-                        "SkillAppId": "test-app-id",
-                        "ConnectionName": "test-skill-connection-name",
+                        "botId": "test-bot-id",
+                        "skillHostEndpoint": "http://localhost:3978/api/skills/",
+                        "skillEndpoint": "http://localhost:39782/api/messages",
+                        "skillAppId": "test-app-id",
+                        "connectionName": "test-skill-connection-name",
+                        "deliveryMode": "expectReplies",
                         "activity": {
                             "$kind": "Microsoft.StaticActivityTemplate",
                             "activity": {
                                 "type": "message",
-                                "text": "skill",
-                                "deliveryMode": "expectReplies"
+                                "text": "skill"
                             }
                         }
                     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkillEndDialog.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_BeginSkillEndDialog.test.dialog
@@ -22,18 +22,18 @@
                 "actions": [
                     {
                         "$kind": "Microsoft.BeginSkill",
-                        "BotId": "test-bot-id",
-                        "SkillHostEndpoint": "http://localhost:3978/api/skills/",
-                        "SkillEndpoint": "http://localhost:39782/api/messages",
-                        "SkillAppId": "test-app-id",
-                        "ConnectionName": "test-skill-connection-name",
-                        "AllowInterruptions": false,
+                        "botId": "test-bot-id",
+                        "skillHostEndpoint": "http://localhost:3978/api/skills/",
+                        "skillEndpoint": "http://localhost:39782/api/messages",
+                        "skillAppId": "test-app-id",
+                        "connectionName": "test-skill-connection-name",
+                        "allowInterruptions": false,
+                        "deliveryMode": "expectReplies",
                         "activity": {
                             "$kind": "Microsoft.StaticActivityTemplate",
                             "activity": {
                                 "type": "message",
-                                "text": "skill",
-                                "deliveryMode": "expectReplies"
+                                "text": "skill"
                             }
                         }
                     },

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs
@@ -381,11 +381,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             // Use Memory for conversation state
             var conversationState = new ConversationState(new MemoryStorage());
             var dialogOptions = CreateSkillDialogOptions(conversationState, mockSkillClient);
+            dialogOptions.DeliveryMode = DeliveryModes.ExpectReplies;
 
             // Create the SkillDialogInstance and the activity to send.
             var sut = new SkillDialog(dialogOptions);
             var activityToSend = (Activity)Activity.CreateMessageActivity();
-            activityToSend.DeliveryMode = DeliveryModes.ExpectReplies;
             activityToSend.Text = Guid.NewGuid().ToString();
             var client = new DialogTestClient(Channels.Test, sut, new BeginSkillDialogOptions { Activity = activityToSend }, conversationState: conversationState);
 

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -1175,6 +1175,27 @@
           "description": "The activity to send to the skill.",
           "$ref": "#/definitions/Microsoft.IActivityTemplate"
         },
+        "deliveryMode": {
+          "title": "Delivery mode",
+          "description": "Delivery Mode to use to communicate with skill.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Delivery Modes",
+              "description": "Delivery Modes.",
+              "default": "expectReplies",
+              "enum": [
+                "normal",
+                "expectReplies",
+                "notification",
+                "ephemeral"
+              ]
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
         "allowInterruptions": {
           "$ref": "#/definitions/booleanExpression",
           "title": "Allow interruptions",


### PR DESCRIPTION
Fixes #5143 

## Description
The default usage of SkillDialog/BeginSkill is to pass an activity through, but SkillDialog is modeled to change the 
delivery mode you have to clone the activity, set the deliverMode and then pass it in.  This is a complex
task that should be captured by a simple DeliverMode property on the SkillDialog/BeginSkill properties.

While coding this a concurrency bug was discovered in BeginSkill where on every turn we were clobbering the underlying 
configuration of the SkillDialog. Changed the initialization to evaluate once and then settings are immutable to reflect
semantics in the way that SkillDialog is coded. 

## Specific Changes
  -  Added DeliveryMode to SkillDialogOptions
  - Changed SkillDialog to set DeliveryMode if the activity doesn't already have a delivery mode.
  - Removed state variables that are not needed because the DialogOptions are immutable.
  - Added DeliveryMode to BeginSkill as expression property
  - Fixed concurrency issue with BeginSkill DialogOption initilaization.
  - updated schema files with new definition for BeginSkill.

## Testing
- updated skill tests to show that DeliverMode as configuration has appropriate effect.

### NOTE
**We should make sure this concurrency bug was not ported to other platforms**