### PR TITLE
feat: Runtime Configuration Builder Updates

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Runtime/ConfigurationConstants.cs
+++ b/libraries/Microsoft.Bot.Builder.Runtime/ConfigurationConstants.cs
@@ -14,11 +14,6 @@ namespace Microsoft.Bot.Builder.Runtime
         public const string ApplicationRootKey = "applicationRoot";
 
         /// <summary>
-        /// The configuration key mapping to the value representing the bot root path.
-        /// </summary>
-        public const string BotKey = "bot";
-
-        /// <summary>
         /// The configuration key mapping to the value representing the default resource identifier
         /// of the dialog to be utilized as the root dialog of the bot.
         /// </summary>


### PR DESCRIPTION
## Description
As part of the adaptive runtime integration process with Composer, changes are being made to no use the ComposerDialogs folder in non-development environments as the bot root. Additionally, adding Orchestrator generated settings as a configuration source in order to support the Orchestrator recognizer plugin.

## Specific Changes
  - Removal of 'bot' application setting.
  - Removal of 'isDevelopment' flag from ConfigurationBuilderExtensions::AddBotRuntimeConfiguration extension methods.
  - Use application root in all environments.
  - Add Orchestrator generated settings as configuration source.

## Testing
Pending manual validation through Composer integration testing.