### PR TITLE
Orchestrator Recognizer: Rename misleading parameter names

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorAdaptiveRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorAdaptiveRecognizer.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
 
         private const float UnknownIntentFilterScore = 0.4F;
         private static BotFramework.Orchestrator.Orchestrator orchestrator = null;
-        private string _modelPath;
-        private string _snapshotPath;
+        private string _modelFolder;
+        private string _snapshotFile;
         private ILabelResolver _resolver = null;
 
         /// <summary>
@@ -56,24 +56,24 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         /// <summary>
         /// Initializes a new instance of the <see cref="OrchestratorAdaptiveRecognizer"/> class.
         /// </summary>
-        /// <param name="modelPath">Path to NLR model.</param>
-        /// <param name="snapshotPath">Path to snapshot.</param>
+        /// <param name="modelFolder">Specifies the base model folder.</param>
+        /// <param name="snapshotFile">Specifies full path to the snapshot file.</param>
         /// <param name="resolver">Label resolver.</param>
-        public OrchestratorAdaptiveRecognizer(string modelPath, string snapshotPath, ILabelResolver resolver = null)
+        public OrchestratorAdaptiveRecognizer(string modelFolder, string snapshotFile, ILabelResolver resolver = null)
         {
             _resolver = resolver;
-            if (modelPath == null)
+            if (modelFolder == null)
             {
-                throw new ArgumentNullException($"Missing `ModelPath` information.");
+                throw new ArgumentNullException($"Missing `ModelFolder` information.");
             }
 
-            if (snapshotPath == null)
+            if (snapshotFile == null)
             {
-                throw new ArgumentNullException($"Missing `SnapshotPath` information.");
+                throw new ArgumentNullException($"Missing `SnapshotFile` information.");
             }
 
-            _modelPath = modelPath;
-            _snapshotPath = snapshotPath;
+            _modelFolder = modelFolder;
+            _snapshotFile = snapshotFile;
             InitializeModel();
         }
 
@@ -83,8 +83,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         /// <value>
         /// Model path.
         /// </value>
-        [JsonProperty("modelPath")]
-        public StringExpression ModelPath { get; set; } = "=settings.orchestrator.modelPath";
+        [JsonProperty("modelFolder")]
+        public StringExpression ModelFolder { get; set; } = "=settings.orchestrator.modelFolder";
 
         /// <summary>
         /// Gets or sets the full path to Orchestrator snapshot file to use.
@@ -92,8 +92,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         /// <value>
         /// Snapshot path.
         /// </value>
-        [JsonProperty("snapshotPath")]
-        public StringExpression SnapshotPath { get; set; } = "=settings.orchestrator.snapshotPath";
+        [JsonProperty("snapshotFile")]
+        public StringExpression SnapshotFile { get; set; } = "=settings.orchestrator.snapshotFile";
 
         /// <summary>
         /// Gets or sets an external entity recognizer.
@@ -135,8 +135,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
             var text = activity.Text ?? string.Empty;
             var detectAmbiguity = DetectAmbiguousIntents.GetValue(dc.State);
 
-            _modelPath = ModelPath.GetValue(dc.State);
-            _snapshotPath = SnapshotPath.GetValue(dc.State);
+            _modelFolder = ModelFolder.GetValue(dc.State);
+            _snapshotFile = SnapshotFile.GetValue(dc.State);
 
             InitializeModel();
 
@@ -224,19 +224,19 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
 
         private void InitializeModel()
         {
-            if (_modelPath == null)
+            if (_modelFolder == null)
             {
-                throw new ArgumentNullException($"Missing `ModelPath` information.");
+                throw new ArgumentNullException($"Missing `ModelFolder` information.");
             }
 
-            if (_snapshotPath == null)
+            if (_snapshotFile == null)
             {
-                throw new ArgumentNullException($"Missing `ShapshotPath` information.");
+                throw new ArgumentNullException($"Missing `ShapshotFile` information.");
             }
 
             if (orchestrator == null && _resolver == null)
             {
-                var fullModelPath = Path.GetFullPath(PathUtils.NormalizePath(_modelPath));
+                var fullModelPath = Path.GetFullPath(PathUtils.NormalizePath(_modelFolder));
 
                 // Create Orchestrator
                 try
@@ -251,7 +251,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
 
             if (_resolver == null)
             {
-                var fullSnapShotPath = Path.GetFullPath(PathUtils.NormalizePath(_snapshotPath));
+                var fullSnapShotPath = Path.GetFullPath(PathUtils.NormalizePath(_snapshotFile));
 
                 // Load the snapshot
                 string content = File.ReadAllText(fullSnapShotPath);

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         /// <value>
         /// Model path.
         /// </value>
-        [JsonProperty("modelPath")]
-        public string ModelPath { get; set; }
+        [JsonProperty("modelFolder")]
+        public string ModelFolder { get; set; }
 
         /// <summary>
         /// Gets or sets the full path to Orchestrator snapshot file to use.
@@ -47,8 +47,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         /// <value>
         /// Snapshot path.
         /// </value>
-        [JsonProperty("snapshotPath")]
-        public string SnapshotPath { get; set; }
+        [JsonProperty("snapshotFile")]
+        public string SnapshotFile { get; set; }
 
         /// <summary>
         /// Gets or sets an external entity recognizer.
@@ -83,8 +83,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
             {
                 Id = this.Id,
                 DetectAmbiguousIntents = this.DetectAmbiguousIntents,
-                ModelPath = this.ModelPath,
-                SnapshotPath = this.SnapshotPath,
+                ModelFolder = this.ModelFolder,
+                SnapshotFile = this.SnapshotFile,
                 DisambiguationScoreThreshold = this.DisambiguationScoreThreshold,
                 ExternalEntityRecognizer = this.ExternalEntityRecognizer,
             };

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Schemas/Microsoft.OrchestratorRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Schemas/Microsoft.OrchestratorRecognizer.schema
@@ -10,17 +10,17 @@
             "title": "Id",
             "description": "Optional unique id using with RecognizerSet."
         },
-        "modelPath": {
+        "modelFolder": {
             "$ref": "schema:#/definitions/stringExpression",
-            "title": "Model",
-            "description": "NLR model file path.",
-            "default": "=settings.orchestrator.modelpath"
+            "title": "Base Model",
+            "description": "Base model folder path.",
+            "default": "=settings.orchestrator.modelfolder"
         },
-        "snapshotPath": {
+        "snapshotFile": {
             "$ref": "schema:#/definitions/stringExpression",
-            "title": "Endpoint key",
-            "description": "SnapShot file path.",
-            "default": "=settings.orchestrator.shapshotpath"
+            "title": "Snapshot File",
+            "description": "Full path to snapshot file.",
+            "default": "=settings.orchestrator.shapshotfile"
         },
         "externalEntityRecognizer": {
             "$kind": "Microsoft.IRecognizer",
@@ -51,7 +51,7 @@
         }
     },
     "required": [
-        "model",
-        "shapShot"
+        "modelFolder",
+        "snapshotFile"
     ]
 }

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Schemas/Microsoft.OrchestratorRecognizer.schema
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Schemas/Microsoft.OrchestratorRecognizer.schema
@@ -14,13 +14,13 @@
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Base Model",
             "description": "Base model folder path.",
-            "default": "=settings.orchestrator.modelfolder"
+            "default": "=settings.orchestrator.modelFolder"
         },
         "snapshotFile": {
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Snapshot File",
-            "description": "Full path to snapshot file.",
-            "default": "=settings.orchestrator.shapshotfile"
+            "description": "Snapshot file.",
+            "default": "=settings.orchestrator.snapshotFile"
         },
         "externalEntityRecognizer": {
             "$kind": "Microsoft.IRecognizer",

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
             var mockResolver = new MockResolver(mockScore);
             var recognizer = new OrchestratorAdaptiveRecognizer(string.Empty, string.Empty, mockResolver)
             {
-                ModelPath = new StringExpression("fakePath"),
-                SnapshotPath = new StringExpression("fakePath")
+                ModelFolder = new StringExpression("fakePath"),
+                SnapshotFile = new StringExpression("fakePath")
             };
 
             var adapter = new TestAdapter(TestAdapter.CreateConversation("ds"));
@@ -56,8 +56,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
             var mockResolver = new MockResolver(mockScore);
             var recognizer = new OrchestratorAdaptiveRecognizer(string.Empty, string.Empty, mockResolver)
             {
-                ModelPath = new StringExpression("fakePath"),
-                SnapshotPath = new StringExpression("fakePath"),
+                ModelFolder = new StringExpression("fakePath"),
+                SnapshotFile = new StringExpression("fakePath"),
                 ExternalEntityRecognizer = new NumberEntityRecognizer()
             };
 
@@ -97,8 +97,8 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
             var mockResolver = new MockResolver(mockScore);
             var recognizer = new OrchestratorAdaptiveRecognizer(string.Empty, string.Empty, mockResolver)
             {
-                ModelPath = new StringExpression("fakePath"),
-                SnapshotPath = new StringExpression("fakePath"),
+                ModelFolder = new StringExpression("fakePath"),
+                SnapshotFile = new StringExpression("fakePath"),
                 DetectAmbiguousIntents = new BoolExpression(true),
                 DisambiguationScoreThreshold = new NumberExpression(0.5)
             };


### PR DESCRIPTION
Note: This checkin associated with :

- Nodejs Orchestrator recognizer update ([nodejs pr](https://github.com/microsoft/botbuilder-js/pull/3251))
- A samples update that uses Orchestrator recognizer ([samples pr](https://github.com/microsoft/BotBuilder-Samples/pull/3062))
- Composer updates (@taicchoumsft : Will submit once new SDK released)
- bf-cli updated (@tsuwandy checked in updates)

## Description
From the first preview, we've received feedback that our parameter names are confusing. 

## Specific Changes
This performs the following parameter renames:
   modelPath => modelFolder
   snapshotPath => snapshotFile

## Testing
Tests have been updated to reflect new parameter names.