### PR TITLE
Use double.Epsilon for equal check in expression

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
@@ -46,7 +46,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
             if (args[0].IsNumber() && args[0].IsNumber())
             {
-                if (Math.Abs(FunctionUtils.CultureInvariantDoubleConvert(args[0]) - FunctionUtils.CultureInvariantDoubleConvert(args[1])) < 0.00000001)
+                if (Math.Abs(FunctionUtils.CultureInvariantDoubleConvert(args[0]) - FunctionUtils.CultureInvariantDoubleConvert(args[1])) < double.Epsilon)
                 {
                     return true;
                 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Sqrt.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Sqrt.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 namespace AdaptiveExpressions.BuiltinFunctions
 {
     /// <summary>
-    /// Returns the logarithm of a specified number.
+    /// Returns the square root of a specified number.
     /// </summary>
     internal class Sqrt : ExpressionEvaluator
     {


### PR DESCRIPTION
Fixes: #5114
Reference: https://github.com/microsoft/botbuilder-dotnet/issues/5114#issuecomment-766661900

## Specific Changes
- Change the minimal value of float/double to `double.Epsilon`
- Fix typo