### PR TITLE
remove references to TrustServiceUrl

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -354,19 +354,6 @@ namespace Microsoft.Bot.Builder
                 // Add audience to TurnContext.TurnState
                 context.TurnState.Add(OAuthScopeKey, audience);
 
-                // If we receive a valid app id in the incoming token claims, add the 
-                // channel service URL to the trusted services list so we can send messages back.
-                // the service URL for skills is trusted because it is applied by the SkillHandler based on the original request
-                // received by the root bot
-                var appIdFromClaims = JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims);
-                if (!string.IsNullOrEmpty(appIdFromClaims))
-                {
-                    if (SkillValidation.IsSkillClaim(claimsIdentity.Claims) || await CredentialProvider.IsValidAppIdAsync(appIdFromClaims).ConfigureAwait(false))
-                    {
-                        AppCredentials.TrustServiceUrl(reference.ServiceUrl);
-                    }
-                }
-
                 using (var connectorClient = await CreateConnectorClientAsync(reference.ServiceUrl, claimsIdentity, audience).ConfigureAwait(false))
                 {
                     // Make the connector client available in turn state

--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="serviceUrl">The service url.</param>
         /// <returns>True if the host of the service url is trusted; False otherwise.</returns>
+        [Obsolete("IsTrustedServiceUrl is not a required part of the security model.")]
 #pragma warning disable CA1801 // Review unused parameters
         public static bool IsTrustedServiceUrl(string serviceUrl)
 #pragma warning restore CA1801 // Review unused parameters

--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="serviceUrl">The service URL.</param>
         /// <remarks>If expiration time is not provided, the expiration time will DateTime.UtcNow.AddDays(1).</remarks>
+        [Obsolete("TrustServiceUrl is not a required part of the security model.")]
 #pragma warning disable CA1801 // Review unused parameters
         public static void TrustServiceUrl(string serviceUrl)
 #pragma warning restore CA1801 // Review unused parameters
@@ -157,6 +158,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="serviceUrl">The service URL.</param>
         /// <param name="expirationTime">The expiration time after which this service url is not trusted anymore.</param>
+        [Obsolete("TrustServiceUrl is not a required part of the security model.")]
 #pragma warning disable CA1801 // Review unused parameters
         public static void TrustServiceUrl(string serviceUrl, DateTime expirationTime)
 #pragma warning restore CA1801 // Review unused parameters

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -83,7 +83,6 @@ namespace Microsoft.Bot.Connector.Authentication
 
             // Validate the header and extract claims.
             var claimsIdentity = await ValidateAuthHeader(authHeader, credentials, provider, activity.ChannelId, authConfig, activity.ServiceUrl, httpClient ?? _httpClient).ConfigureAwait(false);
-            AppCredentials.TrustServiceUrl(activity.ServiceUrl);
             return claimsIdentity;
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -132,7 +132,6 @@ namespace Microsoft.Bot.Connector.Authentication
 
             // Validate the header and extract claims.
             var claimsIdentity = await JwtTokenValidation_ValidateAuthHeaderAsync(authHeader, credentialFactory, activity.ChannelId, authConfiguration, activity.ServiceUrl, httpClient, cancellationToken).ConfigureAwait(false);
-            AppCredentials.TrustServiceUrl(activity.ServiceUrl);
             return claimsIdentity;
         }
 

--- a/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Rest;
 
@@ -39,9 +38,7 @@ namespace Microsoft.Bot.Connector
         public static async Task<ConversationResourceResponse> CreateDirectConversationAsync(this IConversations operations, ChannelAccount bot, ChannelAccount user, Activity activity = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var result = await operations.CreateConversationWithHttpMessagesAsync(GetDirectParameters(bot, user, activity), null, cancellationToken).ConfigureAwait(false);
-            var res = result.Body;
-
-            return res;
+            return result.Body;
         }
 
         /// <summary>
@@ -69,9 +66,7 @@ namespace Microsoft.Bot.Connector
         public static async Task<ConversationResourceResponse> CreateDirectConversationAsync(this IConversations operations, string botAddress, string userAddress, Activity activity = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var result = await operations.CreateConversationWithHttpMessagesAsync(GetDirectParameters(botAddress, userAddress, activity), null, cancellationToken).ConfigureAwait(false);
-            var res = result.Body;
-
-            return res;
+            return result.Body;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
@@ -40,10 +40,6 @@ namespace Microsoft.Bot.Connector
         {
             var result = await operations.CreateConversationWithHttpMessagesAsync(GetDirectParameters(bot, user, activity), null, cancellationToken).ConfigureAwait(false);
             var res = result.Body;
-            if (res.ServiceUrl != null)
-            {
-                MicrosoftAppCredentials.TrustServiceUrl(res.ServiceUrl);
-            }
 
             return res;
         }
@@ -74,10 +70,6 @@ namespace Microsoft.Bot.Connector
         {
             var result = await operations.CreateConversationWithHttpMessagesAsync(GetDirectParameters(botAddress, userAddress, activity), null, cancellationToken).ConfigureAwait(false);
             var res = result.Body;
-            if (res.ServiceUrl != null)
-            {
-                MicrosoftAppCredentials.TrustServiceUrl(res.ServiceUrl);
-            }
 
             return res;
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -290,8 +290,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                         return null;
                     }
                     
-                    // Add ServiceURL to the cache of trusted sites in order to allow token refreshing.
-                    AppCredentials.TrustServiceUrl(claimsIdentity.FindFirst(AuthenticationConstants.ServiceUrlClaim).Value);
                     ClaimsIdentity = claimsIdentity;
                     return claimsIdentity;
                 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
@@ -201,8 +201,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
                         return false;
                     }
 
-                    // Add ServiceURL to the cache of trusted sites in order to allow token refreshing.
-                    AppCredentials.TrustServiceUrl(claimsIdentity.FindFirst(AuthenticationConstants.ServiceUrlClaim).Value);
                     ClaimsIdentity = claimsIdentity;
                 }
 

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -91,25 +91,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         /// <summary>
-        /// Tests with a valid Token and service url; and ensures that Service url is added to Trusted service url list.
-        /// </summary>
-        [Fact]
-        public async void Channel_MsaHeader_Valid_ServiceUrlShouldBeTrusted()
-        {
-            string header = $"Bearer {await new MicrosoftAppCredentials("2cd87869-38a0-4182-9251-d056e8f0ac24", "2.30Vs3VQLKt974F").GetTokenAsync()}";
-            var credentials = new SimpleCredentialProvider("2cd87869-38a0-4182-9251-d056e8f0ac24", string.Empty);
-
-            await JwtTokenValidation.AuthenticateRequest(
-                new Activity { ServiceUrl = "https://smba.trafficmanager.net/amer-client-ss.msg/" },
-                header,
-                credentials,
-                new SimpleChannelProvider(),
-                emptyClient);
-
-            Assert.True(AppCredentials.IsTrustedServiceUrl("https://smba.trafficmanager.net/amer-client-ss.msg/"));
-        }
-
-        /// <summary>
         /// Tests with no authentication header and makes sure the service URL is not added to the trusted list.
         /// </summary>
         [Fact]


### PR DESCRIPTION
Fixes #4833

Remove the references to this code that was made redundant in the last release.

