### PR TITLE
uischema: port uischema 'trigger' part to component schema files

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnActivity.uischema
@@ -19,5 +19,5 @@
 			"prompt": "Which activity type?",
 			"placeholder": "Select an activity type"
 		}
-	} 
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnActivity.uischema
@@ -10,5 +10,14 @@
         ],
         "label": "Activities",
         "subtitle": "Activity received"
-    }
+    },
+    "trigger": {
+		"label": "Activities (Activity received)",
+		"order": 5.1,
+		"submenu": {
+			"label": "Activities",
+			"prompt": "Which activity type?",
+			"placeholder": "Select an activity type"
+		}
+	} 
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnBeginDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnBeginDialog.uischema
@@ -19,5 +19,5 @@
 			"prompt": "Which event?",
 			"placeholder": "Select an event type"
 		}
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnBeginDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnBeginDialog.uischema
@@ -10,5 +10,14 @@
         ],
         "label": "Dialog started",
         "subtitle": "Begin dialog event"
-    }
+    },
+    "trigger": {
+		"label": "Dialog started (Begin dialog event)",
+		"order": 4.1,
+		"submenu": {
+			"label": "Dialog events",
+			"prompt": "Which event?",
+			"placeholder": "Select an event type"
+		}
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCancelDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCancelDialog.uischema
@@ -10,5 +10,10 @@
         "hidden": [
             "actions"
         ]
-    }
+    },
+    "trigger": {
+		"label": "Dialog cancelled (Cancel dialog event)",
+		"order": 4.2,
+		"submenu": "Dialog events"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCancelDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCancelDialog.uischema
@@ -15,5 +15,5 @@
 		"label": "Dialog cancelled (Cancel dialog event)",
 		"order": 4.2,
 		"submenu": "Dialog events"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseIntent.uischema
@@ -8,5 +8,9 @@
         "hidden": [
             "actions"
         ]
-    }
+    },
+    "trigger": {
+		"label": "Duplicated intents recognized",
+		"order": 6
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseIntent.uischema
@@ -12,5 +12,5 @@
     "trigger": {
 		"label": "Duplicated intents recognized",
 		"order": 6
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnConversationUpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnConversationUpdateActivity.uischema
@@ -12,5 +12,10 @@
         "subtitle": "ConversationUpdate activity",
         "description": "Handle the events fired when a user begins a new conversation with the bot.",
         "helpLink": "https://aka.ms/bf-composer-docs-conversation-update-activity"
-    }
+    },
+    "trigger": {
+		"label": "Greeting (ConversationUpdate activity)",
+		"order": 5.2,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnDialogEvent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnDialogEvent.uischema
@@ -14,5 +14,5 @@
     "trigger": {
 		"label": "Custom events",
 		"order": 7
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnDialogEvent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnDialogEvent.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Dialog events",
         "subtitle": "Dialog event"
-    }
+    },
+    "trigger": {
+		"label": "Custom events",
+		"order": 7
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfConversationActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfConversationActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Conversation ended (EndOfConversation activity)",
 		"order": 5.3,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfConversationActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfConversationActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Conversation ended",
         "subtitle": "EndOfConversation activity"
-    }
+    },
+    "trigger": {
+		"label": "Conversation ended (EndOfConversation activity)",
+		"order": 5.3,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
@@ -15,5 +15,5 @@
 		"label": "Error occurred (Error event)",
 		"order": 4.3,
 		"submenu": "Dialog events"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Error occurred",
         "subtitle": "Error event"
-    }
+    },
+    "trigger": {
+		"label": "Error occurred (Error event)",
+		"order": 4.3,
+		"submenu": "Dialog events"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEventActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEventActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Event received (Event activity)",
 		"order": 5.4,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEventActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEventActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Event received",
         "subtitle": "Event activity"
-    }
+    },
+    "trigger": {
+		"label": "Event received (Event activity)",
+		"order": 5.4,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnHandoffActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnHandoffActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Handover to human",
         "subtitle": "Handoff activity"
-    }
+    },
+    "trigger": {
+		"label": "Handover to human (Handoff activity)",
+		"order": 5.5,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnHandoffActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnHandoffActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Handover to human (Handoff activity)",
 		"order": 5.5,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnIntent.uischema
@@ -12,5 +12,9 @@
         "hidden": [
             "actions"
         ]
-    }
+    },
+    "trigger": {
+		"label": "Intent recognized",
+		"order": 1
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnIntent.uischema
@@ -16,5 +16,5 @@
     "trigger": {
 		"label": "Intent recognized",
 		"order": 1
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnInvokeActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnInvokeActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Conversation invoked (Invoke activity)",
 		"order": 5.6,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnInvokeActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnInvokeActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Conversation invoked",
         "subtitle": "Invoke activity"
-    }
+    },
+    "trigger": {
+		"label": "Conversation invoked (Invoke activity)",
+		"order": 5.6,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Message received (Message received activity)",
 		"order": 5.81,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message received",
         "subtitle": "Message received activity"
-    }
+    },
+    "trigger": {
+		"label": "Message received (Message received activity)",
+		"order": 5.81,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageDeleteActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageDeleteActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message deleted",
         "subtitle": "Message deleted activity"
-    }
+    },
+    "trigger": {
+		"label": "Message deleted (Message deleted activity)",
+		"order": 5.82,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageDeleteActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageDeleteActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Message deleted (Message deleted activity)",
 		"order": 5.82,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageReactionActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageReactionActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Message reaction (Message reaction activity)",
 		"order": 5.83,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageReactionActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageReactionActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message reaction",
         "subtitle": "Message reaction activity"
-    }
+    },
+    "trigger": {
+		"label": "Message reaction (Message reaction activity)",
+		"order": 5.83,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageUpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageUpdateActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message updated",
         "subtitle": "Message updated activity"
-    }
+    },
+    "trigger": {
+		"label": "Message updated (Message updated activity)",
+		"order": 5.84,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageUpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageUpdateActivity.uischema
@@ -15,5 +15,5 @@
 		"label": "Message updated (Message updated activity)",
 		"order": 5.84,
 		"submenu": "Activities"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnQnAMatch.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnQnAMatch.uischema
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "label": "QnA Intent recognized",
+      "order": 2
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnRepromptDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnRepromptDialog.uischema
@@ -15,5 +15,5 @@
 		"label": "Re-prompt for input (Reprompt dialog event)",
 		"order": 4.4,
 		"submenu": "Dialog events"
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnRepromptDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnRepromptDialog.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Re-prompt for input",
         "subtitle": "Reprompt dialog event"
-    }
+    },
+    "trigger": {
+		"label": "Re-prompt for input (Reprompt dialog event)",
+		"order": 4.4,
+		"submenu": "Dialog events"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnTypingActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnTypingActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "User is typing",
         "subtitle": "Typing activity"
-    }
+    },
+    "trigger": {
+		"label": "User is typing (Typing activity)",
+		"order": 5.7,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnTypingActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnTypingActivity.uischema
@@ -14,6 +14,6 @@
     "trigger": {
 		"label": "User is typing (Typing activity)",
 		"order": 5.7,
-		"submenu": "Activities"
-	}
+        "submenu": "Activities"
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnUnknownIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnUnknownIntent.uischema
@@ -14,5 +14,5 @@
     "trigger": {
 		"label": "Unknown intent",
 		"order": 3
-	}
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnUnknownIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnUnknownIntent.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Unknown intent",
         "subtitle": "Unknown intent recognized"
-    }
+    },
+    "trigger": {
+		"label": "Unknown intent",
+		"order": 3
+	}
 }


### PR DESCRIPTION
Follows #4341 
Follows #5099 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
In #4341, we port the ui schema `form` part to runtime in order to support the customization of Composer Form Editor;
In #5099, we port the ui schema `flow` part to support the customization of Action UI;

in this PR, the `trigger` part is added to runtime as well to support the customization of Composer's Trigger creation wizard.

Refs ui.schema definition change in SDK repo: https://github.com/microsoft/botframework-sdk/pull/6178

## Affected SDK $kinds
- OnActivity
- OnBeginDialog
- OnCancelDialog
- OnChooseIntent
- OnConversationUpdateActivity
- OnDialogEvent
- OnEndOfConversationActivity
- OnError
- OnEventActivity
- OnHandoffActivity
- OnIntent
- OnInvokeActivity
- OnMessageActivity
- OnMessageDeleteActivity
- OnMessageReactionActivity
- OnMessageUpdateActivity
- OnQnAMatch
- OnRepromptDialog
- OnTypingActivity
- OnUnknownIntent

## Example of 'trigger' uischema
Take `Microsoft.OnMessageActivity` as an example:
```js
{
    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
    "form": {...},
    "trigger": {
	"label": "Message received (Message received activity)",
	"order": 5.81,
	"submenu": "Activities"
    }
}
```
Composer will take this uischema and let `OnMessageActivity` appear under 'Activities'
![image](https://user-images.githubusercontent.com/8528761/106896542-ab97b400-672c-11eb-928c-2cee261c40a0.png)
