### PR TITLE
Revert "Fix deliveryMode.ExpectReplies for skills."

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -210,6 +210,19 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             return ChannelProvider != null && ChannelProvider.IsGovernment() ? new MicrosoftGovernmentAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope) : new MicrosoftAppCredentials(appId, appPassword, HttpClient, Logger, oAuthScope);
         }
 
+        private static T GetBodyContent<T>(string content)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(content);
+            }
+            catch (JsonException)
+            {
+                // This will only happen when the skill didn't return valid json in the content (e.g. when the status code is 500 or there's a bug in the skill)
+                return default;
+            }
+        }
+
         private async Task<InvokeResponse<T>> SecurePostActivityAsync<T>(Uri toUrl, Activity activity, string token, CancellationToken cancellationToken)
         {
             using (var jsonContent = new StringContent(JsonConvert.SerializeObject(activity, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), Encoding.UTF8, "application/json"))
@@ -227,9 +240,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     using (var response = await HttpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
                     {
                         var content = response.Content != null ? await response.Content.ReadAsStringAsync().ConfigureAwait(false) : null;
-                        var invokeResponse = string.IsNullOrEmpty(content) ? new InvokeResponse<T>() : JsonConvert.DeserializeObject<InvokeResponse<T>>(content);
-                        invokeResponse.Status = (int)response.StatusCode;
-                        return invokeResponse;
+                        return new InvokeResponse<T>
+                        {
+                            Status = (int)response.StatusCode,
+                            Body = content?.Length > 0 ? GetBodyContent<T>(content) : default
+                        };
                     }
                 }
             }


### PR DESCRIPTION
Reverts microsoft/botbuilder-dotnet#5142

We did some end to end testing on this and I think the assumption of the original PR is incorrect. 

When the callers requests deliveryMode ExpectReplies, the adapter returns an InvokeResponse where the body is of type ExpectReplies, not of type InvokeResponse<ExpectPreplies> see: 
https://github.com/Microsoft/botbuilder-dotnet/blob/a5d63d2df90827718d4af2b897033a10034c38f4/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs#L457

![image](https://user-images.githubusercontent.com/12264946/106950930-1a5d1900-66fd-11eb-9de2-d642d3762f66.png)
