### PR TITLE
Updated DialogManager to return EoC code (as RunAsync does) and updated tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -355,10 +355,12 @@ namespace Microsoft.Bot.Builder.Dialogs
             if (ShouldSendEndOfConversationToParent(turnContext, turnResult))
             {
                 // Send End of conversation at the end.
+                var code = turnResult.Status == DialogTurnStatus.Complete ? EndOfConversationCodes.CompletedSuccessfully : EndOfConversationCodes.UserCancelled;
                 var activity = new Activity(ActivityTypes.EndOfConversation)
                 {
                     Value = turnResult.Result,
-                    Locale = turnContext.Activity.Locale
+                    Locale = turnContext.Activity.Locale,
+                    Code = code
                 };
                 await turnContext.SendActivityAsync(activity, cancellationToken).ConfigureAwait(false);
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogManagerTests.cs
@@ -403,6 +403,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             {
                 Assert.NotNull(_eocSent);
                 Assert.Equal(ActivityTypes.EndOfConversation, _eocSent.Type);
+                Assert.Equal(EndOfConversationCodes.CompletedSuccessfully, _eocSent.Code);
                 Assert.Equal("SomeName", _eocSent.Value);
                 Assert.Equal("en-GB", _eocSent.Locale);
             }


### PR DESCRIPTION
Fixes #5163
