### PR TITLE
Change BotFrameworkHttpAdapter to return 204 Accepted 

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -411,8 +411,19 @@ namespace Microsoft.Bot.Builder
         {
             BotAssert.ActivityNotNull(activity);
 
-            var claimsIdentity = await JwtTokenValidation.AuthenticateRequest(activity, authHeader, CredentialProvider, ChannelProvider, _authConfiguration, _httpClient).ConfigureAwait(false);
+            var claimsIdentity = await GetClaimsIdentityAsync(authHeader, activity).ConfigureAwait(false);
             return await ProcessActivityAsync(claimsIdentity, activity, callback, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Given a Authorization header and activity validate it and return claimsIdentity.
+        /// </summary>
+        /// <param name="authHeader">"Authorization" header with JWT bearer token.</param>
+        /// <param name="activity">Activity payload.</param>
+        /// <returns>ClaimsIdentity from the bearer token.</returns>
+        public async Task<ClaimsIdentity> GetClaimsIdentityAsync(string authHeader, Activity activity)
+        {
+            return await JwtTokenValidation.AuthenticateRequest(activity, authHeader, CredentialProvider, ChannelProvider, _authConfiguration, _httpClient).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BackgroundTaskService.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BackgroundTaskService.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+{
+    /// <summary>
+    /// Class which tracks running tasks so that when service shuts down it waits for them to finish before shutting down.
+    /// </summary>
+    internal class BackgroundTaskService : IHostedService
+    {
+        private long _taskCounter = 1;
+        private Dictionary<long, Task> _runningTasks = new Dictionary<long, Task>();
+
+        /// <summary>
+        /// Called when service starts.
+        /// </summary>
+        /// <param name="cancellationToken">cancellation token.</param>
+        /// <returns>task.</returns>
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Called when service is stopping.
+        /// </summary>
+        /// <param name="cancellationToken">cancellation token.</param>
+        /// <returns>task.</returns>
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            // wait for all running tasks
+            return Task.WhenAll(_runningTasks.Values);
+        }
+
+        public void AddTask(Task task)
+        {
+            var id = Interlocked.Increment(ref _taskCounter);
+            task = task.ContinueWith(
+                t =>
+                {
+                    _runningTasks.Remove(id);
+                    if (t.IsFaulted)
+                    {
+                        Trace.TraceError($"Task failed: {t.Exception.Message}", t.Exception);
+                    }
+                }, TaskScheduler.Default);
+
+            _runningTasks[id] = task;
+        }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -172,11 +172,10 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
                 try
                 {
-                    var claimsIdentity = await GetClaimsIdentityAsync(authHeader, activity).ConfigureAwait(false);
                     if (activity.DeliveryMode == DeliveryModes.ExpectReplies || activity.Type == ActivityTypes.Invoke)
                     {
                         // Process the inbound activity with the bot
-                        var invokeResponse = await ProcessActivityAsync(claimsIdentity, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
+                        var invokeResponse = await ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
                         // write the response, potentially serializing the InvokeResponse
                         await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
@@ -186,12 +185,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                         // run pipeline in background and return immediately.
                         var turnProcessingTask = ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken)
-                            .ContinueWith(
-                                t => t?.Exception?.Handle((e) =>
-                                {
-                                    Logger.LogError(t.Exception.Message);
-                                    return true;
-                                }), TaskScheduler.Default);
+                            .ContinueWith(t => t?.Exception?.Handle((e) => true), TaskScheduler.Default);
 
                         // when there is a BackgroundTaskService we use it to inform asp.net that we have an async task.
                         if (_backgroundTaskService != null)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     {
         private const string AuthHeaderName = "authorization";
         private const string ChannelIdHeaderName = "channelid";
+        
+        private readonly BackgroundTaskService _backgroundTaskService = new BackgroundTaskService(); // TODO get this from DI
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BotFrameworkHttpAdapter"/> class,
@@ -170,11 +172,35 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
                 try
                 {
-                    // Process the inbound activity with the bot
-                    var invokeResponse = await ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
+                    var claimsIdentity = await GetClaimsIdentityAsync(authHeader, activity).ConfigureAwait(false);
+                    if (activity.DeliveryMode == DeliveryModes.ExpectReplies || activity.Type == ActivityTypes.Invoke)
+                    {
+                        // Process the inbound activity with the bot
+                        var invokeResponse = await ProcessActivityAsync(claimsIdentity, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
-                    // write the response, potentially serializing the InvokeResponse
-                    await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
+                        // write the response, potentially serializing the InvokeResponse
+                        await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
+                    }
+                    else
+                    {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                        // run pipeline in background and return immediately.
+                        var turnProcessingTask = ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken)
+                            .ContinueWith(
+                                t => t?.Exception?.Handle((e) =>
+                                {
+                                    Logger.LogError(t.Exception.Message);
+                                    return true;
+                                }), TaskScheduler.Default);
+
+                        // when there is a BackgroundTaskService we use it to inform asp.net that we have an async task.
+                        if (_backgroundTaskService != null)
+                        {
+                            _backgroundTaskService.AddTask(turnProcessingTask);
+                        }
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                        httpResponse.StatusCode = (int)HttpStatusCode.Accepted;
+                    }
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -183,7 +209,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 }
             }
         }
-        
+
         private static async Task WriteUnauthorizedResponseAsync(string headerName, HttpRequest httpRequest)
         {
             httpRequest.HttpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
@@ -289,7 +315,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                         httpRequest.HttpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                         return null;
                     }
-                    
+
                     ClaimsIdentity = claimsIdentity;
                     return claimsIdentity;
                 }
@@ -319,8 +345,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             if (claimsIdentity.AuthenticationType != AuthenticationConstants.AnonymousAuthType)
             {
                 var audience = ChannelProvider != null && ChannelProvider.IsGovernment() ?
-    GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope :
-    AuthenticationConstants.ToChannelFromBotOAuthScope;
+                    GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope :
+                    AuthenticationConstants.ToChannelFromBotOAuthScope;
 
                 if (SkillValidation.IsSkillClaim(claimsIdentity.Claims))
                 {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
@@ -94,7 +94,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
 
                 try
                 {
-                    var claimsIdentity = await GetClaimsIdentityAsync(authHeader, activity).ConfigureAwait(false);
                     if (activity.DeliveryMode == DeliveryModes.ExpectReplies || activity.Type == ActivityTypes.Invoke)
                     {
                         // process the inbound activity with the bot
@@ -108,12 +107,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                         // run pipeline in background and return immediately.
                         var turnProcessingTask = ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken)
-                            .ContinueWith(
-                                t => t?.Exception?.Handle((e) =>
-                                {
-                                    Logger.LogError(t.Exception.Message);
-                                    return true;
-                                }), TaskScheduler.Default);
+                            .ContinueWith(t => t?.Exception?.Handle((e) => true), TaskScheduler.Default);
 
                         // when in asp.net we tell it about the background task 
                         if (HostingEnvironment.IsHosted)

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BackgroundTaskServiceTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BackgroundTaskServiceTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Schema;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
+{
+    public class BackgroundTaskServiceTests
+    {
+        [Fact]
+        public async Task ValidateTaskAutoRemoval()
+        {
+            var bts = new BackgroundTaskService();
+            bts.AddTask(Task.Delay(1000));
+            bts.AddTask(Task.Delay(1000));
+            bts.AddTask(Task.Delay(1000));
+            bts.AddTask(Task.Delay(1000));
+            await Task.Delay(1);
+            Assert.Equal(4, bts.Pending);
+            await Task.Delay(1000);
+            Assert.Equal(0, bts.Pending);
+        }
+
+        [Fact]
+        public async Task ValidateStopNone()
+        {
+            var bts = new BackgroundTaskService();
+            Assert.Equal(0, bts.Pending);
+            await bts.StopAsync(CancellationToken.None);
+            Assert.Equal(0, bts.Pending);
+        }
+
+        [Fact]
+        public async Task ValidateStop_WithTasks()
+        {
+            var bts = new BackgroundTaskService();
+            bts.AddTask(Task.Delay(1000));
+            bts.AddTask(Task.Delay(1000));
+            bts.AddTask(Task.Delay(1000));
+            bts.AddTask(Task.Delay(1000));
+            Assert.Equal(4, bts.Pending);
+            await bts.StopAsync(CancellationToken.None);
+            Assert.Equal(0, bts.Pending);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5172 
## Description
This changes BotFrameworkHttpAdapter to return 204 and run onTurn processing in a decoupled task.

## Specific Changes
  - changes CloudAdapter/BotFrameworkHttpAdapter to return 204 and run onTurn processing in a decoupled task.
  - new BackgroundTaskService that implements dotnet core IHostingService method for communicating background running tasks to asp.net
  - added GetClaimsIdentity() to make it easyier for custom hosting situations to do the right thing.


## Testing
- existing tests still work.
- Added unit tests for new BackgroundTaskService 

## TODO
Dependency injection of BackgroundTaskService.
```
   services.AddHostingService<BackgroundTaskService>(); 
```