### PR TITLE
Southworks/fix/slack event type text

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     {
         public string Type { get; set; }
 
+        [JsonProperty(PropertyName = "text")]
+        public string Text { get; set; }
+
         [JsonProperty(PropertyName = "user")]
         public string User { get; set; }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/Events/MessageEvent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/Events/MessageEvent.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model.Events
     /// </summary>
     public class MessageEvent : EventType
     {
-        public string Text { get; set; }
-
         [JsonProperty(PropertyName = "channel_type")]
         public string ChannelType { get; set; }
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             var activity = SlackHelper.EventToActivity(slackBody, slackApi.Object);
 
-            Assert.Equal(slackBody.Event.AdditionalProperties["text"].ToString(), activity.Text);
+            Assert.Equal(slackBody.Event.Text, activity.Text);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses #4888

## Description
This PR moves the `Text` property from `MessageEvent` to `EventType` class. This will allow to obtain the text from `Activity.Value` and `Activity.ChannelData.Event` instead of using `Event.AdditionalProperties`.

## Specific Changes
- Added `Text` property in `EventType` and removed it from `MessageEvent`.
- Updated `EventToActivityAsyncShouldReturnActivity` test to support the new `Text` property.

## Testing
In the following image, there is a sneak peek for the tests passing after this change.
![image](https://user-images.githubusercontent.com/62260472/107274721-91611d00-6a2f-11eb-94e6-2d2c81183393.png)