### PR TITLE
Johtaylo/cloudadapterstreaming

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotAdapter.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Bot.Builder
     public abstract class BotAdapter
     {
         /// <summary>
+        /// The key value for any InvokeResponseActivity that would be on the TurnState.
+        /// </summary>
+        public const string InvokeResponseKey = "BotFrameworkAdapter.InvokeResponse";
+
+        /// <summary>
         /// The string value for the bot identity key.
         /// </summary>
         public const string BotIdentityKey = "BotIdentity";

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -47,8 +47,6 @@ namespace Microsoft.Bot.Builder
     /// <seealso cref="IMiddleware"/>h
     public class BotFrameworkAdapter : BotAdapter, IAdapterIntegration, IExtendedUserTokenProvider, IConnectorClientBuilder
     {
-        internal const string InvokeResponseKey = "BotFrameworkAdapter.InvokeResponse";
-
         private static readonly HttpClient DefaultHttpClient = new HttpClient();
 
         private readonly HttpClient _httpClient;

--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Bot.Builder
 
         /// <summary>
         /// This is a helper to create the ClaimsIdentity structure from an appId that will be added to the TurnContext.
-        /// It is inteded for use in proactive and named-pipe scenarios.
+        /// It is intended for use in proactive and named-pipe scenarios.
         /// </summary>
         /// <param name="botAppId">The bot's application id.</param>
         /// <returns>A <see cref="ClaimsIdentity"/> with the audience and appId claims set to the appId.</returns>

--- a/libraries/Microsoft.Bot.Connector/Authentication/AuthenticateRequestResult.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AuthenticateRequestResult.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Bot.Connector.Authentication
     public class AuthenticateRequestResult
     {
         /// <summary>
-        /// Gets or sets a value for the Scope.
+        /// Gets or sets a value for the Audience.
         /// </summary>
         /// <value>
-        /// A value for the Scope.
+        /// A value for the Audience.
         /// </value>
-        public string Scope { get; set; }
+        public string Audience { get; set; }
 
         /// <summary>
         /// Gets or sets a value for the ClaimsIdentity.

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
@@ -68,10 +68,8 @@ namespace Microsoft.Bot.Connector.Authentication
 
             // Is the activity from another bot?
             return SkillValidation.IsSkillClaim(claimsIdentity.Claims)
-                    ?
-                $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}"
-                    :
-                callerId;
+                ? $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}"
+                : callerId;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
@@ -25,6 +25,16 @@ namespace Microsoft.Bot.Connector.Authentication
         public abstract Task<AuthenticateRequestResult> AuthenticateRequestAsync(Activity activity, string authHeader, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Validate Bot Framework Protocol requests.
+        /// </summary>
+        /// <param name="authHeader">The http auth header.</param>
+        /// <param name="channelIdHeader">The channel Id HTTP header.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>Asynchronous Task with <see cref="AuthenticateRequestResult"/>.</returns>
+        /// <exception cref="UnauthorizedAccessException">If the validation returns false.</exception>
+        public abstract Task<AuthenticateRequestResult> AuthenticateStreamingRequestAsync(string authHeader, string channelIdHeader, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Creates a <see cref="ConnectorFactory"/> that can be used to create <see cref="IConnectorClient"/> that use credentials from this particular cloud environment.
         /// </summary>
         /// <param name="claimsIdentity">The inbound <see cref="Activity"/>'s <see cref="ClaimsIdentity"/>.</param>
@@ -38,5 +48,30 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>Asynchronous Task with <see cref="UserTokenClient" /> instance.</returns>
         public abstract Task<UserTokenClient> CreateUserTokenClientAsync(ClaimsIdentity claimsIdentity, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Generates the appropriate callerId to write onto the activity, this might be null.
+        /// </summary>
+        /// <param name="credentialFactory">A <see cref="ServiceClientCredentialsFactory"/> to use.</param>
+        /// <param name="claimsIdentity">The inbound claims.</param>
+        /// <param name="callerId">The default callerId to use if this is not a skill.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The callerId, this might be null.</returns>
+        protected internal async Task<string> GenerateCallerIdAsync(ServiceClientCredentialsFactory credentialFactory, ClaimsIdentity claimsIdentity, string callerId, CancellationToken cancellationToken)
+        {
+            // Is the bot accepting all incoming messages?
+            if (await credentialFactory.IsAuthenticationDisabledAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // Return null so that the callerId is cleared.
+                return null;
+            }
+
+            // Is the activity from another bot?
+            return SkillValidation.IsSkillClaim(claimsIdentity.Claims)
+                    ?
+                $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}"
+                    :
+                callerId;
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
@@ -18,7 +18,20 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <returns>A new <see cref="BotFrameworkAuthentication" /> instance.</returns>
         public static BotFrameworkAuthentication Create()
         {
-            return Create(null, false, null, null, null, null, null, null, null, new PasswordServiceClientCredentialFactory(), new AuthenticationConfiguration(), null, null);
+            return Create(
+                channelService: null,
+                validateAuthority: false,
+                toChannelFromBotLoginUrl: null,
+                toChannelFromBotOAuthScope: null,
+                toBotFromChannelTokenIssuer: null,
+                oAuthUrl: null,
+                toBotFromChannelOpenIdMetadataUrl: null,
+                toBotFromEmulatorOpenIdMetadataUrl: null,
+                callerId: null,
+                credentialFactory: new PasswordServiceClientCredentialFactory(),
+                authConfiguration: new AuthenticationConfiguration(),
+                httpClient: null,
+                logger: null);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthenticationFactory.cs
@@ -13,6 +13,15 @@ namespace Microsoft.Bot.Connector.Authentication
     public static class BotFrameworkAuthenticationFactory
     {
         /// <summary>
+        /// Creates the a <see cref="BotFrameworkAuthentication" /> instance for anonymous testing scenarios.
+        /// </summary>
+        /// <returns>A new <see cref="BotFrameworkAuthentication" /> instance.</returns>
+        public static BotFrameworkAuthentication Create()
+        {
+            return Create(null, false, null, null, null, null, null, null, null, new PasswordServiceClientCredentialFactory(), new AuthenticationConfiguration(), null, null);
+        }
+
+        /// <summary>
         /// Creates the appropriate <see cref="BotFrameworkAuthentication" /> instance.
         /// </summary>
         /// <param name="channelService">The Channel Service.</param>

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -62,15 +62,31 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public override async Task<AuthenticateRequestResult> AuthenticateRequestAsync(Activity activity, string authHeader, CancellationToken cancellationToken)
         {
-            var claimsIdentity = await JwtTokenValidation_AuthenticateRequestAsync(activity, authHeader, _credentialFactory, _authConfiguration, _httpClient, cancellationToken).ConfigureAwait(false);
+            var claimsIdentity = await JwtTokenValidation_AuthenticateRequestAsync(activity, authHeader, cancellationToken).ConfigureAwait(false);
 
-            var scope = SkillValidation.IsSkillClaim(claimsIdentity.Claims) ? JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims) : _toChannelFromBotOAuthScope;
+            var outboundAudience = SkillValidation.IsSkillClaim(claimsIdentity.Claims) ? JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims) : _toChannelFromBotOAuthScope;
 
-            var callerId = await GenerateCallerIdAsync(_credentialFactory, claimsIdentity, cancellationToken).ConfigureAwait(false);
+            var callerId = await GenerateCallerIdAsync(_credentialFactory, claimsIdentity, _callerId, cancellationToken).ConfigureAwait(false);
 
             var connectorFactory = new ConnectorFactoryImpl(BuiltinBotFrameworkAuthentication.GetAppId(claimsIdentity), _toChannelFromBotOAuthScope, _toChannelFromBotLoginUrl, _validateAuthority, _credentialFactory, _httpClient, _logger);
 
-            return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Scope = scope, CallerId = callerId, ConnectorFactory = connectorFactory };
+            return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Audience = outboundAudience, CallerId = callerId, ConnectorFactory = connectorFactory };
+        }
+
+        public override async Task<AuthenticateRequestResult> AuthenticateStreamingRequestAsync(string authHeader, string channelIdHeader, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(channelIdHeader) && !await _credentialFactory.IsAuthenticationDisabledAsync(cancellationToken).ConfigureAwait(false))
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var claimsIdentity = await JwtTokenValidation_ValidateAuthHeaderAsync(authHeader, channelIdHeader, null, cancellationToken).ConfigureAwait(false);
+
+            var outboundAudience = SkillValidation.IsSkillClaim(claimsIdentity.Claims) ? JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims) : _toChannelFromBotOAuthScope;
+
+            var callerId = await GenerateCallerIdAsync(_credentialFactory, claimsIdentity, _callerId, cancellationToken).ConfigureAwait(false);
+
+            return new AuthenticateRequestResult { ClaimsIdentity = claimsIdentity, Audience = outboundAudience, CallerId = callerId };
         }
 
         public override ConnectorFactory CreateConnectorFactory(ClaimsIdentity claimsIdentity)
@@ -87,30 +103,12 @@ namespace Microsoft.Bot.Connector.Authentication
             return new UserTokenClientImpl(appId, credentials, _oAuthUrl, _httpClient, _logger);
         }
 
-        private async Task<string> GenerateCallerIdAsync(ServiceClientCredentialsFactory credentialFactory, ClaimsIdentity claimsIdentity, CancellationToken cancellationToken)
-        {
-            // Is the bot accepting all incoming messages?
-            if (await credentialFactory.IsAuthenticationDisabledAsync(cancellationToken).ConfigureAwait(false))
-            {
-                // Return null so that the callerId is cleared.
-                return null;
-            }
-
-            // Is the activity from another bot?
-            if (SkillValidation.IsSkillClaim(claimsIdentity.Claims))
-            {
-                return $"{CallerIdConstants.BotToBotPrefix}{JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims)}";
-            }
-
-            return _callerId;
-        }
-
         // The following code is based on JwtTokenValidation.AuthenticateRequest
-        private async Task<ClaimsIdentity> JwtTokenValidation_AuthenticateRequestAsync(Activity activity, string authHeader, ServiceClientCredentialsFactory credentialFactory, AuthenticationConfiguration authConfiguration, HttpClient httpClient, CancellationToken cancellationToken)
+        private async Task<ClaimsIdentity> JwtTokenValidation_AuthenticateRequestAsync(Activity activity, string authHeader, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(authHeader))
             {
-                var isAuthDisabled = await credentialFactory.IsAuthenticationDisabledAsync(cancellationToken).ConfigureAwait(false);
+                var isAuthDisabled = await _credentialFactory.IsAuthenticationDisabledAsync(cancellationToken).ConfigureAwait(false);
                 if (!isAuthDisabled)
                 {
                     // No Auth Header. Auth is required. Request is not authorized.
@@ -131,26 +129,26 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             // Validate the header and extract claims.
-            var claimsIdentity = await JwtTokenValidation_ValidateAuthHeaderAsync(authHeader, credentialFactory, activity.ChannelId, authConfiguration, activity.ServiceUrl, httpClient, cancellationToken).ConfigureAwait(false);
+            var claimsIdentity = await JwtTokenValidation_ValidateAuthHeaderAsync(authHeader, activity.ChannelId, activity.ServiceUrl, cancellationToken).ConfigureAwait(false);
             return claimsIdentity;
         }
 
-        private async Task<ClaimsIdentity> JwtTokenValidation_ValidateAuthHeaderAsync(string authHeader, ServiceClientCredentialsFactory credentialFactory, string channelId, AuthenticationConfiguration authConfiguration, string serviceUrl, HttpClient httpClient, CancellationToken cancellationToken)
+        private async Task<ClaimsIdentity> JwtTokenValidation_ValidateAuthHeaderAsync(string authHeader, string channelId, string serviceUrl, CancellationToken cancellationToken)
         {
-            var identity = await JwtTokenValidation_AuthenticateTokenAsync(authHeader, credentialFactory, channelId, authConfiguration, serviceUrl, httpClient, cancellationToken).ConfigureAwait(false);
+            var identity = await JwtTokenValidation_AuthenticateTokenAsync(authHeader, channelId, serviceUrl, cancellationToken).ConfigureAwait(false);
 
-            await JwtTokenValidation_ValidateClaimsAsync(authConfiguration, identity.Claims).ConfigureAwait(false);
+            await JwtTokenValidation_ValidateClaimsAsync(identity.Claims).ConfigureAwait(false);
 
             return identity;
         }
 
-        private async Task JwtTokenValidation_ValidateClaimsAsync(AuthenticationConfiguration authConfig, IEnumerable<Claim> claims)
+        private async Task JwtTokenValidation_ValidateClaimsAsync(IEnumerable<Claim> claims)
         {
-            if (authConfig.ClaimsValidator != null)
+            if (_authConfiguration.ClaimsValidator != null)
             {
                 // Call the validation method if defined (it should throw an exception if the validation fails)
                 var claimsList = claims as IList<Claim> ?? claims.ToList();
-                await authConfig.ClaimsValidator.ValidateClaimsAsync(claimsList).ConfigureAwait(false);
+                await _authConfiguration.ClaimsValidator.ValidateClaimsAsync(claimsList).ConfigureAwait(false);
             }
             else if (SkillValidation.IsSkillClaim(claims))
             {
@@ -158,23 +156,23 @@ namespace Microsoft.Bot.Connector.Authentication
             }
         }
 
-        private async Task<ClaimsIdentity> JwtTokenValidation_AuthenticateTokenAsync(string authHeader, ServiceClientCredentialsFactory credentialFactory, string channelId, AuthenticationConfiguration authConfiguration, string serviceUrl, HttpClient httpClient, CancellationToken cancellationToken)
+        private async Task<ClaimsIdentity> JwtTokenValidation_AuthenticateTokenAsync(string authHeader, string channelId, string serviceUrl, CancellationToken cancellationToken)
         {
             if (SkillValidation.IsSkillToken(authHeader))
             {
-                return await SkillValidation_AuthenticateChannelTokenAsync(authHeader, credentialFactory, httpClient, channelId, authConfiguration, cancellationToken).ConfigureAwait(false);
+                return await SkillValidation_AuthenticateChannelTokenAsync(authHeader, channelId, cancellationToken).ConfigureAwait(false);
             }
 
             if (EmulatorValidation.IsTokenFromEmulator(authHeader))
             {
-                return await EmulatorValidation_AuthenticateEmulatorTokenAsync(authHeader, credentialFactory, httpClient, channelId, authConfiguration, cancellationToken).ConfigureAwait(false);
+                return await EmulatorValidation_AuthenticateEmulatorTokenAsync(authHeader, channelId, cancellationToken).ConfigureAwait(false);
             }
 
-            return await GovernmentChannelValidation_AuthenticateChannelTokenAsync(authHeader, credentialFactory, serviceUrl, httpClient, channelId, authConfiguration, cancellationToken).ConfigureAwait(false);
+            return await GovernmentChannelValidation_AuthenticateChannelTokenAsync(authHeader, serviceUrl, channelId, cancellationToken).ConfigureAwait(false);
         }
 
         // The following code is based on SkillValidation.AuthenticateChannelToken
-        private async Task<ClaimsIdentity> SkillValidation_AuthenticateChannelTokenAsync(string authHeader, ServiceClientCredentialsFactory credentialFactory, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfiguration, CancellationToken cancellationToken)
+        private async Task<ClaimsIdentity> SkillValidation_AuthenticateChannelTokenAsync(string authHeader, string channelId, CancellationToken cancellationToken)
         {
             var tokenValidationParameters =
                 new TokenValidationParameters
@@ -198,19 +196,19 @@ namespace Microsoft.Bot.Connector.Authentication
 
             // TODO: what should the openIdMetadataUrl be here?
             var tokenExtractor = new JwtTokenExtractor(
-                httpClient,
+                _httpClient,
                 tokenValidationParameters,
                 _toBotFromEmulatorOpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfiguration.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements).ConfigureAwait(false);
 
-            await SkillValidation_ValidateIdentityAsync(identity, credentialFactory, cancellationToken).ConfigureAwait(false);
+            await SkillValidation_ValidateIdentityAsync(identity, cancellationToken).ConfigureAwait(false);
 
             return identity;
         }
 
-        private async Task SkillValidation_ValidateIdentityAsync(ClaimsIdentity identity, ServiceClientCredentialsFactory credentialFactory, CancellationToken cancellationToken)
+        private async Task SkillValidation_ValidateIdentityAsync(ClaimsIdentity identity, CancellationToken cancellationToken)
         {
             if (identity == null)
             {
@@ -239,7 +237,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException($"'{AuthenticationConstants.AudienceClaim}' claim is required on skill Tokens.");
             }
 
-            if (!await credentialFactory.IsValidAppIdAsync(audienceClaim, cancellationToken).ConfigureAwait(false))
+            if (!await _credentialFactory.IsValidAppIdAsync(audienceClaim, cancellationToken).ConfigureAwait(false))
             {
                 // The AppId is not valid. Not Authorized.
                 throw new UnauthorizedAccessException("Invalid audience.");
@@ -254,7 +252,7 @@ namespace Microsoft.Bot.Connector.Authentication
         }
 
         // The following code is based on EmulatorValidation.AuthenticateEmulatorToken
-        private async Task<ClaimsIdentity> EmulatorValidation_AuthenticateEmulatorTokenAsync(string authHeader, ServiceClientCredentialsFactory credentialFactory, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfiguration, CancellationToken cancellationToken)
+        private async Task<ClaimsIdentity> EmulatorValidation_AuthenticateEmulatorTokenAsync(string authHeader, string channelId, CancellationToken cancellationToken)
         {
             var toBotFromEmulatorTokenValidationParameters =
                 new TokenValidationParameters()
@@ -277,12 +275,12 @@ namespace Microsoft.Bot.Connector.Authentication
                 };
 
             var tokenExtractor = new JwtTokenExtractor(
-                    httpClient,
+                    _httpClient,
                     toBotFromEmulatorTokenValidationParameters,
                     _toBotFromEmulatorOpenIdMetadataUrl,
                     AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfiguration.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements).ConfigureAwait(false);
             if (identity == null)
             {
                 // No valid identity. Not Authorized.
@@ -341,7 +339,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException($"Unknown Emulator Token version '{tokenVersion}'.");
             }
 
-            if (!await credentialFactory.IsValidAppIdAsync(appID, cancellationToken).ConfigureAwait(false))
+            if (!await _credentialFactory.IsValidAppIdAsync(appID, cancellationToken).ConfigureAwait(false))
             {
                 throw new UnauthorizedAccessException($"Invalid AppId passed on token: {appID}");
             }
@@ -351,19 +349,19 @@ namespace Microsoft.Bot.Connector.Authentication
 
         // The following code is based on GovernmentChannelValidation.AuthenticateChannelToken
 
-        private async Task<ClaimsIdentity> GovernmentChannelValidation_AuthenticateChannelTokenAsync(string authHeader, ServiceClientCredentialsFactory credentialFactory, string serviceUrl, HttpClient httpClient, string channelId, AuthenticationConfiguration authConfig, CancellationToken cancellationToken)
+        private async Task<ClaimsIdentity> GovernmentChannelValidation_AuthenticateChannelTokenAsync(string authHeader, string serviceUrl, string channelId, CancellationToken cancellationToken)
         {
             var tokenValidationParameters = GovernmentChannelValidation_GetTokenValidationParameters();
 
             var tokenExtractor = new JwtTokenExtractor(
-                httpClient,
+                _httpClient,
                 tokenValidationParameters,
                 _toBotFromChannelOpenIdMetadataUrl,
                 AuthenticationConstants.AllowedSigningAlgorithms);
 
-            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, authConfig.RequiredEndorsements).ConfigureAwait(false);
+            var identity = await tokenExtractor.GetIdentityAsync(authHeader, channelId, _authConfiguration.RequiredEndorsements).ConfigureAwait(false);
 
-            await GovernmentChannelValidation_ValidateIdentityAsync(identity, credentialFactory, serviceUrl, cancellationToken).ConfigureAwait(false);
+            await GovernmentChannelValidation_ValidateIdentityAsync(identity, serviceUrl, cancellationToken).ConfigureAwait(false);
 
             return identity;
         }
@@ -384,7 +382,7 @@ namespace Microsoft.Bot.Connector.Authentication
             };
         }
 
-        private async Task GovernmentChannelValidation_ValidateIdentityAsync(ClaimsIdentity identity, ServiceClientCredentialsFactory credentialFactory, string serviceUrl, CancellationToken cancellationToken)
+        private async Task GovernmentChannelValidation_ValidateIdentityAsync(ClaimsIdentity identity, string serviceUrl, CancellationToken cancellationToken)
         {
             if (identity == null)
             {
@@ -422,7 +420,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new UnauthorizedAccessException();
             }
 
-            if (!await credentialFactory.IsValidAppIdAsync(appIdFromClaim, cancellationToken).ConfigureAwait(false))
+            if (!await _credentialFactory.IsValidAppIdAsync(appIdFromClaim, cancellationToken).ConfigureAwait(false))
             {
                 // The AppId is not valid. Not Authorized.
                 throw new UnauthorizedAccessException($"Invalid AppId passed on token: {appIdFromClaim}");

--- a/libraries/Microsoft.Bot.Connector/Authentication/ServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ServiceClientCredentialsFactory.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Bot.Connector.Authentication
         /// A factory method for creating ServiceClientCredentials.
         /// </summary>
         /// <param name="appId">The appId.</param>
-        /// <param name="oauthScope">The oauth scope.</param>
+        /// <param name="audience">The audience.</param>
         /// <param name="loginEndpoint">The login url.</param>
         /// <param name="validateAuthority">The validate authority vale to use.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public abstract Task<ServiceClientCredentials> CreateCredentialsAsync(string appId, string oauthScope, string loginEndpoint, bool validateAuthority, CancellationToken cancellationToken);
+        public abstract Task<ServiceClientCredentials> CreateCredentialsAsync(string appId, string audience, string loginEndpoint, bool validateAuthority, CancellationToken cancellationToken);
     }
 }

--- a/libraries/Microsoft.Bot.Connector/OAuthClient.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClient.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Bot.Connector
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Connector.Authentication;
     using Microsoft.Bot.Schema;
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
@@ -710,7 +711,7 @@ namespace Microsoft.Bot.Connector
         {
             BotSignIn = new BotSignIn(this);
             UserToken = new UserToken(this);
-            BaseUri = new System.Uri("https://token.botframework.com");
+            BaseUri = new System.Uri(AuthenticationConstants.OAuthUrl);
             SerializationSettings = new JsonSerializerSettings
             {
                 Formatting = Newtonsoft.Json.Formatting.Indented,

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ApplicationBuilderExtensions.cs
@@ -86,10 +86,55 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 throw new ArgumentNullException(nameof(applicationBuilder));
             }
 
-            var bot = applicationBuilder.ApplicationServices.GetService(typeof(IBot)) as IBot;
-            _ = (applicationBuilder.ApplicationServices.GetService(typeof(IBotFrameworkHttpAdapter)) as BotFrameworkHttpAdapter).ConnectNamedPipeAsync(pipeName, bot, audience);
+            return applicationBuilder.UseNamedPipes(pipeName, audience, null, null);
+        }
+
+        /// <summary>
+        /// Enables named pipes for this application.
+        /// </summary>
+        /// <param name="applicationBuilder">The application builder that defines the bot's pipeline.<see cref="IApplicationBuilder"/>.</param>
+        /// <param name="pipeName">The name of the named pipe to use when creating the server.</param>
+        /// <param name="audience">The specified recipient of all outgoing activities.</param>
+        /// <param name="appId">The bot's application id.</param>
+        /// <param name="callerId">The caller id.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IApplicationBuilder UseNamedPipes(this IApplicationBuilder applicationBuilder, string pipeName, string audience, string appId, string callerId)
+        {
+            if (applicationBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(applicationBuilder));
+            }
+
+            var bot = applicationBuilder.ApplicationServices.GetRequiredService<IBot>();
+
+            var adapter = applicationBuilder.ApplicationServices.GetRequiredService<IBotFrameworkHttpAdapter>();
+
+            if (typeof(BotFrameworkHttpAdapter).IsAssignableFrom(adapter.GetType()))
+            {
+                // back compatibility: support for the BotFrameworkHttpAdapter
+                _ = ((BotFrameworkHttpAdapter)adapter).ConnectNamedPipeAsync(pipeName, bot, audience);
+            }
+            else if (typeof(CloudAdapter).IsAssignableFrom(adapter.GetType()))
+            {
+                // if any of these values are null then attempt to pull them from configuration
+                var configuration = applicationBuilder.ApplicationServices.GetService<IConfiguration>();
+                if (configuration != null)
+                {
+                    audience = audience ?? configuration.GetSection("ToChannelFromBotOAuthScope")?.Value ?? GetBuiltinDefaultAudience(configuration);
+                    appId = appId ?? configuration.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey)?.Value;
+                    callerId = callerId ?? configuration.GetSection("CallerId")?.Value;
+                }
+
+                _ = ((CloudAdapter)adapter).ConnectNamedPipeAsync(pipeName, bot, appId, audience, callerId);
+            }
 
             return applicationBuilder;
+        }
+
+        private static string GetBuiltinDefaultAudience(IConfiguration configuration)
+        {
+            bool isPublicCloud = string.IsNullOrEmpty(configuration.GetSection("ChannelService")?.Value);
+            return isPublicCloud ? AuthenticationConstants.ToChannelFromBotOAuthScope : GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope;
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -4,11 +4,16 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.WebSockets;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder.Streaming;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Microsoft.Bot.Streaming;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -23,7 +28,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// Initializes a new instance of the <see cref="CloudAdapter"/> class. (Public cloud. No auth. For testing.)
         /// </summary>
         public CloudAdapter()
-            : this(BotFrameworkAuthenticationFactory.Create(null, false, null, null, null, null, null, null, null, new PasswordServiceClientCredentialFactory(), new AuthenticationConfiguration(), null, null))
+            : this(BotFrameworkAuthenticationFactory.Create())
         {
         }
 
@@ -44,7 +49,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// </summary>
         /// <param name="configuration">The application configuration instance.</param>
         /// <param name="httpClient">The HttpClient implementation this adapter should use.</param>
-        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        /// <param name="logger">The <see cref="ILogger"/> implementation this adapter should use.</param>
         public CloudAdapter(
             IConfiguration configuration,
             HttpClient httpClient = null,
@@ -53,54 +58,219 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         {
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Process the inbound http request with the bot resulting in the outbound http response, this method can be called directly from a Controller.
+        /// If the HTTP method is a POST the body will contain the <see cref="Activity"/> to process. 
+        /// </summary>
+        /// <param name="httpRequest">The <see cref="HttpRequest"/>.</param>
+        /// <param name="httpResponse">The <see cref="HttpResponse"/>.</param>
+        /// <param name="bot">The <see cref="IBot"/> implementation to use for this request.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A <see cref="Task"/> that represents the work queued to execute.</returns>
         public async Task ProcessAsync(HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default)
         {
-            if (httpRequest == null)
-            {
-                throw new ArgumentNullException(nameof(httpRequest));
-            }
+            _ = httpRequest ?? throw new ArgumentNullException(nameof(httpRequest));
+            _ = httpResponse ?? throw new ArgumentNullException(nameof(httpResponse));
+            _ = bot ?? throw new ArgumentNullException(nameof(bot));
 
-            if (httpResponse == null)
+            try
             {
-                throw new ArgumentNullException(nameof(httpResponse));
-            }
-
-            if (bot == null)
-            {
-                throw new ArgumentNullException(nameof(bot));
-            }
-
-            if (httpRequest.Method == HttpMethods.Get)
-            {
-                throw new NotImplementedException("web sockets is not yet implemented");
-            }
-            else
-            {
-                // Deserialize the incoming Activity
-                var activity = await HttpHelper.ReadRequestAsync<Activity>(httpRequest).ConfigureAwait(false);
-
-                if (string.IsNullOrEmpty(activity?.Type))
+                // Only GET requests for web socket connects are allowed
+                if (httpRequest.Method == HttpMethods.Get && httpRequest.HttpContext.WebSockets.IsWebSocketRequest)
                 {
-                    httpResponse.StatusCode = (int)HttpStatusCode.BadRequest;
-                    return;
+                    // All socket communication will be handled by the internal streaming-specific BotAdapter
+                    await ConnectAsync(httpRequest, bot, cancellationToken).ConfigureAwait(false);
                 }
-
-                // Grab the auth header from the inbound http request
-                var authHeader = httpRequest.Headers["Authorization"];
-
-                try
+                else if (httpRequest.Method == HttpMethods.Post)
                 {
+                    // Deserialize the incoming Activity
+                    var activity = await HttpHelper.ReadRequestAsync<Activity>(httpRequest).ConfigureAwait(false);
+
+                    // A POST request must contain an Activity 
+                    if (string.IsNullOrEmpty(activity?.Type))
+                    {
+                        httpResponse.StatusCode = (int)HttpStatusCode.BadRequest;
+                        return;
+                    }
+
+                    // Grab the auth header from the inbound http request
+                    var authHeader = httpRequest.Headers["Authorization"];
+
                     // Process the inbound activity with the bot
                     var invokeResponse = await ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
                     // write the response, potentially serializing the InvokeResponse
                     await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
                 }
-                catch (UnauthorizedAccessException)
+                else
                 {
-                    // handle unauthorized here as this layer creates the http response
-                    httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+                    httpResponse.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // handle unauthorized here as this layer creates the http response
+                httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+            }
+        }
+
+        /// <summary>
+        /// Used to connect the adapter to a named pipe.
+        /// </summary>
+        /// <param name="pipeName">The name of the named pipe.</param>
+        /// <param name="bot">The bot instance to use.</param>
+        /// <param name="appId">The bot's application id.</param>
+        /// <param name="audience">The audience to use for outbound communication. This will vary by cloud environment.</param>
+        /// <param name="callerId">The callerId, this may be NULL.</param>
+        /// <returns>A <see cref="Task"/> that represents the work queued to execute.</returns>
+        public async Task ConnectNamedPipeAsync(string pipeName, IBot bot, string appId, string audience, string callerId)
+        {
+            if (string.IsNullOrEmpty(pipeName))
+            {
+                throw new ArgumentNullException(nameof(pipeName));
+            }
+
+            _ = bot ?? throw new ArgumentNullException(nameof(bot));
+
+            if (string.IsNullOrEmpty(audience))
+            {
+                throw new ArgumentNullException(nameof(audience));
+            }
+
+            // The named pipe is local and so there is no network authentication to perform: so we can create the result here.
+            var authenticationRequestResult = new AuthenticateRequestResult
+            {
+                Audience = audience,
+                ClaimsIdentity = appId != null ? CreateClaimsIdentity(appId) : new ClaimsIdentity(),
+                CallerId = callerId
+            };
+
+            // Tie the authentication results, the named pipe, the adapter and the bot together to be ready to handle any inbound activities
+            var streamingActivityProcessor = new StreamingActivityProcessor(authenticationRequestResult, pipeName, this, bot);
+
+            // Start receiving activities on the named pipe
+            await streamingActivityProcessor.ListenAsync().ConfigureAwait(false);
+        }
+
+        private async Task ConnectAsync(HttpRequest httpRequest, IBot bot, CancellationToken cancellationToken)
+        {
+            Logger.LogInformation($"Received request for web socket connect.");
+
+            // Grab the auth header from the inbound http request
+            var authHeader = httpRequest.Headers["Authorization"];
+
+            // Grab the channelId which should be in the http headers
+            var channelIdHeader = httpRequest.Headers["channelid"];
+
+            var authenticationRequestResult = await BotFrameworkAuthentication.AuthenticateStreamingRequestAsync(authHeader, channelIdHeader, cancellationToken).ConfigureAwait(false);
+
+            // Transition the request to a WebSocket connection
+            var socket = await httpRequest.HttpContext.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
+
+            // Tie the authentication results, the socket, the adapter and the bot together to be ready to handle any inbound activities
+            var streamingActivityProcessor = new StreamingActivityProcessor(authenticationRequestResult, socket, this, bot);
+
+            // Start receiving activities on the socket
+            await streamingActivityProcessor.ListenAsync().ConfigureAwait(false);
+        }
+
+        private class StreamingActivityProcessor : IStreamingActivityProcessor
+        {
+            private readonly AuthenticateRequestResult _authenticateRequestResult;
+            private readonly CloudAdapter _adapter;
+            private readonly StreamingRequestHandler _requestHandler;
+
+            public StreamingActivityProcessor(AuthenticateRequestResult authenticateRequestResult, WebSocket socket, CloudAdapter adapter, IBot bot)
+            {
+                _authenticateRequestResult = authenticateRequestResult;
+                _adapter = adapter;
+
+                // Internal reuse of the existing StreamingRequestHandler class
+                _requestHandler = new StreamingRequestHandler(bot, this, socket, _authenticateRequestResult.Audience, adapter.Logger);
+
+                // Fix up the connector factory so connector create from it will send over this connection
+                _authenticateRequestResult.ConnectorFactory = new StreamingConnectorFactory(_requestHandler);
+            }
+
+            public StreamingActivityProcessor(AuthenticateRequestResult authenticateRequestResult, string pipeName, CloudAdapter adapter, IBot bot)
+            {
+                _authenticateRequestResult = authenticateRequestResult;
+                _adapter = adapter;
+
+                // Internal reuse of the existing StreamingRequestHandler class
+                _requestHandler = new StreamingRequestHandler(bot, this, pipeName, _authenticateRequestResult.Audience, adapter.Logger);
+
+                // Fix up the connector factory so connector create from it will send over this connection
+                _authenticateRequestResult.ConnectorFactory = new StreamingConnectorFactory(_requestHandler);
+            }
+
+            public Task ListenAsync() => _requestHandler.ListenAsync();
+
+            Task<InvokeResponse> IStreamingActivityProcessor.ProcessStreamingActivityAsync(Activity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
+                => _adapter.ProcessActivityAsync(_authenticateRequestResult, activity, callback, cancellationToken);
+
+            private class StreamingConnectorFactory : ConnectorFactory
+            {
+                private readonly StreamingRequestHandler _requestHandler;
+                private string _serviceUrl = null;
+
+                public StreamingConnectorFactory(StreamingRequestHandler requestHandler)
+                {
+                    _requestHandler = requestHandler;
+                }
+
+                public override Task<IConnectorClient> CreateAsync(string serviceUrl, string audience, CancellationToken cancellationToken)
+                {
+                    if (_serviceUrl == null)
+                    {
+                        _serviceUrl = serviceUrl;
+                    }
+                    else if (!_serviceUrl.Equals(serviceUrl, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new NotSupportedException("This is a streaming scenario, all connectors from this factory must all be for the same url.");
+                    }
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+                    var streamingHttpClient = new StreamingHttpClient(_requestHandler);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+                    return Task.FromResult<IConnectorClient>(new ConnectorClient(MicrosoftAppCredentials.Empty, streamingHttpClient, false));
+                }
+
+                private class StreamingHttpClient : HttpClient
+                {
+                    private readonly StreamingRequestHandler _requestHandler;
+
+                    public StreamingHttpClient(StreamingRequestHandler requestHandler)
+                    {
+                        _requestHandler = requestHandler ?? throw new ArgumentNullException(nameof(requestHandler));
+                    }
+
+                    public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken)
+                    {
+                        var streamingRequest = await CreateSteamingRequestAsync(httpRequestMessage).ConfigureAwait(false);
+                        var receiveResponse = await _requestHandler.SendStreamingRequestAsync(streamingRequest, cancellationToken).ConfigureAwait(false);
+                        var httpResponseMessage = await CreateHttpResponseAsync(receiveResponse).ConfigureAwait(false);
+                        return httpResponseMessage;
+                    }
+
+                    private async Task<StreamingRequest> CreateSteamingRequestAsync(HttpRequestMessage httpRequestMessage)
+                    {
+                        var streamingRequest = new StreamingRequest
+                        {
+                            Path = httpRequestMessage.RequestUri.OriginalString.Substring(httpRequestMessage.RequestUri.OriginalString.IndexOf("/v3", StringComparison.Ordinal)),
+                            Verb = httpRequestMessage.Method.ToString(),
+                        };
+                        streamingRequest.SetBody(await httpRequestMessage.Content.ReadAsStringAsync().ConfigureAwait(false));
+                        return streamingRequest;
+                    }
+
+                    private async Task<HttpResponseMessage> CreateHttpResponseAsync(ReceiveResponse receiveResponse)
+                    {
+                        var httpResponseMessage = new HttpResponseMessage((HttpStatusCode)receiveResponse.StatusCode);
+                        httpResponseMessage.Content = new StringContent(await receiveResponse.ReadBodyAsStringAsync().ConfigureAwait(false));
+                        return httpResponseMessage;
+                    }
                 }
             }
         }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <summary>
-        /// Process the inbound http request with the bot resulting in the outbound http response, this method can be called directly from a Controller.
+        /// Process the inbound HTTP request with the bot resulting in the outbound http response, this method can be called directly from a Controller.
         /// If the HTTP method is a POST the body will contain the <see cref="Activity"/> to process. 
         /// </summary>
         /// <param name="httpRequest">The <see cref="HttpRequest"/>.</param>
@@ -80,6 +80,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 {
                     // All socket communication will be handled by the internal streaming-specific BotAdapter
                     await ConnectAsync(httpRequest, bot, cancellationToken).ConfigureAwait(false);
+
+                    // Acknowledge the GET request
+                    httpResponse.StatusCode = (int)HttpStatusCode.OK;
                 }
                 else if (httpRequest.Method == HttpMethods.Post)
                 {
@@ -99,7 +102,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     // Process the inbound activity with the bot
                     var invokeResponse = await ProcessActivityAsync(authHeader, activity, bot.OnTurnAsync, cancellationToken).ConfigureAwait(false);
 
-                    // write the response, potentially serializing the InvokeResponse
+                    // Write the response, potentially serializing the InvokeResponse
                     await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
                 }
                 else

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -80,9 +80,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 {
                     // All socket communication will be handled by the internal streaming-specific BotAdapter
                     await ConnectAsync(httpRequest, bot, cancellationToken).ConfigureAwait(false);
-
-                    // Acknowledge the GET request
-                    httpResponse.StatusCode = (int)HttpStatusCode.OK;
                 }
                 else if (httpRequest.Method == HttpMethods.Post)
                 {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
@@ -62,6 +62,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <inheritdoc/>
+        public override Task<AuthenticateRequestResult> AuthenticateStreamingRequestAsync(string authHeader, string channelIdHeader, CancellationToken cancellationToken)
+        {
+            return _inner.AuthenticateStreamingRequestAsync(authHeader, channelIdHeader, cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public override ConnectorFactory CreateConnectorFactory(ClaimsIdentity claimsIdentity)
         {
             return _inner.CreateConnectorFactory(claimsIdentity);

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/ConfigurationBotFrameworkAuthentication.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/ConfigurationBotFrameworkAuthentication.cs
@@ -61,6 +61,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
         }
 
         /// <inheritdoc/>
+        public override Task<AuthenticateRequestResult> AuthenticateStreamingRequestAsync(string authHeader, string channelIdHeader, CancellationToken cancellationToken)
+        {
+            return _inner.AuthenticateStreamingRequestAsync(authHeader, channelIdHeader, cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public override ConnectorFactory CreateConnectorFactory(ClaimsIdentity claimsIdentity)
         {
             return _inner.CreateConnectorFactory(claimsIdentity);

--- a/tests/Auth/bot-authentication/AdapterWithErrorHandler.cs
+++ b/tests/Auth/bot-authentication/AdapterWithErrorHandler.cs
@@ -10,9 +10,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
+    /*
     public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
         public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
+    */
+    public class AdapterWithErrorHandler : CloudAdapter
+    {
+        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState = null)
             : base(configuration, logger: logger)
         {
             OnTurnError = async (turnContext, exception) =>

--- a/tests/Auth/bot-authentication/AdapterWithErrorHandler.cs
+++ b/tests/Auth/bot-authentication/AdapterWithErrorHandler.cs
@@ -10,9 +10,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.BotBuilderSamples
 {
-    public class AdapterWithErrorHandler : CloudAdapter
+    public class AdapterWithErrorHandler : BotFrameworkHttpAdapter
     {
-        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<CloudAdapter> logger, ConversationState conversationState = null)
+        public AdapterWithErrorHandler(IConfiguration configuration, ILogger<BotFrameworkHttpAdapter> logger, ConversationState conversationState = null)
             : base(configuration, logger: logger)
         {
             OnTurnError = async (turnContext, exception) =>

--- a/tests/Auth/bot-authentication/Bots/EchoBot.cs
+++ b/tests/Auth/bot-authentication/Bots/EchoBot.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class EchoBot : ActivityHandler
+    {
+        protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            await turnContext.SendActivityAsync(MessageFactory.Text($"echo: {turnContext.Activity.Text}"), cancellationToken);
+        }
+    }
+}

--- a/tests/Auth/bot-authentication/Bots/EchoBot.cs
+++ b/tests/Auth/bot-authentication/Bots/EchoBot.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;

--- a/tests/Auth/bot-authentication/Controllers/BotController.cs
+++ b/tests/Auth/bot-authentication/Controllers/BotController.cs
@@ -25,6 +25,7 @@ namespace Microsoft.BotBuilderSamples
         }
 
         [HttpPost]
+        [HttpGet]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.

--- a/tests/Auth/bot-authentication/Startup.cs
+++ b/tests/Auth/bot-authentication/Startup.cs
@@ -33,7 +33,8 @@ namespace Microsoft.BotBuilderSamples
             services.AddSingleton<MainDialog>();
 
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
-            services.AddTransient<IBot, AuthBot<MainDialog>>();
+            //services.AddTransient<IBot, AuthBot<MainDialog>>();
+            services.AddTransient<IBot, EchoBot>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -44,9 +45,10 @@ namespace Microsoft.BotBuilderSamples
                 app.UseDeveloperExceptionPage();
             }
 
+            //.UseWebSockets()
             app.UseDefaultFiles()
                 .UseStaticFiles()
-                .UseWebSockets()
+                .UseNamedPipes()
                 .UseRouting()
                 .UseAuthorization()
                 .UseEndpoints(endpoints =>

--- a/tests/Auth/bot-authentication/Startup.cs
+++ b/tests/Auth/bot-authentication/Startup.cs
@@ -46,6 +46,7 @@ namespace Microsoft.BotBuilderSamples
 
             app.UseDefaultFiles()
                 .UseStaticFiles()
+                .UseWebSockets()
                 .UseRouting()
                 .UseAuthorization()
                 .UseEndpoints(endpoints =>

--- a/tests/Auth/bot-authentication/Startup.cs
+++ b/tests/Auth/bot-authentication/Startup.cs
@@ -45,10 +45,10 @@ namespace Microsoft.BotBuilderSamples
                 app.UseDeveloperExceptionPage();
             }
 
-            //.UseWebSockets()
+            //.UseNamedPipes()
             app.UseDefaultFiles()
                 .UseStaticFiles()
-                .UseNamedPipes()
+                .UseWebSockets()
                 .UseRouting()
                 .UseAuthorization()
                 .UseEndpoints(endpoints =>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/CloudOAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/CloudOAuthPromptTests.cs
@@ -755,7 +755,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var activity = new Activity
             {
                 Type = ActivityTypes.Message,
-                Name = SignInConstants.TokenExchangeOperationName,
                 From = new ChannelAccount { Id = userId },
                 Conversation = new ConversationAccount { Id = "conversation-id" },
                 ChannelId = channelId,

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -181,7 +181,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
 
             // Assert
-            Assert.Equal((int)HttpStatusCode.OK, httpResponseMock.Object.StatusCode);
             botFrameworkAuthenticationMock.Verify(x => x.AuthenticateStreamingRequestAsync(It.Is<string>(v => true), It.Is<string>(v => true), It.Is<CancellationToken>(ct => true)), Times.Once());
         }
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = new ClaimsIdentity(),
                 ConnectorFactory = new TestConnectorFactory(),
-                Audience = "scope",
+                Audience = "audience",
                 CallerId = "callerId"
             };
 
@@ -337,7 +337,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = new ClaimsIdentity(),
                 ConnectorFactory = new TestConnectorFactory(),
-                Audience = "scope",
+                Audience = "audience",
                 CallerId = "callerId"
             };
 
@@ -422,7 +422,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = claimsIdentity,
                 ConnectorFactory = new TestConnectorFactory(),
-                Audience = "scope",
+                Audience = "audience",
                 CallerId = "callerId"
             };
 
@@ -440,7 +440,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
 
             // Assert
-            Assert.Equal("scope", bot.Authorization.Parameter);
+            Assert.Equal("audience", bot.Authorization.Parameter);
             Assert.Equal(claimsIdentity, bot.Identity);
             Assert.Equal(userTokenClient, bot.UserTokenClient);
             Assert.True(bot.ConnectorClient != null);
@@ -457,7 +457,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = claimsIdentity,
                 ConnectorFactory = new TestConnectorFactory(),
-                Audience = "scope",
+                Audience = "audience",
                 CallerId = "callerId"
             };
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = new ClaimsIdentity(),
                 ConnectorFactory = new TestConnectorFactory(),
-                Scope = "scope",
+                Audience = "scope",
                 CallerId = "callerId"
             };
 
@@ -243,7 +243,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = new ClaimsIdentity(),
                 ConnectorFactory = new TestConnectorFactory(),
-                Scope = "scope",
+                Audience = "scope",
                 CallerId = "callerId"
             };
 
@@ -327,7 +327,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = claimsIdentity,
                 ConnectorFactory = new TestConnectorFactory(),
-                Scope = "scope",
+                Audience = "scope",
                 CallerId = "callerId"
             };
 
@@ -362,7 +362,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 ClaimsIdentity = claimsIdentity,
                 ConnectorFactory = new TestConnectorFactory(),
-                Scope = "scope",
+                Audience = "scope",
                 CallerId = "callerId"
             };
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
@@ -64,6 +65,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateInvokeActivityStream());
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
@@ -87,11 +89,100 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             }
         }
 
-        [Fact]
-        public async Task WebSocketRequest()
+        [Theory]
+        [InlineData("DELETE")]
+        [InlineData("PUT")]
+        [InlineData("GET")]
+        [InlineData("HEAD")]
+        [InlineData("PATCH")]
+        public async Task MethodNotAllowed(string httpMethod)
         {
-            // TODO: add web socket code into CloudAdapter
-            await Task.CompletedTask;
+            // Arrange
+            var headerDictionaryMock = new Mock<IHeaderDictionary>();
+            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
+
+            var webSocketManagerMock = new Mock<WebSocketManager>();
+            webSocketManagerMock.Setup(w => w.IsWebSocketRequest).Returns(false);
+            var httpContextMock = new Mock<HttpContext>();
+            httpContextMock.Setup(c => c.WebSockets).Returns(webSocketManagerMock.Object);
+            var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(httpMethod);
+            httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
+            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.HttpContext).Returns(httpContextMock.Object);
+
+            var httpResponseMock = new Mock<HttpResponse>().SetupAllProperties();
+
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns((HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(CreateInternalHttpResponse()));
+
+            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+
+            var bot = new MessageBot();
+
+            // Act
+            var cloudEnvironment = BotFrameworkAuthenticationFactory.Create(null, false, null, null, null, null, null, null, null, new PasswordServiceClientCredentialFactory(), new AuthenticationConfiguration(), httpClient, null);
+            var adapter = new CloudAdapter(cloudEnvironment);
+            await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.MethodNotAllowed, httpResponseMock.Object.StatusCode);
+            mockHttpMessageHandler.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Never(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task WebSocketRequestShouldCallAuthenticateStreamingRequestAsync()
+        {
+            // Note this test only checks that a GET request will result in an auth call and a socket accept
+            // it doesn't valid that activities over that socket get to the bot or back
+
+            // Arrange
+            var headerDictionaryMock = new Mock<IHeaderDictionary>();
+            headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
+
+            var webSocketReceiveResult = new Mock<WebSocketReceiveResult>(MockBehavior.Strict, new object[] { 1, WebSocketMessageType.Binary, false });
+
+            var webSocketMock = new Mock<WebSocket>();
+            webSocketMock.Setup(ws => ws.State).Returns(WebSocketState.Open);
+            webSocketMock.Setup(ws => ws.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(webSocketReceiveResult.Object));
+            webSocketMock.Setup(ws => ws.SendAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<WebSocketMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            webSocketMock.Setup(ws => ws.CloseAsync(It.IsAny<WebSocketCloseStatus>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            webSocketMock.Setup(ws => ws.Dispose());
+
+            var webSocketManagerMock = new Mock<WebSocketManager>();
+            webSocketManagerMock.Setup(w => w.IsWebSocketRequest).Returns(true);
+            webSocketManagerMock.Setup(w => w.AcceptWebSocketAsync()).Returns(Task.FromResult(webSocketMock.Object));
+            var httpContextMock = new Mock<HttpContext>();
+            httpContextMock.Setup(c => c.WebSockets).Returns(webSocketManagerMock.Object);
+            var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns("GET");
+            httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
+            httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
+            httpRequestMock.Setup(r => r.HttpContext).Returns(httpContextMock.Object);
+
+            var httpResponseMock = new Mock<HttpResponse>().SetupAllProperties();
+
+            var authenticateRequestResult = new AuthenticateRequestResult
+            {
+                Audience = "audience",
+            };
+
+            var botFrameworkAuthenticationMock = new Mock<BotFrameworkAuthentication>();
+            botFrameworkAuthenticationMock.Setup(
+                x => x.AuthenticateStreamingRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(authenticateRequestResult);
+
+            var bot = new MessageBot();
+
+            // Act
+            var adapter = new CloudAdapter(botFrameworkAuthenticationMock.Object);
+            await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
+
+            // Assert
+            Assert.Equal((int)HttpStatusCode.OK, httpResponseMock.Object.StatusCode);
+            botFrameworkAuthenticationMock.Verify(x => x.AuthenticateStreamingRequestAsync(It.Is<string>(v => true), It.Is<string>(v => true), It.Is<CancellationToken>(ct => true)), Times.Once());
         }
 
         [Fact]
@@ -102,6 +193,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
@@ -156,6 +248,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateBadRequestStream());
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
@@ -182,6 +275,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
@@ -234,6 +328,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream(userId, channelId, conversationId, recipientId, relatesToActivityId));
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 
@@ -316,6 +411,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             headerDictionaryMock.Setup(h => h[It.Is<string>(v => v == "Authorization")]).Returns<string>(null);
 
             var httpRequestMock = new Mock<HttpRequest>();
+            httpRequestMock.Setup(r => r.Method).Returns(HttpMethods.Post);
             httpRequestMock.Setup(r => r.Body).Returns(CreateMessageActivityStream());
             httpRequestMock.Setup(r => r.Headers).Returns(headerDictionaryMock.Object);
 


### PR DESCRIPTION
fixes #4850 #4674

- this adds streaming support to cloud adapter
- we are only supporting asp core
- this does PR does not include the additional unit tests (they are coming)

The most significant code is included in the CloudAdapter class in the integration project. Basically line 126 onwards in that class.

This codes does make some use of the existing streaming SDK integration, specifically StreamingRequestHandler. However, it keeps that dependency internal.

The most significant difference between this implementation and the existing streaming implementation is that all the outbound traffic is actually funneled through an internal HttpClient implementation that abstracts the underlying stream. There was a partial implementation of that idea but it was not wired up nor did it work. This PR does not touch that code.

The existing streaming implementation also performs a token refreshing call (per virtual "request" over the socket) in order to keep the AD registration alive, I've not yet added that.
