### PR TITLE
Clean-up OnChooseEntity and OnChooseProperty schemas and classes

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseEntity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseEntity.schema
@@ -5,10 +5,15 @@
     "description": "Actions to be performed when an entity value needs to be resolved.",
     "type": "object",
     "properties": {
+        "operation": {
+            "type": "string",
+            "title": "Operation",
+            "description": "Operation filter for event."
+        },
         "property": {
             "type": "string",
-            "title": "Property to be set",
-            "description": "Property that will be set after entity is selected."
+            "title": "Property",
+            "description": "Property filter for event."
         },
         "entity": {
             "type": "string",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseProperty.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseProperty.schema
@@ -2,33 +2,5 @@
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
     "title": "On choose property",
-    "description": "Actions to take when there are multiple possible mappings of entities to properties.",
-    "type": "object",
-    "properties": {
-        "entity": {
-            "type": "string",
-            "title": "Entity being assigned",
-            "description": "Entity being assigned to property choice"
-        },
-        "properties": {
-            "type": "array",
-            "title": "Possible properties",
-            "description": "Properties to be chosen between.",
-            "items": {
-                "type": "string",
-                "title": "Property name",
-                "description": "Possible property to choose."
-            }
-        },
-        "entities": {
-            "type": "array",
-            "title": "Entities",
-            "description": "Ambiguous entity names.",
-            "items": {
-                "type": "string",
-                "title": "Entity name",
-                "description": "Entity name being chosen between."
-            }
-        }
-    }
+    "description": "Actions to take when there are multiple possible mappings of entities to properties and operations."
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
@@ -21,14 +21,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Initializes a new instance of the <see cref="OnChooseEntity"/> class.
         /// </summary>
-        /// <param name="property">Optional, property to be assigned for filtering events.</param>
-        /// <param name="entity">Optional, entity name being assigned for filtering events.</param>
+        /// <param name="property">Optional, property for filtering events.</param>
+        /// <param name="entity">Optional, entity for filtering events.</param>
+        /// <param name="operation">Optional, operation for filtering events.</param>
         /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
         /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
-        public OnChooseEntity(string property = null, string entity = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public OnChooseEntity(string property = null, string entity = null, string operation = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
                 @event: AdaptiveEvents.ChooseEntity,
                 actions: actions,
@@ -38,17 +39,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         {
             Property = property;
             Entity = entity;
+            Operation = operation;
         }
 
         /// <summary>
-        /// Gets or sets the property entity resolution will be assigned to for filtering events.
+        /// Gets or sets operation to filter ChooseEntity events.
+        /// </summary>
+        /// <value>Property name.</value>
+        [JsonProperty("operation")]
+        public string Operation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property to filter ChooseEntity events.
         /// </summary>
         /// <value>Property name.</value>
         [JsonProperty("property")]
         public string Property { get; set; }
 
         /// <summary>
-        /// Gets or sets the entity name that is ambiguous for filtering events.
+        /// Gets or sets the entity name that is ambiguous for filtering ChooseEntity events.
         /// </summary>
         /// <value>Entity name.</value>
         [JsonProperty("entity")]
@@ -73,6 +82,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
             if (this.Entity != null)
             {
                 expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.entity.name == '{this.Entity}'"));
+            }
+
+            if (this.Operation != null)
+            {
+                expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.operation == '{this.Operation}'"));
             }
 
             return Expression.AndExpression(expressions.ToArray());

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseProperty.cs
@@ -21,14 +21,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Initializes a new instance of the <see cref="OnChooseProperty"/> class.
         /// </summary>
-        /// <param name="properties">Optional, list of properties being chosen between to filter events.</param>
-        /// <param name="entities">Optional, list of entities being chosen between to filter events.</param>
         /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
         /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
-        public OnChooseProperty(List<string> properties = null, List<string> entities = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public OnChooseProperty(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
                 @event: AdaptiveEvents.ChooseProperty,
                 actions: actions,
@@ -36,50 +34,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 callerPath: callerPath,
                 callerLine: callerLine)
         {
-            this.Properties = properties ?? new List<string>();
-            this.Entities = entities ?? new List<string>();
         }
-
-        /// <summary>
-        /// Gets or sets the properties being chosen between to filter events.
-        /// </summary>
-        /// <value>List of property names.</value>
-        [JsonProperty("properties")]
-#pragma warning disable CA2227 // Collection properties should be read only
-        public List<string> Properties { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
-
-        /// <summary>
-        /// Gets or sets the entities being chosen between to filter events.
-        /// </summary>
-        /// <value>List of entity names.</value>
-        [JsonProperty("entities")]
-#pragma warning disable CA2227 // Collection properties should be read only
-        public List<string> Entities { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets the identity for this rule's action.
         /// </summary>
         /// <returns>String with the identity.</returns>
         public override string GetIdentity()
-            => $"{this.GetType().Name}([{string.Join(",", this.Properties)}], {this.Entities})";
-
-        /// <inheritdoc/>
-        protected override Expression CreateExpression()
-        {
-            var expressions = new List<Expression> { base.CreateExpression() };
-            foreach (var property in this.Properties)
-            {
-                expressions.Add(Expression.Parse($"contains(foreach({TurnPath.DialogEvent}.value, mapping, mapping.property), '{property}')"));
-            }
-
-            foreach (var entity in this.Entities)
-            {
-                expressions.Add(Expression.Parse($"contains(foreach({TurnPath.DialogEvent}.value, mapping, mapping.entity.name), '{entity}')"));
-            }
-
-            return Expression.AndExpression(expressions.ToArray());
-        }
+            => $"{this.GetType().Name}()";
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/ChooseEntity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/ChooseEntity.test.dialog
@@ -1,108 +1,175 @@
 ﻿{
-  "$schema": "../../../tests.schema",
-  "$kind": "Microsoft.Test.Script",
-  "description": "Tests for Choosing Entity",
-  "httpRequestMocks": [
-    "LuisChooseEntity.mock"
-  ],
-  "dialog": {
-    "$kind": "Microsoft.AdaptiveDialog",
-    "recognizer": {
-      "$kind": "Microsoft.LuisRecognizer",
-      "applicationId": "00000000-0000-0000-0000-000000000000",
-      "endpointKey": "00000000000000000000000000000000",
-      "endpoint": "https://westus.api.cognitive.microsoft.com",
-      "predictionOptions": {
-        "IncludeAPIResults": true
-      }
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Tests for Choosing Entity",
+    "httpRequestMocks": [
+        "LuisChooseEntity-wheat.mock",
+        "LuisChooseEntity-whole wheat.mock",
+        "LuisChooseEntity-bread2.mock"
+    ],
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.LuisRecognizer",
+            "applicationId": "00000000-0000-0000-0000-000000000000",
+            "endpointKey": "00000000000000000000000000000000",
+            "endpoint": "https://westus.api.cognitive.microsoft.com",
+            "predictionOptions": {
+                "IncludeAPIResults": true
+            }
+        },
+        "schema": "oneProperty.json",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "welcome"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnEndOfActions",
+                "condition": "=!$Bread",
+                "priority": 0,
+                "actions": [
+                    {
+                        "$kind": "Microsoft.Ask",
+                        "activity": "which value do you what for bread?",
+                        "expectedProperties": [
+                            "Bread"
+                        ]
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnEndOfActions",
+                "condition": "=!$Bread2",
+                "priority": 0,
+                "actions": [
+                    {
+                        "$kind": "Microsoft.Ask",
+                        "activity": "which value do you what for bread2?",
+                        "expectedProperties": [
+                            "Bread2"
+                        ]
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnAssignEntity",
+                "operation": "Add()",
+                "property": "Bread",
+                "entity": "BreadEntity",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "$Bread",
+                        "value": "=@BreadEntity"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnAssignEntity",
+                "operation": "Add()",
+                "property": "Bread2",
+                "entity": "BreadEntity",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "$Bread2",
+                        "value": "=@BreadEntity"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnChooseEntity",
+                "entity": "BreadEntity",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.Ask",
+                        "activity": "Please choose a value for bread from [multi grain wheat, whole wheat]",
+                        "expectedProperties": [
+                            "Bread"
+                        ]
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnChooseEntity",
+                "property": "Bread2",
+                "entity": "BreadEntity",
+                "operation": "Add()",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.Ask",
+                        "activity": "Please choose a value for bread2 from [multi grain wheat, whole wheat]",
+                        "expectedProperties": [
+                            "Bread2"
+                        ]
+                    }
+                ]
+            }
+        ]
     },
-    "schema": "oneProperty.json",
-    "triggers": [
-      {
-        "$kind": "Microsoft.OnBeginDialog",
-        "actions": [
-          {
-            "$kind": "Microsoft.SendActivity",
-            "activity": "welcome"
-          }
-        ]
-      },
-      {
-        "$kind": "Microsoft.OnEndOfActions",
-        "condition": "=!$Bread",
-        "priority": 0,
-        "actions": [
-          {
-            "$kind": "Microsoft.Ask",
-            "activity": "which value do you what for bread ?",
-            "expectedProperties": [
-              "Bread"
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserConversationUpdate",
+            "membersAdded": [
+                "Bot",
+                "User"
+            ],
+            "membersRemoved": []
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "welcome"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "which value do you what for bread?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "wheat"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Please choose a value for bread from [multi grain wheat, whole wheat]"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "whole wheat"
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "$Bread == 'wholeWheat'"
             ]
-          }
-        ]
-      },
-      {
-        "$kind": "Microsoft.OnAssignEntity",
-        "operation": "Add()",
-        "property": "Bread",
-        "entity": "BreadEntity",
-        "actions": [
-          {
-            "$kind": "Microsoft.SetProperty",
-            "property": "$Bread",
-            "value": "=@BreadEntity"
-          }
-        ]
-      },
-      {
-        "$kind": "Microsoft.OnChooseEntity",
-        "entity": "BreadEntity",
-        "actions": [
-          {
-            "$kind": "Microsoft.Ask",
-            "activity": "Please choose a value for bread from [multi grain wheat, whole wheat]",
-            "expectedProperties": [
-              "Bread"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "which value do you what for bread2?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "bread2"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Please choose a value for bread2 from [multi grain wheat, whole wheat]"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "whole wheat"
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "$Bread2 == 'wholeWheat'"
             ]
-          }
-        ]
-      }
+        }
+
     ]
-  },
-  "script": [
-    {
-      "$kind": "Microsoft.Test.UserConversationUpdate",
-      "membersAdded": [
-        "Bot",
-        "User"
-      ],
-      "membersRemoved": []
-    },
-    {
-      "$kind": "Microsoft.Test.AssertReply",
-      "text": "welcome"
-    },
-    {
-      "$kind": "Microsoft.Test.AssertReply",
-      "text": "which value do you what for bread ?"
-    },
-    {
-      "$kind": "Microsoft.Test.UserSays",
-      "text": "wheat"
-    },
-    {
-      "$kind": "Microsoft.Test.AssertReply",
-      "text": "Please choose a value for bread from [multi grain wheat, whole wheat]"
-    },
-    {
-      "$kind": "Microsoft.Test.UserSays",
-      "text": "whole wheat"
-    },
-    {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "$Bread == 'whole wheat'"
-      ]
-    }
-  ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/LuisChooseEntity-bread2.mock.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/LuisChooseEntity-bread2.mock.dialog
@@ -3,25 +3,25 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://westus.api.cognitive.microsoft.com/luis/prediction/v3.0/apps/00000000-0000-0000-0000-000000000000/*",
-    "body": "\"query\": \"wheat\"",
+    "body": "\"query\": \"bread2\"",
     "responses": [
         {
           "content": {
-            "query": "wheat",
+            "query": "bread2",
             "prediction": {
               "topIntent": "sandwich",
               "intents": { "sandwich": { "score": 0.9939042 } },
               "entities": {
-                "BreadProperty": [
+                "Bread2Property": [
                   {
                     "BreadEntity": [ [ "multiGrainWheat", "wholeWheat" ] ],
                     "$instance": {
                       "BreadEntity": [
                         {
                           "type": "BreadEntity",
-                          "text": "wheat",
+                          "text": "bread2",
                           "startIndex": 0,
-                          "length": 5,
+                          "length": 6,
                           "modelTypeId": 1,
                           "modelType": "Entity Extractor",
                           "recognitionSources": [ "model" ]
@@ -31,12 +31,12 @@
                   }
                 ],
                 "$instance": {
-                  "BreadProperty": [
+                  "Bread2Property": [
                     {
-                      "type": "BreadProperty",
-                      "text": "wheat",
+                      "type": "Bread2Property",
+                      "text": "bread2",
                       "startIndex": 0,
-                      "length": 5,
+                      "length": 6,
                       "modelTypeId": 1,
                       "modelType": "Entity Extractor",
                       "recognitionSources": [ "model" ]

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/LuisChooseEntity-wheat.mock.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/LuisChooseEntity-wheat.mock.dialog
@@ -1,0 +1,64 @@
+﻿{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.HttpRequestSequenceMock",
+  "method": "POST",
+  "url": "https://westus.api.cognitive.microsoft.com/luis/prediction/v3.0/apps/00000000-0000-0000-0000-000000000000/*",
+  "body": "\"query\": \"wheat\"",
+  "responses": [
+    {
+      "content": {
+        "query": "wheat",
+        "prediction": {
+          "topIntent": "sandwich",
+          "intents": {
+            "sandwich": {
+              "score": 0.9939042
+            }
+          },
+          "entities": {
+            "BreadProperty": [
+              {
+                "BreadEntity": [
+                  [
+                    "multiGrainWheat",
+                    "wholeWheat"
+                  ]
+                ],
+                "$instance": {
+                  "BreadEntity": [
+                    {
+                      "type": "BreadEntity",
+                      "text": "wheat",
+                      "startIndex": 0,
+                      "length": 5,
+                      "modelTypeId": 1,
+                      "modelType": "Entity Extractor",
+                      "recognitionSources": [
+                        "model"
+                      ]
+                    }
+                  ]
+                }
+              }
+            ],
+            "$instance": {
+              "BreadProperty": [
+                {
+                  "type": "BreadProperty",
+                  "text": "wheat",
+                  "startIndex": 0,
+                  "length": 5,
+                  "modelTypeId": 1,
+                  "modelType": "Entity Extractor",
+                  "recognitionSources": [
+                    "model"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/LuisChooseEntity-whole wheat.mock.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/LuisChooseEntity-whole wheat.mock.dialog
@@ -1,0 +1,44 @@
+﻿{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.HttpRequestSequenceMock",
+  "method": "POST",
+  "url": "https://westus.api.cognitive.microsoft.com/luis/prediction/v3.0/apps/00000000-0000-0000-0000-000000000000/*",
+  "body": "\"query\": \"whole wheat\"",
+  "responses": [
+    {
+      "content": {
+        "query": "whole wheat",
+        "prediction": {
+          "topIntent": "sandwich",
+          "intents": {
+            "sandwich": {
+              "score": 0.9939042
+            }
+          },
+          "entities": {
+            "BreadEntity": [
+              [
+                "wholeWheat"
+              ]
+            ],
+            "$instance": {
+              "BreadEntity": [
+                {
+                  "type": "BreadEntity",
+                  "text": "whole wheat",
+                  "startIndex": 0,
+                  "length": 10,
+                  "modelTypeId": 1,
+                  "modelType": "Entity Extractor",
+                  "recognitionSources": [
+                    "model"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/cachedResponses/=`00000000-0000-0000-0000-000000000000`/550341391.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/cachedResponses/=`00000000-0000-0000-0000-000000000000`/550341391.json
@@ -1,1 +1,0 @@
-{"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource."}}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/oneProperty.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/oneProperty.json
@@ -13,10 +13,23 @@
       "$entities": [
         "BreadEntity"
       ]
+    },
+    "Bread2": {
+      "type": "string",
+      "enum": [
+        "multiGrainWheat",
+        "rye",
+        "white",
+        "wholeWheat"
+      ],
+      "$entities": [
+        "BreadEntity"
+      ]
     }
   },
   "required": [
-    "Bread"
+    "Bread",
+    "Bread2"
   ],
   "$operations": [
     "Add()"

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -3886,7 +3886,10 @@
       "$role": "interface",
       "oneOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/Microsoft.ActivityTemplate"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.StaticActivityTemplate"
         },
         {
           "$ref": "#/definitions/botframework.json/definitions/Activity",
@@ -3895,10 +3898,7 @@
           ]
         },
         {
-          "$ref": "#/definitions/Microsoft.ActivityTemplate"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.StaticActivityTemplate"
+          "type": "string"
         }
       ]
     },
@@ -3908,16 +3908,19 @@
       "$role": "interface",
       "oneOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/CustomAction.dialog"
         },
         {
-          "$ref": "#/definitions/Microsoft.QnAMakerDialog"
+          "$ref": "#/definitions/CustomAction2.dialog"
         },
         {
           "$ref": "#/definitions/Microsoft.AdaptiveDialog"
         },
         {
-          "$ref": "#/definitions/Microsoft.Test.AssertCondition"
+          "$ref": "#/definitions/Microsoft.Ask"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AttachmentInput"
         },
         {
           "$ref": "#/definitions/Microsoft.BeginDialog"
@@ -3935,6 +3938,12 @@
           "$ref": "#/definitions/Microsoft.CancelDialog"
         },
         {
+          "$ref": "#/definitions/Microsoft.ChoiceInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmInput"
+        },
+        {
           "$ref": "#/definitions/Microsoft.ContinueConversation"
         },
         {
@@ -3942,6 +3951,9 @@
         },
         {
           "$ref": "#/definitions/Microsoft.ContinueLoop"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeInput"
         },
         {
           "$ref": "#/definitions/Microsoft.DebugBreak"
@@ -3998,6 +4010,15 @@
           "$ref": "#/definitions/Microsoft.LogAction"
         },
         {
+          "$ref": "#/definitions/Microsoft.NumberInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OAuthInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.QnAMakerDialog"
+        },
+        {
           "$ref": "#/definitions/Microsoft.RepeatDialog"
         },
         {
@@ -4022,6 +4043,12 @@
           "$ref": "#/definitions/Microsoft.TelemetryTrackEventAction"
         },
         {
+          "$ref": "#/definitions/Microsoft.Test.AssertCondition"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TextInput"
+        },
+        {
           "$ref": "#/definitions/Microsoft.ThrowException"
         },
         {
@@ -4029,30 +4056,6 @@
         },
         {
           "$ref": "#/definitions/Microsoft.UpdateActivity"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.Ask"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.AttachmentInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ChoiceInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.ConfirmInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.DateTimeInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.NumberInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.OAuthInput"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.TextInput"
         },
         {
           "$ref": "#/definitions/Teams.GetMeetingParticipant"
@@ -4118,10 +4121,7 @@
           "$ref": "#/definitions/Testbot.Multiply"
         },
         {
-          "$ref": "#/definitions/CustomAction.dialog"
-        },
-        {
-          "$ref": "#/definitions/CustomAction2.dialog"
+          "type": "string"
         }
       ]
     },
@@ -4132,11 +4132,6 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "string",
-          "title": "Reference to Microsoft.IEntityRecognizer",
-          "description": "Reference to Microsoft.IEntityRecognizer .dialog file."
-        },
-        {
           "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
         },
         {
@@ -4189,6 +4184,11 @@
         },
         {
           "$ref": "#/definitions/Microsoft.UrlEntityRecognizer"
+        },
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.IEntityRecognizer",
+          "description": "Reference to Microsoft.IEntityRecognizer .dialog file."
         }
       ]
     },
@@ -4198,13 +4198,13 @@
       "$role": "interface",
       "oneOf": [
         {
-          "type": "string"
-        },
-        {
           "$ref": "#/definitions/Microsoft.ResourceMultiLanguageGenerator"
         },
         {
           "$ref": "#/definitions/Microsoft.TemplateEngineLanguageGenerator"
+        },
+        {
+          "type": "string"
         }
       ]
     },
@@ -4213,30 +4213,6 @@
       "description": "Components which derive from Recognizer class",
       "$role": "interface",
       "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.LuisRecognizer"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.OrchestratorRecognizer"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.CrossTrainedRecognizerSet"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.MultiLanguageRecognizer"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.RecognizerSet"
-        },
-        {
-          "$ref": "#/definitions/Microsoft.RegexRecognizer"
-        },
         {
           "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
         },
@@ -4247,6 +4223,9 @@
           "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"
         },
         {
+          "$ref": "#/definitions/Microsoft.CrossTrainedRecognizerSet"
+        },
+        {
           "$ref": "#/definitions/Microsoft.CurrencyEntityRecognizer"
         },
         {
@@ -4268,13 +4247,22 @@
           "$ref": "#/definitions/Microsoft.IpEntityRecognizer"
         },
         {
+          "$ref": "#/definitions/Microsoft.LuisRecognizer"
+        },
+        {
           "$ref": "#/definitions/Microsoft.MentionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.MultiLanguageRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.NumberEntityRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.NumberRangeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OrchestratorRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.OrdinalEntityRecognizer"
@@ -4286,13 +4274,25 @@
           "$ref": "#/definitions/Microsoft.PhoneNumberEntityRecognizer"
         },
         {
+          "$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RecognizerSet"
+        },
+        {
           "$ref": "#/definitions/Microsoft.RegexEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RegexRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.TemperatureEntityRecognizer"
         },
         {
           "$ref": "#/definitions/Microsoft.UrlEntityRecognizer"
+        },
+        {
+          "type": "string"
         }
       ]
     },
@@ -4302,10 +4302,10 @@
       "$role": "interface",
       "oneOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/Microsoft.TextTemplate"
         },
         {
-          "$ref": "#/definitions/Microsoft.TextTemplate"
+          "type": "string"
         }
       ]
     },
@@ -4314,11 +4314,6 @@
       "title": "Microsoft Triggers",
       "description": "Components which derive from OnCondition class.",
       "oneOf": [
-        {
-          "type": "string",
-          "title": "Reference to Microsoft.ITrigger",
-          "description": "Reference to Microsoft.ITrigger .dialog file."
-        },
         {
           "$ref": "#/definitions/Microsoft.OnActivity"
         },
@@ -4480,6 +4475,11 @@
         },
         {
           "$ref": "#/definitions/Teams.OnTeamUnarchived"
+        },
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.ITrigger",
+          "description": "Reference to Microsoft.ITrigger .dialog file."
         }
       ]
     },
@@ -4488,11 +4488,6 @@
       "title": "Selectors",
       "description": "Components which derive from TriggerSelector class.",
       "oneOf": [
-        {
-          "type": "string",
-          "title": "Reference to Microsoft.ITriggerSelector",
-          "description": "Reference to Microsoft.ITriggerSelector .dialog file."
-        },
         {
           "$ref": "#/definitions/Microsoft.ConditionalSelector"
         },
@@ -4507,6 +4502,11 @@
         },
         {
           "$ref": "#/definitions/Microsoft.TrueSelector"
+        },
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.ITriggerSelector",
+          "description": "Reference to Microsoft.ITriggerSelector .dialog file."
         }
       ]
     },
@@ -5784,10 +5784,15 @@
         }
       },
       "properties": {
+        "operation": {
+          "type": "string",
+          "title": "Operation",
+          "description": "Operation filter for event."
+        },
         "property": {
           "type": "string",
-          "title": "Property to be set",
-          "description": "Property that will be set after entity is selected."
+          "title": "Property",
+          "description": "Property filter for event."
         },
         "entity": {
           "type": "string",
@@ -9246,12 +9251,12 @@
       "$role": "interface",
       "oneOf": [
         {
+          "$ref": "#/definitions/Microsoft.Test.HttpRequestSequenceMock"
+        },
+        {
           "type": "string",
           "title": "Reference to Microsoft.Test.IHttpRequestMock",
           "description": "Reference to Microsoft.Test.IHttpRequestMock .dialog file."
-        },
-        {
-          "$ref": "#/definitions/Microsoft.Test.HttpRequestSequenceMock"
         }
       ]
     },
@@ -9266,12 +9271,12 @@
       "$role": "interface",
       "oneOf": [
         {
+          "$ref": "#/definitions/Microsoft.Test.SettingStringMock"
+        },
+        {
           "type": "string",
           "title": "Reference to Microsoft.Test.ISettingMock",
           "description": "Reference to Microsoft.Test.ISettingMock .dialog file."
-        },
-        {
-          "$ref": "#/definitions/Microsoft.Test.SettingStringMock"
         }
       ]
     },
@@ -9280,11 +9285,6 @@
       "description": "Components which derive from TestAction class",
       "$role": "interface",
       "oneOf": [
-        {
-          "type": "string",
-          "title": "Reference to Microsoft.Test.ITestAction",
-          "description": "Reference to Microsoft.Test.ITestAction .dialog file."
-        },
         {
           "$ref": "#/definitions/Microsoft.Test.AssertNoActivity"
         },
@@ -9320,6 +9320,11 @@
         },
         {
           "$ref": "#/definitions/Microsoft.Test.UserTyping"
+        },
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.Test.ITestAction",
+          "description": "Reference to Microsoft.Test.ITestAction .dialog file."
         }
       ]
     },
@@ -9329,12 +9334,12 @@
       "$role": "interface",
       "oneOf": [
         {
+          "$ref": "#/definitions/Microsoft.Test.UserTokenBasicMock"
+        },
+        {
           "type": "string",
           "title": "Reference to Microsoft.Test.IUserTokenMock",
           "description": "Reference to Microsoft.Test.IUserTokenMock .dialog file."
-        },
-        {
-          "$ref": "#/definitions/Microsoft.Test.UserTokenBasicMock"
         }
       ]
     },

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -5924,7 +5924,7 @@
         "extends(Microsoft.OnCondition)"
       ],
       "title": "On choose property",
-      "description": "Actions to take when there are multiple possible mappings of entities to properties.",
+      "description": "Actions to take when there are multiple possible mappings of entities to properties and operations.",
       "type": "object",
       "required": [
         "$kind"
@@ -5937,31 +5937,6 @@
         }
       },
       "properties": {
-        "entity": {
-          "type": "string",
-          "title": "Entity being assigned",
-          "description": "Entity being assigned to property choice"
-        },
-        "properties": {
-          "type": "array",
-          "title": "Possible properties",
-          "description": "Properties to be chosen between.",
-          "items": {
-            "type": "string",
-            "title": "Property name",
-            "description": "Possible property to choose."
-          }
-        },
-        "entities": {
-          "type": "array",
-          "title": "Entities",
-          "description": "Ambiguous entity names.",
-          "items": {
-            "type": "string",
-            "title": "Entity name",
-            "description": "Entity name being chosen between."
-          }
-        },
         "condition": {
           "$ref": "#/definitions/condition",
           "title": "Condition",


### PR DESCRIPTION
Fixes #5177 

## Description
In writing the documentation for OnChooseEntity and OnChooseProperty I realized the operation was missing from OnChooseEntity and none of the properties for OnChooseProperty were used or even made sense.  This updated both the class and the schema.  These events are only fired if there is a schema and the only current source of schema is form generation which has not been released or documented yet.

## Testing
Improved the OnChooseEntity test to make sure filter properties work.