### PR TITLE
[PORT]Add properties property for Template class

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
@@ -83,6 +84,14 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// The parse tree of this template.
         /// </value>
         public LGTemplateParser.BodyContext TemplateBodyParseTree { get; set; }
+
+        /// <summary>
+        /// Gets or sets properties that are not otherwise defined by the <see cref="Template"/> core type.
+        /// </summary>
+        /// <value>The extended properties for the object.</value>
+#pragma warning disable CA2227 // Collection properties should be read only
+        public JObject Properties { get; set; } = new JObject();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <inheritdoc/>
         public override string ToString() => $"[{Name}({string.Join(", ", Parameters)})]\"{Body}\"";

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Template.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// </summary>
         /// <value>The extended properties for the object.</value>
 #pragma warning disable CA2227 // Collection properties should be read only
-        public JObject Properties { get; set; } = new JObject();
+        public JObject Properties { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <inheritdoc/>

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
@@ -12,6 +12,7 @@ using AdaptiveExpressions;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.LanguageGeneration
 {
@@ -562,6 +563,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                         else
                         {
                             // KeyValueStructuredLine
+                            var structureKey = body.keyValueStructureLine().STRUCTURE_IDENTIFIER();
                             var structureValues = body.keyValueStructureLine().keyValueStructureValue();
                             foreach (var structureValue in structureValues)
                             {
@@ -570,6 +572,8 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                                     FillInExpression(expression);
                                 }
                             }
+
+                            FillInProperties(structureKey.GetText().Trim(), structureValues);
                         }
                     }
                 }
@@ -671,6 +675,18 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var sourceRange = new SourceRange(expressionContext, _template.SourceRange.Source, lineOffset);
                 var expressionRef = new ExpressionRef(exp, sourceRange);
                 _template.Expressions.Add(expressionRef);
+            }
+
+            private void FillInProperties(string key, LGTemplateParser.KeyValueStructureValueContext[] structureValues)
+            {
+                if (structureValues.Length == 1)
+                {
+                    _template.Properties[key] = structureValues[0].GetText();
+                }
+                else if (structureValues.Length > 1)
+                {
+                    _template.Properties[key] = JArray.FromObject(structureValues.Select(u => u.GetText()));
+                }
             }
         }
     }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplatesParser.cs
@@ -565,6 +565,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                             // KeyValueStructuredLine
                             var structureKey = body.keyValueStructureLine().STRUCTURE_IDENTIFIER();
                             var structureValues = body.keyValueStructureLine().keyValueStructureValue();
+                            var typeName = context.structuredBodyNameLine().STRUCTURE_NAME().GetText().Trim();
                             foreach (var structureValue in structureValues)
                             {
                                 foreach (var expression in structureValue.expressionInStructure())
@@ -573,7 +574,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                                 }
                             }
 
-                            FillInProperties(structureKey.GetText().Trim(), structureValues);
+                            FillInProperties(structureKey.GetText().Trim(), structureValues, typeName);
                         }
                     }
                 }
@@ -677,8 +678,15 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 _template.Expressions.Add(expressionRef);
             }
 
-            private void FillInProperties(string key, LGTemplateParser.KeyValueStructureValueContext[] structureValues)
+            private void FillInProperties(string key, LGTemplateParser.KeyValueStructureValueContext[] structureValues, string name)
             {
+                if (_template.Properties == null)
+                {
+                    _template.Properties = new JObject();
+                }
+
+                _template.Properties["$type"] = name;
+
                 if (structureValues.Length == 1)
                 {
                     _template.Properties[key] = structureValues[0].GetText();

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -847,12 +847,12 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestProperties()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("2.lg"));
-            Assert.Empty(templates[0].Properties.Properties());
+            Assert.Null(templates[0].Properties);
 
             templates = Templates.ParseFile(GetExampleFilePath("StructuredTemplate.lg"));
-            Assert.Equal(2, templates[0].Properties.Properties().Count());
             Assert.Equal("${GetAge()}", templates[0].Properties["Text"].ToString());
             Assert.Equal("${GetAge()}", templates[0].Properties["Speak"].ToString());
+            Assert.Equal("Activity", templates[0].Properties["$type"].ToString());
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -844,6 +844,18 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         }
 
         [Fact]
+        public void TestProperties()
+        {
+            var templates = Templates.ParseFile(GetExampleFilePath("2.lg"));
+            Assert.Empty(templates[0].Properties.Properties());
+
+            templates = Templates.ParseFile(GetExampleFilePath("StructuredTemplate.lg"));
+            Assert.Equal(2, templates[0].Properties.Properties().Count());
+            Assert.Equal("${GetAge()}", templates[0].Properties["Text"].ToString());
+            Assert.Equal("${GetAge()}", templates[0].Properties["Speak"].ToString());
+        }
+
+        [Fact]
         public void TemplateCRUD_Normal()
         {
             var templates = Templates.ParseFile(GetExampleFilePath("CrudInit.lg"));


### PR DESCRIPTION
Fixes #5181
## Description
For some requirements from Composer side. Describe here:
Structure LG parsed result should cover the common key/value pairs results.

For example:
```
# template
[Activity
 Text=good
 Speak=hi
]
```

The parsed Template would contains a property named `properties`, in which would contains:
```
properties: {Text: "good", Speak:"hi", $type:'Activity'}
```


## Particular cases
- Pure Expression reference would be ignore
```
[A
 key1=value1
 ${T2()}     -> this one would be ignored
]
```
- would keep the origin list info
```
[A
 list = a | b
]
```

the properties would be:
`{list: ['a', 'b'], $type: 'A'}`
