### PR TITLE
Change dict to case insensitive.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/MultiLanguageRecognizer.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -52,7 +53,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
         /// </value>
         [JsonProperty("recognizers")]
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IDictionary<string, Recognizer> Recognizers { get; set; } = new Dictionary<string, Recognizer>();
+        public IDictionary<string, Recognizer> Recognizers { get; set; } = new Dictionary<string, Recognizer>(StringComparer.OrdinalIgnoreCase);
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/MultiLanguageRecognizerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,6 +59,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
+        [Fact]
+        public async Task MultiLanguageRecognizerTest_LocaleCaseInsensitivity()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -91,7 +98,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
 
         private static MultiLanguageRecognizer GetRecognizer() => new MultiLanguageRecognizer
         {
-            Recognizers = new Dictionary<string, Recognizer>
+            Recognizers = new Dictionary<string, Recognizer>(StringComparer.OrdinalIgnoreCase)
             {
                 {
                     "en-us", new RegexRecognizer

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/MultiLanguageRecognizerTests/MultiLanguageRecognizerTest_LocaleCaseInsensitivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/MultiLanguageRecognizerTests/MultiLanguageRecognizerTest_LocaleCaseInsensitivity.test.dialog
@@ -1,0 +1,97 @@
+﻿{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.MultiLanguageRecognizer",
+            "recognizers": {
+                "en-us": {
+                    "$kind": "Microsoft.RegexRecognizer",
+                    "intents": [
+                        {
+                            "intent": "Greeting",
+                            "pattern": "(?i)howdy"
+                        },
+                        {
+                            "intent": "Goodbye",
+                            "pattern": "(?i)bye"
+                        }
+                    ]
+                },
+                "": {
+                    "$kind": "Microsoft.RegexRecognizer",
+                    "intents": [
+                        {
+                            "intent": "Greeting",
+                            "pattern": "(?i)salve"
+                        },
+                        {
+                            "intent": "Goodbye",
+                            "pattern": "(?i)vale dicere"
+                        }
+                    ]
+                }
+            }
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "Greeting",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "greeting intent"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "Goodbye",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "goodbye intent"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "default rule"
+                    }
+                ]
+            }
+        ],
+        "defaultResultProperty": "dialog.result"
+    },
+    "locale": "en-US",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "howdy"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "greeting intent"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "bye"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "goodbye intent"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "vale dicere"
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "default rule"
+        }
+    ]
+}


### PR DESCRIPTION
When the runtime passes a locale capitalized,for example as `en-US`, the `MultiLanguageRecognizer` treats this as an unrecognized locale.

The fix here is to use a case-insensitive dictionary to store the map of locale to recognizers. 