### PR TITLE
Replacing ConnectorClient should Dispose existing

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -226,14 +226,16 @@ namespace Microsoft.Bot.Builder.Dialogs
                     var serviceUrl = dc.Context.Activity.ServiceUrl;
                     var claimsIdentity = turnContext.TurnState.Get<ClaimsIdentity>(BotAdapter.BotIdentityKey);
                     var audience = callerInfo.Scope;
-                    var connectorClient = await UserTokenAccess.CreateConnectorClientAsync(turnContext, serviceUrl, claimsIdentity, audience, cancellationToken).ConfigureAwait(false);
-                    if (turnContext.TurnState.Get<IConnectorClient>() != null)
+                    var newConnectorClient = await UserTokenAccess.CreateConnectorClientAsync(turnContext, serviceUrl, claimsIdentity, audience, cancellationToken).ConfigureAwait(false);
+                    var oldConnectorClient = turnContext.TurnState.Get<IConnectorClient>();
+                    if (oldConnectorClient != null)
                     {
-                        turnContext.TurnState.Set(connectorClient);
+                        turnContext.TurnState.Set(newConnectorClient);
+                        oldConnectorClient.Dispose();
                     }
                     else
                     {
-                        turnContext.TurnState.Add(connectorClient);
+                        turnContext.TurnState.Add(newConnectorClient);
                     }
                 }
             }


### PR DESCRIPTION
The code in the OAuthPrompt that replaces the disposable ConnectorClient should call Dispose on the existing client.

This does make assumptions about the lifetime and ownership of objects, but the TurnContext/TurnState is an inherently fragile mechanism and unlike the built in platform DI system lacks any explicit semantics around lifetime. In this case the assumption is the ConnectorClient is owned by the BotFrameworkAdapter which created it, that implies this should be Disposed here.