### PR TITLE
Rename entity to value in form related triggers 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -917,13 +917,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     // TODO: For now, I'm going to dereference to a one-level array value.  There is a bug in the current code in the distinction between
                     // @ which is supposed to unwrap down to non-array and @@ which returns the whole thing. @ in the curent code works by doing [0] which
                     // is not enough.
-                    var entity = nextAssignment.Entity.Value;
+                    var entity = nextAssignment.Value.Value;
                     if (!(entity is JArray))
                     {
                         entity = new object[] { entity };
                     }
 
-                    actionContext.State.SetValue($"{TurnPath.Recognized}.entities.{nextAssignment.Entity.Name}", entity);
+                    actionContext.State.SetValue($"{TurnPath.Recognized}.entities.{nextAssignment.Value.Name}", entity);
                     assignments.Dequeue(actionContext);
                 }
 
@@ -1299,7 +1299,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     {
                         assignments.Add(new EntityAssignment
                         {
-                            Entity = alternative,
+                            Value = alternative,
                             Property = alternative.Property,
                             Operation = alternative.Operation,
                             IsExpected = expected.Contains(alternative.Property)
@@ -1324,7 +1324,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                             {
                                 assignments.Add(new EntityAssignment
                                 {
-                                    Entity = entity,
+                                    Value = entity,
                                     Property = propSchema.Name,
                                     Operation = entity.Operation,
                                     IsExpected = isExpected
@@ -1335,7 +1335,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                                 // Recast property with no value as match for property entities
                                 assignments.Add(new EntityAssignment
                                 {
-                                    Entity = entity,
+                                    Value = entity,
                                     Property = propSchema.Name,
                                     Operation = null,
                                     IsExpected = isExpected,
@@ -1353,7 +1353,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 {
                     // Assign missing operation
                     if (lastEvent == AdaptiveEvents.ChooseEntity
-                        && assignment.Entity.Property == nextAssignment.Property)
+                        && assignment.Value.Property == nextAssignment.Property)
                     {
                         // Property and value match ambiguous entity
                         assignment.Operation = AdaptiveEvents.ChooseEntity;
@@ -1382,7 +1382,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                             {
                                 assignments.Add(new EntityAssignment
                                 {
-                                    Entity = alternative,
+                                    Value = alternative,
                                     Operation = AdaptiveEvents.ChooseProperty,
                                     IsExpected = true
                                 });
@@ -1401,7 +1401,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     {
                         var assignment = new EntityAssignment
                         {
-                            Entity = alternative,
+                            Value = alternative,
                             Property = null,
                             Operation = alternative.Operation,
                             IsExpected = false
@@ -1432,7 +1432,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 {
                     assignment.Event = AdaptiveEvents.ChooseProperty;
                 }
-                else if (assignment.Entity.Value is JArray arr)
+                else if (assignment.Value.Value is JArray arr)
                 {
                     if (arr.Count > 1)
                     {
@@ -1441,7 +1441,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     else
                     {
                         assignment.Event = AdaptiveEvents.AssignEntity;
-                        assignment.Entity.Value = arr[0];
+                        assignment.Value.Value = arr[0];
                     }
                 }
                 else
@@ -1474,7 +1474,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                         candidate = null;
                         foreach (var mapping in choices)
                         {
-                            if (mapping.Entity.Name == entity)
+                            if (mapping.Value.Name == entity)
                             {
                                 candidate = mapping;
                                 break;
@@ -1484,7 +1484,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                         if (candidate != null)
                         {
                             // Remove any overlapping entities without a common root
-                            choices.RemoveAll(choice => choice == candidate || (!choice.Entity.SharesRoot(candidate.Entity) && choice.Entity.Overlaps(candidate.Entity)));
+                            choices.RemoveAll(choice => choice == candidate || (!choice.Value.SharesRoot(candidate.Value) && choice.Value.Overlaps(candidate.Value)));
                             yield return candidate;
                         }
                     }
@@ -1505,14 +1505,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             string operation = null;
             if (assignment.Property != null)
             {
-                if (askDefault != null && (askDefault.TryGetValue(assignment.Entity.Name, out var askOp) || askDefault.TryGetValue(string.Empty, out askOp)))
+                if (askDefault != null && (askDefault.TryGetValue(assignment.Value.Name, out var askOp) || askDefault.TryGetValue(string.Empty, out askOp)))
                 {
                     operation = askOp.Value<string>();
                 }
                 else if (dialogDefault != null
                         && (dialogDefault.TryGetValue(assignment.Property, out var entities)
                             || dialogDefault.TryGetValue(string.Empty, out entities))
-                        && ((entities as JObject).TryGetValue(assignment.Entity.Name, out var dialogOp)
+                        && ((entities as JObject).TryGetValue(assignment.Value.Name, out var dialogOp)
                             || (entities as JObject).TryGetValue(string.Empty, out dialogOp)))
                 {
                     operation = dialogOp.Value<string>();
@@ -1549,7 +1549,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                                 candidate.IsExpected descending,
                                 candidate.Operation == DefaultOperation(candidate, askDefaultOp, defaultOp) descending
                               select candidate).ToList();
-            var usedEntities = new HashSet<EntityInfo>(from candidate in candidates select candidate.Entity);
+            var usedEntities = new HashSet<EntityInfo>(from candidate in candidates select candidate.Value);
             List<string> expectedChoices = null;
             var choices = new List<EntityAssignment>();
             while (candidates.Any())
@@ -1558,25 +1558,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
                 // Alternatives are either for the same entity or from different roots
                 var alternatives = (from alt in candidates
-                                    where candidate.Entity.Overlaps(alt.Entity) && (!candidate.Entity.SharesRoot(alt.Entity) || candidate.Entity == alt.Entity)
+                                    where candidate.Value.Overlaps(alt.Value) && (!candidate.Value.SharesRoot(alt.Value) || candidate.Value == alt.Value)
                                     select alt).ToList();
                 candidates = candidates.Except(alternatives).ToList();
                 foreach (var alternative in alternatives)
                 {
-                    usedEntities.Add(alternative.Entity);
+                    usedEntities.Add(alternative.Value);
                 }
 
-                if (candidate.IsExpected && candidate.Entity.Name != UtteranceKey)
+                if (candidate.IsExpected && candidate.Value.Name != UtteranceKey)
                 {
                     // If expected binds entity, drop unexpected alternatives unless they have an explicit operation
-                    alternatives.RemoveAll(a => !a.IsExpected && a.Entity.Operation == null);
+                    alternatives.RemoveAll(a => !a.IsExpected && a.Value.Operation == null);
                 }
 
                 // Find alternative that covers the largest amount of utterance
-                candidate = (from alternative in alternatives orderby alternative.Entity.Name == UtteranceKey ? 0 : alternative.Entity.End - alternative.Entity.Start descending select alternative).First();
+                candidate = (from alternative in alternatives orderby alternative.Value.Name == UtteranceKey ? 0 : alternative.Value.End - alternative.Value.Start descending select alternative).First();
 
                 // Remove all alternatives that are fully contained in largest
-                alternatives.RemoveAll(a => candidate.Entity.Covers(a.Entity));
+                alternatives.RemoveAll(a => candidate.Value.Covers(a.Value));
 
                 var mapped = false;
                 if (candidate.Operation == AdaptiveEvents.ChooseEntity)
@@ -1584,21 +1584,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     // Property has resolution so remove entity ambiguity
                     var entityChoices = existing.Dequeue(actionContext);
                     candidate.Operation = entityChoices.Operation;
-                    if (candidate.Entity.Value is JArray values && values.Count > 1)
+                    if (candidate.Value.Value is JArray values && values.Count > 1)
                     {
                         // Resolve ambiguous response to one of the original choices
-                        var originalChoices = entityChoices.Entity.Value as JArray;
+                        var originalChoices = entityChoices.Value.Value as JArray;
                         var intersection = values.Intersect(originalChoices);
                         if (intersection.Any())
                         {
-                            candidate.Entity.Value = intersection;
+                            candidate.Value.Value = intersection;
                         }
                     }
                 }
                 else if (candidate.Operation == AdaptiveEvents.ChooseProperty)
                 {
                     choices = nextAssignment.Alternatives.ToList();
-                    var choice = choices.Find(a => MatchesAssignment(candidate.Entity, a));
+                    var choice = choices.Find(a => MatchesAssignment(candidate.Value, a));
                     if (choice != null)
                     {
                         // Resolve choice, pretend it was expected and add to assignments
@@ -1615,7 +1615,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                         }
 
                         AddAssignment(choice, assignments);
-                        choices.RemoveAll(c => c.Entity.Overlaps(choice.Entity));
+                        choices.RemoveAll(c => c.Value.Overlaps(choice.Value));
                         mapped = true;
                     }
                 }
@@ -1639,10 +1639,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 while (choices.Any())
                 {
                     var choice = choices.First();
-                    var overlaps = from alt in choices where choice.Entity.Overlaps(alt.Entity) select alt;
+                    var overlaps = from alt in choices where choice.Value.Overlaps(alt.Value) select alt;
                     choice.AddAlternatives(overlaps);
                     AddAssignment(choice, assignments);
-                    choices.RemoveAll(c => c.Entity.Overlaps(choice.Entity));
+                    choices.RemoveAll(c => c.Value.Overlaps(choice.Value));
                 }
 
                 existing.Dequeue(actionContext);
@@ -1664,15 +1664,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 foreach (var bAlt in b.Alternatives)
                 {
-                    if (aAlt.Property == bAlt.Property && aAlt.Entity.Value != null && bAlt.Entity.Value != null)
+                    if (aAlt.Property == bAlt.Property && aAlt.Value.Value != null && bAlt.Value.Value != null)
                     {
                         var prop = dialogSchema.PathToSchema(aAlt.Property);
                         if (!prop.IsArray)
                         {
-                            replaces = -aAlt.Entity.WhenRecognized.CompareTo(bAlt.Entity.WhenRecognized);
+                            replaces = -aAlt.Value.WhenRecognized.CompareTo(bAlt.Value.WhenRecognized);
                             if (replaces == 0)
                             {
-                                replaces = -aAlt.Entity.Start.CompareTo(bAlt.Entity.Start);
+                                replaces = -aAlt.Value.Start.CompareTo(bAlt.Value.Start);
                             }
 
                             if (replaces != 0)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignment.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 {
     /// <summary>
-    /// Possible assignment of an entity to a property.
+    /// Possible assignment of entities to operation, property and value.
     /// </summary>
     public class EntityAssignment
     {
@@ -18,25 +18,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public string Event { get; set; }
 
         /// <summary>
-        /// Gets or sets name of property being assigned.
+        /// Gets or sets property.
         /// </summary>
-        /// <value>Property being assigned.</value>
+        /// <value>Property.</value>
         [JsonProperty("property")]
         public string Property { get; set; }
 
         /// <summary>
-        /// Gets or sets operation to assign entity to property.
+        /// Gets or sets operation to apply to property and value.
         /// </summary>
-        /// <value>Operation to assign entity to property.</value>
+        /// <value>Operation.</value>
         [JsonProperty("operation")]
         public string Operation { get; set; }
 
         /// <summary>
-        /// Gets or sets entity being assigned.
+        /// Gets or sets recognized entity value.
         /// </summary>
-        /// <value>Entity being assigned.</value>
-        [JsonProperty("entity")]
-        public EntityInfo Entity { get; set; }
+        /// <value>Value.</value>
+        [JsonProperty("value")]
+        public EntityInfo Value { get; set; }
 
         /// <summary>
         /// Gets or sets an alternative assignment.
@@ -116,6 +116,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <returns>A string that represents the current object.</returns>
         public override string ToString()
-            => (IsExpected ? "+" : string.Empty) + $"{Event}: {Property} = {Operation}({Entity})";
+            => (IsExpected ? "+" : string.Empty) + $"{Event}: {Property} = {Operation}({Value})";
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignmentComparer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityAssignmentComparer.cs
@@ -52,11 +52,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     if (comparison == 0)
                     {
                         // Order by history
-                        comparison = x.Entity.WhenRecognized.CompareTo(y.Entity.WhenRecognized);
+                        comparison = x.Value.WhenRecognized.CompareTo(y.Value.WhenRecognized);
                         if (comparison == 0)
                         {
                             // Order by position in utterance
-                            comparison = x.Entity.Start.CompareTo(y.Entity.Start);
+                            comparison = x.Value.Start.CompareTo(y.Value.Start);
                         }
                     }
                 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnAssignEntity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnAssignEntity.schema
@@ -2,23 +2,23 @@
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
     "title": "On entity assignment",
-    "description": "Actions to take when an entity should be assigned to a property.",
+    "description": "Actions to apply an operation on a property and value.",
     "type": "object",
     "properties": {
-        "property": {
-            "type": "string",
-            "title": "Property",
-            "description": "Property that will be set after entity is selected."
-        },
-        "entity": {
-            "type": "string",
-            "title": "Entity",
-            "description": "Entity being put into property"
-        },
         "operation": {
             "type": "string",
             "title": "Operation",
-            "description": "Operation for assigning entity."
+            "description": "Operation filter on event."
+        },
+        "property": {
+            "type": "string",
+            "title": "Property",
+            "description": "Property filter on event."
+        },
+        "value": {
+            "type": "string",
+            "title": "Value",
+            "description": "Value filter on event."
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseEntity.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseEntity.schema
@@ -2,23 +2,23 @@
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
     "title": "On choose entity",
-    "description": "Actions to be performed when an entity value needs to be resolved.",
+    "description": "Actions to be performed when value is ambiguous for operator and property.",
     "type": "object",
     "properties": {
         "operation": {
             "type": "string",
             "title": "Operation",
-            "description": "Operation filter for event."
+            "description": "Operation filter on event."
         },
         "property": {
             "type": "string",
             "title": "Property",
-            "description": "Property filter for event."
+            "description": "Property filter on event."
         },
-        "entity": {
+        "value": {
             "type": "string",
-            "title": "Ambiguous entity",
-            "description": "Ambiguous entity"
+            "title": "Ambiguous value",
+            "description": "Ambiguous value filter on event."
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnAssignEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnAssignEntity.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Initializes a new instance of the <see cref="OnAssignEntity"/> class.
         /// </summary>
-        /// <param name="property">Optional, property to be assigned for filtering events.</param>
-        /// <param name="entity">Optional, entity name being assigned for filtering events.</param>
-        /// <param name="operation">Optional, operation being used to assign the entity for filtering events.</param>
+        /// <param name="property">Optional, property filter on event.</param>
+        /// <param name="val">Optional, value filter on event.</param>
+        /// <param name="operation">Optional, operation filter on event.</param>
         /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
         /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
-        public OnAssignEntity(string property = null, string entity = null, string operation = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public OnAssignEntity(string property = null, string val = null, string operation = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
                 @event: AdaptiveEvents.AssignEntity,
                 actions: actions,
@@ -38,28 +38,28 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 callerLine: callerLine)
         {
             Property = property;
-            Entity = entity;
+            Value = val;
             Operation = operation;
         }
 
         /// <summary>
-        /// Gets or sets the property to be assigned for filtering events.
+        /// Gets or sets the property filter on events.
         /// </summary>
-        /// <value>Property name.</value>
+        /// <value>Property.</value>
         [JsonProperty("property")]
         public string Property { get; set; }
 
         /// <summary>
-        /// Gets or sets the entity name being assigned for filtering events.
+        /// Gets or sets the value filter on events.
         /// </summary>
-        /// <value>Entity name.</value>
-        [JsonProperty("entity")]
-        public string Entity { get; set; }
+        /// <value>Value.</value>
+        [JsonProperty("value")]
+        public string Value { get; set; }
 
         /// <summary>
-        /// Gets or sets the operation being used to assign the entity for filtering events.
+        /// Gets or sets the operation filter on events.
         /// </summary>
-        /// <value>Operation name.</value>
+        /// <value>Operation.</value>
         [JsonProperty("operation")]
         public string Operation { get; set; }
 
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// </summary>
         /// <returns>String with the identity.</returns>
         public override string GetIdentity()
-            => $"{GetType().Name}({this.Property}, {this.Entity})";
+            => $"{GetType().Name}({this.Property}, {this.Value})";
 
         /// <inheritdoc/>
         protected override Expression CreateExpression()
@@ -79,9 +79,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.property == '{this.Property}'"));
             }
 
-            if (this.Entity != null)
+            if (this.Value != null)
             {
-                expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.entity.name == '{this.Entity}'"));
+                expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.value.name == '{this.Value}'"));
             }
 
             if (this.Operation != null)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnChooseEntity.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Initializes a new instance of the <see cref="OnChooseEntity"/> class.
         /// </summary>
-        /// <param name="property">Optional, property for filtering events.</param>
-        /// <param name="entity">Optional, entity for filtering events.</param>
-        /// <param name="operation">Optional, operation for filtering events.</param>
+        /// <param name="property">Optional, property filter on event.</param>
+        /// <param name="val">Optional, value filter on event.</param>
+        /// <param name="operation">Optional, operation filter on event.</param>
         /// <param name="actions">Optional, actions to add to the plan when the rule constraints are met.</param>
         /// <param name="condition">Optional, condition which needs to be met for the actions to be executed.</param>
         /// <param name="callerPath">Optional, source file full path.</param>
         /// <param name="callerLine">Optional, line number in source file.</param>
         [JsonConstructor]
-        public OnChooseEntity(string property = null, string entity = null, string operation = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+        public OnChooseEntity(string property = null, string val = null, string operation = null, List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(
                 @event: AdaptiveEvents.ChooseEntity,
                 actions: actions,
@@ -38,37 +38,37 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 callerLine: callerLine)
         {
             Property = property;
-            Entity = entity;
+            Value = val;
             Operation = operation;
         }
 
         /// <summary>
-        /// Gets or sets operation to filter ChooseEntity events.
+        /// Gets or sets operation filter on event.
         /// </summary>
-        /// <value>Property name.</value>
+        /// <value>Operation.</value>
         [JsonProperty("operation")]
         public string Operation { get; set; }
 
         /// <summary>
-        /// Gets or sets the property to filter ChooseEntity events.
+        /// Gets or sets the property filter on event.
         /// </summary>
-        /// <value>Property name.</value>
+        /// <value>Property.</value>
         [JsonProperty("property")]
         public string Property { get; set; }
 
         /// <summary>
-        /// Gets or sets the entity name that is ambiguous for filtering ChooseEntity events.
+        /// Gets or sets the value filter on event.
         /// </summary>
-        /// <value>Entity name.</value>
-        [JsonProperty("entity")]
-        public string Entity { get; set; }
+        /// <value>Value.</value>
+        [JsonProperty("value")]
+        public string Value { get; set; }
 
         /// <summary>
         /// Gets the identity for this rule's action.
         /// </summary>
         /// <returns>String with the identity.</returns>
         public override string GetIdentity()
-            => $"{GetType().Name}({this.Property}, {this.Entity})";
+            => $"{GetType().Name}({this.Property}, {this.Value})";
 
         /// <inheritdoc/>
         protected override Expression CreateExpression()
@@ -79,9 +79,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
                 expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.property == '{this.Property}'"));
             }
 
-            if (this.Entity != null)
+            if (this.Value != null)
             {
-                expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.entity.name == '{this.Entity}'"));
+                expressions.Add(Expression.Parse($"{TurnPath.DialogEvent}.value.value.name == '{this.Value}'"));
             }
 
             if (this.Operation != null)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskRetriesAssign.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskRetriesAssign.test.dialog
@@ -46,7 +46,7 @@
                 "$kind": "Microsoft.OnAssignEntity",
                 "operation": "Add()",
                 "property": "Bread",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskRetriesOnChooseEntity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskRetriesOnChooseEntity.test.dialog
@@ -60,7 +60,7 @@
                 "$kind": "Microsoft.OnAssignEntity",
                 "operation": "Add()",
                 "property": "Bread",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskRetriesOnChooseProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskRetriesOnChooseProperty.test.dialog
@@ -59,7 +59,7 @@
                 "$kind": "Microsoft.OnAssignEntity",
                 "operation": "Add()",
                 "property": "Meat",
-                "entity": "MeatEntity",
+                "value": "MeatEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/DefaultOp.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/DefaultOp.test.dialog
@@ -45,7 +45,7 @@
                 "$kind": "Microsoft.OnAssignEntity",
                 "operation": "Add()",
                 "property": "Bread",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AssignEntityTests/AddEntity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AssignEntityTests/AddEntity.test.dialog
@@ -45,7 +45,7 @@
         "$kind": "Microsoft.OnAssignEntity",
         "operation": "Add()",
         "property": "Bread",
-        "entity": "BreadEntity",
+        "value": "BreadEntity",
         "actions": [
           {
             "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AssignEntityTests/ClearEntity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AssignEntityTests/ClearEntity.test.dialog
@@ -37,7 +37,7 @@
         "$kind": "Microsoft.OnAssignEntity",
         "operation": "Add()",
         "property": "Bread",
-        "entity": "BreadEntity",
+        "value": "BreadEntity",
         "actions": [
           {
             "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AssignEntityTests/RemoveEntity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AssignEntityTests/RemoveEntity.test.dialog
@@ -37,7 +37,7 @@
         "$kind": "Microsoft.OnAssignEntity",
         "operation": "Add()",
         "property": "Toppings",
-        "entity": "ToppingsEntity",
+        "value": "ToppingsEntity",
         "actions": [
           {
             "$kind": "Microsoft.SendActivity",
@@ -55,7 +55,7 @@
         "$kind": "Microsoft.OnAssignEntity",
         "operation": "Remove()",
         "property": "Toppings",
-        "entity": "ToppingsEntity",
+        "value": "ToppingsEntity",
         "actions": [
           {
             "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/ChooseEntity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChooseEntityTests/ChooseEntity.test.dialog
@@ -61,7 +61,7 @@
                 "$kind": "Microsoft.OnAssignEntity",
                 "operation": "Add()",
                 "property": "Bread",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.SetProperty",
@@ -74,7 +74,7 @@
                 "$kind": "Microsoft.OnAssignEntity",
                 "operation": "Add()",
                 "property": "Bread2",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.SetProperty",
@@ -85,7 +85,7 @@
             },
             {
                 "$kind": "Microsoft.OnChooseEntity",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "actions": [
                     {
                         "$kind": "Microsoft.Ask",
@@ -99,7 +99,7 @@
             {
                 "$kind": "Microsoft.OnChooseEntity",
                 "property": "Bread2",
-                "entity": "BreadEntity",
+                "value": "BreadEntity",
                 "operation": "Add()",
                 "actions": [
                     {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChoosePropertyTests/ChooseProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ChoosePropertyTests/ChooseProperty.test.dialog
@@ -55,7 +55,7 @@
         "$kind": "Microsoft.OnAssignEntity",
         "operation": "Add()",
         "property": "Meat",
-        "entity": "MeatEntity",
+        "value": "MeatEntity",
         "actions": [
           {
             "$kind": "Microsoft.SendActivity",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/GeneratorTests/sandwich/en-us/library/sandwich-library-Choose.en-us.lg
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/GeneratorTests/sandwich/en-us/library/sandwich-library-Choose.en-us.lg
@@ -5,19 +5,19 @@
 # getChooseEnumEntityText(property)
 - ```
 ${getAutoHelpText()}
-Please choose a value for ${getPropertyNameText(property)} from [${join(foreach(turn.dialogEvent.value.entity.value, val, getEntityValueText(property, val)), ', ')}]
+Please choose a value for ${getPropertyNameText(property)} from [${join(foreach(turn.dialogEvent.value.value.value, val, getEntityValueText(property, val)), ', ')}]
 ```
 
 # getChooseEnumArrayEntityText(property)
 - ```
 ${getAutoHelpText()}
-Please choose a value for ${getPropertyNameText(property)} from [${join(foreach(turn.dialogEvent.value.entity.value, val, getEntityValueText(property, val)), ', ')}]
+Please choose a value for ${getPropertyNameText(property)} from [${join(foreach(turn.dialogEvent.value.value.value, val, getEntityValueText(property, val)), ', ')}]
 ``` 
 
 # getChoosePropertiesText
 - Did you mean ${join(foreach(turn.dialogevent.value, choice, getChoosePropertyEntityText(choice)), " or ")}?
 
 # getChoosePropertyEntityText(property)
-- ${displayOperation(property.operation, property.property, property.entity.text)}
+- ${displayOperation(property.operation, property.property, property.value.text)}
 
 > Generator: 93a3aa39268f6423f0103cd0f9d5a3c2

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/GeneratorTests/sandwich/sandwich.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/GeneratorTests/sandwich/sandwich.dialog
@@ -82,7 +82,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Quantity",
-      "entity": "number",
+      "value": "number",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -116,7 +116,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Quantity",
-      "entity": "number",
+      "value": "number",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -162,7 +162,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Length",
-      "entity": "dimension",
+      "value": "dimension",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -184,7 +184,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Length",
-      "entity": "dimension",
+      "value": "dimension",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -319,7 +319,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Name",
-      "entity": "personName",
+      "value": "personName",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -351,7 +351,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Name",
-      "entity": "personName",
+      "value": "personName",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -378,7 +378,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Name",
-      "entity": "utterance",
+      "value": "utterance",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -480,7 +480,7 @@
     },
     {
       "$kind": "Microsoft.OnChooseEntity",
-      "entity": "BreadEntity",
+      "value": "BreadEntity",
       "actions": [
         {
           "$kind": "Microsoft.Ask",
@@ -500,7 +500,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Bread",
-      "entity": "BreadEntity",
+      "value": "BreadEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -532,7 +532,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Bread",
-      "entity": "BreadEntity",
+      "value": "BreadEntity",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -629,7 +629,7 @@
     },
     {
       "$kind": "Microsoft.OnChooseEntity",
-      "entity": "MeatEntity",
+      "value": "MeatEntity",
       "actions": [
         {
           "$kind": "Microsoft.Ask",
@@ -649,7 +649,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Meat",
-      "entity": "MeatEntity",
+      "value": "MeatEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -681,7 +681,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Meat",
-      "entity": "MeatEntity",
+      "value": "MeatEntity",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -778,7 +778,7 @@
     },
     {
       "$kind": "Microsoft.OnChooseEntity",
-      "entity": "CheeseEntity",
+      "value": "CheeseEntity",
       "actions": [
         {
           "$kind": "Microsoft.Ask",
@@ -798,7 +798,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Cheese",
-      "entity": "CheeseEntity",
+      "value": "CheeseEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -830,7 +830,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Cheese",
-      "entity": "CheeseEntity",
+      "value": "CheeseEntity",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -927,7 +927,7 @@
     },
     {
       "$kind": "Microsoft.OnChooseEntity",
-      "entity": "ToppingsEntity",
+      "value": "ToppingsEntity",
       "actions": [
         {
           "$kind": "Microsoft.Ask",
@@ -947,7 +947,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Toppings",
-      "entity": "ToppingsEntity",
+      "value": "ToppingsEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -980,7 +980,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Toppings",
-      "entity": "ToppingsEntity",
+      "value": "ToppingsEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -1073,7 +1073,7 @@
     },
     {
       "$kind": "Microsoft.OnChooseEntity",
-      "entity": "SaucesEntity",
+      "value": "SaucesEntity",
       "actions": [
         {
           "$kind": "Microsoft.Ask",
@@ -1093,7 +1093,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Sauces",
-      "entity": "SaucesEntity",
+      "value": "SaucesEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -1126,7 +1126,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Sauces",
-      "entity": "SaucesEntity",
+      "value": "SaucesEntity",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -1168,7 +1168,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Add()",
       "property": "Price",
-      "entity": "money",
+      "value": "money",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
@@ -1190,7 +1190,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Remove()",
       "property": "Price",
-      "entity": "money",
+      "value": "money",
       "actions": [
         {
           "$kind": "Microsoft.IfCondition",
@@ -1253,7 +1253,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Set()",
       "property": "CancelConfirmation",
-      "entity": "boolean",
+      "value": "boolean",
       "actions": [
         {
           "$kind": "Microsoft.SetProperty",
@@ -1303,7 +1303,7 @@
       "$kind": "Microsoft.OnAssignEntity",
       "operation": "Set()",
       "property": "CompleteConfirmation",
-      "entity": "boolean",
+      "value": "boolean",
       "actions": [
         {
           "$kind": "Microsoft.SetProperty",
@@ -1343,7 +1343,7 @@
         {
           "$kind": "Microsoft.SetProperty",
           "property": "$PropertyToChange",
-          "value": "=turn.dialogEvent.value.entity.name"
+          "value": "=turn.dialogEvent.value.value.name"
         }
       ],
       "$designer": {
@@ -1360,7 +1360,7 @@
         {
           "$kind": "Microsoft.SetProperty",
           "property": "$PropertyToChange",
-          "value": "=turn.dialogEvent.value.entity.name"
+          "value": "=turn.dialogEvent.value.value.name"
         }
       ],
       "$designer": {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                     // In either case we try installing latest bf if the schema changed to make sure the
                     // discrepancy is not because we are using a different version of the CLI
                     // and we ensure it is installed while on it.
-                    error = RunCommand("/C npm i -g @microsoft/botframework-cli@next");
+                    error = RunCommand("/C npm i -g @microsoft/botframework-cli@next --force");
                     if (error.Length != 0)
                     {
                         throw new InvalidOperationException(error);

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -5595,7 +5595,7 @@
         "extends(Microsoft.OnCondition)"
       ],
       "title": "On entity assignment",
-      "description": "Actions to take when an entity should be assigned to a property.",
+      "description": "Actions to apply an operation on a property and value.",
       "type": "object",
       "required": [
         "$kind"
@@ -5608,20 +5608,20 @@
         }
       },
       "properties": {
-        "property": {
-          "type": "string",
-          "title": "Property",
-          "description": "Property that will be set after entity is selected."
-        },
-        "entity": {
-          "type": "string",
-          "title": "Entity",
-          "description": "Entity being put into property"
-        },
         "operation": {
           "type": "string",
           "title": "Operation",
-          "description": "Operation for assigning entity."
+          "description": "Operation filter on event."
+        },
+        "property": {
+          "type": "string",
+          "title": "Property",
+          "description": "Property filter on event."
+        },
+        "value": {
+          "type": "string",
+          "title": "Value",
+          "description": "Value filter on event."
         },
         "condition": {
           "$ref": "#/definitions/condition",
@@ -5802,7 +5802,7 @@
         "extends(Microsoft.OnCondition)"
       ],
       "title": "On choose entity",
-      "description": "Actions to be performed when an entity value needs to be resolved.",
+      "description": "Actions to be performed when value is ambiguous for operator and property.",
       "type": "object",
       "required": [
         "$kind"
@@ -5818,17 +5818,17 @@
         "operation": {
           "type": "string",
           "title": "Operation",
-          "description": "Operation filter for event."
+          "description": "Operation filter on event."
         },
         "property": {
           "type": "string",
           "title": "Property",
-          "description": "Property filter for event."
+          "description": "Property filter on event."
         },
-        "entity": {
+        "value": {
           "type": "string",
-          "title": "Ambiguous entity",
-          "description": "Ambiguous entity"
+          "title": "Ambiguous value",
+          "description": "Ambiguous value filter on event."
         },
         "condition": {
           "$ref": "#/definitions/condition",


### PR DESCRIPTION
Both operation and property are also entities so it was strange to have an entity property--renaming it to value makes the intent clearer.

