### PR TITLE
uischema: add Teams uischema to enable new kinds in Composer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMeetingParticipant.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMeetingParticipant.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMember.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMember.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedMembers.uischema
@@ -9,5 +9,8 @@
             "continuationToken",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedTeamMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedTeamMembers.uischema
@@ -10,5 +10,8 @@
             "continuationToken",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamChannels.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamChannels.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamDetails.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamDetails.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamMember.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamMember.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendAppBasedLinkQueryResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendAppBasedLinkQueryResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEActionResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEActionResponse.uischema
@@ -13,5 +13,8 @@
             "completionBotId",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAttachmentsResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAttachmentsResponse.uischema
@@ -10,5 +10,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAuthResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAuthResponse.uischema
@@ -9,5 +9,8 @@
             "resultProperty",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEBotMessagePreviewResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEBotMessagePreviewResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEConfigQuerySettingUrlResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEConfigQuerySettingUrlResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEMessageResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEMessageResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMESelectItemResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMESelectItemResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMessageToTeamsChannel.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMessageToTeamsChannel.uischema
@@ -10,5 +10,8 @@
             "conversationReferenceProperty",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabAuthResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabAuthResponse.uischema
@@ -9,5 +9,8 @@
             "resultProperty",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabCardResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabCardResponse.uischema
@@ -7,5 +7,8 @@
             "cards",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleCardResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleCardResponse.uischema
@@ -13,5 +13,8 @@
             "completionBotId",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleMessageResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleMessageResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleUrlResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleUrlResponse.uischema
@@ -14,5 +14,8 @@
             "completionBotId",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnAppBasedLinkQuery.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnAppBasedLinkQuery.uischema
@@ -15,7 +15,7 @@
       "submenu": {
         "label": "Microsoft Teams",
         "prompt": "Which Teams event?",
-        "placeholder": "Select a Teams event type",
+        "placeholder": "Select a Teams event type"
       }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnAppBasedLinkQuery.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnAppBasedLinkQuery.uischema
@@ -10,5 +10,12 @@
         ],
         "label": "Teams app based link query",
         "subtitle": "Invoke activity.name='composeExtension/queryLink'"
+    },
+    "trigger": {
+      "submenu": {
+        "label": "Microsoft Teams",
+        "prompt": "Which Teams event?",
+        "placeholder": "Select a Teams event type",
+      }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnCardAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnCardAction.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams card action invoke",
         "subtitle": "Invoke activity with no activity.name"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnFileConsent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnFileConsent.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewEdit.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewEdit.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension preview edit submit action",
         "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'edit'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - BotMessagePreviewEdit"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewSend.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewSend.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension preview send submit action",
         "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'send'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - BotMessagePreviewSend"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMECardButtonClicked.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMECardButtonClicked.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension card button clicked",
         "subtitle": "Invoke activity.name='composeExtension/onCardButtonClicked'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - car button clicked"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigQuerySettingUrl.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigQuerySettingUrl.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension configuration query setting url",
         "subtitle": "Invoke activity.name='composeExtension/querySettingUrl'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on config query setting url"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigSetting.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigSetting.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension configuration setting",
         "subtitle": "Invoke activity.name='composeExtension/setting'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on config setting"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEFetchTask.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEFetchTask.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension fetch task",
         "subtitle": "Invoke activity.name='composeExtension/fetchTask'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on fetch task"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEQuery.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEQuery.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension query",
         "subtitle": "Invoke activity.name='composeExtension/query'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on query"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESelectItem.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESelectItem.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension select item",
         "subtitle": "Invoke activity.name='composeExtension/selectItem'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on select item"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESubmitAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESubmitAction.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension submit action",
         "subtitle": "Invoke activity.name='composeExtension/submitAction'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on submit action"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams O365 connector card action",
         "subtitle": "Invoke activity.name='actionableMessage/executeAction'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabFetch.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabFetch.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams tab fetch",
         "subtitle": "Invoke activity.name='tab/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams task module fetch",
         "subtitle": "Invoke activity.name='task/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams task module submit",
         "subtitle": "Invoke activity.name='task/submit'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendHandoffActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendHandoffActivity.uischema
@@ -4,5 +4,12 @@
         "label": "Send a handoff request",
         "subtitle": "Send Handoff Activity",
         "helpLink": "https://aka.ms/bfc-send-handoff-activity"
+    },
+    "menu": {
+        "submenu": [ "Access external resources" ],
+        "label": "Send Handoff Event"
+    },
+    "flow": {
+        "widget": "ActionHeader"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnActivity.uischema
@@ -10,5 +10,14 @@
         ],
         "label": "Activities",
         "subtitle": "Activity received"
+    },
+    "trigger": {
+		"label": "Activities (Activity received)",
+		"order": 5.1,
+		"submenu": {
+			"label": "Activities",
+			"prompt": "Which activity type?",
+			"placeholder": "Select an activity type"
+		}
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnBeginDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnBeginDialog.uischema
@@ -10,5 +10,14 @@
         ],
         "label": "Dialog started",
         "subtitle": "Begin dialog event"
+    },
+    "trigger": {
+		"label": "Dialog started (Begin dialog event)",
+		"order": 4.1,
+		"submenu": {
+			"label": "Dialog events",
+			"prompt": "Which event?",
+			"placeholder": "Select an event type"
+		}
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCancelDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCancelDialog.uischema
@@ -10,5 +10,10 @@
         "hidden": [
             "actions"
         ]
+    },
+    "trigger": {
+		"label": "Dialog cancelled (Cancel dialog event)",
+		"order": 4.2,
+		"submenu": "Dialog events"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnChooseIntent.uischema
@@ -8,5 +8,9 @@
         "hidden": [
             "actions"
         ]
+    },
+    "trigger": {
+		"label": "Duplicated intents recognized",
+		"order": 6
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnConversationUpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnConversationUpdateActivity.uischema
@@ -12,5 +12,10 @@
         "subtitle": "ConversationUpdate activity",
         "description": "Handle the events fired when a user begins a new conversation with the bot.",
         "helpLink": "https://aka.ms/bf-composer-docs-conversation-update-activity"
-    }
+    },
+    "trigger": {
+		"label": "Greeting (ConversationUpdate activity)",
+		"order": 5.2,
+		"submenu": "Activities"
+	}
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnDialogEvent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnDialogEvent.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Dialog events",
         "subtitle": "Dialog event"
+    },
+    "trigger": {
+		"label": "Custom events",
+		"order": 7
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfConversationActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEndOfConversationActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Conversation ended",
         "subtitle": "EndOfConversation activity"
+    },
+    "trigger": {
+		"label": "Conversation ended (EndOfConversation activity)",
+		"order": 5.3,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Error occurred",
         "subtitle": "Error event"
+    },
+    "trigger": {
+		"label": "Error occurred (Error event)",
+		"order": 4.3,
+		"submenu": "Dialog events"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEventActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnEventActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Event received",
         "subtitle": "Event activity"
+    },
+    "trigger": {
+		"label": "Event received (Event activity)",
+		"order": 5.4,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnHandoffActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnHandoffActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Handover to human",
         "subtitle": "Handoff activity"
+    },
+    "trigger": {
+		"label": "Handover to human (Handoff activity)",
+		"order": 5.5,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnIntent.uischema
@@ -12,5 +12,9 @@
         "hidden": [
             "actions"
         ]
+    },
+    "trigger": {
+		"label": "Intent recognized",
+		"order": 1
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnInvokeActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnInvokeActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Conversation invoked",
         "subtitle": "Invoke activity"
+    },
+    "trigger": {
+		"label": "Conversation invoked (Invoke activity)",
+		"order": 5.6,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message received",
         "subtitle": "Message received activity"
+    },
+    "trigger": {
+		"label": "Message received (Message received activity)",
+		"order": 5.81,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageDeleteActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageDeleteActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message deleted",
         "subtitle": "Message deleted activity"
+    },
+    "trigger": {
+		"label": "Message deleted (Message deleted activity)",
+		"order": 5.82,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageReactionActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageReactionActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message reaction",
         "subtitle": "Message reaction activity"
+    },
+    "trigger": {
+		"label": "Message reaction (Message reaction activity)",
+		"order": 5.83,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageUpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnMessageUpdateActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Message updated",
         "subtitle": "Message updated activity"
+    },
+    "trigger": {
+		"label": "Message updated (Message updated activity)",
+		"order": 5.84,
+		"submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnQnAMatch.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnQnAMatch.uischema
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "label": "QnA Intent recognized",
+      "order": 2
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnRepromptDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnRepromptDialog.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "Re-prompt for input",
         "subtitle": "Reprompt dialog event"
+    },
+    "trigger": {
+		"label": "Re-prompt for input (Reprompt dialog event)",
+		"order": 4.4,
+		"submenu": "Dialog events"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnTypingActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnTypingActivity.uischema
@@ -10,5 +10,10 @@
         ],
         "label": "User is typing",
         "subtitle": "Typing activity"
+    },
+    "trigger": {
+		"label": "User is typing (Typing activity)",
+		"order": 5.7,
+        "submenu": "Activities"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnUnknownIntent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnUnknownIntent.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Unknown intent",
         "subtitle": "Unknown intent recognized"
+    },
+    "trigger": {
+		"label": "Unknown intent",
+		"order": 3
     }
 }

--- a/tests/tests.uischema
+++ b/tests/tests.uischema
@@ -709,6 +709,15 @@
         "*"
       ],
       "subtitle": "Activity received"
+    },
+    "trigger": {
+      "label": "Activities (Activity received)",
+      "order": 5.1,
+      "submenu": {
+        "label": "Activities",
+        "placeholder": "Select an activity type",
+        "prompt": "Which activity type?"
+      }
     }
   },
   "Microsoft.OnAssignEntity": {
@@ -735,6 +744,15 @@
         "*"
       ],
       "subtitle": "Begin dialog event"
+    },
+    "trigger": {
+      "label": "Dialog started (Begin dialog event)",
+      "order": 4.1,
+      "submenu": {
+        "label": "Dialog events",
+        "placeholder": "Select an event type",
+        "prompt": "Which event?"
+      }
     }
   },
   "Microsoft.OnCancelDialog": {
@@ -748,6 +766,11 @@
         "*"
       ],
       "subtitle": "Cancel dialog event"
+    },
+    "trigger": {
+      "label": "Dialog cancelled (Cancel dialog event)",
+      "order": 4.2,
+      "submenu": "Dialog events"
     }
   },
   "Microsoft.OnChooseEntity": {
@@ -770,6 +793,10 @@
         "condition",
         "*"
       ]
+    },
+    "trigger": {
+      "label": "Duplicated intents recognized",
+      "order": 6
     }
   },
   "Microsoft.OnCondition": {
@@ -798,6 +825,11 @@
         "*"
       ],
       "subtitle": "ConversationUpdate activity"
+    },
+    "trigger": {
+      "label": "Greeting (ConversationUpdate activity)",
+      "order": 5.2,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnDialogEvent": {
@@ -811,6 +843,10 @@
         "*"
       ],
       "subtitle": "Dialog event"
+    },
+    "trigger": {
+      "label": "Custom events",
+      "order": 7
     }
   },
   "Microsoft.OnEndOfActions": {
@@ -837,6 +873,11 @@
         "*"
       ],
       "subtitle": "EndOfConversation activity"
+    },
+    "trigger": {
+      "label": "Conversation ended (EndOfConversation activity)",
+      "order": 5.3,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnError": {
@@ -850,6 +891,11 @@
         "*"
       ],
       "subtitle": "Error event"
+    },
+    "trigger": {
+      "label": "Error occurred (Error event)",
+      "order": 4.3,
+      "submenu": "Dialog events"
     }
   },
   "Microsoft.OnEventActivity": {
@@ -863,6 +909,11 @@
         "*"
       ],
       "subtitle": "Event activity"
+    },
+    "trigger": {
+      "label": "Event received (Event activity)",
+      "order": 5.4,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnHandoffActivity": {
@@ -876,6 +927,11 @@
         "*"
       ],
       "subtitle": "Handoff activity"
+    },
+    "trigger": {
+      "label": "Handover to human (Handoff activity)",
+      "order": 5.5,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnInstallationUpdateActivity": {
@@ -904,6 +960,10 @@
         "*"
       ],
       "subtitle": "Intent recognized"
+    },
+    "trigger": {
+      "label": "Intent recognized",
+      "order": 1
     }
   },
   "Microsoft.OnInvokeActivity": {
@@ -917,6 +977,11 @@
         "*"
       ],
       "subtitle": "Invoke activity"
+    },
+    "trigger": {
+      "label": "Conversation invoked (Invoke activity)",
+      "order": 5.6,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnMessageActivity": {
@@ -930,6 +995,11 @@
         "*"
       ],
       "subtitle": "Message received activity"
+    },
+    "trigger": {
+      "label": "Message received (Message received activity)",
+      "order": 5.81,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnMessageDeleteActivity": {
@@ -943,6 +1013,11 @@
         "*"
       ],
       "subtitle": "Message deleted activity"
+    },
+    "trigger": {
+      "label": "Message deleted (Message deleted activity)",
+      "order": 5.82,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnMessageReactionActivity": {
@@ -956,6 +1031,11 @@
         "*"
       ],
       "subtitle": "Message reaction activity"
+    },
+    "trigger": {
+      "label": "Message reaction (Message reaction activity)",
+      "order": 5.83,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnMessageUpdateActivity": {
@@ -969,6 +1049,17 @@
         "*"
       ],
       "subtitle": "Message updated activity"
+    },
+    "trigger": {
+      "label": "Message updated (Message updated activity)",
+      "order": 5.84,
+      "submenu": "Activities"
+    }
+  },
+  "Microsoft.OnQnAMatch": {
+    "trigger": {
+      "label": "QnA Intent recognized",
+      "order": 2
     }
   },
   "Microsoft.OnRepromptDialog": {
@@ -982,6 +1073,11 @@
         "*"
       ],
       "subtitle": "Reprompt dialog event"
+    },
+    "trigger": {
+      "label": "Re-prompt for input (Reprompt dialog event)",
+      "order": 4.4,
+      "submenu": "Dialog events"
     }
   },
   "Microsoft.OnTypingActivity": {
@@ -995,6 +1091,11 @@
         "*"
       ],
       "subtitle": "Typing activity"
+    },
+    "trigger": {
+      "label": "User is typing (Typing activity)",
+      "order": 5.7,
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnUnknownIntent": {
@@ -1008,6 +1109,10 @@
         "*"
       ],
       "subtitle": "Unknown intent recognized"
+    },
+    "trigger": {
+      "label": "Unknown intent",
+      "order": 3
     }
   },
   "Microsoft.QnAMakerDialog": {
@@ -1080,10 +1185,19 @@
     }
   },
   "Microsoft.SendHandoffActivity": {
+    "flow": {
+      "widget": "ActionHeader"
+    },
     "form": {
       "helpLink": "https://aka.ms/bfc-send-handoff-activity",
       "label": "Send a handoff request",
       "subtitle": "Send Handoff Activity"
+    },
+    "menu": {
+      "label": "Send Handoff Event",
+      "submenu": [
+        "Access external resources"
+      ]
     }
   },
   "Microsoft.SetProperties": {

--- a/tests/tests.uischema
+++ b/tests/tests.uischema
@@ -1370,6 +1370,22 @@
       "subtitle": "Update Activity"
     }
   },
+  "Teams.GetMeetingParticipant": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetMember": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
   "Teams.GetPagedMembers": {
     "form": {
       "label": "Get paged members",
@@ -1380,6 +1396,12 @@
         "*"
       ],
       "subtitle": "Gets members of a one-on-one, group, or team conversation."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
     }
   },
   "Teams.GetPagedTeamMembers": {
@@ -1393,6 +1415,36 @@
         "*"
       ],
       "subtitle": "Gets members for a team conversation."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetTeamChannels": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetTeamDetails": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetTeamMember": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
     }
   },
   "Teams.OnAppBasedLinkQuery": {
@@ -1406,6 +1458,13 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/queryLink'"
+    },
+    "trigger": {
+      "submenu": {
+        "label": "Microsoft Teams",
+        "placeholder": "Select a Teams event type",
+        "prompt": "Which Teams event?"
+      }
     }
   },
   "Teams.OnCardAction": {
@@ -1419,6 +1478,34 @@
         "*"
       ],
       "subtitle": "Invoke activity with no activity.name"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelCreated": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelDeleted": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelRenamed": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelRestored": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnFileConsent": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEBotMessagePreviewEdit": {
@@ -1432,6 +1519,10 @@
         "*"
       ],
       "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'edit'"
+    },
+    "trigger": {
+      "label": "Messaging extension - BotMessagePreviewEdit",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEBotMessagePreviewSend": {
@@ -1445,6 +1536,10 @@
         "*"
       ],
       "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'send'"
+    },
+    "trigger": {
+      "label": "Messaging extension - BotMessagePreviewSend",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMECardButtonClicked": {
@@ -1458,6 +1553,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/onCardButtonClicked'"
+    },
+    "trigger": {
+      "label": "Messaging extension - car button clicked",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEConfigQuerySettingUrl": {
@@ -1471,6 +1570,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/querySettingUrl'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on config query setting url",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEConfigSetting": {
@@ -1484,6 +1587,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/setting'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on config setting",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEFetchTask": {
@@ -1497,6 +1604,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/fetchTask'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on fetch task",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEQuery": {
@@ -1510,6 +1621,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/query'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on query",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMESelectItem": {
@@ -1523,6 +1638,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/selectItem'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on select item",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMESubmitAction": {
@@ -1536,6 +1655,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/submitAction'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on submit action",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnO365ConnectorCardAction": {
@@ -1549,6 +1672,9 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='actionableMessage/executeAction'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnTabFetch": {
@@ -1562,6 +1688,14 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='tab/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTabSubmit": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnTaskModuleFetch": {
@@ -1575,6 +1709,9 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='task/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnTaskModuleSubmit": {
@@ -1588,6 +1725,34 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='task/submit'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamArchived": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamDeleted": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamRenamed": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamRestored": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamUnarchived": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.SendAppBasedLinkQueryResponse": {
@@ -1600,6 +1765,12 @@
         "*"
       ],
       "subtitle": "Send a response to a query link request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendMEActionResponse": {
@@ -1616,6 +1787,12 @@
         "*"
       ],
       "subtitle": "Send a response for a messaging extension request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEAttachmentsResponse": {
@@ -1629,6 +1806,12 @@
         "*"
       ],
       "subtitle": "Send an invoke response containing one or more attachments to a messaging extension request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEAuthResponse": {
@@ -1641,6 +1824,12 @@
         "*"
       ],
       "subtitle": "Send a response to a messaging extensin requiring auth."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEBotMessagePreviewResponse": {
@@ -1653,6 +1842,12 @@
         "*"
       ],
       "subtitle": "Send a bot message preview response to a messaging extension request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEConfigQuerySettingUrlResponse": {
@@ -1665,6 +1860,12 @@
         "*"
       ],
       "subtitle": "Send a response to a query setting config url request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEMessageResponse": {
@@ -1677,6 +1878,12 @@
         "*"
       ],
       "subtitle": "Send a message response containing text only."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMESelectItemResponse": {
@@ -1689,6 +1896,12 @@
         "*"
       ],
       "subtitle": "Send a messaging extension response when an item is selected"
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMessageToTeamsChannel": {
@@ -1702,6 +1915,12 @@
         "*"
       ],
       "subtitle": "Create a thread and send a message to a teams channel."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTabAuthResponse": {
@@ -1714,6 +1933,12 @@
         "*"
       ],
       "subtitle": "Send a response to a cards tab requiring auth."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTabCardResponse": {
@@ -1724,6 +1949,12 @@
         "*"
       ],
       "subtitle": "Send a tab continue response containing adaptive cards."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTaskModuleCardResponse": {
@@ -1740,6 +1971,12 @@
         "*"
       ],
       "subtitle": "Send a continue response containing a card."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTaskModuleMessageResponse": {
@@ -1752,6 +1989,12 @@
         "*"
       ],
       "subtitle": "Send a message response containing text only."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTaskModuleUrlResponse": {
@@ -1769,6 +2012,12 @@
         "*"
       ],
       "subtitle": "Send a continue response containing a url."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   }
 }


### PR DESCRIPTION
#minor

## Description
Add uischema options for Teams kinds to enable them in Composer.

## Changes
1. Add 'menu' uischema for all Teams Actions to enable them under 'Microsoft Teams' label when creating an action
2. Add 'trigger' uischema for all Teams TriggerConditions to enable them under 'Microsoft Teams' when creating a trigger
3. Update the `test.uischema` with the newest generated version

< Screenshots >
![image](https://user-images.githubusercontent.com/8528761/108539482-062f3380-731b-11eb-8b79-637bf55f3b69.png)
![image](https://user-images.githubusercontent.com/8528761/108539505-0fb89b80-731b-11eb-96fa-b05bbb7e7ff2.png)
