### PR TITLE
fix the bug about built-in function 'titleCase'

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/TitleCase.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/TitleCase.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace AdaptiveExpressions.BuiltinFunctions
@@ -40,6 +41,16 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     var ti = locale.TextInfo;
                     result = ti.ToTitleCase(inputStr);
+
+                    // Case that starts with number.
+                    result = Regex.Replace(
+                        result,
+                        "([0-9]+[a-zA-Z]+)",
+                        new MatchEvaluator((m) =>
+                        {
+                            return m.Captures[0].Value.ToLower(locale);
+                        }),
+                        RegexOptions.IgnoreCase);
                 }
             }
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -352,6 +352,7 @@ namespace AdaptiveExpressions.Tests
             Test("sentenceCase('aBC', 'fr-FR')", "Abc"),
             Test("titleCase('a', 'en-US')", "A"),
             Test("titleCase('abc dEF', 'en-US')", "Abc Def"),
+            Test("titleCase('today, February 17th', 'en-US')", "Today, February 17th"),
             #endregion
 
             #region accessor and element


### PR DESCRIPTION
Fixes #5235

## Description
The default [ToTitleCase](https://docs.microsoft.com/en-us/dotnet/api/system.globalization.textinfo.totitlecase?view=netcore-3.1) could not cover all cases. It would convert the first letter following the number to the upper case. It is not correct.

## Specific Changes
Add additional rules to make `titleCase` more accurate.

