### PR TITLE
Fixing synonym parsing in list entity

### DIFF
--- a/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/NewEntitySection.cs
+++ b/libraries/Parsers/Microsoft.Bot.Builder.Parsers.LU/NewEntitySection.cs
@@ -167,12 +167,13 @@ namespace Microsoft.Bot.Builder.Parsers.LU
                     }
                     else
                     {
-                        var splitedStr = trimedItemStr.Split('-');
-                        bodyElement.Synonyms.Add(splitedStr[1].Trim());
+                        var index = trimedItemStr.IndexOf('-');
+                        var synonym = trimedItemStr.Remove(index, 1);
+                        bodyElement.Synonyms.Add(synonym.Trim());
 
                         if (bodyElement.NormalizedValue == null) 
                         {
-                            bodyElement.NormalizedValue = splitedStr[1].Trim();
+                            bodyElement.NormalizedValue = synonym.Trim();
                         }
                     }
                 }

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Fixtures/testLU310.json
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Fixtures/testLU310.json
@@ -1,0 +1,38 @@
+{
+  "sections": [
+    {
+      "Errors": [
+
+      ],
+      "SectionType": "NewEntitySection",
+      "Id": "newEntitySection_l_new_customtype",
+      "Body": "",
+      "Name": "l_new_customtype",
+      "Range": {
+        "Start": {
+          "Line": 2,
+          "Character": 0
+        },
+        "End": {
+          "Line": 6,
+          "Character": 21
+        }
+      },
+      "Type": "list",
+      "SynonymsList": [
+        {
+          "NormalizedValue": "o_32b332a7",
+          "Synonyms": [
+            "Power Apps",
+            "Model - driven app",
+            "Canvas App"
+          ]
+        }
+      ]
+    }
+  ],
+  "content": "> Power Platform Product\n@ list l_new_customtype =\n    -o_32b332a7 :\n        - Power Apps\n        - Model - driven app\n        - Canvas App\n",
+  "errors": [
+
+  ]
+}

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Fixtures/testLU310.txt
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Fixtures/testLU310.txt
@@ -1,0 +1,6 @@
+﻿> Power Platform Product
+@ list l_new_customtype =
+    -o_32b332a7 :
+        - Power Apps
+        - Model - driven app
+        - Canvas App

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
@@ -65,6 +65,12 @@
     <None Update="Fixtures\testLU3.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\testLU310.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\testLU310.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\testLU4.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Parser/LuParserTests.cs
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Parser/LuParserTests.cs
@@ -354,6 +354,7 @@ namespace Microsoft.Bot.Builder.Parsers.LU.Tests.Parser
         [InlineData("testLU307")]
         [InlineData("testLU308")]
         [InlineData("testLU309")]
+        [InlineData("testLU310")]
         public void ParseLuContentAutomated(string fileName)
         {
             var path = Path.Combine(Directory.GetCurrentDirectory(), "Fixtures", fileName + ".txt");


### PR DESCRIPTION
PVA reported and issue when parsing list entities with dashes in the synonyms list.
The fix changes the parsing of the synonym String and adds a test to cover this scenario.
