### PR TITLE
cherry-pick to 4.12: Runtime: Fix bug in CoreAdapter registration. SkillHttpClient needs a BotAdapter registered

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -146,8 +146,11 @@ namespace Microsoft.Bot.Builder.Integration.Runtime.Extensions
             services.AddSingleton<IChannelProvider, ConfigurationChannelProvider>();
 
             // CoreAdapter registration
+            services.AddSingleton<CoreBotAdapter>();
             services.AddSingleton<IBotFrameworkHttpAdapter, CoreBotAdapter>();
-            services.AddSingleton<BotAdapter>(sp => sp.GetService<CoreBotAdapter>());
+
+            // Needed for SkillsHttpClient which depends on BotAdapter
+            services.AddSingleton<BotAdapter, CoreBotAdapter>(); 
             
             // Adapter settings so the default adapter is homogeneous with the configured adapters at the controller / registration level
             services.AddSingleton(new AdapterSettings() { Route = defaultRoute, Enabled = true, Name = typeof(CoreBotAdapter).FullName });

--- a/tests/integration/Microsoft.Bot.Builder.Integration.Runtime.Tests/Extensions/AdapterRegistrationTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.Runtime.Tests/Extensions/AdapterRegistrationTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Integration.Runtime;
+using Microsoft.Bot.Builder.Integration.Runtime.Extensions;
+using Microsoft.Bot.Builder.Integration.Runtime.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
+{
+    public class AdapterRegistrationTests
+    {
+        [Fact]
+        public void CoreBotAdapterRegistered()
+        {
+            // Setup
+            IServiceCollection services = new ServiceCollection();
+            IConfiguration configuration = new ConfigurationBuilder().Build();
+
+            // We do this here since in asp.net core world this is done for us, but here we need to do it manually.
+            services.AddSingleton(configuration);
+
+            // Test
+            services.AddBotRuntime(configuration);
+
+            // Assert
+            var provider = services.BuildServiceProvider();
+
+            // Core adapter should be register for as IBotFrameworkHttpAdapter for controllers
+            Assertions.AssertService<IBotFrameworkHttpAdapter, CoreBotAdapter>(services, provider, ServiceLifetime.Singleton);
+
+            // Core adapter should be register for as BotAdapter for Skill HttpClient
+            Assertions.AssertService<BotAdapter, CoreBotAdapter>(services, provider, ServiceLifetime.Singleton);
+
+            // Adapter settings should be registered for multi-adapter controllers.
+            Assertions.AssertService<AdapterSettings>(
+                services, 
+                provider, 
+                ServiceLifetime.Singleton, 
+                adapterSettings =>
+                {
+                    Assert.Equal("messages", adapterSettings.Route);
+                    Assert.Equal(typeof(CoreBotAdapter).FullName, adapterSettings.Name);
+                    Assert.True(adapterSettings.Enabled);
+                });
+        }
+    }
+}


### PR DESCRIPTION
Runtime: Fix bug in CoreAdapter registration. SkillHttpClient needs a BotAdapter registered (#5241)

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->