### PR TITLE
Assign a default  TemplateEngineLanguageGenerator to Generator

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
@@ -85,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// Language Generator override.
         /// </value>
         [JsonProperty("generator")]
-        public LanguageGenerator Generator { get; set; }
+        public LanguageGenerator Generator { get; set; } = new TemplateEngineLanguageGenerator();
 
         /// <summary>
         /// Gets or sets trigger handlers to respond to conditions which modifying the executing plan. 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -731,10 +731,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             {
                 dialogContext.Services.Set(this.Generator);
             }
-            else if (Generator == null && dialogContext.Services.Get<LanguageGenerator>() == null)
-            {
-                dialogContext.Services.Set(new TemplateEngineLanguageGenerator());
-            }
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// Language Generator override.
         /// </value>
         [JsonProperty("generator")]
-        public LanguageGenerator Generator { get; set; } = new TemplateEngineLanguageGenerator();
+        public LanguageGenerator Generator { get; set; }
 
         /// <summary>
         /// Gets or sets trigger handlers to respond to conditions which modifying the executing plan. 
@@ -730,6 +730,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             if (Generator != null)
             {
                 dialogContext.Services.Set(this.Generator);
+            }
+            else if (Generator == null && dialogContext.Services.Get<LanguageGenerator>() == null)
+            {
+                dialogContext.Services.Set(new TemplateEngineLanguageGenerator());
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors;
 using Microsoft.Bot.Builder.Dialogs.Debugging;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/ActivityTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/ActivityTemplate.cs
@@ -71,20 +71,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
 
             if (!string.IsNullOrEmpty(this.Template))
             {
-                var languageGenerator = dialogContext.Services.Get<LanguageGenerator>();
-                if (languageGenerator != null)
-                {
-                    var lgStringResult = await languageGenerator.GenerateAsync(dialogContext, this.Template, data ?? dialogContext.State, cancellationToken).ConfigureAwait(false);
-                    var result = ActivityFactory.FromObject(lgStringResult);
-                    return result;
-                }
-                else
-                {
-                    var message = Activity.CreateMessageActivity();
-                    message.Text = this.Template;
-                    message.Speak = this.Template;
-                    return message as Activity;
-                }
+                var languageGenerator = dialogContext.Services.Get<LanguageGenerator>() ?? new TemplateEngineLanguageGenerator();
+                var lgStringResult = await languageGenerator.GenerateAsync(dialogContext, this.Template, data ?? dialogContext.State, cancellationToken).ConfigureAwait(false);
+                var result = ActivityFactory.FromObject(lgStringResult);
+                return result;
             }
 
             return null;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Templates/TextTemplate.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
@@ -64,18 +65,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Templates
                 throw new InvalidOperationException($"The {nameof(this.Template)} property can't be empty.");
             }
 
-            var languageGenerator = dialogContext.Services.Get<LanguageGenerator>();
-            if (languageGenerator != null)
-            {
-                var result = await languageGenerator.GenerateAsync(
-                    dialogContext,
-                    template: Template,
-                    data: data ?? dialogContext.State,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-                return result.ToString();
-            }
-
-            return null;
+            var languageGenerator = dialogContext.Services.Get<LanguageGenerator>() ?? new TemplateEngineLanguageGenerator();
+            var result = await languageGenerator.GenerateAsync(
+                                dialogContext,
+                                template: Template,
+                                data: data ?? dialogContext.State,
+                                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return result.ToString();
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal("default2", await lg.GenerateAsync(GetDialogContext("foo", lg), "${test2()}", null));
         }
 
-        public class TestLanguageGeneratorMiddlewareDialog : AdaptiveDialog
+        public class TestLanguageGeneratorMiddlewareDialog : Dialog
         {
             public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext dialogContext, object options = null, CancellationToken cancellationToken = default)
             {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             Assert.Equal("default2", await lg.GenerateAsync(GetDialogContext("foo", lg), "${test2()}", null));
         }
 
-        public class TestLanguageGeneratorMiddlewareDialog : Dialog
+        public class TestLanguageGeneratorMiddlewareDialog : AdaptiveDialog
         {
             public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext dialogContext, object options = null, CancellationToken cancellationToken = default)
             {
@@ -372,6 +372,33 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             .Send("turn4")
                 .AssertReply("ContinueDialog test3:subDialog.lg")
                 .AssertReply("Done")
+            .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task TestLGWithDefaultGenerator()
+        {
+            var dialog = new AdaptiveDialog()
+            {
+                Triggers = new List<OnCondition>()
+                {
+                    new OnBeginDialog()
+                    {
+                        Actions = new List<Dialog>()
+                        {
+                            new SendActivity("hi ${titleCase('jack')}")
+                        }
+                    }
+                }
+            };
+
+            DialogManager dm = new DialogManager(dialog);
+            await CreateFlow(async (turnContext, cancellationToken) =>
+            {
+                await dm.OnTurnAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+            })
+            .Send("hi")
+                .AssertReply("hi Jack")
             .StartTestAsync();
         }
 


### PR DESCRIPTION
Fixes #5102

## Description
Originally, while user wants to apply LG template feature in AdaptiveDialog, he/she should add a specific LG resource in `Generator` property.
It does not align with the current design pattern. It's good to have the data binding work ootb, and by adding a default empty TemplateEngine, AdaptiveDialog can leverage the capability of LG engine to do data binding (though lg file is empty). That's also kind of naturally aligned with current design
