### PR TITLE
Switch priority in triggers to float type

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -1029,7 +1029,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 // Utterance is a special entity that corresponds to the full utterance
                 entities[UtteranceKey] = new List<EntityInfo>
                 {
-                    new EntityInfo { Priority = int.MaxValue, Coverage = 1.0, Start = 0, End = utterance.Length, Name = UtteranceKey, Score = 0.0, Type = "string", Value = utterance, Text = utterance }
+                    new EntityInfo { Priority = float.MaxValue, Coverage = 1.0, Start = 0, End = utterance.Length, Name = UtteranceKey, Score = 0.0, Type = "string", Value = utterance, Text = utterance }
                 };
                 var recognized = AssignEntities(actionContext, entities, assignments, lastEvent);
                 var unrecognized = SplitUtterance(utterance, recognized);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/EntityInfo.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// </summary>
         /// <value>Relative priority of entity.</value>
         [JsonProperty("priority")]
-        public int Priority { get; set; }
+        public float Priority { get; set; }
 
         /// <summary>
         /// Gets or sets how much 0-1.0 of the original utterance is covered by entity.

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCondition.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnCondition.schema
@@ -22,7 +22,7 @@
             }
         },
         "priority": {
-            "$ref": "schema:#/definitions/integerExpression",
+            "$ref": "schema:#/definitions/numberExpression",
             "title": "Priority",
             "description": "Priority for trigger with 0 being the highest and < 0 ignored."
         },

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Selectors/FirstSelector.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Selectors
         public override Task<IReadOnlyList<OnCondition>> SelectAsync(ActionContext context, CancellationToken cancellationToken)
         {
             OnCondition selection = null;
-            var lowestPriority = int.MaxValue;
+            var lowestPriority = float.MaxValue;
             if (_evaluate)
             {
                 for (var i = 0; i < _conditionals.Count; i++)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnCondition.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// </summary>
         /// <value>Priority of condition expression.</value>
         [JsonProperty("priority")]
-        public IntExpression Priority { get; set; } = new IntExpression();
+        public NumberExpression Priority { get; set; } = new NumberExpression();
 
         /// <summary>
         /// Gets or sets a value indicating whether rule should only run once per unique set of memory paths.
@@ -154,7 +154,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// </summary>
         /// <param name="actionContext">Context to use for evaluation.</param>
         /// <returns>Computed priority.</returns>
-        public int CurrentPriority(ActionContext actionContext)
+        public float CurrentPriority(ActionContext actionContext)
         {
             var (priority, error) = this.Priority.TryGetValue(actionContext.State);
             if (error != null)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/SelectorTests.cs
@@ -64,5 +64,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
+
+        [Fact]
+        public async Task SelectorTests_Float_Priority()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/SelectorTests/SelectorTests_Float_Priority.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/SelectorTests/SelectorTests_Float_Priority.test.dialog
@@ -1,0 +1,80 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "$kind": "Microsoft.IntentPattern",
+                    "intent": "a",
+                    "pattern": "a"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "a",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "rule1"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.a",
+                        "value": "=1.2"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "a",
+                "priority": "=user.a + 1.1",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "rule2"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "a",
+                "priority": "=user.a",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "rule3"
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": false,
+        "selector": {
+            "$kind": "Microsoft.FirstSelector"
+        },
+        "defaultResultProperty": "dialog.result"
+    },
+    "locale": "en-us",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "a"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "rule1"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "a"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "rule3"
+        }
+    ]
+}


### PR DESCRIPTION
closes: #5082 
Now the priority in triggers is float number, where 0 is the highest and less than 0 is ignored.

The `priority` property in OnCondition now is NumberExpression, the default value is 0.
