### PR TITLE
Make syntax error message more readable in Expression

### DIFF
--- a/libraries/AdaptiveExpressions/parser/ParserErrorListener.cs
+++ b/libraries/AdaptiveExpressions/parser/ParserErrorListener.cs
@@ -29,7 +29,8 @@ namespace AdaptiveExpressions
         /// <param name="e">The RecognitionException.</param>
         public override void SyntaxError(TextWriter output, IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
         {
-            throw new SyntaxErrorException(msg) { Source = $"({line}:{charPositionInLine})", };
+            var syntaxErrorMessage = "Invalid expression format.";
+            throw new SyntaxErrorException(syntaxErrorMessage) { Source = $"({line}:{charPositionInLine})", };
         }
     }
 }

--- a/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
+++ b/tests/AdaptiveExpressions.Tests/BadExpressionTests.cs
@@ -16,7 +16,6 @@ namespace AdaptiveExpressions.Tests
             Test("fun(a, b, c"),
             Test("func(A,b,b,)"),
             Test("\"hello'"),
-            Test("'hello'.length()"), // not supported currently
             Test("user.lists.{dialog.listName}"),
             Test("`hi` world")
         };
@@ -29,6 +28,7 @@ namespace AdaptiveExpressions.Tests
             Test("a.func()"), // no such function
             Test("(1.foreach)()"), // error func
             Test("('str'.foreach)()"), // error func
+            Test("'hello'.length()"), // not supported currently
             #endregion
 
             #region Operators test
@@ -486,7 +486,8 @@ namespace AdaptiveExpressions.Tests
         [MemberData(nameof(SyntaxErrorExpressions))]
         public void ParseSyntaxErrors(string exp)
         {
-            Assert.Throws<SyntaxErrorException>(() => Expression.Parse(exp));
+            var exception = Assert.Throws<SyntaxErrorException>(() => Expression.Parse(exp));
+            Assert.Equal("Invalid expression format.", exception.Message);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #5256

## Description
The error thrown by `Antlr` is not readable for non-developer users. Change it to the general expression format error.