### PR TITLE
Johtaylo/dialogrunasync

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Dialogs.Memory;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
@@ -34,12 +36,61 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken).ConfigureAwait(false);
 
+            // drop the return value - the whole point of this function is that the caller doesn't care
+            await InternalRunAsync(turnContext, dialog.Id, dialogContext, cancellationToken).ConfigureAwait(false);
+        }
+
+        internal static async Task<DialogTurnResult> InternalRunAsync(ITurnContext turnContext, string dialogId, DialogContext dialogContext, CancellationToken cancellationToken)
+        {
             // map TurnState into root dialog context.services
             foreach (var service in turnContext.TurnState)
             {
                 dialogContext.Services[service.Key] = service.Value;
             }
 
+            var dialogStateManager = new DialogStateManager(dialogContext);
+            await dialogStateManager.LoadAllScopesAsync(cancellationToken).ConfigureAwait(false);
+            dialogContext.Context.TurnState.Add(dialogStateManager);
+
+            DialogTurnResult dialogTurnResult = null;
+
+            // Loop as long as we are getting valid OnError handled we should continue executing the actions for the turn.
+            //
+            // NOTE: We loop around this block because each pass through we either complete the turn and break out of the loop
+            // or we have had an exception AND there was an OnError action which captured the error.  We need to continue the 
+            // turn based on the actions the OnError handler introduced.
+            var endOfTurn = false;
+            while (!endOfTurn)
+            {
+                try
+                {
+                    dialogTurnResult = await InnerRunAsync(turnContext, dialogId, dialogContext, cancellationToken).ConfigureAwait(false);
+
+                    // turn successfully completed, break the loop
+                    endOfTurn = true;
+                }
+                catch (Exception err)
+                {
+                    // fire error event, bubbling from the leaf.
+                    var handled = await dialogContext.EmitEventAsync(DialogEvents.Error, err, bubble: true, fromLeaf: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                    if (!handled)
+                    {
+                        // error was NOT handled, throw the exception and end the turn. (This will trigger the Adapter.OnError handler and end the entire dialog stack)
+                        throw;
+                    }
+                }
+            }
+
+            // save all state scopes to their respective botState locations.
+            await dialogStateManager.SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // return the redundant result because the DialogManager contract expects it
+            return dialogTurnResult;
+        }
+
+        private static async Task<DialogTurnResult> InnerRunAsync(ITurnContext turnContext, string dialogId, DialogContext dialogContext, CancellationToken cancellationToken)
+        {
             // Handle EoC and Reprompt event from a parent bot (can be root bot to skill or skill to skill)
             if (IsFromParentToSkill(turnContext))
             {
@@ -49,15 +100,13 @@ namespace Microsoft.Bot.Builder.Dialogs
                     if (!dialogContext.Stack.Any())
                     {
                         // No dialogs to cancel, just return.
-                        return;
+                        return new DialogTurnResult(DialogTurnStatus.Empty);
                     }
 
                     var activeDialogContext = GetActiveDialogContext(dialogContext);
 
                     // Send cancellation message to the top dialog in the stack to ensure all the parents are canceled in the right order. 
-                    await activeDialogContext.CancelAllDialogsAsync(true, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                    return;
+                    return await activeDialogContext.CancelAllDialogsAsync(true, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
 
                 // Handle a reprompt event sent from the parent.
@@ -66,11 +115,11 @@ namespace Microsoft.Bot.Builder.Dialogs
                     if (!dialogContext.Stack.Any())
                     {
                         // No dialogs to reprompt, just return.
-                        return;
+                        return new DialogTurnResult(DialogTurnStatus.Empty);
                     }
 
                     await dialogContext.RepromptDialogAsync(cancellationToken).ConfigureAwait(false);
-                    return;
+                    return new DialogTurnResult(DialogTurnStatus.Waiting);
                 }
             }
 
@@ -78,8 +127,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             var result = await dialogContext.ContinueDialogAsync(cancellationToken).ConfigureAwait(false);
             if (result.Status == DialogTurnStatus.Empty)
             {
-                result = await dialogContext.BeginDialogAsync(dialog.Id, null, cancellationToken).ConfigureAwait(false);
+                result = await dialogContext.BeginDialogAsync(dialogId, null, cancellationToken).ConfigureAwait(false);
             }
+
+            await SendStateSnapshotTraceAsync(dialogContext, cancellationToken).ConfigureAwait(false);
 
             // Skills should send EoC when the dialog completes.
             if (result.Status == DialogTurnStatus.Complete || result.Status == DialogTurnStatus.Cancelled)
@@ -92,6 +143,23 @@ namespace Microsoft.Bot.Builder.Dialogs
                     await turnContext.SendActivityAsync(activity, cancellationToken).ConfigureAwait(false);
                 }
             }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Helper to send a trace activity with a memory snapshot of the active dialog DC. 
+        /// </summary>
+        private static async Task SendStateSnapshotTraceAsync(DialogContext dialogContext, CancellationToken cancellationToken)
+        {
+            var traceLabel = dialogContext.Context.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity claimIdentity && SkillValidation.IsSkillClaim(claimIdentity.Claims)
+                ? "Skill State"
+                : "Bot State";
+
+            // send trace of memory
+            var snapshot = GetActiveDialogContext(dialogContext).State.GetMemorySnapshot();
+            var traceActivity = (Activity)Activity.CreateTraceActivity("BotState", "https://www.botframework.com/schemas/botState", snapshot, traceLabel);
+            await dialogContext.Context.SendActivityAsync(traceActivity, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
@@ -34,6 +34,12 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken).ConfigureAwait(false);
 
+            // map TurnState into root dialog context.services
+            foreach (var service in turnContext.TurnState)
+            {
+                dialogContext.Services[service.Key] = service.Value;
+            }
+
             // Handle EoC and Reprompt event from a parent bot (can be root bot to skill or skill to skill)
             if (IsFromParentToSkill(turnContext))
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
@@ -31,8 +31,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task RunAsync(this Dialog dialog, ITurnContext turnContext, IStatePropertyAccessor<DialogState> accessor, CancellationToken cancellationToken)
         {
-            var dialogSet = new DialogSet(accessor) { TelemetryClient = dialog.TelemetryClient };
+            var dialogSet = new DialogSet(accessor);
             dialogSet.Add(dialog);
+
+            // look for the IBotTelemetryClient on the TurnState, if not there take it from the Dialog, if not there fall back to the "null" default
+            var telemetryClient = turnContext.TurnState.Get<IBotTelemetryClient>() ?? dialog.TelemetryClient ?? new NullBotTelemetryClient();
+            dialog.TelemetryClient = telemetryClient;
+            dialogSet.TelemetryClient = telemetryClient;
 
             var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs
@@ -35,13 +35,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             dialogSet.Add(dialog);
 
             // look for the IBotTelemetryClient on the TurnState, if not there take it from the Dialog, if not there fall back to the "null" default
-            var telemetryClient = turnContext.TurnState.Get<IBotTelemetryClient>() ?? dialog.TelemetryClient ?? new NullBotTelemetryClient();
-            dialog.TelemetryClient = telemetryClient;
-            dialogSet.TelemetryClient = telemetryClient;
+            dialogSet.TelemetryClient = turnContext.TurnState.Get<IBotTelemetryClient>() ?? dialog.TelemetryClient ?? NullBotTelemetryClient.Instance;
 
             var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken).ConfigureAwait(false);
 
-            // drop the return value - the whole point of this function is that the caller doesn't care
             await InternalRunAsync(turnContext, dialog.Id, dialogContext, cancellationToken).ConfigureAwait(false);
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogManager.cs
@@ -3,14 +3,9 @@
 
 using System;
 using System.Linq;
-using System.Security.Claims;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs.Memory;
-using Microsoft.Bot.Builder.Skills;
-using Microsoft.Bot.Connector.Authentication;
-using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs
@@ -186,90 +181,13 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Create DialogContext
             var dc = new DialogContext(Dialogs, context, dialogState);
 
-            // promote initial TurnState into dc.services for contextual services
-            foreach (var service in dc.Services)
-            {
-                dc.Services[service.Key] = service.Value;
-            }
-
-            // map TurnState into root dialog context.services
-            foreach (var service in context.TurnState)
-            {
-                dc.Services[service.Key] = service.Value;
-            }
-
-            // get the DialogStateManager configuration
-            var dialogStateManager = new DialogStateManager(dc, StateConfiguration);
-            await dialogStateManager.LoadAllScopesAsync(cancellationToken).ConfigureAwait(false);
-            dc.Context.TurnState.Add(dialogStateManager);
-
-            DialogTurnResult turnResult = null;
-
-            // Loop as long as we are getting valid OnError handled we should continue executing the actions for the turn.
-            //
-            // NOTE: We loop around this block because each pass through we either complete the turn and break out of the loop
-            // or we have had an exception AND there was an OnError action which captured the error.  We need to continue the 
-            // turn based on the actions the OnError handler introduced.
-            var endOfTurn = false;
-            while (!endOfTurn)
-            {
-                try
-                {
-                    if (context.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity claimIdentity && SkillValidation.IsSkillClaim(claimIdentity.Claims))
-                    {
-                        // The bot is running as a skill.
-                        turnResult = await HandleSkillOnTurnAsync(dc, cancellationToken).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        // The bot is running as root bot.
-                        turnResult = await HandleBotOnTurnAsync(dc, cancellationToken).ConfigureAwait(false);
-                    }
-
-                    // turn successfully completed, break the loop
-                    endOfTurn = true;
-                }
-                catch (Exception err)
-                {
-                    // fire error event, bubbling from the leaf.
-                    var handled = await dc.EmitEventAsync(DialogEvents.Error, err, bubble: true, fromLeaf: true, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                    if (!handled)
-                    {
-                        // error was NOT handled, throw the exception and end the turn. (This will trigger the Adapter.OnError handler and end the entire dialog stack)
-                        throw;
-                    }
-                }
-            }
-
-            // save all state scopes to their respective botState locations.
-            await dialogStateManager.SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
+            // Call the common dialog "continue/begin" execution pattern shared with the classic RunAsync extension method
+            var turnResult = await DialogExtensions.InternalRunAsync(context, _rootDialogId, dc, cancellationToken).ConfigureAwait(false);
 
             // save BotState changes
             await botStateSet.SaveAllChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
 
             return new DialogManagerResult { TurnResult = turnResult };
-        }
-
-        /// <summary>
-        /// Helper to send a trace activity with a memory snapshot of the active dialog DC. 
-        /// </summary>
-        private static async Task SendStateSnapshotTraceAsync(DialogContext dc, string traceLabel, CancellationToken cancellationToken)
-        {
-            // send trace of memory
-            var snapshot = GetActiveDialogContext(dc).State.GetMemorySnapshot();
-            var traceActivity = (Activity)Activity.CreateTraceActivity("BotState", "https://www.botframework.com/schemas/botState", snapshot, traceLabel);
-            await dc.Context.SendActivityAsync(traceActivity, cancellationToken).ConfigureAwait(false);
-        }
-
-        private static bool IsFromParentToSkill(ITurnContext turnContext)
-        {
-            if (turnContext.TurnState.Get<SkillConversationReference>(SkillHandler.SkillConversationReferenceKey) != null)
-            {
-                return false;
-            }
-
-            return turnContext.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity claimIdentity && SkillValidation.IsSkillClaim(claimIdentity.Claims);
         }
 
         // Recursively walk up the DC stack to find the active DC.
@@ -282,89 +200,6 @@ namespace Microsoft.Bot.Builder.Dialogs
             }
 
             return GetActiveDialogContext(child);
-        }
-
-        /// <summary>
-        /// Helper to determine if we should send an EndOfConversation to the parent or not.
-        /// </summary>
-        private static bool ShouldSendEndOfConversationToParent(ITurnContext context, DialogTurnResult turnResult)
-        {
-            if (!(turnResult.Status == DialogTurnStatus.Complete || turnResult.Status == DialogTurnStatus.Cancelled))
-            {
-                // The dialog is still going, don't return EoC.
-                return false;
-            }
-
-            if (context.TurnState.Get<IIdentity>(BotAdapter.BotIdentityKey) is ClaimsIdentity claimIdentity && SkillValidation.IsSkillClaim(claimIdentity.Claims))
-            {
-                // EoC Activities returned by skills are bounced back to the bot by SkillHandler.
-                // In those cases we will have a SkillConversationReference instance in state.
-                var skillConversationReference = context.TurnState.Get<SkillConversationReference>(SkillHandler.SkillConversationReferenceKey);
-                if (skillConversationReference != null)
-                {
-                    // If the skillConversationReference.OAuthScope is for one of the supported channels, we are at the root and we should not send an EoC.
-                    return skillConversationReference.OAuthScope != AuthenticationConstants.ToChannelFromBotOAuthScope && skillConversationReference.OAuthScope != GovernmentAuthenticationConstants.ToChannelFromBotOAuthScope;
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private async Task<DialogTurnResult> HandleSkillOnTurnAsync(DialogContext dc, CancellationToken cancellationToken)
-        {
-            // the bot is running as a skill. 
-            var turnContext = dc.Context;
-
-            // Process remote cancellation
-            if (turnContext.Activity.Type == ActivityTypes.EndOfConversation && dc.ActiveDialog != null && IsFromParentToSkill(turnContext))
-            {
-                // Handle remote cancellation request from parent.
-                var activeDialogContext = GetActiveDialogContext(dc);
-
-                // Send cancellation message to the top dialog in the stack to ensure all the parents are canceled in the right order. 
-                return await activeDialogContext.CancelAllDialogsAsync(true, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-
-            // Handle reprompt
-            // Process a reprompt event sent from the parent.
-            if (turnContext.Activity.Type == ActivityTypes.Event && turnContext.Activity.Name == DialogEvents.RepromptDialog)
-            {
-                if (dc.ActiveDialog == null)
-                {
-                    return new DialogTurnResult(DialogTurnStatus.Empty);
-                }
-
-                await dc.RepromptDialogAsync(cancellationToken).ConfigureAwait(false);
-                return new DialogTurnResult(DialogTurnStatus.Waiting);
-            }
-
-            // Continue execution
-            // - This will apply any queued up interruptions and execute the current/next step(s).
-            var turnResult = await dc.ContinueDialogAsync(cancellationToken).ConfigureAwait(false);
-            if (turnResult.Status == DialogTurnStatus.Empty)
-            {
-                // restart root dialog
-                turnResult = await dc.BeginDialogAsync(_rootDialogId, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-
-            await SendStateSnapshotTraceAsync(dc, "Skill State", cancellationToken).ConfigureAwait(false);
-
-            if (ShouldSendEndOfConversationToParent(turnContext, turnResult))
-            {
-                // Send End of conversation at the end.
-                var code = turnResult.Status == DialogTurnStatus.Complete ? EndOfConversationCodes.CompletedSuccessfully : EndOfConversationCodes.UserCancelled;
-                var activity = new Activity(ActivityTypes.EndOfConversation)
-                {
-                    Value = turnResult.Result,
-                    Locale = turnContext.Activity.Locale,
-                    Code = code
-                };
-                await turnContext.SendActivityAsync(activity, cancellationToken).ConfigureAwait(false);
-            }
-
-            return turnResult;
         }
 
         /// <summary>
@@ -392,34 +227,6 @@ namespace Microsoft.Bot.Builder.Dialogs
                     }
                 }
             }
-        }
-
-        private async Task<DialogTurnResult> HandleBotOnTurnAsync(DialogContext dc, CancellationToken cancellationToken)
-        {
-            DialogTurnResult turnResult;
-
-            // the bot is running as a root bot. 
-            if (dc.ActiveDialog == null)
-            {
-                // start root dialog
-                turnResult = await dc.BeginDialogAsync(_rootDialogId, cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                // Continue execution
-                // - This will apply any queued up interruptions and execute the current/next step(s).
-                turnResult = await dc.ContinueDialogAsync(cancellationToken).ConfigureAwait(false);
-
-                if (turnResult.Status == DialogTurnStatus.Empty)
-                {
-                    // restart root dialog
-                    turnResult = await dc.BeginDialogAsync(_rootDialogId, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            await SendStateSnapshotTraceAsync(dc, "Bot State", cancellationToken).ConfigureAwait(false);
-
-            return turnResult;
         }
     }
 }


### PR DESCRIPTION
Fixes #5293 

This fix removes the duplicate code. It follows the suggestion made in the associated issue to share an _internal_ implementation.

The main reason for this is because the DialogManager is expected to return a DialogTurnResult. RunAsync never returned this, because the very point of the function was to hide this, and the associated continue-begin dance, as it is meaningless to the caller. (Note when use directly in an IBot implementation the result is, naturally, ignored.)

The other, even more obscure, reason is that the DialogManager exposes indirectly the DialogSet the DialogContext uses. As it is, it seems hard to predict whether an application could make use of a potential side effect of that leak in the abstraction. Making this change this way with the internal function doesn't impact that as the internal function takes an already created DialogContext.