### PR TITLE
Update Orchestrator package to point at correct label version (#5279)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.BotFramework.Orchestrator" Version="4.12.0-*" />
+    <PackageReference Include="Microsoft.BotFramework.Orchestrator" Version="4.12.0-preview" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
Orchestrator Recognizer use the non-preview R12 package.

