### PR TITLE
Support null for buildin function empty

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Empty.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Empty.cs
@@ -22,7 +22,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                   ExpressionType.Empty,
                   Function,
                   FunctionUtils.ValidateUnary,
-                  FunctionUtils.VerifyContainer)
+                  FunctionUtils.VerifyContainerOrNull)
         {
         }
 

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -320,6 +320,26 @@ namespace AdaptiveExpressions
         }
 
         /// <summary>
+        /// Verify value contains elements or null.
+        /// </summary>
+        /// <param name="value">Value to check.</param>
+        /// <param name="expression">Expression that led to value.</param>
+        /// <param name="number">No function.</param>
+        /// <returns>Error or null if valid.</returns>
+#pragma warning disable CA1801 // Review unused parameters (we can't remove the number parameter without breaking binary compat)
+        public static string VerifyContainerOrNull(object value, Expression expression, int number)
+#pragma warning restore CA1801 // Review unused parameters
+        {
+            string error = null;
+            if (value != null && !(value is string) && !(value is IList) && !(value is IEnumerable))
+            {
+                error = $"{expression} must be a string or list or a null object.";
+            }
+
+            return error;
+        }
+
+        /// <summary>
         /// Verify value contains elements.
         /// </summary>
         /// <param name="value">Value to check.</param>

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -968,6 +968,7 @@ namespace AdaptiveExpressions.Tests
             Test("count(createArray('h', 'e', 'l', 'l', 'o'))", 5),
             Test("reverse(split(hello,'e'))", new List<object> { "llo", "h" }),
             Test("reverse(createArray('h', 'e', 'l', 'l', 'o'))", new List<object> { "o", "l", "l", "e", "h" }),
+            Test("empty(null)", true),
             Test("empty('')", true),
             Test("empty('a')", false),
             Test("empty(bag)", false),


### PR DESCRIPTION
Fixes #5337

## Description
The [doc](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-prebuilt-functions?view=azure-bot-service-4.0#empty) of `empty` shows that if the input is null, `true` would be given.

Example:
```
empty(null)   -> true
```