### PR TITLE
Added SetSpeakMiddleware to Runtime

### DIFF
--- a/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    /// Support the DirectLine speech and telephony channels to ensure the appropriate SSML tags are set 
+    /// on the Activity Speak property.
+    /// </summary>
+    public class SetSpeakMiddleware : IMiddleware
+    {
+        private readonly string _voiceName;
+        private readonly bool _fallbackToTextForSpeak;
+        private readonly string _lang;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetSpeakMiddleware"/> class.
+        /// </summary>
+        /// <param name="voiceName">The SSML voice name attribute value.</param>
+        /// <param name="lang">The xml:lang value.</param>
+        /// <param name="fallbackToTextForSpeak">true if an empt Activity.Speak is populated with Activity.Text.</param>
+        public SetSpeakMiddleware(string voiceName, string lang, bool fallbackToTextForSpeak)
+        {
+            _voiceName = voiceName;
+            _fallbackToTextForSpeak = fallbackToTextForSpeak;
+            _lang = lang ?? throw new ArgumentNullException(nameof(lang));
+        }
+
+        /// <summary>
+        /// Processes an incoming activity.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <seealso cref="ITurnContext"/>
+        /// <seealso cref="IActivity"/>
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        {
+            turnContext.OnSendActivities(async (ctx, activities, nextSend) =>
+            {
+                foreach (var activity in activities)
+                {
+                    if (activity.Type == ActivityTypes.Message)
+                    {
+                        if (_fallbackToTextForSpeak && string.IsNullOrEmpty(activity.Speak))
+                        {
+                            activity.Speak = activity.Text;
+                        }
+
+                        if (!string.IsNullOrEmpty(activity.Speak)
+                            && !string.IsNullOrEmpty(_voiceName)
+                            && (string.Equals(turnContext.Activity.ChannelId, Channels.DirectlineSpeech, StringComparison.OrdinalIgnoreCase)
+                                || string.Equals(turnContext.Activity.ChannelId, Channels.Emulator, StringComparison.OrdinalIgnoreCase)
+                                || string.Equals(turnContext.Activity.ChannelId, "telephony", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            if (!HasTag("speak", activity.Speak))
+                            {
+                                if (!HasTag("voice", activity.Speak))
+                                {
+                                    activity.Speak = $"<voice name='{_voiceName}'>{activity.Speak}</voice>";
+                                }
+
+                                activity.Speak = $"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{_lang}'>{activity.Speak}</speak>";
+                            }
+                        }
+                    }
+                }
+
+                return await nextSend().ConfigureAwait(false);
+            });
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+
+        private bool HasTag(string tagName, string speakText)
+        {
+            try
+            {
+                var speakSsmlDoc = XDocument.Parse(speakText);
+
+                if (speakSsmlDoc.Root != null && speakSsmlDoc.Root.AncestorsAndSelf().Any(x => x.Name.LocalName.ToLowerInvariant() == tagName))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            catch (XmlException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -244,6 +244,14 @@ namespace Microsoft.Bot.Builder.Integration.Runtime.Extensions
             {
                 services.AddSingleton<ShowTypingMiddleware>();
             }
+
+            if (featureSettings.Speak != null)
+            {
+                services.AddSingleton<IMiddleware>(sp => new SetSpeakMiddleware(
+                    featureSettings.Speak.VoiceFontName, 
+                    featureSettings.Speak.Lang, 
+                    featureSettings.Speak.FallbackToTextForSpeechIfEmpty));
+            }
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Settings/FeatureSettings.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Settings/FeatureSettings.cs
@@ -47,5 +47,13 @@ namespace Microsoft.Bot.Builder.Integration.Runtime.Settings
         /// The blob transcript store settings.
         /// </value>
         public BlobsStorageSettings BlobTranscript { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SetSpeakMiddleware settings.
+        /// </summary>
+        /// <value>
+        /// The SetSpeakMiddleware settings.
+        /// </value>
+        public SpeakSettings Speak { get; set; }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Settings/SpeakSettings.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/Settings/SpeakSettings.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Builder.Integration.Runtime.Settings
+{
+    /// <summary>
+    /// Speak settings for the runtim.  This is used by SetSpeakMiddleware.
+    /// </summary>
+    public class SpeakSettings
+    {
+        /// <summary>
+        /// Gets or sets the SSML voice name attribute value.
+        /// </summary>
+        /// <value>
+        /// The SSML voice name attribute value.
+        /// </value>
+        public string VoiceFontName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets the behavior to set an empty Activity.Speak 
+        /// property with the value from Activity.Text.
+        /// </summary>
+        /// <value>
+        /// true to indicates empty Activity.Speak should be set with Activity.Text.
+        /// </value>
+        public bool FallbackToTextForSpeechIfEmpty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the xml:lang value for a SSML speak element.
+        /// </summary>
+        /// <value>
+        /// The xml:lang value.
+        /// </value>
+        public string Lang { get; set; }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/SetSpeakMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/SetSpeakMiddlewareTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    public class SetSpeakMiddlewareTests
+    {
+        [Fact]
+        public void ConstructorValidation()
+        {
+            // no 'lang'
+            Assert.Throws<ArgumentNullException>(() => new SetSpeakMiddleware("voice", null, false));
+        }
+
+        [Fact]
+        public async Task NoFallback()
+        {
+            var adapter = new TestAdapter(CreateConversation("NoFallback"))
+                .Use(new SetSpeakMiddleware("male", "en-us", false));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var activity = MessageFactory.Text("OK");
+
+                await context.SendActivityAsync(activity);
+            })
+                .Send("foo")
+                .AssertReply(obj =>
+                {
+                    var activity = obj.AsMessageActivity();
+                    Assert.Null(activity.Speak);
+                })
+                .StartTestAsync();
+        }
+
+        // fallback is true, for any ChannelId other than emulator, directlinespeech, or telephony should
+        // just set Activity.Speak to Activity.Text if Speak is empty. 
+        [Fact]
+        public async Task FallbackNullSpeak()
+        {
+            var adapter = new TestAdapter(CreateConversation("Fallback"))
+                .Use(new SetSpeakMiddleware("male", "en-us", true));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var activity = MessageFactory.Text("OK");
+
+                await context.SendActivityAsync(activity);
+            })
+                .Send("foo")
+                .AssertReply(obj =>
+                    {
+                        var activity = obj.AsMessageActivity();
+                        Assert.Equal(activity.Text, activity.Speak);
+                    })
+                .StartTestAsync();
+        }
+
+        // fallback is true, for any ChannelId other than emulator, directlinespeech, or telephony should
+        // leave a non-empty Speak unchanged.
+        [Fact]
+        public async Task FallbackWithSpeak()
+        {
+            var adapter = new TestAdapter(CreateConversation("Fallback"))
+                .Use(new SetSpeakMiddleware("male", "en-us", true));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var activity = MessageFactory.Text("OK");
+                activity.Speak = "speak value";
+
+                await context.SendActivityAsync(activity);
+            })
+                .Send("foo")
+                .AssertReply(obj =>
+                {
+                    var activity = obj.AsMessageActivity();
+                    Assert.Equal("speak value", activity.Speak);
+                })
+                .StartTestAsync();
+        }
+
+        // Voice is added to Speak property.
+        [Theory]
+        [InlineData(Channels.Emulator)]
+        [InlineData(Channels.DirectlineSpeech)]
+        [InlineData("telephony")]
+        public async Task AddVoice(string channelId)
+        {
+            var adapter = new TestAdapter(CreateConversation("Fallback", channelId: channelId))
+                .Use(new SetSpeakMiddleware("male", "en-us", true));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var activity = MessageFactory.Text("OK");
+
+                await context.SendActivityAsync(activity);
+            })
+                .Send("foo")
+                .AssertReply(obj =>
+                {
+                    var activity = obj.AsMessageActivity();
+                    Assert.Equal(
+                        "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-us'><voice name='male'>OK</voice></speak>", 
+                        activity.Speak);
+                })
+                .StartTestAsync();
+        }
+
+        // With no 'voice' specified, the Speak property is unchanged.
+        [Theory]
+        [InlineData(Channels.Emulator)]
+        [InlineData(Channels.DirectlineSpeech)]
+        [InlineData("telephony")]
+        public async Task AddNoVoice(string channelId)
+        {
+            var adapter = new TestAdapter(CreateConversation("Fallback", channelId: channelId))
+                .Use(new SetSpeakMiddleware(null, "en-us", true));
+
+            await new TestFlow(adapter, async (context, cancellationToken) =>
+            {
+                var activity = MessageFactory.Text("OK");
+
+                await context.SendActivityAsync(activity);
+            })
+                .Send("foo")
+                .AssertReply(obj =>
+                {
+                    var activity = obj.AsMessageActivity();
+                    Assert.Equal(
+                        "OK",
+                        activity.Speak);
+                })
+                .StartTestAsync();
+        }
+
+        private static ConversationReference CreateConversation(string name, string user = "User1", string bot = "Bot", string channelId = "test")
+        {
+            return new ConversationReference
+            {
+                ChannelId = channelId,
+                ServiceUrl = "https://test.com",
+                Conversation = new ConversationAccount(false, name, name),
+                User = new ChannelAccount(id: user.ToLowerInvariant(), name: user),
+                Bot = new ChannelAccount(id: bot.ToLowerInvariant(), name: bot),
+                Locale = "en-us"
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5266 

The middleware was taken from the previous runtime.

This makes SetSpeakMiddleware available to Runtime via the "features" node in config (as it does for other Runtime supported middleware).

Of special note:  I put SetSpeakMiddleware in BotBuilder.  But we may want it elsewhere?