### PR TITLE
Add ObjectExpressionConverters to support Send Handoff Activity action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveComponentRegistration.cs
@@ -220,6 +220,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             yield return new ObjectExpressionConverter<ChoiceFactoryOptions>();
             yield return new ObjectExpressionConverter<FindChoicesOptions>();
             yield return new ObjectExpressionConverter<ConversationReference>();
+            yield return new ObjectExpressionConverter<object>();
+            yield return new ObjectExpressionConverter<Transcript>();
 
             yield return new ArrayExpressionConverter<string>();
             yield return new ArrayExpressionConverter<Choice>();


### PR DESCRIPTION
Fixes #5360 

## Description
Adds missing ObjectExpressionConverters to the SDK to support properties on the SendHandoffActivity adaptive action.