### PR TITLE
Allow LuisRecognizer to recognize without turnContext

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -493,6 +493,21 @@ namespace Microsoft.Bot.Builder.AI.Luis
         }
 
         /// <summary>
+        /// Return results of the analysis (Suggested actions and intents).
+        /// </summary>
+        /// <remarks>No telemetry is provided when using this method.</remarks>
+        /// <param name="utterance">utterance to recognize.</param>
+        /// <param name="recognizerOptions">A <see cref="LuisRecognizerOptions"/> instance to be used by the call.
+        /// This parameter overrides the default <see cref="LuisRecognizerOptions"/> passed in the constructor.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>The LUIS results of the analysis of the current message text in the current turn's context activity.</returns>
+        public virtual async Task<RecognizerResult> RecognizeAsync(string utterance, LuisRecognizerOptions recognizerOptions = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            recognizerOptions ??= _luisRecognizerOptions;
+            return await RecognizeInternalAsync(utterance, recognizerOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Invoked prior to a LuisResult being logged.
         /// </summary>
         /// <param name="recognizerResult">The Luis Results for the call.</param>
@@ -634,6 +649,20 @@ namespace Microsoft.Bot.Builder.AI.Luis
             var recognizer = predictionOptions ?? _luisRecognizerOptions;
             var result = await recognizer.RecognizeInternalAsync(dialogContext, activity, HttpClient, cancellationToken).ConfigureAwait(false);
             await OnRecognizerResultAsync(result, dialogContext.Context, telemetryProperties, telemetryMetrics, cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a RecognizerResult object.
+        /// </summary>
+        /// <param name="utterance">utterance to recognize.</param>
+        /// <param name="predictionOptions">LuisRecognizerOptions implementation to override current properties.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>RecognizerResult object.</returns>
+        private async Task<RecognizerResult> RecognizeInternalAsync(string utterance, LuisRecognizerOptions predictionOptions, CancellationToken cancellationToken)
+        {
+            var recognizer = predictionOptions ?? _luisRecognizerOptions;
+            var result = await recognizer.RecognizeInternalAsync(utterance, HttpClient, cancellationToken).ConfigureAwait(false);
             return result;
         }
 

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizerOptions.cs
@@ -65,5 +65,8 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
         // Support DialogContext
         internal abstract Task<RecognizerResult> RecognizeInternalAsync(DialogContext context, Activity activity, HttpClient httpClient, CancellationToken cancellationToken);
+
+        // Support string utterance
+        internal abstract Task<RecognizerResult> RecognizeInternalAsync(string utterance, HttpClient httpClient, CancellationToken cancellationToken);
     }
 }

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -139,6 +139,34 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [Fact]
+        public async Task UtteranceWithoutTurnContext()
+        {
+            const string utterance = "email about something wicked this way comes from bart simpson and also kb435";
+            const string responsePath = "Patterns.json";
+            var expectedPath = GetFilePath(responsePath);
+            JObject oracle;
+            using (var expectedJsonReader = new JsonTextReader(new StreamReader(expectedPath)))
+            {
+                oracle = (JObject)await JToken.ReadFromAsync(expectedJsonReader);
+            }
+
+            var mockResponse = oracle["v2"]["response"];
+
+            GetEnvironmentVars();
+
+            var mockHttp = GetMockHttpClientHandlerObject(utterance, new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(mockResponse))));
+            var options = new LuisPredictionOptions { IncludeAllIntents = true, IncludeInstanceData = true };
+            var luisRecognizer = GetLuisRecognizer(mockHttp, false, options) as LuisRecognizer;
+            var result = await luisRecognizer.RecognizeAsync(utterance);
+
+            Assert.NotNull(result);
+            Assert.Null(result.AlteredText);
+            Assert.Equal(utterance, result.Text);
+            Assert.NotNull(result.Intents);
+            Assert.NotNull(result.Entities);
+        }
+
+        [Fact]
         public async Task V1DatetimeResolution()
         {
             const string utterance = "at 4";

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -110,6 +110,34 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [Fact]
+        public async Task UtteranceWithoutTurnContext()
+        {
+            const string utterance = "email about something wicked this way comes from bart simpson and also kb435";
+            const string responsePath = "Patterns.json";
+            var expectedPath = GetFilePath(responsePath);
+            JObject oracle;
+            using (var expectedJsonReader = new JsonTextReader(new StreamReader(expectedPath)))
+            {
+                oracle = (JObject)await JToken.ReadFromAsync(expectedJsonReader);
+            }
+
+            var mockResponse = oracle["v3"]["response"];
+
+            GetEnvironmentVars();
+
+            var mockHttp = GetMockHttpClientHandlerObject(utterance, new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(mockResponse))));
+            var options = new LuisV3.LuisPredictionOptions { IncludeAllIntents = true, IncludeInstanceData = true };
+            var luisRecognizer = GetLuisRecognizer(mockHttp, options) as LuisRecognizer;
+            var result = await luisRecognizer.RecognizeAsync(utterance);
+
+            Assert.NotNull(result);
+            Assert.Null(result.AlteredText);
+            Assert.Equal(utterance, result.Text);
+            Assert.NotNull(result.Intents);
+            Assert.NotNull(result.Entities);
+        }
+
+        [Fact]
         public async Task TraceActivity()
         {
             const string utterance = @"My name is Emad";


### PR DESCRIPTION
Fixes #4157

## Do We Want This?

In the linked issue, there's some discussion about whether or not this change is wanted, but no resolution. Personally, I think this would be very useful, but I'm not happy with:

* This being the only `RecognizeAsync()` method that doesn't use any telemetry. It *could*, but LUIS telemetry currently requires `TurnContext`, so it would necessitate more changes
* There were quite a few methods/overrides that had to be added to get this to work, whereas it seems like a relatively simple request. I'm not super C# smart and don't work in the AI library much, so maybe there's a better way?

## Description

Allows developers to call `<LuisRecognizer>.RecognizeAsync(<utterance>)` without providing `TurnContext`, giving them more flexibility integrating LUIS with their bot.