### PR TITLE
Hand-off: add converters to support hand off action

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveBotComponent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveBotComponent.cs
@@ -204,6 +204,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ObjectExpressionConverter<ChoiceFactoryOptions>>>();
             services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ObjectExpressionConverter<FindChoicesOptions>>>();
             services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ObjectExpressionConverter<ConversationReference>>>();
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ObjectExpressionConverter<Transcript>>>();
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ObjectExpressionConverter<object>>>();
 
             services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<string>>>();
             services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<Choice>>>();


### PR DESCRIPTION
Originally added as part of this PR: https://github.com/microsoft/botbuilder-dotnet/pull/5361/files

Now ported these converters to the new model.