### PR TITLE
Adds skill processing for commands

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandlerImpl.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandlerImpl.cs
@@ -91,39 +91,23 @@ namespace Microsoft.Bot.Builder.Skills
             return resourceResponse ?? new ResourceResponse(Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
         }
 
-        private static void ApplyEoCToTurnContextActivity(ITurnContext turnContext, Activity endOfConversationActivity)
+        private static void ApplySkillActivityToTurnContext(ITurnContext turnContext, Activity activity)
         {
-            // transform the turnContext.Activity to be the EndOfConversation.
-            turnContext.Activity.Type = endOfConversationActivity.Type;
-            turnContext.Activity.Text = endOfConversationActivity.Text;
-            turnContext.Activity.Code = endOfConversationActivity.Code;
-
-            turnContext.Activity.ReplyToId = endOfConversationActivity.ReplyToId;
-            turnContext.Activity.Value = endOfConversationActivity.Value;
-            turnContext.Activity.Entities = endOfConversationActivity.Entities;
-            turnContext.Activity.Locale = endOfConversationActivity.Locale;
-            turnContext.Activity.LocalTimestamp = endOfConversationActivity.LocalTimestamp;
-            turnContext.Activity.Timestamp = endOfConversationActivity.Timestamp;
-            turnContext.Activity.ChannelData = endOfConversationActivity.ChannelData;
-            turnContext.Activity.Properties = endOfConversationActivity.Properties;
-        }
-
-        private static void ApplyEventToTurnContextActivity(ITurnContext turnContext, Activity eventActivity)
-        {
-            // transform the turnContext.Activity to be the EventActivity.
-            turnContext.Activity.Type = eventActivity.Type;
-            turnContext.Activity.Name = eventActivity.Name;
-            turnContext.Activity.Value = eventActivity.Value;
-            turnContext.Activity.RelatesTo = eventActivity.RelatesTo;
-
-            turnContext.Activity.ReplyToId = eventActivity.ReplyToId;
-            turnContext.Activity.Value = eventActivity.Value;
-            turnContext.Activity.Entities = eventActivity.Entities;
-            turnContext.Activity.Locale = eventActivity.Locale;
-            turnContext.Activity.LocalTimestamp = eventActivity.LocalTimestamp;
-            turnContext.Activity.Timestamp = eventActivity.Timestamp;
-            turnContext.Activity.ChannelData = eventActivity.ChannelData;
-            turnContext.Activity.Properties = eventActivity.Properties;
+            // adapter.ContinueConversation() sends an event activity with ContinueConversation in the name.
+            // this warms up the incoming middlewares but once that's done and we hit the custom callback,
+            // we need to swap the values back to the ones received from the skill so the bot gets the actual activity.
+            turnContext.Activity.ChannelData = activity.ChannelData;
+            turnContext.Activity.Code = activity.Code;
+            turnContext.Activity.Entities = activity.Entities;
+            turnContext.Activity.Locale = activity.Locale;
+            turnContext.Activity.LocalTimestamp = activity.LocalTimestamp;
+            turnContext.Activity.Name = activity.Name;
+            turnContext.Activity.Properties = activity.Properties;
+            turnContext.Activity.RelatesTo = activity.RelatesTo;
+            turnContext.Activity.ReplyToId = activity.ReplyToId;
+            turnContext.Activity.Timestamp = activity.Timestamp;
+            turnContext.Activity.Type = activity.Type;
+            turnContext.Activity.Value = activity.Value;
         }
 
         private async Task<SkillConversationReference> GetSkillConversationReferenceAsync(string conversationId, CancellationToken cancellationToken)
@@ -208,7 +192,7 @@ namespace Microsoft.Bot.Builder.Skills
 
         private async Task SendToBotAsync(Activity activity, ITurnContext turnContext, CancellationToken ct)
         {
-            ApplyEoCToTurnContextActivity(turnContext, activity);
+            ApplySkillActivityToTurnContext(turnContext, activity);
             await _bot.OnTurnAsync(turnContext, ct).ConfigureAwait(false);
         }
     }

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandlerImpl.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandlerImpl.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Bot.Builder.Skills
             turnContext.Activity.RelatesTo = activity.RelatesTo;
             turnContext.Activity.ReplyToId = activity.ReplyToId;
             turnContext.Activity.Timestamp = activity.Timestamp;
+            turnContext.Activity.Text = activity.Text;
             turnContext.Activity.Type = activity.Type;
             turnContext.Activity.Value = activity.Value;
         }

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/CloudSkillHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/CloudSkillHandlerTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -28,114 +27,89 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         private static readonly string TestActivityId = Guid.NewGuid().ToString("N");
 
         [Theory]
-        [InlineData(ActivityTypes.EndOfConversation)]
-        [InlineData(ActivityTypes.Event)]
-        [InlineData(ActivityTypes.Message)]
-        public async Task TestSendToConversationAsync(string activityType)
+        [InlineData(ActivityTypes.Message, null)]
+        [InlineData(ActivityTypes.Message, "replyToId")]
+        [InlineData(ActivityTypes.Event, null)]
+        [InlineData(ActivityTypes.Event, "replyToId")]
+        [InlineData(ActivityTypes.EndOfConversation, null)]
+        [InlineData(ActivityTypes.EndOfConversation, "replyToId")]
+        public async Task TestSendAndReplyToConversationAsync(string activityType, string replyToId)
         {
             // Arrange
+            var mockObjects = new CloudSkillHandlerTestMocks();
             var activity = new Activity(activityType);
-            var conversationIdFactory = new TestSkillConversationIdFactory();
-            string conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
-
-            var adapter = new Mock<BotAdapter>();
-            adapter.Setup(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
-                .Callback<ClaimsIdentity, ConversationReference, string, BotCallbackHandler, CancellationToken>(async (token, conv, audience, callback, cancel) =>
-                {
-                    var turn = new TurnContext(adapter.Object, conv.GetContinuationActivity());
-                    await callback(turn, cancel);
-
-                    // Assert the callback set the right properties.
-                    Assert.Equal($"{CallerIdConstants.BotToBotPrefix}{TestSkillId}", turn.Activity.CallerId);
-                });
-            adapter.Setup(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()))
-                .Callback<ITurnContext, Activity[], CancellationToken>((turn, activities, cancel) =>
-                {
-                    // Messages should not have a caller id set when sent back to the caller.
-                    Assert.Null(activities[0].CallerId);
-                    Assert.Null(activities[0].ReplyToId);
-
-                    // Do nothing, we don't want the activities sent to the channel in the tests.
-                })
-                .Returns(Task.FromResult(new[] { new ResourceResponse("resourceId") }));
-
-            var bot = new Mock<IBot>();
-            var auth = new Mock<BotFrameworkAuthentication>();
-            auth.Setup(a => a.AuthenticateChannelRequestAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns<string, CancellationToken>(AuthenticateChannelRequest);
+            var conversationId = await mockObjects.CreateAndApplyConversationIdAsync(activity);
 
             // Act
-            var sut = new CloudSkillHandler(adapter.Object, bot.Object, conversationIdFactory, auth.Object);
-            var response = await sut.HandleSendToConversationAsync(TestAuthHeader, conversationId, activity);
+            var sut = new CloudSkillHandler(mockObjects.Adapter.Object, mockObjects.Bot.Object, mockObjects.ConversationIdFactory, mockObjects.Auth.Object);
+            var response = replyToId == null ? await sut.HandleSendToConversationAsync(TestAuthHeader, conversationId, activity) : await sut.HandleReplyToActivityAsync(TestAuthHeader, conversationId, replyToId, activity);
 
             // Assert
-            adapter.Verify(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+            // Assert the turnContext.
+            Assert.Equal($"{CallerIdConstants.BotToBotPrefix}{TestSkillId}", mockObjects.TurnContext.Activity.CallerId);
+            Assert.NotNull(mockObjects.TurnContext.TurnState.Get<SkillConversationReference>(CloudSkillHandler.SkillConversationReferenceKey));
+
+            // Assert based on activity type,
             if (activityType == ActivityTypes.Message)
             {
-                // Assert mock SendActivitiesAsync was called
-                adapter.Verify(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
+                // We should get the resourceId returned by the mock.
                 Assert.Equal("resourceId", response.Id);
+
+                // The activity should not be sent to the bot
+                Assert.Null(mockObjects.BotActivity);
+
+                // Assert the activity sent to the channel.
+                Assert.Equal(activityType, mockObjects.SentActivity.Type);
+                Assert.Null(mockObjects.SentActivity.CallerId);
+                Assert.Equal(replyToId, mockObjects.SentActivity.ReplyToId);
             }
             else
             {
-                // Assert mock SendActivitiesAsync was not called
-                adapter.Verify(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()), Times.Never);
+                // If the activity is bounced back to the bot we will get a GUID and not the mocked resourceId.
+                Assert.NotEqual("resourceId", response.Id);
+
+                // Assert the activity sent back to the bot.
+                Assert.NotNull(mockObjects.BotActivity);
+                Assert.Equal(activityType, mockObjects.BotActivity.Type);
+
+                // The activity should not be sent back to the channel.
+                Assert.Null(mockObjects.SentActivity);
             }
         }
 
         [Theory]
-        [InlineData(ActivityTypes.Message)]
-        [InlineData(ActivityTypes.Event)]
-        [InlineData(ActivityTypes.EndOfConversation)]
-        public async Task TestReplyToActivityAsync(string activityType)
+        [InlineData(ActivityTypes.Command, "application/myApplicationCommand", null)]
+        [InlineData(ActivityTypes.Command, "application/myApplicationCommand", "replyToId")]
+        [InlineData(ActivityTypes.Command, "other/myBotCommand", null)]
+        [InlineData(ActivityTypes.Command, "other/myBotCommand", "replyToId")]
+        [InlineData(ActivityTypes.CommandResult, "application/myApplicationCommandResult", null)]
+        [InlineData(ActivityTypes.CommandResult, "application/myApplicationCommandResult", "replyToId")]
+        [InlineData(ActivityTypes.CommandResult, "other/myBotCommand", null)]
+        [InlineData(ActivityTypes.CommandResult, "other/myBotCommand", "replyToId")]
+        public async Task TestCommandActivities(string commandActivityType, string name, string replyToId)
         {
             // Arrange
-            var activity = new Activity(activityType);
-            var conversationIdFactory = new TestSkillConversationIdFactory();
-            string conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
-
-            var adapter = new Mock<BotAdapter>();
-            adapter.Setup(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
-                .Callback<ClaimsIdentity, ConversationReference, string, BotCallbackHandler, CancellationToken>(async (token, conv, audience, callback, cancel) =>
-                {
-                    var turn = new TurnContext(adapter.Object, conv.GetContinuationActivity());
-                    await callback(turn, cancel);
-
-                    // Assert the callback set the right properties.
-                    Assert.Equal($"{CallerIdConstants.BotToBotPrefix}{TestSkillId}", turn.Activity.CallerId);
-                });
-            adapter.Setup(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()))
-                .Callback<ITurnContext, Activity[], CancellationToken>((turn, activities, cancel) =>
-                {
-                    // Messages should not have a caller id set when sent back to the caller.
-                    Assert.Null(activities[0].CallerId);
-                    Assert.Equal(TestActivityId, activities[0].ReplyToId);
-
-                    // Do nothing, we don't want the activities sent to the channel in the tests.
-                })
-                .Returns(Task.FromResult(new[] { new ResourceResponse("resourceId") }));
-
-            var bot = new Mock<IBot>();
-            var auth = new Mock<BotFrameworkAuthentication>();
-            auth.Setup(a => a.AuthenticateChannelRequestAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns<string, CancellationToken>(AuthenticateChannelRequest);
+            var mockObjects = new CloudSkillHandlerTestMocks();
+            var activity = new Activity(commandActivityType) { Name = name };
+            var conversationId = await mockObjects.CreateAndApplyConversationIdAsync(activity);
 
             // Act
-            var sut = new CloudSkillHandler(adapter.Object, bot.Object, conversationIdFactory, auth.Object);
-            var response = await sut.HandleReplyToActivityAsync(TestAuthHeader, conversationId, TestActivityId, activity);
+            var sut = new CloudSkillHandler(mockObjects.Adapter.Object, mockObjects.Bot.Object, mockObjects.ConversationIdFactory, mockObjects.Auth.Object);
+            var response = replyToId == null ? await sut.HandleSendToConversationAsync(TestAuthHeader, conversationId, activity) : await sut.HandleReplyToActivityAsync(TestAuthHeader, conversationId, replyToId, activity);
 
             // Assert
-            adapter.Verify(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
-            if (activityType == ActivityTypes.Message)
+            // Assert the turnContext.
+            Assert.Equal($"{CallerIdConstants.BotToBotPrefix}{TestSkillId}", mockObjects.TurnContext.Activity.CallerId);
+            Assert.NotNull(mockObjects.TurnContext.TurnState.Get<SkillConversationReference>(CloudSkillHandler.SkillConversationReferenceKey));
+            if (name.StartsWith("application/"))
             {
-                // Assert mock SendActivitiesAsync was called
-                adapter.Verify(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
-                Assert.Equal("resourceId", response.Id);
+                Assert.NotNull(mockObjects.SentActivity);
+                Assert.Null(mockObjects.BotActivity);
             }
             else
             {
-                // Assert mock SendActivitiesAsync was not called
-                adapter.Verify(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()), Times.Never);
+                Assert.Null(mockObjects.SentActivity);
+                Assert.NotNull(mockObjects.BotActivity);
             }
         }
 
@@ -145,7 +119,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             // Arrange
             var activity = (Activity)Activity.CreateMessageActivity();
             var conversationIdFactory = new TestSkillConversationIdFactory();
-            string conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
+            var conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
 
             var adapter = new Mock<BotAdapter>();
             adapter.Setup(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
@@ -181,7 +155,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             var activity = (Activity)Activity.CreateMessageActivity();
             var message = activity.Text = $"TestUpdate {DateTime.Now}.";
             var conversationIdFactory = new TestSkillConversationIdFactory();
-            string conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
+            var conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
 
             var adapter = new Mock<BotAdapter>();
             adapter.Setup(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
@@ -208,7 +182,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 
             // Act
             var sut = new CloudSkillHandler(adapter.Object, bot.Object, conversationIdFactory, auth.Object);
-            ResourceResponse response = await sut.HandleUpdateActivityAsync(TestAuthHeader, conversationId, TestActivityId, activity);
+            var response = await sut.HandleUpdateActivityAsync(TestAuthHeader, conversationId, TestActivityId, activity);
 
             // Assert
             adapter.Verify(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
@@ -251,6 +225,127 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             token.AddClaim(new Claim(AuthenticationConstants.ServiceUrlClaim, TestBotEndpoint));
 
             return Task.FromResult(token);
+        }
+
+        /// <summary>
+        /// Helper class with mocks for adapter, bot and auth needed to instantiate CloudSkillHandler and run tests.
+        /// This class also captures the activities sent back to the turn and the channel so we can run asserts on them.
+        /// </summary>
+        private class CloudSkillHandlerTestMocks
+        {
+            public CloudSkillHandlerTestMocks()
+            {
+                Adapter = CreateMockAdapter();
+                Auth = CreateMockBotFrameworkAuthentication();
+                Bot = CreateMockBot();
+                ConversationIdFactory = new TestSkillConversationIdFactory();
+            }
+
+            public SkillConversationIdFactoryBase ConversationIdFactory { get; }
+
+            public Mock<BotAdapter> Adapter { get; }
+
+            public Mock<BotFrameworkAuthentication> Auth { get;  }
+
+            public Mock<IBot> Bot { get;  }
+
+            // Gets the TurnContext created to call the bot.
+            public TurnContext TurnContext { get; private set; }
+            
+            /// <summary>
+            /// Gets the Activity sent to the channel.
+            /// </summary>
+            public Activity SentActivity { get; private set; }
+
+            /// <summary>
+            /// Gets the Activity sent to the Bot.
+            /// </summary>
+            public Activity BotActivity { get; private set; }
+
+            public async Task<string> CreateAndApplyConversationIdAsync(Activity activity)
+            {
+                activity.ApplyConversationReference(new ConversationReference
+                {
+                    Conversation = new ConversationAccount(id: TestBotId),
+                    ServiceUrl = TestBotEndpoint
+                });
+
+                var skill = new BotFrameworkSkill
+                {
+                    AppId = TestSkillId,
+                    Id = "skill",
+                    SkillEndpoint = new Uri(TestSkillEndpoint)
+                };
+
+                var options = new SkillConversationIdFactoryOptions
+                {
+                    FromBotOAuthScope = TestBotId,
+                    FromBotId = TestBotId,
+                    Activity = activity,
+                    BotFrameworkSkill = skill
+                };
+
+                return await ConversationIdFactory.CreateSkillConversationIdAsync(options, CancellationToken.None);
+            }
+
+            private Mock<BotAdapter> CreateMockAdapter()
+            {
+                var adapter = new Mock<BotAdapter>();
+
+                // Mock the adapter ContinueConversationAsync method
+                // This code block catches and executes the custom bot callback created by the service handler.
+                adapter.Setup(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
+                    .Callback<ClaimsIdentity, ConversationReference, string, BotCallbackHandler, CancellationToken>(async (token, conv, audience, botCallbackHandler, cancel) =>
+                    {
+                        // Create and capture the TurnContext so we can run assertions on it.
+                        TurnContext = new TurnContext(adapter.Object, conv.GetContinuationActivity());
+                        await botCallbackHandler(TurnContext, cancel);
+                    });
+
+                // Mock the adapter SendActivitiesAsync method (this for the cases where activity is sent back to the parent or channel)
+                adapter.Setup(a => a.SendActivitiesAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity[]>(), It.IsAny<CancellationToken>()))
+                    .Callback<ITurnContext, Activity[], CancellationToken>((turn, activities, cancel) =>
+                    {
+                        // Capture the activity sent to the channel
+                        SentActivity = activities[0];
+
+                        // Do nothing, we don't want the activities sent to the channel in the tests.
+                    })
+                    .Returns(Task.FromResult(new[]
+                    {
+                        // Return a well known resourceId so we can assert we capture the right return value.
+                        new ResourceResponse("resourceId")
+                    }));
+                return adapter;
+            }
+
+            private Mock<IBot> CreateMockBot()
+            {
+                var bot = new Mock<IBot>();
+                bot.Setup(b => b.OnTurnAsync(It.IsAny<ITurnContext>(), It.IsAny<CancellationToken>()))
+                    .Callback<ITurnContext, CancellationToken>((turnContext, ct) =>
+                    {
+                        BotActivity = turnContext.Activity;
+                    });
+                return bot;
+            }
+
+            private Mock<BotFrameworkAuthentication> CreateMockBotFrameworkAuthentication()
+            {
+                var auth = new Mock<BotFrameworkAuthentication>();
+                auth.Setup(a => a.AuthenticateChannelRequestAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns<string, CancellationToken>((authHeader, cancellationToken) =>
+                    {
+                        var claimsIdentity = new ClaimsIdentity();
+
+                        claimsIdentity.AddClaim(new Claim(AuthenticationConstants.AudienceClaim, TestBotId));
+                        claimsIdentity.AddClaim(new Claim(AuthenticationConstants.AppIdClaim, TestSkillId));
+                        claimsIdentity.AddClaim(new Claim(AuthenticationConstants.ServiceUrlClaim, TestBotEndpoint));
+
+                        return Task.FromResult(claimsIdentity);
+                    });
+                return auth;
+            }
         }
 
         private class TestSkillConversationIdFactory : SkillConversationIdFactoryBase

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/CloudSkillHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/CloudSkillHandlerTests.cs
@@ -17,14 +17,8 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 {
     public class CloudSkillHandlerTests
     {
-        private static readonly string TestBotId = Guid.NewGuid().ToString("N");
-        private static readonly string TestBotEndpoint = "http://testbot.com/api/messages";
-
         private static readonly string TestSkillId = Guid.NewGuid().ToString("N");
-        private static readonly string TestSkillEndpoint = "http://testskill.com/api/messages";
-
         private static readonly string TestAuthHeader = string.Empty; // Empty since claims extraction is being mocked
-        private static readonly string TestActivityId = Guid.NewGuid().ToString("N");
 
         [Theory]
         [InlineData(ActivityTypes.Message, null)]
@@ -138,86 +132,27 @@ namespace Microsoft.Bot.Builder.Tests.Skills
 
             // Assert
             Assert.NotNull(mockObjects.TurnContext.TurnState.Get<SkillConversationReference>(CloudSkillHandler.SkillConversationReferenceKey));
-            Assert.Equal(activityToDelete, mockObjects.ActivityIdToUpdateOrDelete);
+            Assert.Equal(activityToDelete, mockObjects.ActivityIdToDelete);
         }
 
         [Fact]
         public async void TestUpdateActivityAsync()
         {
             // Arrange
-            var activity = (Activity)Activity.CreateMessageActivity();
-            var message = activity.Text = $"TestUpdate {DateTime.Now}.";
-            var conversationIdFactory = new TestSkillConversationIdFactory();
-            var conversationId = await CreateTestSkillConversationIdAsync(conversationIdFactory, activity);
-
-            var adapter = new Mock<BotAdapter>();
-            adapter.Setup(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()))
-                .Callback<ClaimsIdentity, ConversationReference, string, BotCallbackHandler, CancellationToken>(async (token, conv, audience, callback, cancel) =>
-                {
-                    var turn = new TurnContext(adapter.Object, conv.GetContinuationActivity());
-                    await callback(turn, cancel);
-
-                    // Assert the callback set the right properties.
-                    Assert.Equal($"{CallerIdConstants.BotToBotPrefix}{TestSkillId}", turn.Activity.CallerId);
-                });
-            adapter.Setup(a => a.UpdateActivityAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<ITurnContext, Activity, CancellationToken>((turn, newActivity, cancel) =>
-                {
-                    Assert.Equal(TestActivityId, newActivity.ReplyToId);
-                    Assert.Equal(message, newActivity.Text);
-                })
-                .Returns(Task.FromResult(new ResourceResponse("resourceId")));
-
-            var bot = new Mock<IBot>();
-            var auth = new Mock<BotFrameworkAuthentication>();
-            auth.Setup(a => a.AuthenticateChannelRequestAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns<string, CancellationToken>(AuthenticateChannelRequest);
+            var mockObjects = new CloudSkillHandlerTestMocks();
+            var activity = new Activity(ActivityTypes.Message) { Text = $"TestUpdate {DateTime.Now}." };
+            var conversationId = await mockObjects.CreateAndApplyConversationIdAsync(activity);
+            var activityToUpdate = Guid.NewGuid().ToString();
 
             // Act
-            var sut = new CloudSkillHandler(adapter.Object, bot.Object, conversationIdFactory, auth.Object);
-            var response = await sut.HandleUpdateActivityAsync(TestAuthHeader, conversationId, TestActivityId, activity);
+            var sut = new CloudSkillHandler(mockObjects.Adapter.Object, mockObjects.Bot.Object, mockObjects.ConversationIdFactory, mockObjects.Auth.Object);
+            var response = await sut.HandleUpdateActivityAsync(TestAuthHeader, conversationId, activityToUpdate, activity);
 
             // Assert
-            adapter.Verify(a => a.ContinueConversationAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<ConversationReference>(), It.IsAny<string>(), It.IsAny<BotCallbackHandler>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
-            adapter.Verify(a => a.UpdateActivityAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
             Assert.Equal("resourceId", response.Id);
-        }
-
-        private async Task<string> CreateTestSkillConversationIdAsync(SkillConversationIdFactoryBase conversationIdFactory, Activity activity)
-        {
-            activity.ApplyConversationReference(new ConversationReference
-            {
-                Conversation = new ConversationAccount(id: TestBotId),
-                ServiceUrl = TestBotEndpoint
-            });
-
-            var skill = new BotFrameworkSkill
-            {
-                AppId = TestSkillId,
-                Id = "skill",
-                SkillEndpoint = new Uri(TestSkillEndpoint)
-            };
-
-            var options = new SkillConversationIdFactoryOptions
-            {
-                FromBotOAuthScope = TestBotId,
-                FromBotId = TestBotId,
-                Activity = activity,
-                BotFrameworkSkill = skill
-            };
-
-            return await conversationIdFactory.CreateSkillConversationIdAsync(options, CancellationToken.None);
-        }
-
-        private Task<ClaimsIdentity> AuthenticateChannelRequest(string authHeader, CancellationToken cancellationToken)
-        {
-            var token = new ClaimsIdentity();
-
-            token.AddClaim(new Claim(AuthenticationConstants.AudienceClaim, TestBotId));
-            token.AddClaim(new Claim(AuthenticationConstants.AppIdClaim, TestSkillId));
-            token.AddClaim(new Claim(AuthenticationConstants.ServiceUrlClaim, TestBotEndpoint));
-
-            return Task.FromResult(token);
+            Assert.NotNull(mockObjects.TurnContext.TurnState.Get<SkillConversationReference>(CloudSkillHandler.SkillConversationReferenceKey));
+            Assert.Equal(activityToUpdate, mockObjects.TurnContext.Activity.Id);
+            Assert.Equal(activity.Text, mockObjects.UpdateActivity.Text);
         }
 
         /// <summary>
@@ -226,6 +161,11 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         /// </summary>
         private class CloudSkillHandlerTestMocks
         {
+            private static readonly string TestBotId = Guid.NewGuid().ToString("N");
+            private static readonly string TestBotEndpoint = "http://testbot.com/api/messages";
+
+            private static readonly string TestSkillEndpoint = "http://testskill.com/api/messages";
+
             public CloudSkillHandlerTestMocks()
             {
                 Adapter = CreateMockAdapter();
@@ -256,9 +196,14 @@ namespace Microsoft.Bot.Builder.Tests.Skills
             public Activity BotActivity { get; private set; }
 
             /// <summary>
+            /// Gets the update activity.
+            /// </summary>
+            public Activity UpdateActivity { get; private set; }
+
+            /// <summary>
             /// Gets the Activity sent to the Bot.
             /// </summary>
-            public string ActivityIdToUpdateOrDelete { get; private set; }
+            public string ActivityIdToDelete { get; private set; }
 
             public async Task<string> CreateAndApplyConversationIdAsync(Activity activity)
             {
@@ -320,8 +265,17 @@ namespace Microsoft.Bot.Builder.Tests.Skills
                     .Callback<ITurnContext, ConversationReference, CancellationToken>((turn, conv, cancel) =>
                     {
                         // Capture the activity id to delete so we can assert it. 
-                        ActivityIdToUpdateOrDelete = conv.ActivityId;
+                        ActivityIdToDelete = conv.ActivityId;
                     });
+
+                // Mock the UpdateActivityAsync method
+                adapter.Setup(a => a.UpdateActivityAsync(It.IsAny<ITurnContext>(), It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
+                    .Callback<ITurnContext, Activity, CancellationToken>((turn, newActivity, cancel) =>
+                    {
+                        // Capture the activity to update.
+                        UpdateActivity = newActivity;
+                    })
+                    .Returns(Task.FromResult(new ResourceResponse("resourceId")));
 
                 return adapter;
             }


### PR DESCRIPTION
Fixes #5314

## Description
Updated SkillHandleImpl to process Command and CommandResult activities based on the spec.

In this PR, I also refactored the CloudSkillHandlerTests class by moving duplicated code and mocks inside a private CloudSkillHandlerTestMocks class.

I also found out that assertions in Moq based objects don't work (see [this](http://blachniet.com/blog/assertions-in-moq-callbacks/) for more details) so changed the implementation to capture internal state in the mock callback methods and moved the assertions to the main test methods.

