### PR TITLE
have AdaptiveDialogBot pick up Dialogs from services collection

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/ConfigurationAdaptiveDialogBot.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/ConfigurationAdaptiveDialogBot.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Memory;
@@ -31,6 +32,7 @@ namespace Microsoft.Bot.Builder.Integration.Runtime
         /// <param name="botFrameworkAuthentication">A <see cref="BotFrameworkAuthentication"/> for making calls to Bot Builder Skills.</param>
         /// <param name="scopes">A set of <see cref="MemoryScope"/> that will be added to the <see cref="ITurnContext"/>.</param>
         /// <param name="pathResolvers">A set of <see cref="IPathResolver"/> that will be added to the <see cref="ITurnContext"/>.</param>
+        /// <param name="dialogs">Custom <see cref="Dialog"/> that will be added to the root DialogSet.</param>
         /// <param name="logger">An <see cref="ILogger"/> instance.</param>
         public ConfigurationAdaptiveDialogBot(
             IConfiguration configuration,
@@ -41,6 +43,7 @@ namespace Microsoft.Bot.Builder.Integration.Runtime
             BotFrameworkAuthentication botFrameworkAuthentication = null,
             IEnumerable<MemoryScope> scopes = default,
             IEnumerable<IPathResolver> pathResolvers = default,
+            IEnumerable<Dialog> dialogs = default,
             ILogger logger = null)
             : base(
                 configuration.GetSection(ConfigurationConstants.RootDialogKey).Value,
@@ -53,6 +56,7 @@ namespace Microsoft.Bot.Builder.Integration.Runtime
                 botFrameworkAuthentication ?? BotFrameworkAuthenticationFactory.Create(),
                 scopes ?? Enumerable.Empty<MemoryScope>(),
                 pathResolvers ?? Enumerable.Empty<IPathResolver>(),
+                dialogs ?? Enumerable.Empty<Dialog>(),
                 logger: logger ?? NullLogger<AdaptiveDialogBot>.Instance)
         {
         }

--- a/tests/Auth/bot-authentication/Akhenaten.cs
+++ b/tests/Auth/bot-authentication/Akhenaten.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+
+namespace AuthenticationBot
+{
+    public class Akhenaten : ComponentDialog
+    {
+        public Akhenaten()
+            : base(nameof(Akhenaten))
+        {
+            AddDialog(new WaterfallDialog(nameof(WaterfallDialog), new WaterfallStep[] { FirstStepAsync }));
+            InitialDialogId = nameof(WaterfallDialog);
+        }
+
+        private async Task<DialogTurnResult> FirstStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+        {
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text("Akhenaten was here."), cancellationToken);
+            return await stepContext.EndDialogAsync(null, cancellationToken);
+        }
+    }
+}

--- a/tests/Auth/bot-authentication/AuthenticationBot.csproj
+++ b/tests/Auth/bot-authentication/AuthenticationBot.csproj
@@ -20,6 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="hello.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="test.dialog">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/Auth/bot-authentication/Startup.cs
+++ b/tests/Auth/bot-authentication/Startup.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using AuthenticationBot;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.BotFramework;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
@@ -54,6 +56,8 @@ namespace Microsoft.BotBuilderSamples
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             //services.AddTransient<IBot, AuthBot<MainDialog>>();
             //services.AddTransient<IBot, EchoBot>();
+
+            services.AddSingleton<Dialog, Akhenaten>();
 
             services.AddBotRuntime(Configuration);
         }

--- a/tests/Auth/bot-authentication/hello.dialog
+++ b/tests/Auth/bot-authentication/hello.dialog
@@ -5,8 +5,8 @@
       "$kind": "Microsoft.OnMessageActivity",
       "actions": [
         {
-          "$kind": "Microsoft.BeginDialog",
-          "dialog": "Akhenaten"
+          "$kind": "Microsoft.SendActivity",
+          "activity": "Hello world"
         }
       ]
     }


### PR DESCRIPTION
For migration we can easily have the bot pick up any Dialogs from the services collection and add them to the AdaptiveDialog's Dialogs property.

This way a package containing coded dialogs could trivially wrap them in a ComponentDialog and then AddSingleton that to the services collection where it can be invoked with the BeginDialog action. See the Auth test project - it runs a ComponentDialog this way.

This is a small non-breaking change.

Incidentally testing this I found the error handling within the AdaptiveDialog world not particularly friendly but that's a different matter and can be addressed independently.