### PR TITLE
Added AdaptiveTestingBotComponent

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerBotComponent.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerBotComponent.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<QnAMakerRecognizer>(QnAMakerRecognizer.Kind));
 
             services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<Metadata>>>();
-            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<QnARequestContext>>>();
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ObjectExpressionConverter<QnARequestContext>>>();
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingBotComponent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingBotComponent.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
         public override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         {
             // Converters
-            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<TestAction>>>();
-            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<HttpRequestMock>>>();
-            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<SettingMock>>>();
-            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<UserTokenMock>>>();
+            services.AddSingleton<JsonConverterFactory, InterfaceConverterFactory<TestAction>>();
+            services.AddSingleton<JsonConverterFactory, InterfaceConverterFactory<HttpRequestMock>>();
+            services.AddSingleton<JsonConverterFactory, InterfaceConverterFactory<SettingMock>>();
+            services.AddSingleton<JsonConverterFactory, InterfaceConverterFactory<UserTokenMock>>();
 
             // Actions for within normal bot flow
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertCondition>(AssertCondition.Kind));

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingBotComponent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingBotComponent.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using AdaptiveExpressions.Converters;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Actions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.SettingMocks;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.UserTokenMocks;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Converters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
+{
+    /// <summary>
+    /// Adaptive Testing <see cref="BotComponent"/> definition.
+    /// </summary>
+    public class AdaptiveTestingBotComponent : BotComponent
+    {
+        /// <inheritdoc/>
+        public override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            // Converters
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<TestAction>>>();
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<HttpRequestMock>>>();
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<SettingMock>>>();
+            services.AddSingleton<JsonConverterFactory, JsonConverterFactory<ArrayExpressionConverter<UserTokenMock>>>();
+
+            // Actions for within normal bot flow
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertCondition>(AssertCondition.Kind));
+
+            // Test script actions
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<TestScript>(TestScript.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserSays>(UserSays.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserTyping>(UserTyping.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserConversationUpdate>(UserConversationUpdate.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserActivity>(UserActivity.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserDelay>(UserDelay.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertReply>(AssertReply.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertReplyOneOf>(AssertReplyOneOf.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertReplyActivity>(AssertReplyActivity.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertNoActivity>(AssertNoActivity.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<MemoryAssertions>(MemoryAssertions.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<HttpRequestSequenceMock>(HttpRequestSequenceMock.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserTokenBasicMock>(UserTokenBasicMock.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<SetProperties>(SetProperties.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<SettingStringMock>(SettingStringMock.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<CustomEvent>(CustomEvent.Kind));
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingComponentRegistration.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingComponentRegistration.cs
@@ -1,17 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.Actions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.SettingMocks;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.UserTokenMocks;
-using Microsoft.Bot.Builder.Dialogs.Debugging;
-using Microsoft.Bot.Builder.Dialogs.Declarative;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Converters;
-using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
-using Newtonsoft.Json;
+using System;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Obsolete;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 {
@@ -19,40 +10,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
     /// Component registration for AdaptiveTesting resources.
     /// </summary>
     /// <remarks>This should be the last registration since it may add testing overrides for other components.</remarks>
-    public class AdaptiveTestingComponentRegistration : ComponentRegistration, IComponentDeclarativeTypes
+    [Obsolete("Use `AdaptiveTestingBotComponent`.")]
+    public class AdaptiveTestingComponentRegistration : DeclarativeComponentRegistrationBridge<AdaptiveTestingBotComponent>
     {
-        /// <inheritdoc/>
-        public virtual IEnumerable<DeclarativeType> GetDeclarativeTypes(ResourceExplorer resourceExplorer)
-        {
-            // Actions for within normal bot flow
-            yield return new DeclarativeType<AssertCondition>(AssertCondition.Kind);
-
-            // Test script actions
-            yield return new DeclarativeType<TestScript>(TestScript.Kind);
-            yield return new DeclarativeType<UserSays>(UserSays.Kind);
-            yield return new DeclarativeType<UserTyping>(UserTyping.Kind);
-            yield return new DeclarativeType<UserConversationUpdate>(UserConversationUpdate.Kind);
-            yield return new DeclarativeType<UserActivity>(UserActivity.Kind);
-            yield return new DeclarativeType<UserDelay>(UserDelay.Kind);
-            yield return new DeclarativeType<AssertReply>(AssertReply.Kind);
-            yield return new DeclarativeType<AssertReplyOneOf>(AssertReplyOneOf.Kind);
-            yield return new DeclarativeType<AssertReplyActivity>(AssertReplyActivity.Kind);
-            yield return new DeclarativeType<AssertNoActivity>(AssertNoActivity.Kind); 
-            yield return new DeclarativeType<MemoryAssertions>(MemoryAssertions.Kind);
-            yield return new DeclarativeType<HttpRequestSequenceMock>(HttpRequestSequenceMock.Kind);
-            yield return new DeclarativeType<UserTokenBasicMock>(UserTokenBasicMock.Kind);
-            yield return new DeclarativeType<SetProperties>(SetProperties.Kind);
-            yield return new DeclarativeType<SettingStringMock>(SettingStringMock.Kind);
-            yield return new DeclarativeType<CustomEvent>(CustomEvent.Kind);
-        }
-
-        /// <inheritdoc/>
-        public virtual IEnumerable<JsonConverter> GetConverters(ResourceExplorer resourceExplorer, SourceContext sourceContext)
-        {
-            yield return new InterfaceConverter<TestAction>(resourceExplorer, sourceContext);
-            yield return new InterfaceConverter<HttpRequestMock>(resourceExplorer, sourceContext);
-            yield return new InterfaceConverter<SettingMock>(resourceExplorer, sourceContext);
-            yield return new InterfaceConverter<UserTokenMock>(resourceExplorer, sourceContext);
-        }
     }
 }


### PR DESCRIPTION
Converted AdaptiveTestComponentRegistration to AdaptiveTestingBotComponent.  Obsoleted AdaptiveTestComponentRegistration  and changed to extend DeclarativeComponentRegistrationBridge.

This could be cherry picked to 4.13.  Required to convert old test cases using AdaptiveTestComponentRegistration and correct QnAMakerBotComponent

For QnAMakerBotComponent, the original code in QnAMakerComponentRegistration was:

```
        /// <summary>
        /// Gets JsonConverters for DeclarativeTypes for QnAMaker.
        /// </summary>
        /// <param name="resourceExplorer">resourceExplorer to use for resolving references.</param>
        /// <param name="sourceContext">SourceContext to build debugger source map.</param>
        /// <returns>enumeration of json converters.</returns>
        public IEnumerable<JsonConverter> GetConverters(ResourceExplorer resourceExplorer, SourceContext sourceContext)
        {
            yield return new ArrayExpressionConverter<Metadata>();
            yield return new ObjectExpressionConverter<QnARequestContext>();
        }
```

Change made to QnAMakerBotComponent to correct the QnARequestContext converter.