### PR TITLE
Settings scope: support backward compat setting scope, remove ComponentRegistration in DialogStateManager (#5397)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -40,8 +40,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
         /// <param name="configuration">Configuration for the dialog state manager. Default is <c>null</c>.</param>
         public DialogStateManager(DialogContext dc, DialogStateManagerConfiguration configuration = null)
         {
-            ComponentRegistration.Add(new DialogsComponentRegistration());
-
             _dialogContext = dc ?? throw new ArgumentNullException(nameof(dc));
             Configuration = configuration ?? dc.Context.TurnState.Get<DialogStateManagerConfiguration>();
             if (Configuration == null)

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Startup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Builder.AI.Luis;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
@@ -18,6 +19,7 @@ namespace Microsoft.Bot.Builder
         public Startup(IMessageSink messageSink)
             : base(messageSink)
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder.AI.QnA;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
@@ -15,6 +16,7 @@ namespace Microsoft.Bot.Builder
         public Startup(IMessageSink messageSink)
             : base(messageSink)
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
 
         public ActivityFactoryTests()
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/LGGeneratorTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
     {
         public LGGeneratorTests()
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Startup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.AI.QnA;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
@@ -26,6 +27,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.Tests
 
             Configuration = builder.Build();
 
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new LanguageGenerationComponentRegistration());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder.AI.QnA;
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Xunit;
@@ -14,6 +15,7 @@ namespace Microsoft.Bot.Builder
         public Startup(IMessageSink messageSink)
             : base(messageSink)
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new LanguageGenerationComponentRegistration());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Startup.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Bot.Builder.Dialogs.Adaptive;
+﻿using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
 using Microsoft.Bot.Builder.Dialogs.Declarative;
 using Xunit;
@@ -14,6 +15,7 @@ namespace Microsoft.Bot.Builder
         public Startup(IMessageSink messageSink)
             : base(messageSink)
         {
+            ComponentRegistration.Add(new DialogsComponentRegistration());
             ComponentRegistration.Add(new DeclarativeComponentRegistration());
             ComponentRegistration.Add(new AdaptiveComponentRegistration());
             ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());


### PR DESCRIPTION
Cherry pick of https://github.com/microsoft/botbuilder-dotnet/pull/5397

* Settings scope: support backward compat setting scope, remove ComponentRegistration in DialogStateManager
* Legacy settings: add test that failed before and now passes with the fix

SettingsScope was not working in a backward compatible way because of 3 subtle things happening simultaneously:

DialogStateManager was registering the DialogcomponentRegistration by itself
We removed IConfiguration from the turnState, so legacy SettingsMemoryScope did not have access to configuration in turn state (so the registration in dialog state manager was not getting any settings)
SettingsMemoryScope only gets evaluated once
Here we remove the DialogStateManager call to DialogComponentRegistration since this is the last call to ComponentRegistration in non-test code. Legacy code will still work because legacy adapters still add IConfiguration to the turnState. New code will use the new route.

Also, fixing a breaking change where we would break folks using the default constructor of SettingsMemoryScope.

Note that tests still rely on ComponentRegistration and we have an R14 change to remove these, basically by moving the TestAdapter and TestScript to the BotComponent pattern. This work is tracked here: https://github.com/microsoft/botbuilder-dotnet/issues/5396

