### PR TITLE
[Cherry Pick 4.13] Update SetSpeakMiddleware to remove lang aligned with existing runtime (#5404)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -201,8 +201,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
             if (featureSettings.SetSpeak != null)
             {
                 services.AddSingleton<IMiddleware>(sp => new SetSpeakMiddleware(
-                    featureSettings.SetSpeak.VoiceFontName, 
-                    featureSettings.SetSpeak.Lang, 
+                    featureSettings.SetSpeak.VoiceFontName,
                     featureSettings.SetSpeak.FallbackToTextForSpeechIfEmpty));
             }
         }

--- a/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
@@ -20,19 +20,16 @@ namespace Microsoft.Bot.Builder
     {
         private readonly string _voiceName;
         private readonly bool _fallbackToTextForSpeak;
-        private readonly string _lang;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SetSpeakMiddleware"/> class.
         /// </summary>
         /// <param name="voiceName">The SSML voice name attribute value.</param>
-        /// <param name="lang">The xml:lang value.</param>
         /// <param name="fallbackToTextForSpeak">true if an empt Activity.Speak is populated with Activity.Text.</param>
-        public SetSpeakMiddleware(string voiceName, string lang, bool fallbackToTextForSpeak)
+        public SetSpeakMiddleware(string voiceName, bool fallbackToTextForSpeak)
         {
             _voiceName = voiceName;
             _fallbackToTextForSpeak = fallbackToTextForSpeak;
-            _lang = lang ?? throw new ArgumentNullException(nameof(lang));
         }
 
         /// <summary>
@@ -62,7 +59,7 @@ namespace Microsoft.Bot.Builder
                             && !string.IsNullOrEmpty(_voiceName)
                             && (string.Equals(turnContext.Activity.ChannelId, Channels.DirectlineSpeech, StringComparison.OrdinalIgnoreCase)
                                 || string.Equals(turnContext.Activity.ChannelId, Channels.Emulator, StringComparison.OrdinalIgnoreCase)
-                                || string.Equals(turnContext.Activity.ChannelId, "telephony", StringComparison.OrdinalIgnoreCase)))
+                                || string.Equals(turnContext.Activity.ChannelId, Channels.Telephony, StringComparison.OrdinalIgnoreCase)))
                         {
                             if (!HasTag("speak", activity.Speak))
                             {
@@ -71,7 +68,7 @@ namespace Microsoft.Bot.Builder
                                     activity.Speak = $"<voice name='{_voiceName}'>{activity.Speak}</voice>";
                                 }
 
-                                activity.Speak = $"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{_lang}'>{activity.Speak}</speak>";
+                                activity.Speak = $"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{activity.Locale ?? "en-US"}'>{activity.Speak}</speak>";
                             }
                         }
                     }

--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -106,5 +106,10 @@ namespace Microsoft.Bot.Connector
         /// Twilio channel.
         /// </summary>
         public const string Twilio = "twilio-sms";
+
+        /// <summary>
+        /// Telephony channel.
+        /// </summary>
+        public const string Telephony = "telephony";
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/SetSpeakMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/SetSpeakMiddlewareTests.cs
@@ -13,17 +13,10 @@ namespace Microsoft.Bot.Builder.Tests
     public class SetSpeakMiddlewareTests
     {
         [Fact]
-        public void ConstructorValidation()
-        {
-            // no 'lang'
-            Assert.Throws<ArgumentNullException>(() => new SetSpeakMiddleware("voice", null, false));
-        }
-
-        [Fact]
         public async Task NoFallback()
         {
             var adapter = new TestAdapter(CreateConversation("NoFallback"))
-                .Use(new SetSpeakMiddleware("male", "en-us", false));
+                .Use(new SetSpeakMiddleware("male", false));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {
@@ -46,7 +39,7 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task FallbackNullSpeak()
         {
             var adapter = new TestAdapter(CreateConversation("Fallback"))
-                .Use(new SetSpeakMiddleware("male", "en-us", true));
+                .Use(new SetSpeakMiddleware("male", true));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {
@@ -69,7 +62,7 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task FallbackWithSpeak()
         {
             var adapter = new TestAdapter(CreateConversation("Fallback"))
-                .Use(new SetSpeakMiddleware("male", "en-us", true));
+                .Use(new SetSpeakMiddleware("male", true));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {
@@ -95,7 +88,7 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task AddVoice(string channelId)
         {
             var adapter = new TestAdapter(CreateConversation("Fallback", channelId: channelId))
-                .Use(new SetSpeakMiddleware("male", "en-us", true));
+                .Use(new SetSpeakMiddleware("male", true));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {
@@ -122,7 +115,7 @@ namespace Microsoft.Bot.Builder.Tests
         public async Task AddNoVoice(string channelId)
         {
             var adapter = new TestAdapter(CreateConversation("Fallback", channelId: channelId))
-                .Use(new SetSpeakMiddleware(null, "en-us", true));
+                .Use(new SetSpeakMiddleware(null, true));
 
             await new TestFlow(adapter, async (context, cancellationToken) =>
             {


### PR DESCRIPTION
### Description

- Removes the lang argument from the SetSpeakMiddleware implementation to align with the current implementation in the Composer runtime (https://github.com/microsoft/BotFramework-Composer/blob/ea04f990e0b675b8ce35f315d5a6c1d6264ae525/runtime/dotnet/core/SetSpeakMiddleware.cs)

- Update adaptive runtime ServiceCollectionExtensions class to ensure middleware is added correctly.

- Also added telephony to the channel constants.

Once this is merged the adaptive runtime implementation will need to be updated to remove the argument when adding the middleware.