### PR TITLE
Cherry pick Remove HostBuilderContext parameter from AddBotRuntimeConfiguration() #5439  Merged

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/ConfigurationBuilderExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/ConfigurationBuilderExtensionsTests.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.Extensions
@@ -20,17 +17,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.Extensions
             var sut = new ConfigurationBuilder();
             Assert.Throws<ArgumentNullException>(() =>
             {
-                sut.AddBotRuntimeConfiguration(null, "blah");
+                sut.AddBotRuntimeConfiguration(null);
             });
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                sut.AddBotRuntimeConfiguration(new HostBuilderContext(new Dictionary<object, object>()), null);
-            });
-
-            Assert.Throws<ArgumentNullException>(() =>
-            {
-                sut.AddBotRuntimeConfiguration(new HostBuilderContext(new Dictionary<object, object>()), string.Empty);
+                ConfigurationBuilderExtensions.AddBotRuntimeConfiguration(null, "blah");
             });
         }
 
@@ -42,15 +34,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.Extensions
         public void LoadsAppSettings(string environmentName, string expectedSetting)
         {
             // Arrange
-            var mockBuilderContext = new HostBuilderContext(new Dictionary<object, object>())
-            {
-                HostingEnvironment = new TestHostingEnvironment { EnvironmentName = environmentName }
-            };
             var applicationRoot = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Extensions", "ConfigurationBuilderExtensionsFiles");
 
             // Act
             var sut = new ConfigurationBuilder();
-            sut.AddBotRuntimeConfiguration(mockBuilderContext, applicationRoot, "settings");
+            sut.AddBotRuntimeConfiguration(applicationRoot, "settings", environmentName);
             var actualConfig = sut.Build();
 
             // Assert runtime properties.
@@ -59,24 +47,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.Extensions
 
             // Assert appsettings values are loaded based on EnvironmentName.
             Assert.Equal(expectedSetting, actualConfig["testSetting"]);
-        }
-
-#if NETCOREAPP2_1
-        /// <summary>
-        /// Help implementation of <see cref="Microsoft.Extensions.Hosting.IHostEnvironment"/> use for testing.
-        /// </summary>
-        private class TestHostingEnvironment : Microsoft.Extensions.Hosting.IHostingEnvironment
-#else
-        private class TestHostingEnvironment : IHostEnvironment
-#endif
-        {
-            public string EnvironmentName { get; set; }
-
-            public string ApplicationName { get; set; }
-
-            public string ContentRootPath { get; set; }
-
-            public IFileProvider ContentRootFileProvider { get; set; }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaced HostBuilderContext parameter in ConfigurationBuilderExtensions.AddBotRuntimeConfiguration() extension method by explicit EnvironmentName (optional) in order to support azure functions and dotnet core apps. (#5439)
