### PR TITLE
Cherry-Pick 5237 to main: uischema: add Teams uischema to enable new kinds in Composer (#5237)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMeetingParticipant.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMeetingParticipant.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMember.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetMember.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedMembers.uischema
@@ -9,5 +9,8 @@
             "continuationToken",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedTeamMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetPagedTeamMembers.uischema
@@ -10,5 +10,8 @@
             "continuationToken",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamChannels.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamChannels.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamDetails.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamDetails.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamMember.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.GetTeamMember.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Microsoft Teams data"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendAppBasedLinkQueryResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendAppBasedLinkQueryResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEActionResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEActionResponse.uischema
@@ -13,5 +13,8 @@
             "completionBotId",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAttachmentsResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAttachmentsResponse.uischema
@@ -10,5 +10,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAuthResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEAuthResponse.uischema
@@ -9,5 +9,8 @@
             "resultProperty",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEBotMessagePreviewResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEBotMessagePreviewResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEConfigQuerySettingUrlResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEConfigQuerySettingUrlResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEMessageResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMEMessageResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMESelectItemResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMESelectItemResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Messaging extension"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMessageToTeamsChannel.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendMessageToTeamsChannel.uischema
@@ -10,5 +10,8 @@
             "conversationReferenceProperty",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabAuthResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabAuthResponse.uischema
@@ -9,5 +9,8 @@
             "resultProperty",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabCardResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTabCardResponse.uischema
@@ -7,5 +7,8 @@
             "cards",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleCardResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleCardResponse.uischema
@@ -13,5 +13,8 @@
             "completionBotId",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleMessageResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleMessageResponse.uischema
@@ -9,5 +9,8 @@
             "cacheDuration",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleUrlResponse.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/Actions/Teams.SendTaskModuleUrlResponse.uischema
@@ -14,5 +14,8 @@
             "completionBotId",
             "*"
         ]
+    },
+    "menu": {
+      "submenu": ["Microsoft Teams", "Response"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnAppBasedLinkQuery.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnAppBasedLinkQuery.uischema
@@ -10,5 +10,12 @@
         ],
         "label": "Teams app based link query",
         "subtitle": "Invoke activity.name='composeExtension/queryLink'"
+    },
+    "trigger": {
+      "submenu": {
+        "label": "Microsoft Teams",
+        "prompt": "Which Teams event?",
+        "placeholder": "Select a Teams event type"
+      }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnCardAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnCardAction.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams card action invoke",
         "subtitle": "Invoke activity with no activity.name"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnFileConsent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnFileConsent.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewEdit.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewEdit.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension preview edit submit action",
         "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'edit'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - BotMessagePreviewEdit"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewSend.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEBotMessagePreviewSend.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension preview send submit action",
         "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'send'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - BotMessagePreviewSend"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMECardButtonClicked.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMECardButtonClicked.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension card button clicked",
         "subtitle": "Invoke activity.name='composeExtension/onCardButtonClicked'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - car button clicked"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigQuerySettingUrl.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigQuerySettingUrl.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension configuration query setting url",
         "subtitle": "Invoke activity.name='composeExtension/querySettingUrl'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on config query setting url"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigSetting.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEConfigSetting.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension configuration setting",
         "subtitle": "Invoke activity.name='composeExtension/setting'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on config setting"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEFetchTask.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEFetchTask.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension fetch task",
         "subtitle": "Invoke activity.name='composeExtension/fetchTask'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on fetch task"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEQuery.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMEQuery.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension query",
         "subtitle": "Invoke activity.name='composeExtension/query'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on query"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESelectItem.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESelectItem.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension select item",
         "subtitle": "Invoke activity.name='composeExtension/selectItem'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on select item"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESubmitAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnMESubmitAction.uischema
@@ -10,5 +10,9 @@
         ],
         "label": "Teams messaging extension submit action",
         "subtitle": "Invoke activity.name='composeExtension/submitAction'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams",
+      "label": "Messaging extension - on submit action"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams O365 connector card action",
         "subtitle": "Invoke activity.name='actionableMessage/executeAction'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabFetch.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabFetch.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams tab fetch",
         "subtitle": "Invoke activity.name='tab/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams task module fetch",
         "subtitle": "Invoke activity.name='task/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.uischema
@@ -10,5 +10,8 @@
         ],
         "label": "Teams task module submit",
         "subtitle": "Invoke activity.name='task/submit'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.uischema
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+}

--- a/tests/tests.uischema
+++ b/tests/tests.uischema
@@ -1472,6 +1472,22 @@
       ]
     }
   },
+  "Teams.GetMeetingParticipant": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetMember": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
   "Teams.GetPagedMembers": {
     "form": {
       "label": "Get paged members",
@@ -1482,6 +1498,12 @@
         "*"
       ],
       "subtitle": "Gets members of a one-on-one, group, or team conversation."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
     }
   },
   "Teams.GetPagedTeamMembers": {
@@ -1495,6 +1517,36 @@
         "*"
       ],
       "subtitle": "Gets members for a team conversation."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetTeamChannels": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetTeamDetails": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
+    }
+  },
+  "Teams.GetTeamMember": {
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Get Microsoft Teams data"
+      ]
     }
   },
   "Teams.OnAppBasedLinkQuery": {
@@ -1508,6 +1560,13 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/queryLink'"
+    },
+    "trigger": {
+      "submenu": {
+        "label": "Microsoft Teams",
+        "placeholder": "Select a Teams event type",
+        "prompt": "Which Teams event?"
+      }
     }
   },
   "Teams.OnCardAction": {
@@ -1521,6 +1580,34 @@
         "*"
       ],
       "subtitle": "Invoke activity with no activity.name"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelCreated": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelDeleted": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelRenamed": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnChannelRestored": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnFileConsent": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEBotMessagePreviewEdit": {
@@ -1534,6 +1621,10 @@
         "*"
       ],
       "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'edit'"
+    },
+    "trigger": {
+      "label": "Messaging extension - BotMessagePreviewEdit",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEBotMessagePreviewSend": {
@@ -1547,6 +1638,10 @@
         "*"
       ],
       "subtitle": "Invoke with activity.value.botMessagePreviewAction == 'send'"
+    },
+    "trigger": {
+      "label": "Messaging extension - BotMessagePreviewSend",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMECardButtonClicked": {
@@ -1560,6 +1655,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/onCardButtonClicked'"
+    },
+    "trigger": {
+      "label": "Messaging extension - car button clicked",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEConfigQuerySettingUrl": {
@@ -1573,6 +1672,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/querySettingUrl'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on config query setting url",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEConfigSetting": {
@@ -1586,6 +1689,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/setting'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on config setting",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEFetchTask": {
@@ -1599,6 +1706,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/fetchTask'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on fetch task",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMEQuery": {
@@ -1612,6 +1723,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/query'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on query",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMESelectItem": {
@@ -1625,6 +1740,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/selectItem'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on select item",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnMESubmitAction": {
@@ -1638,6 +1757,10 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='composeExtension/submitAction'"
+    },
+    "trigger": {
+      "label": "Messaging extension - on submit action",
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnO365ConnectorCardAction": {
@@ -1651,6 +1774,9 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='actionableMessage/executeAction'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnTabFetch": {
@@ -1664,6 +1790,14 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='tab/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTabSubmit": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnTaskModuleFetch": {
@@ -1677,6 +1811,9 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='task/fetch'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.OnTaskModuleSubmit": {
@@ -1690,6 +1827,34 @@
         "*"
       ],
       "subtitle": "Invoke activity.name='task/submit'"
+    },
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamArchived": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamDeleted": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamRenamed": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamRestored": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
+    }
+  },
+  "Teams.OnTeamUnarchived": {
+    "trigger": {
+      "submenu": "Microsoft Teams"
     }
   },
   "Teams.SendAppBasedLinkQueryResponse": {
@@ -1702,6 +1867,12 @@
         "*"
       ],
       "subtitle": "Send a response to a query link request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendMEActionResponse": {
@@ -1718,6 +1889,12 @@
         "*"
       ],
       "subtitle": "Send a response for a messaging extension request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEAttachmentsResponse": {
@@ -1731,6 +1908,12 @@
         "*"
       ],
       "subtitle": "Send an invoke response containing one or more attachments to a messaging extension request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEAuthResponse": {
@@ -1743,6 +1926,12 @@
         "*"
       ],
       "subtitle": "Send a response to a messaging extensin requiring auth."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEBotMessagePreviewResponse": {
@@ -1755,6 +1944,12 @@
         "*"
       ],
       "subtitle": "Send a bot message preview response to a messaging extension request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEConfigQuerySettingUrlResponse": {
@@ -1767,6 +1962,12 @@
         "*"
       ],
       "subtitle": "Send a response to a query setting config url request."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMEMessageResponse": {
@@ -1779,6 +1980,12 @@
         "*"
       ],
       "subtitle": "Send a message response containing text only."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMESelectItemResponse": {
@@ -1791,6 +1998,12 @@
         "*"
       ],
       "subtitle": "Send a messaging extension response when an item is selected"
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Messaging extension"
+      ]
     }
   },
   "Teams.SendMessageToTeamsChannel": {
@@ -1804,6 +2017,12 @@
         "*"
       ],
       "subtitle": "Create a thread and send a message to a teams channel."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTabAuthResponse": {
@@ -1816,6 +2035,12 @@
         "*"
       ],
       "subtitle": "Send a response to a cards tab requiring auth."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTabCardResponse": {
@@ -1826,6 +2051,12 @@
         "*"
       ],
       "subtitle": "Send a tab continue response containing adaptive cards."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTaskModuleCardResponse": {
@@ -1842,6 +2073,12 @@
         "*"
       ],
       "subtitle": "Send a continue response containing a card."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTaskModuleMessageResponse": {
@@ -1854,6 +2091,12 @@
         "*"
       ],
       "subtitle": "Send a message response containing text only."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   },
   "Teams.SendTaskModuleUrlResponse": {
@@ -1871,6 +2114,12 @@
         "*"
       ],
       "subtitle": "Send a continue response containing a url."
+    },
+    "menu": {
+      "submenu": [
+        "Microsoft Teams",
+        "Response"
+      ]
     }
   }
 }


### PR DESCRIPTION
* Update handoff action uischema to show in Composer action menu (#5231)

* uischema: port uischema 'trigger' part to component schema files (#5160)

* add trigger uischema

* update whitespaces

* update UT output uischema

* add Teams Actions menu uischema

* add trigger uischema for Teams Triggers

* check in merged uischema

Co-authored-by: Gary Pretty <gary@garypretty.co.uk>

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->