### PR TITLE
Alexa Channel Id added

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Bot.Connector
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         /// <summary>
+        /// Alexa channel.
+        /// </summary>
+        public const string Alexa = "alexa";
+
+        /// <summary>
         /// Console channel.
         /// </summary>
         public const string Console = "console";


### PR DESCRIPTION
#minor

## Description
Alexa its now a channel supported by the Bot Builder. 
This manner we can check Channel Id using this Alexa constant

before:
```csharp
if (activity.ChannelId == "alexa")
```
after:
```csharp
if (activity.ChannelId == Channels.Alexa)
```

## Specific Changes
Alexa Channel Id added 