### PR TITLE
[Cherry Pick 4.13] Runtime uses connectionString for ApplicationInsights

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -129,13 +129,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
         {
             var telemetrySettings = configuration.GetSection(TelemetrySettings.TelemetrySettingsKey).Get<TelemetrySettings>();
 
-            if (string.IsNullOrEmpty(telemetrySettings?.InstrumentationKey))
+            if (string.IsNullOrEmpty(telemetrySettings?.Options?.ConnectionString) && string.IsNullOrEmpty(telemetrySettings?.Options?.InstrumentationKey))
             {
                 services.AddSingleton<IBotTelemetryClient, NullBotTelemetryClient>();
             }
             else
             {
-                services.AddApplicationInsightsTelemetry(telemetrySettings.InstrumentationKey);
+                services.AddApplicationInsightsTelemetry(telemetrySettings.Options);
                 services.AddSingleton<IBotTelemetryClient, BotTelemetryClient>();
 
                 services.AddTransient<IHttpContextAccessor, HttpContextAccessor>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/TelemetrySettings.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/TelemetrySettings.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings
 {
     /// <summary>
@@ -17,12 +19,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings
         public static string TelemetrySettingsKey => $"{ConfigurationConstants.RuntimeSettingsKey}:telemetry";
 
         /// <summary>
-        /// Gets or sets the telemetry instrumentation key.
+        /// Gets or sets the telemetry <see cref="ApplicationInsightsServiceOptions"/>.
         /// </summary>
         /// <value>
-        /// Telemetry instrumentation key.
+        /// <see cref="ApplicationInsightsServiceOptions"/>.
         /// </value>
-        public string InstrumentationKey { get; set; }
+        public ApplicationInsightsServiceOptions Options { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to log personal information to the telemetry system.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/TelemetryRegistrationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/TelemetryRegistrationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Hosting;
 #if NETCOREAPP2_1
@@ -33,7 +34,10 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
             };
             yield return new object[]
             {
-                new TelemetrySettings() { InstrumentationKey = string.Empty }
+                new TelemetrySettings()
+                {
+                    Options = new ApplicationInsightsServiceOptions() { ConnectionString = null }
+                }
             };
         }
 
@@ -62,7 +66,7 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
             // Setup
             IServiceCollection services = new ServiceCollection();
 
-            var telemetrySettings = new TelemetrySettings() { InstrumentationKey = Guid.NewGuid().ToString() };
+            var telemetrySettings = new TelemetrySettings() { Options = new ApplicationInsightsServiceOptions() { ConnectionString = Guid.NewGuid().ToString() } };
             IConfiguration configuration = new ConfigurationBuilder().AddRuntimeSettings(new RuntimeSettings() { Telemetry = telemetrySettings }).Build();
 
             services.AddTransient<IHttpContextAccessor, HttpContextAccessor>();


### PR DESCRIPTION
Fixes #5456 