### PR TITLE
SDK Adapters: include schemas guaranteeing no duplicates in package

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Microsoft.Bot.Builder.Adapters.Facebook.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Microsoft.Bot.Builder.Adapters.Facebook.csproj
@@ -13,6 +13,7 @@
     <Description>Library for connecting bots with Facebook.</Description>
     <Summary>This library implements C# classes for the Facebook adapter.</Summary>
     <PackageTags>msbot-component;msbot-adapter</PackageTags>
+    <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -20,6 +21,11 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="**/*.schema" />
+    <Content Include="**/*.uischema" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Microsoft.Bot.Builder.Adapters.Slack.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Microsoft.Bot.Builder.Adapters.Slack.csproj
@@ -13,6 +13,7 @@
     <Description>Library for connecting bots with Slack.</Description>
     <Summary>This library implements C# classes for the Slack adapter.</Summary>
     <PackageTags>msbot-component;msbot-adapter</PackageTags>
+    <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,6 +27,11 @@
     <NoWarn>$(NoWarn);CS8002;CS1591</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="**/*.schema" />
+    <Content Include="**/*.uischema" />
+  </ItemGroup>
+    
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SlackAPI" Version="1.1.2" />

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/Microsoft.Bot.Builder.Adapters.Twilio.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/Microsoft.Bot.Builder.Adapters.Twilio.csproj
@@ -13,6 +13,7 @@
     <Description>Library for connecting bots with Twilio SMS API.</Description>
     <Summary>This library implements C# classes for Twilio adapter.</Summary>
     <PackageTags>msbot-component;msbot-adapter</PackageTags>
+    <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,6 +27,11 @@
     <NoWarn>$(NoWarn),CS8002</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="**/*.schema" />
+    <Content Include="**/*.uischema" />
+  </ItemGroup>
+    
   <ItemGroup>
     <PackageReference Include="Twilio" Version="5.37.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/Microsoft.Bot.Builder.Adapters.Webex.csproj
@@ -13,6 +13,7 @@
     <Description>Library for connecting bots with Webex Teams API.</Description>
     <Summary>This library implements C# classes for the Webex Adapter</Summary>
     <PackageTags>msbot-component;msbot-adapter</PackageTags>
+    <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -25,6 +26,11 @@
     <NoWarn>$(NoWarn);CS8002;</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Content Include="**/*.schema" />
+    <Content Include="**/*.uischema" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Thrzn41.WebexTeams" Version="1.6.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />


### PR DESCRIPTION
#minor

This makes csproj files for adapters consistent with the other cs proj by:

- Include schemas and ui schemas the way other csproj do. Example from established project (adaptive dialogs): https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj#L32
- Get all content in a single folder to avoid duplication (which makes schemamerge fail). Example from established project (adaptive dialogs): https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj#L17