### PR TITLE
Add null check for From property in CreateReply

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Bot.Schema
                 Type = ActivityTypes.Message,
                 Timestamp = DateTime.UtcNow,
                 From = new ChannelAccount(id: this.Recipient?.Id, name: this.Recipient?.Name),
-                Recipient = new ChannelAccount(id: this.From.Id, name: this.From.Name),
+                Recipient = new ChannelAccount(id: this.From?.Id, name: this.From?.Name),
                 ReplyToId = this.Id,
                 ServiceUrl = this.ServiceUrl,
                 ChannelId = this.ChannelId,

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -177,6 +177,18 @@ namespace Microsoft.Bot.Schema.Tests
         }
 
         [Fact]
+        public void CreateReplyAllowsNullFrom()
+        {
+            // https://github.com/Microsoft/botbuilder-dotnet/issues/5499
+            var activity = CreateActivity();
+            activity.From = null;
+            var reply = activity.CreateReply();
+
+            // CreateReply flips From and Recipient
+            Assert.Null(reply.Recipient.Id);
+        }
+        
+        [Fact]
         public void CreateTraceAllowsNullRecipient()
         {
             // https://github.com/Microsoft/botbuilder-dotnet/issues/1580


### PR DESCRIPTION
Fixes #5499 

## Description
NullReferenceException being thrown when calling CreateReply method with default/null From property in Activity. Added null check similar to CreateTrace method.

## Specific Changes
  - Null check for From property in CreateReply method