### PR TITLE
uischema: add missing ui options

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Schemas/Microsoft.QnAMakerDialog.uischema
@@ -1,5 +1,11 @@
 {
   "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "label": "Connect to QnA Knowledgebase",
+    "submenu": [
+      "Access external resources"
+    ]
+  },
   "flow": {
     "widget": "ActionCard",
     "body": "=action.hostname"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginDialog.uischema
@@ -18,6 +18,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Begin a new dialog",
+        "submenu": ["Dialog management"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BeginSkill.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Connect to a skill",
+        "submenu": ["Access external resources"]
+    },
     "flow": {
         "widget": "ActionCard",
         "colors": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BreakLoop.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.BreakLoop.uischema
@@ -3,5 +3,9 @@
     "form": {
         "label": "Break out of loop",
         "subtitle": "Break out of loop"
+    },
+    "menu": {
+        "label": "Break out of loop",
+        "submenu": ["Looping"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.CancelAllDialogs.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.CancelAllDialogs.uischema
@@ -5,6 +5,10 @@
         "subtitle": "Cancel All Dialogs",
         "helpLink": "https://aka.ms/bfc-understanding-dialogs"
     },
+    "menu": {
+        "label": "Cancel all active dialogs",
+        "submenu": ["Dialog management"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.CancelDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.CancelDialog.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Cancel dialog",
+      "submenu": ["Dialog management"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueConversation.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueConversation.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Continue conversation",
+      "submenu": ["Dialog management"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueConversationLater.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueConversationLater.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Continue conversation later",
+      "submenu": ["Dialog management"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueLoop.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ContinueLoop.uischema
@@ -3,5 +3,9 @@
     "form": {
         "label": "Continue loop",
         "subtitle": "Continue loop"
+    },
+    "menu": {
+        "label": "Continue loop",
+        "submenu": ["Looping"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DebugBreak.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DebugBreak.uischema
@@ -2,5 +2,9 @@
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "form": {
         "label": "Debug Break"
+    },
+    "menu": {
+        "label": "Debug Break",
+        "submenu": ["Debugging options"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DebugBreak.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DebugBreak.uischema
@@ -4,7 +4,7 @@
         "label": "Debug Break"
     },
     "menu": {
-        "label": "Debug Break",
+        "label": "Debug break",
         "submenu": ["Debugging options"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteActivity.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Delete activity",
+      "submenu": ["Manage properties"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperties.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperties.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Delete properties",
+        "submenu": ["Manage properties"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperty.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.DeleteProperty.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Delete a property",
+        "submenu": ["Manage properties"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": "=action.property"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EditArray.uischema
@@ -17,6 +17,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Edit an array property",
+        "submenu": ["Manage properties"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EmitEvent.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EmitEvent.uischema
@@ -5,6 +5,10 @@
         "subtitle": "Emit Event",
         "helpLink": "https://aka.ms/bfc-custom-events"
     },
+    "menu": {
+        "label": "Emit a custom event",
+        "submenu": ["Access external resources"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EndDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EndDialog.uischema
@@ -4,5 +4,9 @@
         "label": "End this dialog",
         "subtitle": "End Dialog",
         "helpLink": "https://aka.ms/bfc-understanding-dialogs"
+    },
+    "menu": {
+        "label": "End this dialog",
+        "submenu": ["Dialog management"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EndTurn.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.EndTurn.uischema
@@ -4,5 +4,9 @@
         "label": "End turn",
         "subtitle": "End Turn",
         "helpLink": "https://aka.ms/bfc-understanding-dialogs"
+    },
+    "menu": {
+        "label": "End turn",
+        "submenu": ["Dialog management"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.uischema
@@ -29,6 +29,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Loop: For each item",
+        "submenu": ["Looping"]
+    },
     "flow": {
         "widget": "ForeachWidget",
         "nowrap": true,

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ForeachPage.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ForeachPage.uischema
@@ -30,6 +30,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Loop: For each page (multiple items)",
+        "submenu": ["Looping"]
+    },
     "flow": {
         "widget": "ForeachWidget",
         "nowrap": true,

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetActivityMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetActivityMembers.uischema
@@ -1,5 +1,11 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "menu": {
+        "label": "Get activity members",
+        "submenu": [
+            "Manage properties"
+        ]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationMembers.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationMembers.uischema
@@ -1,5 +1,11 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "menu": {
+        "label": "Get conversation members",
+        "submenu": [
+            "Manage properties"
+        ]
+    },
     "flow": {
         "widget": "ActionCard",
         "footer": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationReference.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GetConversationReference.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Get conversation reference",
+      "submenu": ["Dialog management"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GotoAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.GotoAction.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Go to action",
+      "submenu": ["Dialog management"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.uischema
@@ -19,6 +19,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Send an HTTP request",
+        "submenu": ["Access external resources"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.IfCondition.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.IfCondition.uischema
@@ -9,6 +9,10 @@
         ],
         "helpLink": "https://aka.ms/bfc-controlling-conversation-flow"
     },
+    "menu": {
+        "label": "Branch: If/else",
+        "submenu": ["Create a condition"]
+    },
     "flow": {
         "widget": "IfConditionWidget",
         "nowrap": true,

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.LogAction.uischema
@@ -4,5 +4,9 @@
         "label": "Log to console",
         "subtitle": "Log Action",
         "helpLink": "https://aka.ms/composer-telemetry"
+    },
+    "menu": {
+        "label": "Log to console",
+        "submenu": ["Debugging options"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.RepeatDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.RepeatDialog.uischema
@@ -8,5 +8,9 @@
             "options",
             "*"
         ]
+    },
+    "menu": {
+        "label": "Repeat this dialog",
+        "submenu": ["Dialog management"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ReplaceDialog.uischema
@@ -10,6 +10,10 @@
             "*"
         ]
     },
+    "menu": {
+        "label": "Replace this dialog",
+        "submenu": ["Dialog management"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SendActivity.uischema
@@ -9,6 +9,10 @@
             "*"
         ]
     },
+    "menu": {
+        "label": "Send a response",
+        "submenu": false
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperties.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperties.uischema
@@ -16,6 +16,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Set properties",
+        "submenu": ["Manage properties"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperty.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SetProperty.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Set a property",
+        "submenu": ["Manage properties"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": "${coalesce(action.property, \"?\")} : ${coalesce(action.value, \"?\")}"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SignOutUser.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SignOutUser.uischema
@@ -3,5 +3,9 @@
     "form": {
         "label": "Sign out user",
         "subtitle": "Signout User"
+    },
+    "menu": {
+        "label": "Sign out user",
+        "submenu": ["Access external resources"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.uischema
@@ -20,6 +20,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Branch: Switch (multiple options)",
+        "submenu": ["Create a condition"]
+    },
     "flow": {
         "widget": "SwitchConditionWidget",
         "nowrap": true,

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TelemetryTrackEventAction.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TelemetryTrackEventAction.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+      "label": "Emit a telemetry track event",
+      "submenu": ["Debugging options"]
+  }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ThrowException.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.ThrowException.uischema
@@ -4,6 +4,10 @@
         "label": "Throw an exception",
         "subtitle": "Throw an exception"
     },
+    "menu": {
+        "label": "Throw exception",
+        "submenu": ["Debugging options"]
+    },
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TraceActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.TraceActivity.uischema
@@ -4,5 +4,9 @@
         "label": "Emit a trace event",
         "subtitle": "Trace Activity",
         "helpLink": "https://aka.ms/composer-telemetry"
+    },
+    "menu": {
+        "label": "Emit a trace event",
+        "submenu": ["Debugging options"]
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.UpdateActivity.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.UpdateActivity.uischema
@@ -4,6 +4,10 @@
         "label": "Update an activity",
         "subtitle": "Update Activity"
     },
+    "menu": {
+        "label": "Update an activity",
+        "submenu": ["Manage properties"]
+    },
     "flow": {
         "widget": "ActionCard",
         "header": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.Ask.uischema
@@ -9,6 +9,10 @@
             "*"
         ]
     },
+    "menu": {
+        "label": "Ask Activity",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "ActionCard",
         "header": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.AttachmentInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.AttachmentInput.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "File or attachment",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "PromptWidget",
         "body": "=action.prompt",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ChoiceInput.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Multi-choice",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "PromptWidget",
         "body": "=action.prompt",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.ConfirmInput.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Confirmation",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "PromptWidget",
         "body": "=action.prompt",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.DateTimeInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.DateTimeInput.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Date or time",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "PromptWidget",
         "body": "=action.prompt",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.NumberInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.NumberInput.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Number",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "PromptWidget",
         "body": "=action.prompt",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.OAuthInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.OAuthInput.uischema
@@ -9,6 +9,16 @@
             "*"
         ]
     },
+    "menu": [
+        {
+            "label": "OAuth login",
+            "submenu": ["Ask a question"]
+        },
+        {
+            "label": "OAuth login",
+            "submenu": ["Access external resources"]
+        }
+    ],
     "flow": {
         "widget": "ActionCard",
         "body": {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.TextInput.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.TextInput.uischema
@@ -12,6 +12,10 @@
             }
         }
     },
+    "menu": {
+        "label": "Text",
+        "submenu": ["Ask a question"]
+    },
     "flow": {
         "widget": "PromptWidget",
         "body": "=action.prompt",

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnContinueConversation.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnContinueConversation.uischema
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "form": {
+      "hidden": [
+          "actions"
+      ]
+  },
+  "trigger": {
+    "submenu": "Activities"
+  }
+}

--- a/tests/tests.uischema
+++ b/tests/tests.uischema
@@ -53,6 +53,12 @@
         "*"
       ],
       "subtitle": "Ask Activity"
+    },
+    "menu": {
+      "label": "Ask Activity",
+      "submenu": [
+        "Ask a question"
+      ]
     }
   },
   "Microsoft.AttachmentInput": {
@@ -101,6 +107,12 @@
         }
       },
       "subtitle": "Attachment Input"
+    },
+    "menu": {
+      "label": "File or attachment",
+      "submenu": [
+        "Ask a question"
+      ]
     }
   },
   "Microsoft.BeginDialog": {
@@ -134,6 +146,12 @@
         }
       },
       "subtitle": "Begin Dialog"
+    },
+    "menu": {
+      "label": "Begin a new dialog",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.BeginSkill": {
@@ -169,12 +187,24 @@
         }
       },
       "subtitle": "Skill Dialog"
+    },
+    "menu": {
+      "label": "Connect to a skill",
+      "submenu": [
+        "Access external resources"
+      ]
     }
   },
   "Microsoft.BreakLoop": {
     "form": {
       "label": "Break out of loop",
       "subtitle": "Break out of loop"
+    },
+    "menu": {
+      "label": "Break out of loop",
+      "submenu": [
+        "Looping"
+      ]
     }
   },
   "Microsoft.CancelAllDialogs": {
@@ -190,6 +220,20 @@
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
       "label": "Cancel all active dialogs",
       "subtitle": "Cancel All Dialogs"
+    },
+    "menu": {
+      "label": "Cancel all active dialogs",
+      "submenu": [
+        "Dialog management"
+      ]
+    }
+  },
+  "Microsoft.CancelDialog": {
+    "menu": {
+      "label": "Cancel dialog",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.ChoiceInput": {
@@ -238,6 +282,12 @@
         }
       },
       "subtitle": "Choice Input"
+    },
+    "menu": {
+      "label": "Multi-choice",
+      "submenu": [
+        "Ask a question"
+      ]
     }
   },
   "Microsoft.ConfirmInput": {
@@ -286,12 +336,40 @@
         }
       },
       "subtitle": "Confirm Input"
+    },
+    "menu": {
+      "label": "Confirmation",
+      "submenu": [
+        "Ask a question"
+      ]
+    }
+  },
+  "Microsoft.ContinueConversation": {
+    "menu": {
+      "label": "Continue conversation",
+      "submenu": [
+        "Dialog management"
+      ]
+    }
+  },
+  "Microsoft.ContinueConversationLater": {
+    "menu": {
+      "label": "Continue conversation later",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.ContinueLoop": {
     "form": {
       "label": "Continue loop",
       "subtitle": "Continue loop"
+    },
+    "menu": {
+      "label": "Continue loop",
+      "submenu": [
+        "Looping"
+      ]
     }
   },
   "Microsoft.DateTimeInput": {
@@ -340,11 +418,31 @@
         }
       },
       "subtitle": "Date Time Input"
+    },
+    "menu": {
+      "label": "Date or time",
+      "submenu": [
+        "Ask a question"
+      ]
     }
   },
   "Microsoft.DebugBreak": {
     "form": {
       "label": "Debug Break"
+    },
+    "menu": {
+      "label": "Debug break",
+      "submenu": [
+        "Debugging options"
+      ]
+    }
+  },
+  "Microsoft.DeleteActivity": {
+    "menu": {
+      "label": "Delete activity",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.DeleteProperties": {
@@ -366,6 +464,12 @@
         }
       },
       "subtitle": "Delete Properties"
+    },
+    "menu": {
+      "label": "Delete properties",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.DeleteProperty": {
@@ -384,6 +488,12 @@
         }
       },
       "subtitle": "Delete Property"
+    },
+    "menu": {
+      "label": "Delete a property",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.EditActions": {
@@ -427,6 +537,12 @@
         }
       },
       "subtitle": "Edit Array"
+    },
+    "menu": {
+      "label": "Edit an array property",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.EmitEvent": {
@@ -442,6 +558,12 @@
       "helpLink": "https://aka.ms/bfc-custom-events",
       "label": "Emit a custom event",
       "subtitle": "Emit Event"
+    },
+    "menu": {
+      "label": "Emit a custom event",
+      "submenu": [
+        "Access external resources"
+      ]
     }
   },
   "Microsoft.EndDialog": {
@@ -449,6 +571,12 @@
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
       "label": "End this dialog",
       "subtitle": "End Dialog"
+    },
+    "menu": {
+      "label": "End this dialog",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.EndTurn": {
@@ -456,6 +584,12 @@
       "helpLink": "https://aka.ms/bfc-understanding-dialogs",
       "label": "End turn",
       "subtitle": "End Turn"
+    },
+    "menu": {
+      "label": "End turn",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.FacebookAdapter": {
@@ -511,6 +645,12 @@
         }
       },
       "subtitle": "For Each"
+    },
+    "menu": {
+      "label": "Loop: For each item",
+      "submenu": [
+        "Looping"
+      ]
     }
   },
   "Microsoft.ForeachPage": {
@@ -551,6 +691,12 @@
         }
       },
       "subtitle": "For Each Page"
+    },
+    "menu": {
+      "label": "Loop: For each page (multiple items)",
+      "submenu": [
+        "Looping"
+      ]
     }
   },
   "Microsoft.GetActivityMembers": {
@@ -566,6 +712,12 @@
         "widget": "PropertyDescription"
       },
       "widget": "ActionCard"
+    },
+    "menu": {
+      "label": "Get activity members",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.GetConversationMembers": {
@@ -576,6 +728,28 @@
         "widget": "PropertyDescription"
       },
       "widget": "ActionCard"
+    },
+    "menu": {
+      "label": "Get conversation members",
+      "submenu": [
+        "Manage properties"
+      ]
+    }
+  },
+  "Microsoft.GetConversationReference": {
+    "menu": {
+      "label": "Get conversation reference",
+      "submenu": [
+        "Dialog management"
+      ]
+    }
+  },
+  "Microsoft.GotoAction": {
+    "menu": {
+      "label": "Go to action",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.HttpRequest": {
@@ -612,6 +786,12 @@
         }
       },
       "subtitle": "HTTP Request"
+    },
+    "menu": {
+      "label": "Send an HTTP request",
+      "submenu": [
+        "Access external resources"
+      ]
     }
   },
   "Microsoft.IfCondition": {
@@ -631,6 +811,12 @@
       ],
       "label": "Branch: If/Else",
       "subtitle": "If Condition"
+    },
+    "menu": {
+      "label": "Branch: If/else",
+      "submenu": [
+        "Create a condition"
+      ]
     }
   },
   "Microsoft.LogAction": {
@@ -638,6 +824,12 @@
       "helpLink": "https://aka.ms/composer-telemetry",
       "label": "Log to console",
       "subtitle": "Log Action"
+    },
+    "menu": {
+      "label": "Log to console",
+      "submenu": [
+        "Debugging options"
+      ]
     }
   },
   "Microsoft.NumberInput": {
@@ -686,6 +878,12 @@
         }
       },
       "subtitle": "Number Input"
+    },
+    "menu": {
+      "label": "Number",
+      "submenu": [
+        "Ask a question"
+      ]
     }
   },
   "Microsoft.OAuthInput": {
@@ -712,7 +910,21 @@
         "*"
       ],
       "subtitle": "OAuth Input"
-    }
+    },
+    "menu": [
+      {
+        "label": "OAuth login",
+        "submenu": [
+          "Ask a question"
+        ]
+      },
+      {
+        "label": "OAuth login",
+        "submenu": [
+          "Access external resources"
+        ]
+      }
+    ]
   },
   "Microsoft.OnActivity": {
     "form": {
@@ -862,6 +1074,16 @@
         "*"
       ],
       "subtitle": "Condition"
+    }
+  },
+  "Microsoft.OnContinueConversation": {
+    "form": {
+      "hidden": [
+        "actions"
+      ]
+    },
+    "trigger": {
+      "submenu": "Activities"
     }
   },
   "Microsoft.OnConversationUpdateActivity": {
@@ -1171,6 +1393,12 @@
     "flow": {
       "body": "=action.hostname",
       "widget": "ActionCard"
+    },
+    "menu": {
+      "label": "Connect to QnA Knowledgebase",
+      "submenu": [
+        "Access external resources"
+      ]
     }
   },
   "Microsoft.RegexRecognizer": {
@@ -1189,6 +1417,12 @@
         "*"
       ],
       "subtitle": "Repeat Dialog"
+    },
+    "menu": {
+      "label": "Repeat this dialog",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.ReplaceDialog": {
@@ -1208,6 +1442,12 @@
         "*"
       ],
       "subtitle": "Replace Dialog"
+    },
+    "menu": {
+      "label": "Replace this dialog",
+      "submenu": [
+        "Dialog management"
+      ]
     }
   },
   "Microsoft.SendActivity": {
@@ -1234,6 +1474,10 @@
         "*"
       ],
       "subtitle": "Send Activity"
+    },
+    "menu": {
+      "label": "Send a response",
+      "submenu": false
     }
   },
   "Microsoft.SendHandoffActivity": {
@@ -1275,6 +1519,12 @@
         }
       },
       "subtitle": "Set Properties"
+    },
+    "menu": {
+      "label": "Set properties",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.SetProperty": {
@@ -1293,12 +1543,24 @@
         }
       },
       "subtitle": "Set Property"
+    },
+    "menu": {
+      "label": "Set a property",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.SignOutUser": {
     "form": {
       "label": "Sign out user",
       "subtitle": "Signout User"
+    },
+    "menu": {
+      "label": "Sign out user",
+      "submenu": [
+        "Access external resources"
+      ]
     }
   },
   "Microsoft.SlackAdapter": {
@@ -1345,6 +1607,20 @@
         }
       },
       "subtitle": "Switch Condition"
+    },
+    "menu": {
+      "label": "Branch: Switch (multiple options)",
+      "submenu": [
+        "Create a condition"
+      ]
+    }
+  },
+  "Microsoft.TelemetryTrackEventAction": {
+    "menu": {
+      "label": "Emit a telemetry track event",
+      "submenu": [
+        "Debugging options"
+      ]
     }
   },
   "Microsoft.TextInput": {
@@ -1393,6 +1669,12 @@
         }
       },
       "subtitle": "Text Input"
+    },
+    "menu": {
+      "label": "Text",
+      "submenu": [
+        "Ask a question"
+      ]
     }
   },
   "Microsoft.ThrowException": {
@@ -1407,6 +1689,12 @@
     "form": {
       "label": "Throw an exception",
       "subtitle": "Throw an exception"
+    },
+    "menu": {
+      "label": "Throw exception",
+      "submenu": [
+        "Debugging options"
+      ]
     }
   },
   "Microsoft.TraceActivity": {
@@ -1414,6 +1702,12 @@
       "helpLink": "https://aka.ms/composer-telemetry",
       "label": "Emit a trace event",
       "subtitle": "Trace Activity"
+    },
+    "menu": {
+      "label": "Emit a trace event",
+      "submenu": [
+        "Debugging options"
+      ]
     }
   },
   "Microsoft.TwilioAdapter": {
@@ -1453,6 +1747,12 @@
     "form": {
       "label": "Update an activity",
       "subtitle": "Update Activity"
+    },
+    "menu": {
+      "label": "Update an activity",
+      "submenu": [
+        "Manage properties"
+      ]
     }
   },
   "Microsoft.WebexAdapter": {


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Add missing UI options in *.uischema files. Fixes several issues in Composer.

Closes https://github.com/microsoft/BotFramework-Composer/issues/7034
Closes https://github.com/microsoft/BotFramework-Composer/issues/7035

## Specific Changes
<!-- Please list the changes in a concise manner. -->
  - Add missing `menu` uischema for built-in actions (duplicated from Composer, Composer will remove those hardcoded uischema)
  - Add missing `menu` uischema for several actions mentioned in https://github.com/microsoft/BotFramework-Composer/issues/7034
  - Add missing `trigger` uischema for triggers mentioned in https://github.com/microsoft/BotFramework-Composer/issues/7035

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->