### PR TITLE
[#5302][Slack Adapter] Skill not answering messages to Virtual Assistant/Root Bot connected to Slack

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -227,7 +227,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                     Id = innerEvent.User ?? innerEvent.BotId ?? eventRequest.TeamId
                 },
                 ChannelData = eventRequest,
-                Type = ActivityTypes.Event
+                Type = ActivityTypes.Event,
+                ServiceUrl = "https://slack.botframework.com/"
             };
 
             activity.Recipient = new ChannelAccount()

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackHelper.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 {
     internal static class SlackHelper
     {
+        private const string SlackServiceUrl = "https://slack.botframework.com/";
+
         /// <summary>
         /// Formats a BotBuilder activity into an outgoing Slack message.
         /// </summary>
@@ -228,7 +230,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 },
                 ChannelData = eventRequest,
                 Type = ActivityTypes.Event,
-                ServiceUrl = "https://slack.botframework.com/"
+                ServiceUrl = SlackServiceUrl
             };
 
             activity.Recipient = new ChannelAccount()


### PR DESCRIPTION
Addresses #5302

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR adds the missing service URL in the activities interpreted from slack events, causing the replies from a skill to throw a 500 error when received in the host.

Note: This change by itself is not enough to use a skill in slack, while this fixes the communication issue with the message sent from the skill to the host, then the host fails to send the message to slack if the adapter injected in the skill controller doesn't implement the slack adapter.

## Specific Changes
<!-- Please list the changes in a concise manner. -->
Added the slack service URL to a const variable and used when creating the activity from an event in the SlackHelper class.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
In the image below you can see the message received in the host from the skill is responded OK.
![image](https://user-images.githubusercontent.com/38112957/114038118-f8485a00-9857-11eb-8ec6-a9e499cc7820.png)
![image](https://user-images.githubusercontent.com/38112957/114039575-3db95700-9859-11eb-95b9-2a1ff8400cc0.png)

