### PR TITLE
Update Adaptive Runtime to add telemetry client to the TurnState

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/ConfigurationAdaptiveDialogBot.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/ConfigurationAdaptiveDialogBot.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.ApplicationInsights;
+using Microsoft.Bot.Builder.ApplicationInsights;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Memory;
 using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
@@ -28,6 +30,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime
         /// <param name="skillConversationIdFactoryBase">The <see cref="SkillConversationIdFactoryBase"/> implementation to use for this <see cref="AdaptiveDialog"/>.</param>
         /// <param name="languagePolicy">The <see cref="LanguagePolicy"/> implementation to use for this <see cref="AdaptiveDialog"/>.</param>
         /// <param name="botFrameworkAuthentication">A <see cref="BotFrameworkAuthentication"/> for making calls to Bot Builder Skills.</param>
+        /// <param name="telemetryClient">A <see cref="IBotTelemetryClient"/> for logging bot telemetry events.</param>
         /// <param name="scopes">A set of <see cref="MemoryScope"/> that will be added to the <see cref="ITurnContext"/>.</param>
         /// <param name="pathResolvers">A set of <see cref="IPathResolver"/> that will be added to the <see cref="ITurnContext"/>.</param>
         /// <param name="dialogs">Custom <see cref="Dialog"/> that will be added to the root DialogSet.</param>
@@ -40,6 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime
             SkillConversationIdFactoryBase skillConversationIdFactoryBase,
             LanguagePolicy languagePolicy,
             BotFrameworkAuthentication botFrameworkAuthentication = null,
+            IBotTelemetryClient telemetryClient = null,
             IEnumerable<MemoryScope> scopes = default,
             IEnumerable<IPathResolver> pathResolvers = default,
             IEnumerable<Dialog> dialogs = default,
@@ -53,6 +57,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime
                 skillConversationIdFactoryBase,
                 languagePolicy,
                 botFrameworkAuthentication ?? BotFrameworkAuthenticationFactory.Create(),
+                telemetryClient ?? new NullBotTelemetryClient(),
                 scopes ?? Enumerable.Empty<MemoryScope>(),
                 pathResolvers ?? Enumerable.Empty<IPathResolver>(),
                 dialogs ?? Enumerable.Empty<Dialog>(),

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -315,10 +315,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             var action = this.Actions[offset];
             var actionName = action.GetType().Name.ToString();
+            dc.Parent.ActiveDialog.State.TryGetValue("instanceId", out var instanceId);
 
             var properties = new Dictionary<string, string>()
             {
-                { "DialogId", action.Id },
+                { "DialogId", dc.Parent.ActiveDialog.Id },
+                { "InstanceId", instanceId?.ToString() },
                 { "Kind", $"Microsoft.{actionName}" },
                 { "ActionId", $"Microsoft.{action.Id}" },
             };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ActionScope.cs
@@ -315,12 +315,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             var action = this.Actions[offset];
             var actionName = action.GetType().Name.ToString();
-            dc.Parent.ActiveDialog.State.TryGetValue("instanceId", out var instanceId);
 
             var properties = new Dictionary<string, string>()
             {
-                { "DialogId", dc.Parent.ActiveDialog.Id },
-                { "InstanceId", instanceId?.ToString() },
+                { "DialogId", action.Id },
                 { "Kind", $"Microsoft.{actionName}" },
                 { "ActionId", $"Microsoft.{action.Id}" },
             };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -210,14 +210,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 Value = options,
                 Bubble = false
             };
-
-            var instanceId = Guid.NewGuid().ToString();
-            activeDialogState["instanceId"] = instanceId;
-
+            
             var properties = new Dictionary<string, string>()
                 {
                     { "DialogId", Id },
-                    { "InstanceId", instanceId },
                     { "Kind", Kind }
                 };
             TelemetryClient.TrackEvent("AdaptiveDialogStart", properties);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -211,9 +211,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 Bubble = false
             };
 
+            var instanceId = Guid.NewGuid().ToString();
+            activeDialogState["instanceId"] = instanceId;
+
             var properties = new Dictionary<string, string>()
                 {
                     { "DialogId", Id },
+                    { "InstanceId", instanceId },
                     { "Kind", Kind }
                 };
             TelemetryClient.TrackEvent("AdaptiveDialogStart", properties);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialogBot.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialogBot.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         private readonly ConversationState _conversationState;
         private readonly UserState _userState;
         private readonly BotFrameworkAuthentication _botFrameworkAuthentication;
+        private readonly IBotTelemetryClient _telemetryClient;
         private readonly LanguagePolicy _languagePolicy;
         private readonly IEnumerable<MemoryScope> _memoryScopes;
         private readonly IEnumerable<IPathResolver> _pathResolvers;
@@ -51,6 +52,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         /// <param name="skillConversationIdFactoryBase">A <see cref="SkillConversationIdFactoryBase"/> implementation.</param>
         /// <param name="languagePolicy">A <see cref="LanguagePolicy"/> to use.</param>
         /// <param name="botFrameworkAuthentication">A <see cref="BotFrameworkAuthentication"/> used to obtain a client for making calls to Bot Builder Skills.</param>
+        /// <param name="telemetryClient">A <see cref="IBotTelemetryClient"/> used to log bot telemetry events.</param>
         /// <param name="scopes">Custom <see cref="MemoryScope"/> implementations that extend the memory system.</param>
         /// <param name="pathResolvers">Custom <see cref="IPathResolver"/> that add new resolvers path shortcuts to memory scopes.</param>
         /// <param name="dialogs">Custom <see cref="Dialog"/> that will be added to the root DialogSet.</param>
@@ -64,6 +66,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             SkillConversationIdFactoryBase skillConversationIdFactoryBase,
             LanguagePolicy languagePolicy,
             BotFrameworkAuthentication botFrameworkAuthentication,
+            IBotTelemetryClient telemetryClient,
             IEnumerable<MemoryScope> scopes = default,
             IEnumerable<IPathResolver> pathResolvers = default,
             IEnumerable<Dialog> dialogs = default,
@@ -77,6 +80,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             _skillConversationIdFactoryBase = skillConversationIdFactoryBase ?? throw new ArgumentNullException(nameof(skillConversationIdFactoryBase));
             _languagePolicy = languagePolicy ?? throw new ArgumentNullException(nameof(languagePolicy));
             _botFrameworkAuthentication = botFrameworkAuthentication ?? throw new ArgumentNullException(nameof(botFrameworkAuthentication));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
             _memoryScopes = scopes ?? Enumerable.Empty<MemoryScope>();
             _pathResolvers = pathResolvers ?? Enumerable.Empty<IPathResolver>();
             _dialogs = dialogs ?? Enumerable.Empty<Dialog>();
@@ -119,6 +123,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             turnContext.TurnState.Add(_resourceExplorer.TryGetResource(_languageGeneratorId, out var resource) ? (LanguageGenerator)new ResourceMultiLanguageGenerator(_languageGeneratorId) : new TemplateEngineLanguageGenerator());
             turnContext.TurnState.Add(_languageGeneratorManagers.GetOrAdd(_resourceExplorer, _ => new LanguageGeneratorManager(_resourceExplorer)));
             turnContext.TurnState.Add(_languagePolicy);
+            turnContext.TurnState.Add(_telemetryClient);
 
             // put this on the TurnState using Set because some adapters (like BotFrameworkAdapter and CloudAdapter) will have already added it
             turnContext.TurnState.Set<BotCallbackHandler>(OnTurnAsync);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogBotTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogBotTests.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
             var turnContext = new TurnContext(adapterMock.Object, activity);
 
+            var telemetryClient = new NullBotTelemetryClient();
+
             // Act
             var bot = new AdaptiveDialogBot(
                 "main.dialog", 
@@ -66,6 +68,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 skillConversationIdFactory,
                 languagePolicy,
                 botFrameworkAuthenticationMock.Object,
+                telemetryClient,
                 logger: logger);
             
             await bot.OnTurnAsync(turnContext, CancellationToken.None);
@@ -116,6 +119,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
             var turnContext = new TurnContext(adapterMock.Object, activity);
 
+            var telemetryClient = new NullBotTelemetryClient();
+
             // Act
             var bot = new AdaptiveDialogBot(
                 "main.dialog",
@@ -126,6 +131,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 skillConversationIdFactory,
                 languagePolicy,
                 botFrameworkAuthenticationMock.Object,
+                telemetryClient,
                 logger: logger);
             
             var exception = await Record.ExceptionAsync(() => ((IBot)bot).OnTurnAsync(turnContext, CancellationToken.None));


### PR DESCRIPTION
Fixes #5504 

## Description
PR to ensure adaptive dialog events are being logged correctly.

## Specific Changes

- Ensures the IBotTelemetryClient is added to the TurnState, which then ensures adaptive dialog events are correctly captured.
- Amends the value of dialogId captured on the AdaptiveDialogAction event to use the parent dialog Id.
- Adds an Instance Id property to the AdaptiveDialogStart / AdaptiveDialogComplete / AdaptiveDialogAction events to ensure they can be correlated within App Insights queries (this brings parity with waterfall dialog telemetry events).