### PR TITLE
Update to ensure ContinueConversationAsync works with an empty AppId

### DIFF
--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -278,6 +278,11 @@ namespace Microsoft.Bot.Builder
         /// <returns>A <see cref="ClaimsIdentity"/> with the audience and appId claims set to the appId.</returns>
         protected ClaimsIdentity CreateClaimsIdentity(string botAppId)
         {
+            if (botAppId == null)
+            {
+                botAppId = string.Empty;
+            }
+
             // Hand craft Claims Identity.
             return new ClaimsIdentity(new List<Claim>
             {

--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -278,11 +278,6 @@ namespace Microsoft.Bot.Builder
         /// <returns>A <see cref="ClaimsIdentity"/> with the audience and appId claims set to the appId.</returns>
         protected ClaimsIdentity CreateClaimsIdentity(string botAppId)
         {
-            if (string.IsNullOrWhiteSpace(botAppId))
-            {
-                throw new ArgumentNullException(nameof(botAppId));
-            }
-
             // Hand craft Claims Identity.
             return new ClaimsIdentity(new List<Claim>
             {


### PR DESCRIPTION
Fixes #5491 

## Description
Removes the null argument check when constructing creds for ContinueConversationAsync to ensure it can be called without an AppId.