### PR TITLE
Apply Expression equal function in LG library

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
@@ -21,66 +21,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
         public Equal()
             : base(
                   ExpressionType.Equal,
-                  Function,
+                  (args) => !FunctionUtils.CommonEquals(args[0], args[1]),
                   FunctionUtils.ValidateBinary)
         {
-        }
-
-        private static bool Function(IReadOnlyList<object> args)
-        {
-            if (args[0] == null || args[1] == null)
-            {
-                // null will only equals to null
-                return args[0] == null && args[1] == null;
-            }
-
-            if (FunctionUtils.TryParseList(args[0], out IList l0) && l0.Count == 0 && (FunctionUtils.TryParseList(args[1], out IList l1) && l1.Count == 0))
-            {
-                return true;
-            }
-
-            if (GetPropertyCount(args[0]) == 0 && GetPropertyCount(args[1]) == 0)
-            {
-                return true;
-            }
-
-            if (args[0].IsNumber() && args[0].IsNumber())
-            {
-                if (Math.Abs(FunctionUtils.CultureInvariantDoubleConvert(args[0]) - FunctionUtils.CultureInvariantDoubleConvert(args[1])) < double.Epsilon)
-                {
-                    return true;
-                }
-            }
-
-            try
-            {
-                return args[0] == args[1] || (args[0] != null && args[0].Equals(args[1]));
-            }
-#pragma warning disable CA1031 // Do not catch general exception types (we return false if it fails for whatever reason)
-            catch
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
-                return false;
-            }
-        }
-
-        private static int GetPropertyCount(object obj)
-        {
-            if (obj is IDictionary dictionary)
-            {
-                return dictionary.Count;
-            }
-            else if (obj is JObject jobj)
-            {
-                return jobj.Properties().Count();
-            }
-            else if (!(obj is JValue) && obj.GetType().IsValueType == false && obj.GetType().FullName != "System.String")
-            {
-                // exclude constant type.
-                return obj.GetType().GetProperties().Length;
-            }
-
-            return -1;
         }
     }
 }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Equal.cs
@@ -21,7 +21,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
         public Equal()
             : base(
                   ExpressionType.Equal,
-                  (args) => !FunctionUtils.CommonEquals(args[0], args[1]),
+                  (args) => FunctionUtils.CommonEquals(args[0], args[1]),
                   FunctionUtils.ValidateBinary)
         {
         }

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/NotEqual.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/NotEqual.cs
@@ -20,66 +20,9 @@ namespace AdaptiveExpressions.BuiltinFunctions
         public NotEqual()
             : base(
                   ExpressionType.NotEqual,
-                  (args) => !Function(args),
+                  (args) => !FunctionUtils.CommonEquals(args[0], args[1]),
                   FunctionUtils.ValidateBinary)
         {
-        }
-
-        private static bool Function(IReadOnlyList<object> args)
-        {
-            if (args[0] == null || args[1] == null)
-            {
-                // null will only equals to null
-                return args[0] == null && args[1] == null;
-            }
-
-            if (FunctionUtils.TryParseList(args[0], out IList l0) && l0.Count == 0 && (FunctionUtils.TryParseList(args[1], out IList l1) && l1.Count == 0))
-            {
-                return true;
-            }
-
-            if (GetPropertyCount(args[0]) == 0 && GetPropertyCount(args[1]) == 0)
-            {
-                return true;
-            }
-
-            if (args[0].IsNumber() && args[0].IsNumber())
-            {
-                if (Math.Abs(FunctionUtils.CultureInvariantDoubleConvert(args[0]) - FunctionUtils.CultureInvariantDoubleConvert(args[1])) < double.Epsilon)
-                {
-                    return true;
-                }
-            }
-
-            try
-            {
-                return args[0] == args[1] || (args[0] != null && args[0].Equals(args[1]));
-            }
-#pragma warning disable CA1031 // Do not catch general exception types (we return false if the operation fails for whatever reason)
-            catch
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
-                return false;
-            }
-        }
-
-        private static int GetPropertyCount(object obj)
-        {
-            if (obj is IDictionary dictionary)
-            {
-                return dictionary.Count;
-            }
-            else if (obj is JObject jobj)
-            {
-                return jobj.Properties().Count();
-            }
-            else if (!(obj is JValue) && obj.GetType().IsValueType == false && obj.GetType().FullName != "System.String")
-            {
-                // exclude constant type.
-                return obj.GetType().GetProperties().Length;
-            }
-
-            return -1;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -281,8 +281,6 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                 var caseErrorPrefix = "Case '" + caseExprs[0].GetText() + "': ";
                 var caseExprResult = EvalExpression(caseExprs[0].GetText(), caseExprs[0], switchCaseNode.switchCaseStat().GetText(), caseErrorPrefix);
-                var r1 = switchExprResult.GetType();
-                var r2 = caseExprResult.GetType();
                 if (FunctionUtils.CommonEquals(switchExprResult, caseExprResult))
                 {
                     return Visit(switchCaseNode.normalTemplateBody());

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs
@@ -281,7 +281,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
                 var caseErrorPrefix = "Case '" + caseExprs[0].GetText() + "': ";
                 var caseExprResult = EvalExpression(caseExprs[0].GetText(), caseExprs[0], switchCaseNode.switchCaseStat().GetText(), caseErrorPrefix);
-                if (switchExprResult == caseExprResult || (switchExprResult != null && switchExprResult.Equals(caseExprResult)))
+                var r1 = switchExprResult.GetType();
+                var r2 = caseExprResult.GetType();
+                if (FunctionUtils.CommonEquals(switchExprResult, caseExprResult))
                 {
                     return Visit(switchCaseNode.normalTemplateBody());
                 }

--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
                 var caseExprs = switchCaseNode.switchCaseStat().expression();
                 var caseErrorPrefix = "Case '" + caseExprs[0].GetText() + "': ";
                 var caseExprResult = EvalExpression(caseExprs[0].GetText(), switchCaseNode.switchCaseStat().GetText(), caseErrorPrefix);
-                if (switchExprResult[0] == caseExprResult[0] || (switchExprResult[0] != null && switchExprResult[0].Equals(caseExprResult[0])))
+                if (FunctionUtils.CommonEquals(switchExprResult[0], caseExprResult[0]))
                 {
                     return Visit(switchCaseNode.normalTemplateBody());
                 }

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/switchcase.lg
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Examples/switchcase.lg
@@ -6,3 +6,12 @@
         -Happy Sunday!
     -DEFAULT:  
         -Work Hard!
+
+# EqualSwitchTest
+- SWITCH: ${score}
+  - CASE: ${1}
+    - Low
+  - CASE: ${5}
+    - High
+  - DEFAULT:
+    - Unknown (${score} == 1 ? ${score == 1})

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -244,6 +244,9 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             evaled = templates.Evaluate("greetInAWeek", new { day = "Monday" }).ToString();
             Assert.True(evaled == "Work Hard!");
+
+            evaled = templates.Evaluate("EqualSwitchTest", new { score = 1L }).ToString();
+            Assert.True(evaled == "Low");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #5508

## Description
Firstly, let me explain the cause of the bug:
```
        {
          "$kind": "Microsoft.SetProperty",
          "property": "$answer",
          "value": {
            "score": 1
          }
        },
```
Here is a `SetProperty` action,  and in the LG template, the customer uses :
`${$answer.score}` to achieve the score.

Actually, In dialog memory manager, if the value is a `JObject`, it would use  `jobj.TryGetValue` to get the result.
https://github.com/microsoft/botbuilder-dotnet/blob/fc5fb14800ce84c8e84a24f8d2e8553d36d51420/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs#L647

And, the result would be a long int(Int64) format data but not a Int32 format data. So, the result is actually `1L`, but not `1`

Another side, In the comparison of switch expression and case expression, the LG SDK treat they are different.
Original code:
https://github.com/microsoft/botbuilder-dotnet/blob/fc5fb14800ce84c8e84a24f8d2e8553d36d51420/libraries/Microsoft.Bot.Builder.LanguageGeneration/Evaluator.cs#L284


## Specific Changes
Unify the comparison mechanism of LG and expression. Apply the equal function of Expression in LG library.
