### PR TITLE
CherryPick to 4.13: Update to ensure ContinueConversationAsync works with an empty AppId(#5515)

### DIFF
--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -278,9 +278,9 @@ namespace Microsoft.Bot.Builder
         /// <returns>A <see cref="ClaimsIdentity"/> with the audience and appId claims set to the appId.</returns>
         protected ClaimsIdentity CreateClaimsIdentity(string botAppId)
         {
-            if (string.IsNullOrWhiteSpace(botAppId))
+            if (botAppId == null)
             {
-                throw new ArgumentNullException(nameof(botAppId));
+                botAppId = string.Empty;
             }
 
             // Hand craft Claims Identity.


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botbuilder-dotnet/issues/5491

* Update to ensure ContinueConversationAsync works with an empty AppId

* Default botAppId to string.Empty
