### PR TITLE
SSO + adaptive runtime: Save state before sending OAuthCard to prevent race conditions

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -308,9 +308,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
         private async Task SendOAuthCardAsync(DialogContext dc, IMessageActivity prompt, CancellationToken cancellationToken)
         {
+            // Save state prior to sending OAuthCard: the invoke response for a token exchange from the root bot could come in
+            // before this method ends, which means that if the state is not saved, the OAuthInput would not be at the top of the stuck, 
+            // and the token exchange invoke would get discarded.
+            await dc.Context.TurnState.Get<ConversationState>().SaveChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
+
+            // Prepare OAuthCard
             var title = await Title.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);
             var text = await Text.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);
             var settings = new OAuthPromptSettings { ConnectionName = ConnectionName?.GetValue(dc.State), Title = title, Text = text };
+
+            // Send OAuthCard to root bot. The root bot could attempt to do a token exchange or if it cannot do token exchange for this connection
+            // it will let the card get to the user to allow them to sign in.
             await OAuthPrompt.SendOAuthCardAsync(settings, dc.Context, prompt, cancellationToken).ConfigureAwait(false);
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -309,8 +309,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         private async Task SendOAuthCardAsync(DialogContext dc, IMessageActivity prompt, CancellationToken cancellationToken)
         {
             // Save state prior to sending OAuthCard: the invoke response for a token exchange from the root bot could come in
-            // before this method ends, which means that if the state is not saved, the OAuthInput would not be at the top of the stuck, 
-            // and the token exchange invoke would get discarded.
+            // before this method ends or could land in another instance in scale-out scenarios, which means that if the state is not saved, 
+            // the OAuthInput would not be at the top of the stack, and the token exchange invoke would get discarded.
             await dc.Context.TurnState.Get<ConversationState>().SaveChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
 
             // Prepare OAuthCard

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -314,8 +314,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             await dc.Context.TurnState.Get<ConversationState>().SaveChangesAsync(dc.Context, false, cancellationToken).ConfigureAwait(false);
 
             // Prepare OAuthCard
-            var title = await Title.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);
-            var text = await Text.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);
+            var title = Title == null ? null : await Title.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);
+            var text = Text == null ? null : await Text.GetValueAsync(dc, cancellationToken).ConfigureAwait(false);
             var settings = new OAuthPromptSettings { ConnectionName = ConnectionName?.GetValue(dc.State), Title = title, Text = text };
 
             // Send OAuthCard to root bot. The root bot could attempt to do a token exchange or if it cannot do token exchange for this connection


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/5544
and https://github.com/microsoft/botbuilder-dotnet/issues/5516

Modifying OAuthInput to save state prior to sending an OAuthCard. The invoke response for a token exchange from the root bot could come in before the method finishes or could land in another instance in a scale-out scenario. This means that if the state is not saved prior to sending the card, race conditions lead to OAuthInput not being at the top of the stack when the invoke for token exchange comes in, resulting in the token exchange request being discarded.

[Extremely simplified vision of the simplest SSO flow for general understanding. Lots of details missing bug should help understand the situation]
![image](https://user-images.githubusercontent.com/21318528/116267424-40f58380-a731-11eb-8061-974d0c0946c2.png)

With this change, because we save state prior to sending the oauth card, if the root bot wants to do an exchange, we'll always be ready in the skill side to perform the token exchange.
