### PR TITLE
Support timestamp without timezone postfix in getTimeOfDay

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/ConvertFromUtc.cs
@@ -17,7 +17,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
     /// </summary>
     internal class ConvertFromUtc : ExpressionEvaluator
     {
-        private const string DefaultFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
+        public const string DefaultFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConvertFromUtc"/> class.

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetTimeOfDay.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetTimeOfDay.cs
@@ -34,7 +34,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             }
                             else if (DateTime.TryParseExact(
                                    s: args[0].ToString(),
-                                   format: "yyyy-MM-ddTHH:mm:ss.fffffffK",
+                                   format: ConvertFromUtc.DefaultFormat,
                                    provider: CultureInfo.InvariantCulture,
                                    style: DateTimeStyles.RoundtripKind,
                                    result: out var parsed))

--- a/libraries/AdaptiveExpressions/BuiltinFunctions/GetTimeOfDay.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/GetTimeOfDay.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Globalization;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -26,9 +27,24 @@ namespace AdaptiveExpressions.BuiltinFunctions
                             object value = null;
                             string error = null;
                             (value, error) = FunctionUtils.NormalizeToDateTime(args[0]);
+                            var timestamp = DateTime.Now;
                             if (error == null)
                             {
-                                var timestamp = (DateTime)value;
+                                timestamp = (DateTime)value;
+                            }
+                            else if (DateTime.TryParseExact(
+                                   s: args[0].ToString(),
+                                   format: "yyyy-MM-ddTHH:mm:ss.fffffffK",
+                                   provider: CultureInfo.InvariantCulture,
+                                   style: DateTimeStyles.RoundtripKind,
+                                   result: out var parsed))
+                            {
+                                error = null;
+                                timestamp = parsed;
+                            }
+
+                            if (error == null)
+                            {
                                 if (timestamp.Hour == 0 && timestamp.Minute == 0)
                                 {
                                     value = "midnight";

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -877,6 +877,8 @@ namespace AdaptiveExpressions.Tests
             Test("dateReadBack(timestamp, addDays(timestamp, 1))", "tomorrow"),
             Test("dateReadBack(timestampObj, addDays(timestamp, 1))", "tomorrow"),
             Test("dateReadBack(addDays(timestamp, 1),timestamp)", "yesterday"),
+            Test("getTimeOfDay(convertFromUTC('2018-03-15T11:00:00.000Z', 'W. Europe Standard Time'))", "noon"),
+            Test("getTimeOfDay('2018-03-15T00:00:00.0000000')", "midnight"),
             Test("getTimeOfDay('2018-03-15T00:00:00.000Z')", "midnight"),
             Test("getTimeOfDay(timestampObj)", "afternoon"),
             Test("getTimeOfDay('2018-03-15T08:00:00.000Z')", "morning"),


### PR DESCRIPTION
closes:  https://github.com/microsoft/botbuilder-dotnet/issues/5552

## Cause of the issue
- The input of datetime functions (like `getTimeOfDay`), only accepts the original datetime format("yyyy-MM-ddTHH:mm:ss.fffZ")
- The output format of `convertFromUTC` was changed from "yyyy-MM-ddTHH:mm:ss.fffZ" to "yyyy-MM-ddTHH:mm:ss.fffffffK" in R12, which is correct because a time converted from UTC should no longer have the "Z" postfix.  This is also aligned with WDL's convention. 
- Then the result of `convertFromUTC` doesn't fit in the input of `getTimeOfDay`, error occurs.

In a summary, the current datetime functions input format is too strict. 

## Changes
Expand the input of date time functions to cover the case of timestamp without timezone postfix. 
