### PR TITLE
[Part 1] Increase Microsoft.Bot.Schema.Teams code coverage

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/AppBasedLinkQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/AppBasedLinkQuery.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -23,7 +22,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the  <see cref="AppBasedLinkQuery"/> class.
         /// </summary>
         /// <param name="url">Url queried by user.</param>
-        public AppBasedLinkQuery(string url = default(string))
+        public AppBasedLinkQuery(string url = default)
         {
             Url = url;
             CustomInit();
@@ -41,7 +40,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Gets or sets state, which is the magic code for OAuth Flow.
         /// </summary>
-        /// <value>The state,w hich is the magic code for OAuth Flow.</value>
+        /// <value>The state, which is the magic code for OAuth Flow.</value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
 

--- a/libraries/Microsoft.Bot.Schema/Teams/AttachmentExtensions.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/AttachmentExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Bot.Schema;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Schema.Teams
@@ -28,9 +27,7 @@ namespace Microsoft.Bot.Schema.Teams
                 ContentUrl = attachment.ContentUrl,
                 Name = attachment.Name,
                 ThumbnailUrl = attachment.ThumbnailUrl,
-                Preview = previewAttachment == null ?
-                    JObject.FromObject(attachment).ToObject<Attachment>() :
-                    previewAttachment,
+                Preview = previewAttachment ?? JObject.FromObject(attachment).ToObject<Attachment>(),
             };
         }
     }

--- a/libraries/Microsoft.Bot.Schema/Teams/CacheInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/CacheInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="cacheType">Type of Cache Info.</param>
         /// <param name="cacheDuration">Duration of the Cached Info.</param>
-        public CacheInfo(string cacheType = default(string), int cacheDuration = default(int))
+        public CacheInfo(string cacheType = default, int cacheDuration = default)
         {
             CacheType = cacheType;
             CacheDuration = cacheDuration;

--- a/libraries/Microsoft.Bot.Schema/Teams/ChannelInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ChannelInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="id">Unique identifier representing a channel.</param>
         /// <param name="name">Name of the channel.</param>
-        public ChannelInfo(string id = default(string), string name = default(string))
+        public ChannelInfo(string id = default, string name = default)
         {
             Id = id;
             Name = name;

--- a/libraries/Microsoft.Bot.Schema/Teams/ConversationList.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConversationList.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the <see cref="ConversationList"/> class.
         /// </summary>
         /// <param name="conversations">The IList of conversations.</param>
-        public ConversationList(IList<ChannelInfo> conversations = default(IList<ChannelInfo>))
+        public ConversationList(IList<ChannelInfo> conversations = default)
         {
             Conversations = conversations;
             CustomInit();

--- a/libraries/Microsoft.Bot.Schema/Teams/FileConsentCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FileConsentCard.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="declineContext">Context sent back to the Bot if user
         /// declined. This is free flow schema and is sent back in Value field
         /// of Activity.</param>
-        public FileConsentCard(string description = default(string), long? sizeInBytes = default(long?), object acceptContext = default(object), object declineContext = default(object))
+        public FileConsentCard(string description = default, long? sizeInBytes = default, object acceptContext = default, object declineContext = default)
         {
             Description = description;
             SizeInBytes = sizeInBytes;

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/AppBasedLinkQueryTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/AppBasedLinkQueryTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class AppBasedLinkQueryTests
+    {
+        [Fact]
+        public void AppBasedLinkQueryInits()
+        {
+            var url = "http://example.com";
+            var state = "magicCode";
+
+            var appBasedLinkQuery = new AppBasedLinkQuery(url)
+            {
+                State = state
+            };
+
+            Assert.NotNull(appBasedLinkQuery);
+            Assert.IsType<AppBasedLinkQuery>(appBasedLinkQuery);
+            Assert.Equal(url, appBasedLinkQuery.Url);
+            Assert.Equal(state, appBasedLinkQuery.State);
+        }
+
+        [Fact]
+        public void AppBasedLinkQueryInitsWithNoArgs()
+        {
+            var appBasedLinkQuery = new AppBasedLinkQuery();
+
+            Assert.NotNull(appBasedLinkQuery);
+            Assert.IsType<AppBasedLinkQuery>(appBasedLinkQuery);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/AttachmentExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/AttachmentExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class AttachmentExtensionsTests
+    {
+        [Theory]
+        [ClassData(typeof(TestPreviewAttachment))]
+        public void ToMessagingExtensionAttachment(Attachment previewAttachment)
+        {
+            var contentType = "contentType";
+            var contentUrl = "http://my-content-url.com";
+            var content = new { };
+            var name = "name";
+            var thumbnailUrl = "http://my-thumbnail-url.com";
+            var attachment = new Attachment(contentType, contentUrl, new { }, name, thumbnailUrl);
+
+            var messagingExtensionAttachment = AttachmentExtensions.ToMessagingExtensionAttachment(attachment, previewAttachment);
+
+            Assert.NotNull(messagingExtensionAttachment);
+            Assert.IsType<MessagingExtensionAttachment>(messagingExtensionAttachment);
+            Assert.Equal(contentType, messagingExtensionAttachment.ContentType);
+            Assert.Equal(contentUrl, messagingExtensionAttachment.ContentUrl);
+            Assert.Equal(content, messagingExtensionAttachment.Content);
+            Assert.Equal(name, messagingExtensionAttachment.Name);
+            Assert.Equal(thumbnailUrl, messagingExtensionAttachment.ThumbnailUrl);
+            
+            if (previewAttachment != null)
+            {
+                Assert.Equal(previewAttachment, messagingExtensionAttachment.Preview);
+            }
+            else
+            {
+                var preview = messagingExtensionAttachment.Preview;
+                Assert.Equal(contentType, preview.ContentType);
+                Assert.Equal(contentUrl, preview.ContentUrl);
+                Assert.Equal(name, preview.Name);
+                Assert.Equal(thumbnailUrl, preview.ThumbnailUrl);
+            }
+        }
+
+        internal class TestPreviewAttachment : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { new Attachment() };
+                yield return new object[] { null };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/CacheInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/CacheInfoTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class CacheInfoTests
+    {
+        [Fact]
+        public void CacheInfoInits()
+        {
+            var cacheType = "cacheType";
+            var cacheDuration = 1000;
+            var cacheInfo = new CacheInfo(cacheType, cacheDuration);
+
+            Assert.NotNull(cacheInfo);
+            Assert.IsType<CacheInfo>(cacheInfo);
+            Assert.Equal(cacheType, cacheInfo.CacheType);
+            Assert.Equal(cacheDuration, cacheInfo.CacheDuration);
+        }
+        
+        [Fact]
+        public void CacheInfoInitsWithNoArgs()
+        {
+            var cacheInfo = new CacheInfo();
+
+            Assert.NotNull(cacheInfo);
+            Assert.IsType<CacheInfo>(cacheInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/ChannelInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/ChannelInfoTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class ChannelInfoTests
+    {
+        [Fact]
+        public void ChannelInfoInits()
+        {
+            var id = "channelId";
+            var name = "watercooler";
+            var channelInfo = new ChannelInfo(id, name);
+
+            Assert.NotNull(channelInfo);
+            Assert.IsType<ChannelInfo>(channelInfo);
+            Assert.Equal(id, channelInfo.Id);
+            Assert.Equal(name, channelInfo.Name);
+        }
+
+        [Fact]
+        public void ChannelInfoInitsWithNoArgs()
+        {
+            var channelInfo = new ChannelInfo();
+
+            Assert.NotNull(channelInfo);
+            Assert.IsType<ChannelInfo>(channelInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/ConversationListTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/ConversationListTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class ConversationListTests
+    {
+        [Fact]
+        public void ConversationListInits()
+        {
+            var conversations = new List<ChannelInfo>()
+            {
+                new ChannelInfo("123", "watercooler"),
+                new ChannelInfo("456", "release train"),
+            };
+            var conversationList = new ConversationList(conversations);
+
+            Assert.NotNull(conversationList);
+            Assert.IsType<ConversationList>(conversationList);
+            Assert.Equal(conversations, conversationList.Conversations);
+            Assert.Equal(conversations.Count, conversationList.Conversations.Count);
+            Assert.Equal(conversations[0].Id, conversationList.Conversations[0].Id);
+            Assert.Equal(conversations[1].Id, conversationList.Conversations[1].Id);
+        }
+        
+        [Fact]
+        public void ConversationListInitsWithNoArgs()
+        {
+            var conversationList = new ConversationList();
+
+            Assert.NotNull(conversationList);
+            Assert.IsType<ConversationList>(conversationList);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/FileConsentCardTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/FileConsentCardTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class FileConsentCardTests
+    {
+        [Fact]
+        public void FileConsentCardInits()
+        {
+            var description = "A text document about butterflies";
+            long sizeInBytes = 4000;
+            var acceptContext = "free flow schema sent back in Value field of Activity with file upload consent";
+            var declineContext = "free flow schema sent back in Value field of Activity with decline of file upload";
+
+            var fileConsentCard = new FileConsentCard(description, sizeInBytes, acceptContext, declineContext);
+
+            Assert.NotNull(fileConsentCard);
+            Assert.IsType<FileConsentCard>(fileConsentCard);
+            Assert.Equal(description, fileConsentCard.Description);
+            Assert.Equal(sizeInBytes, fileConsentCard.SizeInBytes);
+            Assert.Equal(acceptContext, fileConsentCard.AcceptContext);
+            Assert.Equal(declineContext, fileConsentCard.DeclineContext);
+        }
+        
+        [Fact]
+        public void FileConsentCardInitsWithNoArgs()
+        {
+            var fileConsentCard = new FileConsentCard();
+
+            Assert.NotNull(fileConsentCard);
+            Assert.IsType<FileConsentCard>(fileConsentCard);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5567 

## Description
Part 1 of 8.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 6.23%
![image](https://user-images.githubusercontent.com/35248895/117715883-bc255380-b18d-11eb-93c5-6bea84d936c2.png)

Current Coverage: 14.09%
![image](https://user-images.githubusercontent.com/35248895/120873182-e6ccb700-c555-11eb-8600-26a1e807ec5e.png)
