### PR TITLE
Adjust how Activity.From is populated when sending

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 }
                 else
                 {
-                    var messageOptions = TwilioHelper.ActivityToTwilio(activity, _twilioClient.Options.TwilioNumber);
+                    var messageOptions = TwilioHelper.ActivityToTwilio(activity);
 
                     var res = await _twilioClient.SendMessageAsync(messageOptions, cancellationToken)
                         .ConfigureAwait(false);

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -30,19 +30,19 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         /// Creates Twilio SMS message options object from a Bot Framework <see cref="Activity"/>.
         /// </summary>
         /// <param name="activity">The activity.</param>
-        /// <param name="twilioNumber">The Twilio phone number assigned to the bot.</param>
+        /// <param name="twilioNumber">Optional. The Twilio phone number assigned to the bot. If not provided, defaults to Activity.From.Id to allow WhatsApp and other future integrations.</param>
         /// <returns>The Twilio message options object.</returns>
         /// <seealso cref="TwilioAdapter.SendActivitiesAsync(ITurnContext, Activity[], System.Threading.CancellationToken)"/>
-        public static TwilioMessageOptions ActivityToTwilio(Activity activity, string twilioNumber)
+        public static TwilioMessageOptions ActivityToTwilio(Activity activity, string twilioNumber = null)
         {
             if (activity == null)
             {
                 throw new ArgumentNullException(nameof(activity));
             }
 
-            if (string.IsNullOrWhiteSpace(twilioNumber))
+            if (string.IsNullOrWhiteSpace(twilioNumber) && string.IsNullOrWhiteSpace(activity.From?.Id))
             {
-                throw new ArgumentNullException(nameof(twilioNumber));
+                throw new ArgumentException($"Either {nameof(twilioNumber)} or {nameof(activity.From.Id)} must be provided.");
             }
 
             var mediaUrls = new List<Uri>();
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
             {
                 To = activity.Conversation.Id,
                 ApplicationSid = activity.Conversation.Id,
-                From = twilioNumber,
+                From = twilioNumber ?? activity.From.Id,
                 Body = activity.Text
             };
 
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
             {
                 throw new ArgumentNullException(nameof(payload));
             }
-            
+
             var twilioMessage = JsonConvert.DeserializeObject<TwilioMessage>(JsonConvert.SerializeObject(payload));
 
             return new Activity()

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             activity.Object.Attachments = new List<Attachment> { new Attachment(contentUrl: "http://example.com") };
             activity.Object.Conversation = new ConversationAccount(id: "MockId");
             activity.Object.Text = "Hello, Bot!";
+            activity.Object.From = new ChannelAccount { Id = "MockId" };
 
             const string resourceIdentifier = "Mocked Resource Identifier";
             var twilioApi = new Mock<TwilioClientWrapper>(_testOptions);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
@@ -58,16 +58,54 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
+        public void ActivityToTwilioShouldReturnMessageOptionWithFromIdDefaultedToActivityFromId()
+        {
+            var activity = new Activity
+            {
+                Conversation = new ConversationAccount
+                {
+                    Id = "MockConversation"
+                },
+                From = new ChannelAccount
+                {
+                    Id = "MockId"
+                }
+            };
+            var messageOption = TwilioHelper.ActivityToTwilio(activity);
+
+            Assert.Equal(activity.From.Id, messageOption.From);
+        }
+
+        [Fact]
+        public void ActivityToTwilioShouldReturnMessageOptionWithFromIdSetToTwilioNumberWhenProvided()
+        {
+            var activity = new Activity
+            {
+                Conversation = new ConversationAccount
+                {
+                    Id = "MockConversation"
+                },
+                From = new ChannelAccount
+                {
+                    Id = "MockId"
+                }
+            };
+            var mockTwilioId = "mockTwilioId";
+            var messageOption = TwilioHelper.ActivityToTwilio(activity, mockTwilioId);
+
+            Assert.Equal(mockTwilioId, messageOption.From);
+        }
+
+        [Fact]
         public void ActivityToTwilioShouldShouldThrowArgumentNullExceptionWithNullActivity()
         {
             Assert.Throws<ArgumentNullException>(() => { TwilioHelper.ActivityToTwilio(null, TwilioNumber); });
         }
 
         [Fact]
-        public void ActivityToTwilioShouldThrowArgumentNullExceptionWithEmptyOrInvalidNumber()
+        public void ActivityToTwilioShouldThrowArgumentExceptionIfNoNumberAndNoActivityFromId()
         {
-            Assert.Throws<ArgumentNullException>(() => { TwilioHelper.ActivityToTwilio(default, "not_a_number"); });
-            Assert.Throws<ArgumentNullException>(() => { TwilioHelper.ActivityToTwilio(default, string.Empty); });
+            Assert.Throws<ArgumentException>(() => { TwilioHelper.ActivityToTwilio(new Activity(), null); });
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #5569 

## Description
Twilio allows using both a "normal" phone number (`+15552223333`) or WhatsApp number (`whatsapp:+15552223333`), and only allows communication from one type to another. Example:

1. `+15552223333` can send to `+15559998888`
2. `whatsapp:+15552223333` can send to `whatsapp:+15559998888`
3. `+15552223333` CANNOT send to `whatsapp:+15559998888`
4. `whatsapp:+15552223333` CANNOT send to `+15559998888`

All outgoing messages in the Twilio adapter have their `Activity.From` populated by the developer input from `appsettings.json`. This is problematic if the bot is meant to use both regular and WhatsApp numbers.

## Specific Changes

1. Make providing `TwilioNumber` to `ActivityToTwilio()` optional
2. If `TwilioNumber` is not provided in `ActivityToTwilio()`, use `From.Id`
3. Do not pass `TwilioNumber`, by default, through `SendActivities()`

## Discussion

This seemed like the least-breaking-change that I could make. I also considered setting *all* outgoing messages to use `From.Id`, but was concerned with how that might work with proactive messages.

## Testing

Unable to test until Twilio grants me WhatsApp integration access. Pending.