### PR TITLE
Support object comparison in ==

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Contains.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Contains.cs
@@ -35,7 +35,15 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     // list to find a value
                     var operands = FunctionUtils.ResolveListValue(ilist);
-                    found = operands.Contains(args[1]);
+
+                    foreach (var item in operands)
+                    {
+                        if (FunctionUtils.CommonEquals(item, args[1]))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
                 }
                 else if (args[1] is string string2)
                 {

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -767,9 +767,21 @@ namespace AdaptiveExpressions
             obj1 = ResolveValue(obj1);
             obj2 = ResolveValue(obj2);
 
-            if (TryParseList(obj1, out IList l0) && l0.Count == 0 && TryParseList(obj2, out IList l1) && l1.Count == 0)
+            if (TryParseList(obj1, out IList l0) && TryParseList(obj2, out IList l1))
             {
-                return true;
+                if (l0.Count == 0 && l1.Count == 0)
+                {
+                    return true;
+                }
+                else if (l0.Count != l1.Count)
+                {
+                    return false;
+                }
+                else
+                {
+                    var isEqual = true;
+                    
+                }
             }
 
             if (GetPropertyCount(obj1) == 0 && GetPropertyCount(obj2) == 0)

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -767,34 +767,49 @@ namespace AdaptiveExpressions
             obj1 = ResolveValue(obj1);
             obj2 = ResolveValue(obj2);
 
-            if (TryParseList(obj1, out IList l0) && TryParseList(obj2, out IList l1))
-            {
-                if (l0.Count == 0 && l1.Count == 0)
-                {
-                    return true;
-                }
-                else if (l0.Count != l1.Count)
-                {
-                    return false;
-                }
-                else
-                {
-                    var isEqual = true;
-                    
-                }
-            }
-
-            if (GetPropertyCount(obj1) == 0 && GetPropertyCount(obj2) == 0)
-            {
-                return true;
-            }
-
+            // Number Comparison
             if (obj1.IsNumber() && obj2.IsNumber())
             {
                 if (Math.Abs(CultureInvariantDoubleConvert(obj1) - CultureInvariantDoubleConvert(obj2)) < double.Epsilon)
                 {
                     return true;
                 }
+            }
+
+            // Array Comparison
+            if (TryParseList(obj1, out IList l0) && TryParseList(obj2, out IList l1))
+            {
+                if (l0.Count != l1.Count)
+                {
+                    return false;
+                }
+
+                var isEqual = true;
+                for (var i = 0; i < l0.Count; i++)
+                {
+                    if (!CommonEquals(l0[i], l1[i]))
+                    {
+                        isEqual = false;
+                        break;
+                    }
+                }
+
+                return isEqual;
+            }
+
+            // Object Comparison
+            var propertyCountOfObj1 = GetPropertyCount(obj1);
+            var propertyCountOfObj2 = GetPropertyCount(obj2);
+            if (propertyCountOfObj1 >= 0 && propertyCountOfObj2 >= 0)
+            {
+                if (propertyCountOfObj1 != propertyCountOfObj2)
+                {
+                    return false;
+                }
+
+                var jObj1 = JObject.FromObject(obj1);
+                var jObj2 = JObject.FromObject(obj2);
+                return JToken.DeepEquals(jObj1, jObj2);
             }
 
             try

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -767,15 +767,6 @@ namespace AdaptiveExpressions
             obj1 = ResolveValue(obj1);
             obj2 = ResolveValue(obj2);
 
-            // Number Comparison
-            if (obj1.IsNumber() && obj2.IsNumber())
-            {
-                if (Math.Abs(CultureInvariantDoubleConvert(obj1) - CultureInvariantDoubleConvert(obj2)) < double.Epsilon)
-                {
-                    return true;
-                }
-            }
-
             // Array Comparison
             if (TryParseList(obj1, out IList l0) && TryParseList(obj2, out IList l1))
             {
@@ -810,6 +801,15 @@ namespace AdaptiveExpressions
                 var jObj1 = JObject.FromObject(obj1);
                 var jObj2 = JObject.FromObject(obj2);
                 return JToken.DeepEquals(jObj1, jObj2);
+            }
+
+            // Number Comparison
+            if (obj1.IsNumber() && obj2.IsNumber())
+            {
+                if (Math.Abs(CultureInvariantDoubleConvert(obj1) - CultureInvariantDoubleConvert(obj2)) < double.Epsilon)
+                {
+                    return true;
+                }
             }
 
             try

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -513,9 +513,10 @@ namespace AdaptiveExpressions.Tests
             Test("timestampObj2 <= timestampObj", true),
             Test("timestampObj == timestampObj2", false),
             Test("timestampObj == timestampObj", true),
+            Test("where([{a: 1, b:{c: 2}}, {b: 2}], x, x == { b: { c: 2}, a: 1})[0].b.c", 2),
             #endregion
 
-            #region  String functions test
+#region  String functions test
             Test("concat(hello,world)", "helloworld"),
             Test("concat(hello,\r\nworld)", "helloworld"),
             Test("concat('hello','world')", "helloworld"),
@@ -963,6 +964,7 @@ namespace AdaptiveExpressions.Tests
             Test("contains(items, 'hi')", false),
             Test("contains(bag, 'three')", true),
             Test("contains(bag, 'xxx')", false),
+            Test("contains([{ a: 1, b: { c: 2} }, { b: 2}], { a: 1, b: { c: 2} })", true),
             Test("concat(null, [1, 2], null)", new List<object> { 1, 2 }),
             Test("concat(createArray(1, 2), createArray(3, 4))", new List<object> { 1, 2, 3, 4 }),
             Test("concat(['a', 'b'], ['b', 'c'], ['c', 'd'])", new List<object> { "a", "b", "b", "c", "c", "d" }),

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -516,7 +516,7 @@ namespace AdaptiveExpressions.Tests
             Test("where([{a: 1, b:{c: 2}}, {b: 2}], x, x == { b: { c: 2}, a: 1})[0].b.c", 2),
             #endregion
 
-#region  String functions test
+            #region  String functions test
             Test("concat(hello,world)", "helloworld"),
             Test("concat(hello,\r\nworld)", "helloworld"),
             Test("concat('hello','world')", "helloworld"),


### PR DESCRIPTION
Fixes #5563

## Description
Support object comparison in `==`

## Specific Changes
1. Support object comparison in `contains`
2. Support object comparison for operator `==` and `!=`