### PR TITLE
SDK Adapter components: Consume passed in IConfiguration instead of the one registered in DI

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         {
             if (FacebookAdapter.HasConfiguration(configuration))
             {
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
                 services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>(sp => new FacebookAdapter(configuration));
             }
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         {
             if (FacebookAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>(sp => new FacebookAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         {
             if (FacebookAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<FacebookAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>();
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (SlackAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<SlackAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>();
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (SlackAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>(sp => new SlackAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (SlackAdapter.HasConfiguration(configuration))
             {
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
                 services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>(sp => new SlackAdapter(configuration));
             }
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         {
             if (TwilioAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>(sp => new TwilioAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         {
             if (TwilioAdapter.HasConfiguration(configuration))
             {
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
                 services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>(sp => new TwilioAdapter(configuration));
             }
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         {
             if (TwilioAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<TwilioAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>();
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             if (WebexAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<WebexAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>();
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             if (WebexAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>(sp => new WebexAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             if (WebexAdapter.HasConfiguration(configuration))
             {
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
                 services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>(sp => new WebexAdapter(configuration));
             }
         }


### PR DESCRIPTION
Fixes #5581

Currently, SDK adapters register their component using the full dependency injection approach, where IConfiguration gets passed by DI. The problem with this is that now the components receive a subsection of the IConfiguration, so the DI construction pattern cannot be used as-is. The solution is to register sdk adapter components as follows:

```csharp
services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>(sp => new SlackAdapter(configuration));
```

where `configuration` is the IConfiguration passed in `Botcomponent.ConfigureServices()`.

Workaround is to add this line to the startup.cs 

```csharp
services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>(sp => new SlackAdapter(Configuration.GetSection(typeof(SlackAdapter).Assembly.GetName().Name)));
```

In addition to the respective using statements in the same file

```csharp
using Microsoft.Bot.Builder.Integration.AspNet.Core;
using Microsoft.Bot.Builder.Adapters.Slack;
```

and adding a reference to Microsoft.Bot.Builder.Integration.AspNet.Core in the runtime.