### PR TITLE
[Cherry pick] SDK Adapter components: Consume passed in IConfiguration instead of the one registered in DI (#5582)

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,10 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         {
             if (FacebookAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<FacebookAdapter>();
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
+                services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>(sp => new FacebookAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,10 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         {
             if (SlackAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<SlackAdapter>();
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
+                services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>(sp => new SlackAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,10 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
         {
             if (TwilioAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<TwilioAdapter>();
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
+                services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>(sp => new TwilioAdapter(configuration));
             }
         }
     }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +20,10 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
         {
             if (WebexAdapter.HasConfiguration(configuration))
             {
-                services.AddSingleton<WebexAdapter>();
+                // Components require the component configuration which is the subsection
+                // assigned to the component. When the botbuilder-dotnet issue #5583 gets resolved, this could
+                // change to the no-parameter overload.
+                services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>(sp => new WebexAdapter(configuration));
             }
         }
     }


### PR DESCRIPTION
Cherry pick of: https://github.com/microsoft/botbuilder-dotnet/pull/5582