### PR TITLE
Multi workspace slack adapter.

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/NewSlackMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/NewSlackMessage.cs
@@ -70,5 +70,11 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
         /// <value>The attachments that could come with the message.</value>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "it needs to be set in ActivityToSlack method")]
         public List<SlackAttachment> Attachments { get; set; } = new List<SlackAttachment>();
+
+        /// <summary>
+        /// Gets or sets the the Team Id the message will be sent from.
+        /// </summary>
+        /// <value>The Team Id the bot sends the message from.</value>
+        public string TeamId { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -47,7 +47,17 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <param name="options">An instance of <see cref="SlackAdapterOptions"/>.</param>
         /// <param name="logger">The ILogger implementation this adapter should use.</param>
         public SlackAdapter(IConfiguration configuration, SlackAdapterOptions options = null, ILogger logger = null)
-            : this(new SlackClientWrapper(new SlackClientWrapperOptions(configuration[SlackVerificationTokenKey], configuration[SlackBotTokenKey], configuration[SlackClientSigningSecretKey])), options, logger)
+            : this(
+                new SlackClientWrapper(
+                    new SlackClientWrapperOptions(
+                        configuration["SlackClientId"],
+                        configuration["SlackVerificationToken"],
+                        configuration["SlackBotToken"],
+                        configuration["SlackClientSigningSecret"],
+                        options.GetTokenForWorkspace,
+                        options.GetBotUserIdentity)),
+                options,
+                logger)
         {
         }
 
@@ -301,7 +311,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 {
                     var serializedPayload = JsonConvert.SerializeObject(postValues);
                     var payload = JsonConvert.DeserializeObject<CommandPayload>(serializedPayload);
-                    activity = SlackHelper.CommandToActivity(payload, _slackClient);
+                    activity = await SlackHelper.CommandToActivityAsync(payload, _slackClient).ConfigureAwait(false);
                 }
             }
             else if (requestContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
@@ -326,7 +336,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 {
                     // this is an event api post
                     var eventRequest = bodyObject.ToObject<EventRequest>();
-                    activity = SlackHelper.EventToActivity(eventRequest, _slackClient);
+                    activity = await SlackHelper.EventToActivityAsync(eventRequest, _slackClient).ConfigureAwait(false);
                 }
             }
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Threading.Tasks;
+
 namespace Microsoft.Bot.Builder.Adapters.Slack
 {
     /// <summary>
@@ -15,5 +18,21 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// A value indicating whether the signatures of incoming requests should be verified.
         /// </value>
         public bool VerifyIncomingRequests { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a delegate to retrieve a bot token for a given workspace id.
+        /// </summary>
+        /// <value>
+        /// The delegate that retrieves a bot token for a given workspace id.
+        /// </value>
+        public Func<string, Task<string>> GetTokenForWorkspace { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate to retrieve a bot user id for a given workspace id.
+        /// </summary>
+        /// <value>
+        /// The delegate that retrieves a bot user id for a given workspace id.
+        /// </value>
+        public Func<string, Task<string>> GetBotUserIdentity { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -49,7 +49,11 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 throw new InvalidOperationException(message + Environment.NewLine + "Required: include a verificationToken or clientSigningSecret to verify incoming Events API webhooks");
             }
 
-            _api = new SlackTaskClient(options.SlackBotToken);
+            if (Options.SlackBotToken != null)
+            {
+                _api = new SlackTaskClient(options.SlackBotToken);
+            }
+
             LoginWithSlackAsync(default).Wait();
         }
 
@@ -167,7 +171,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
 
             var data = new NameValueCollection
             {
-                ["token"] = Options.SlackBotToken,
+                ["token"] = Options.SlackBotToken ?? await Options.GetTokenForWorkspace(message.TeamId).ConfigureAwait(false),
                 ["channel"] = message.Channel,
                 ["text"] = message.Text,
                 ["thread_ts"] = message.ThreadTs,
@@ -201,9 +205,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// </summary>
         /// <param name="activity">An Activity.</param>
         /// <returns>The identity of the bot's user.</returns>
-        public virtual string GetBotUserIdentity(Activity activity)
+        public virtual async Task<string> GetBotUserIdentityAsync(Activity activity)
         {
-            return Identity;
+            return Identity ?? await Options.GetBotUserIdentity(activity.Conversation.TenantId).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -217,10 +221,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             {
                 Identity = await TestAuthAsync(cancellationToken).ConfigureAwait(false);
             }
-            else if (string.IsNullOrWhiteSpace(Options.SlackClientId) ||
-                     string.IsNullOrWhiteSpace(Options.SlackClientSecret) ||
-                     Options.SlackRedirectUri == null ||
-                     Options.SlackScopes.Count == 0)
+            else if (string.IsNullOrWhiteSpace(Options.SlackClientId))
             {
                 throw new InvalidOperationException("Missing Slack API credentials! Provide SlackClientId, SlackClientSecret, scopes and SlackRedirectUri as part of the SlackAdapter options.");
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapperOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapperOptions.cs
@@ -16,14 +16,26 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <summary>
         /// Initializes a new instance of the <see cref="SlackClientWrapperOptions"/> class.
         /// </summary>
+        /// <param name="slackClientId">The ClientId of the bot app in slack.</param>
         /// <param name="slackVerificationToken">A token for validating the origin of incoming webhooks.</param>
         /// <param name="slackBotToken">A token for a bot to work on a single workspace.</param>
         /// <param name="slackClientSigningSecret">The token used to validate that incoming webhooks are originated from Slack.</param>
-        public SlackClientWrapperOptions(string slackVerificationToken, string slackBotToken, string slackClientSigningSecret)
+        /// <param name="getTokenForWorkspace">Func to get a token for a bot to work on a given workspace.</param>
+        /// <param name="getBotUserIdentity">Func to get bot id in a given workspace.</param>
+        public SlackClientWrapperOptions(
+            string slackClientId,
+            string slackVerificationToken,
+            string slackBotToken,
+            string slackClientSigningSecret,
+            Func<string, Task<string>> getTokenForWorkspace,
+            Func<string, Task<string>> getBotUserIdentity)
         {
+            SlackClientId = slackClientId;
             SlackVerificationToken = slackVerificationToken;
             SlackBotToken = slackBotToken;
             SlackClientSigningSecret = slackClientSigningSecret;
+            GetTokenForWorkspace = getTokenForWorkspace;
+            GetBotUserIdentity = getBotUserIdentity;
         }
 
         /// <summary>
@@ -68,5 +80,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
         /// <returns>The scopes array.</returns>
         /// <value>An array of scope names that are being requested during the oauth process.</value>
         public List<string> SlackScopes { get; } = new List<string>();
+
+        public Func<string, Task<string>> GetTokenForWorkspace { get; }
+
+        public Func<string, Task<string>> GetBotUserIdentity { get; }
     }
 }


### PR DESCRIPTION
Doesn't include installation of the bot, only receiving messages.
Also detecting unistallation event.

Fixes #5519 

I understand that there are some major changes in the adapter going on but wanted to leave here what worked for me in case it's useful.

This does not include the installation OAuth flow nor the storage of the slack token and bot id. This is handled somewhere else. 
The idea of this change is that the adapter can fetch those values wherever they are stored. Agnostic of how any given app would store those. Users need to just pass a couple of Func with the code to retrieve the bot token and the bot id respectively. Although in my experience the bot id is the same in all workspaces I installed the bot so no sure why this needs to be stored upon installation.

It also correctly receives the uninstallation event from slack.