### PR TITLE
feat: AdaptiveExpressions: Allow 0 to convert as false bool

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Bool.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Bool.cs
@@ -23,7 +23,13 @@ namespace AdaptiveExpressions.BuiltinFunctions
 
         private static bool Function(IReadOnlyList<object> args)
         {
-            return FunctionUtils.IsLogicTrue(args[0]);
+            var arg = args[0];
+            if (arg is int @int)
+            {
+                arg = @int != 0;
+            }
+
+            return FunctionUtils.IsLogicTrue(arg);
         }
     }
 }

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -1062,7 +1062,7 @@ namespace AdaptiveExpressions
             {
                 result = instanceBool;
             }
-            else if (instance == null)
+            else if (instance == null || instance as int? == 0)
             {
                 result = false;
             }

--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -1062,7 +1062,7 @@ namespace AdaptiveExpressions
             {
                 result = instanceBool;
             }
-            else if (instance == null || instance as int? == 0)
+            else if (instance == null)
             {
                 result = false;
             }

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -653,7 +653,7 @@ namespace AdaptiveExpressions.Tests
             Test("equals(max(createArray(1, 2, 3, 4)), 4.0)", true),
             Test("equals(max(createArray(1, 2, 3, 4), 5.0), 5)", true),
             Test("equals(hello == 'world', bool('true'))", false), // false, true
-            Test("equals(hello == 'world', bool(0))", true), // false, false
+            Test("equals(hello == 'world', bool(0))", true), // true, true
             Test("equals(hello == 'world', bool(1))", false), // false, true
             Test("if(!exists(one), 'r1', 'r2')", "r2"), // false
             Test("if(!!exists(one), 'r1', 'r2')", "r1"), // true

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -653,7 +653,8 @@ namespace AdaptiveExpressions.Tests
             Test("equals(max(createArray(1, 2, 3, 4)), 4.0)", true),
             Test("equals(max(createArray(1, 2, 3, 4), 5.0), 5)", true),
             Test("equals(hello == 'world', bool('true'))", false), // false, true
-            Test("equals(hello == 'world', bool(0))", false), // false, true
+            Test("equals(hello == 'world', bool(0))", true), // false, false
+            Test("equals(hello == 'world', bool(1))", false), // false, true
             Test("if(!exists(one), 'r1', 'r2')", "r2"), // false
             Test("if(!!exists(one), 'r1', 'r2')", "r1"), // true
             Test("if(0, 'r1', 'r2')", "r1"), // true
@@ -724,7 +725,7 @@ namespace AdaptiveExpressions.Tests
             Test("string(bool(1))", "true"),
             Test("string(bag.set)", "{\"four\":4.0}"),
             Test("bool(1)", true),
-            Test("bool(0)", true),
+            Test("bool(0)", false),
             Test("bool(null)", false),
             Test("bool(hello * 5)", false),
             Test("bool('false')", true),
@@ -732,14 +733,14 @@ namespace AdaptiveExpressions.Tests
             Test("[1,2,3]", new List<object> { 1, 2, 3 }),
             Test("[1,2,3, [4,5]]", new List<object> { 1, 2, 3, new List<object> { 4, 5 } }),
             Test("\"[1,2,3]\"", "[1,2,3]"),
-            Test("[1, bool(0), string(bool(1)), float(\'10\')]", new List<object> { 1, true, "true", 10.0 }),
+            Test("[1, bool(0), string(bool(1)), float(\'10\')]", new List<object> { 1, false, "true", 10.0 }),
             Test("[\"a\", \"b[]\", \"c[][][]\"][1]", "b[]"),
             Test("[\'a\', [\'b\', \'c\']][1][0]", "b"),
             Test("union([\"a\", \"b\", \"c\"], [\"d\", [\"e\", \"f\"], \"g\"][1])", new List<string> { "a", "b", "c", "e", "f" }),
             Test("union([\"a\", \"b\", \"c\"], [\"d\", [\"e\", \"f\"], \"g\"][1])[1]",  "b"),
             Test("createArray('h', 'e', 'l', 'l', 'o')", new List<object> { "h", "e", "l", "l", "o" }),
             Test("createArray('h',\r\n 'e',\r\n 'l',\r\n 'l',\r\n 'o')", new List<object> { "h", "e", "l", "l", "o" }),
-            Test("createArray(1, bool(0), string(bool(1)), float('10'))", new List<object> { 1, true, "true", 10.0f }),
+            Test("createArray(1, bool(0), string(bool(1)), float('10'))", new List<object> { 1, false, "true", 10.0f }),
             Test("createArray()", new List<object> { }),
             Test("[]", new List<object> { }),
             Test("binary(hello)", new byte[] { 104, 101, 108, 108, 111 }),

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_AllowInterruptionAlwaysWithFailedValidation.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_AllowInterruptionAlwaysWithFailedValidation.test.dialog
@@ -53,7 +53,7 @@
                     {
                         "$kind": "Microsoft.SetProperty",
                         "property": "turn.interrupted",
-                        "value": "=False"
+                        "value": "=bool(0)"
                     }
                 ]
             }


### PR DESCRIPTION
Fixes #5615 

## Description
[The docs](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-prebuilt-functions?view=azure-bot-service-4.0#bool) state that at least `1` and `0` should convert to true/false, respectively.

![image](https://user-images.githubusercontent.com/40401643/119877181-8c8c8000-bedd-11eb-9536-c48bf23a3c2f.png)

However, currently all integers are evaluated as "True" (see tests, prior to this change).

## Specific Changes
Allowed converting `0` to false. All other integers will be considered "truthy" and convert to `True`. Some alternatives might be to:

1. Throw an error if `int` and not `1` or `0`,
2. Only `1` is `True` and all others are `False`

This just seemed to make the most sense to me.

# Willing to Change

* I'm okay nixing this PR; I just saw the docs didn't match
* I'm okay re-working the code such that only `1` is `True` and all other values are `False`

## Note

I originally tried making changes to `FunctionUtils.IsLogicTrue()`, which is called by `Bool()`, but that affected a much larger surface area than anticipated.