### PR TITLE
Fix invalid cast exception when sending delay activities through cloud adapter

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     // hack directly in the POST method. Replicating that here
                     // to keep the behavior as close as possible to facilitate
                     // more realistic tests.
-                    var delayMs = (int)activity.Value;
+                    var delayMs = Convert.ToInt32(activity.Value, CultureInfo.InvariantCulture);
 
                     await Task.Delay(delayMs).ConfigureAwait(false);
                 }

--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Security.Claims;
 using System.Security.Principal;
@@ -76,7 +77,7 @@ namespace Microsoft.Bot.Builder
 
                 if (activity.Type == ActivityTypesEx.Delay)
                 {
-                    var delayMs = (int)activity.Value;
+                    var delayMs = Convert.ToInt32(activity.Value, CultureInfo.InvariantCulture);
                     await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
                 }
                 else if (activity.Type == ActivityTypesEx.InvokeResponse)

--- a/tests/Microsoft.Bot.Builder.Tests/Adapters/TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapters/TestAdapterTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Reflection;
+using System.Diagnostics;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +11,7 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Xunit;
+using Activity = Microsoft.Bot.Schema.Activity;
 
 namespace Microsoft.Bot.Builder.Tests.Adapters
 {
@@ -533,6 +534,32 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
             status = await adapter.GetTokenStatusAsync(turnContext, oAuthAppCredentials, userId, "DEF");
             Assert.NotNull(status);
             Assert.Single(status);
+        }
+
+        [Fact]
+        public async Task TestAdapter_Delay()
+        {
+            var adapter = new TestAdapter();
+
+            using var turnContext = new TurnContext(adapter, new Activity());
+
+            var activities = new[]
+            {
+                new Activity(ActivityTypes.Delay, value: 275),
+                new Activity(ActivityTypes.Delay, value: 275L),
+                new Activity(ActivityTypes.Delay, value: 275F),
+                new Activity(ActivityTypes.Delay, value: 275D),
+            };
+
+            Stopwatch sw = new Stopwatch();
+
+            sw.Start();
+
+            await adapter.SendActivitiesAsync(turnContext, activities, default);
+
+            sw.Stop();
+
+            Assert.True(sw.Elapsed.TotalSeconds > 1, $"Delay only lasted {sw.Elapsed}");
         }
 
         [Theory]

--- a/tests/Microsoft.Bot.Builder.Tests/AllowNullIdTestAdapter.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/AllowNullIdTestAdapter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -205,7 +206,7 @@ namespace Microsoft.Bot.Builder.Adapters
                     // hack directly in the POST method. Replicating that here
                     // to keep the behavior as close as possible to facilitate
                     // more realistic tests.
-                    var delayMs = (int)activity.Value;
+                    var delayMs = Convert.ToInt32(activity.Value, CultureInfo.InvariantCulture);
 
                     await Task.Delay(delayMs).ConfigureAwait(false);
                 }

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpAdapterTests.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.WebSockets;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -196,6 +194,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             // Assert
             botMock.Verify(m => m.OnTurnAsync(It.Is<TurnContext>(tc => true), It.Is<CancellationToken>(ct => true)), Times.Never());
             Assert.Equal((int)HttpStatusCode.BadRequest, httpResponseMock.Object.StatusCode);
+        }
+
+        [Fact]
+        public async Task Delay()
+        {
+            await DelayHelper.Test(new BotFrameworkHttpAdapter());
         }
 
         private static Stream CreateMessageActivityStream()

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -19,7 +19,6 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Rest;
 using Microsoft.Rest.Serialization;
 using Moq;
@@ -536,6 +535,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             Assert.Equal(expectedServiceUrl, actualServiceUrl4);
             Assert.Equal(expectedServiceUrl, actualServiceUrl5);
             Assert.Equal(expectedServiceUrl, actualServiceUrl6);
+        }
+
+        [Fact]
+        public async Task CloudAdapterDelay()
+        {
+            await DelayHelper.Test(new CloudAdapter());
         }
 
         private static Stream CreateMessageActivityStream(string userId, string channelId, string conversationId, string recipient, string relatesToActivityId)

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/DelayHelper.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/DelayHelper.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
+using Xunit;
+using Activity = Microsoft.Bot.Schema.Activity;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
+{
+    public static class DelayHelper
+    {
+        public static async Task Test(BotAdapter adapter)
+        {
+            using var turnContext = new TurnContext(adapter, new Activity());
+
+            var activities = new[]
+            {
+                new Activity(ActivityTypes.Delay, value: 275),
+                new Activity(ActivityTypes.Delay, value: 275L),
+                new Activity(ActivityTypes.Delay, value: 275F),
+                new Activity(ActivityTypes.Delay, value: 275D),
+            };
+
+            Stopwatch sw = new Stopwatch();
+
+            sw.Start();
+
+            await adapter.SendActivitiesAsync(turnContext, activities, default);
+
+            sw.Stop();
+
+            Assert.True(sw.Elapsed.TotalSeconds > 1, $"Delay only lasted {sw.Elapsed}");
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotFramework-Composer/issues/7880

## Description

The cloud adapter tried to cast a delay activity's value to `int`. Because the value is an object, all numbers are boxed and therefore cannot be unboxed and cast to a different numeric type using a normal cast operation. We need to use `Convert.ToInt32` instead.

The problem was also present in the test adapter so I've fixed it there too. The problem was not present in the Bot Framework HTTP adapter, but for the sake of completeness I've included a test for it anyway. The problem was present in the allow-null-ID test adapter and I fixed it there because I saw that it's supposed to mimic the other adapters, but I didn't include a test for it because it's not part of a public library.

## Specific Changes

  - Change `(int)` to `Convert.ToInt32` in the cloud adapter, the test adapter, and the allow-null-ID test adapter
  - Clean up some using statements
  - Add delay tests

## Testing

- `CloudAdapterTests.CloudAdapterDelay`
- `BotFrameworkHttpAdapterTests.Delay`
- `TestAdapterTests.TestAdapter_Delay`