### PR TITLE
Updated error handling so it doesn't return json content

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Json.cs
@@ -39,7 +39,7 @@ namespace AdaptiveExpressions.BuiltinFunctions
                                     }
                                     catch (JsonReaderException err)
                                     {
-                                        error = $"Unexpected character at Path {err.Path}, line {err.LineNumber}, position {err.LinePosition} when parsing {args[0]}.";
+                                        error = err.Message;
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #5328

Updated code to return the native JsonReaderException message that doesn't expose the original json and still provides enough information about the parsing error.

