### PR TITLE
Fix PUT method in HttpRequest throws null reference exception

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -330,8 +330,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                         {
                             using var putContent = new StringContent(instanceBody.ToString(), Encoding.UTF8, contentType);
                             traceInfo.request.content = instanceBody.ToString();
-                            traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
                             request.Content = putContent;
+                            traceInfo.request.headers = JObject.FromObject(request.Content.Headers.ToDictionary(t => t.Key, t => (object)t.Value?.FirstOrDefault()));
                             response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
                         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -527,6 +527,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .WithContent("[\r\n  {\r\n    \"text\": \"Joe is 52\",\r\n    \"age\": 52\r\n  },\r\n  {\r\n    \"text\": \"text\",\r\n    \"age\": 11\r\n  }\r\n]".Replace("\r\n", Environment.NewLine))
                 .Respond("plain/text", "array");
 
+            handler
+                .When(HttpMethod.Put, "http://foo.com/")
+                .WithContent("Joe is 52")
+                .Respond("plain/text", "put:string");
+
+            handler
+                .When(HttpMethod.Put, "http://foo.com/")
+                .WithContent("{\r\n  \"text\": \"Joe is 52\",\r\n  \"age\": 52\r\n}".Replace("\r\n", Environment.NewLine))
+                .Respond("plain/text", "put:object");
+
+            handler
+                .When(HttpMethod.Put, "http://foo.com/")
+                .WithHeaders(new List<KeyValuePair<string, string>>()
+                {
+                    new KeyValuePair<string, string>("bound", "52"),
+                    new KeyValuePair<string, string>("unbound", "dialog.age")
+                })
+                .WithContent("[\r\n  {\r\n    \"text\": \"Joe is 52\",\r\n    \"age\": 52\r\n  },\r\n  {\r\n    \"text\": \"text\",\r\n    \"age\": 11\r\n  }\r\n]".Replace("\r\n", Environment.NewLine))
+                .Respond("plain/text", "put:array");
+
             // Reply with a bytes array and this bytes array would be base64encoded by the sdk
             handler
                 .When(HttpMethod.Get, "http://foo.com/image")
@@ -628,6 +648,51 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                             new SendActivity("${turn.lastresult.content}"),
                             new HttpRequest()
                             {
+                                Url = "http://foo.com/",
+                                Method = HttpRequest.HttpMethod.PUT,
+                                ContentType = "plain/text",
+                                Body = "${dialog.name} is ${dialog.age}"
+                            },
+                            new SendActivity("${turn.lastresult.content}"),
+                            new HttpRequest()
+                            {
+                                Url = "http://foo.com/",
+                                Method = HttpRequest.HttpMethod.PUT,
+                                ContentType = "application/json",
+                                Body = JToken.FromObject(new
+                                {
+                                    text = "${dialog.name} is ${dialog.age}",
+                                    age = "=dialog.age"
+                                })
+                            },
+                            new SendActivity("${turn.lastresult.content}"),
+                            new HttpRequest()
+                            {
+                                Url = "http://foo.com/",
+                                Method = HttpRequest.HttpMethod.PUT,
+                                ContentType = "application/json",
+                                Headers = new Dictionary<string, AdaptiveExpressions.Properties.StringExpression>()
+                                {
+                                    { "bound", "=dialog.age" },
+                                    { "unbound", "dialog.age" }
+                                },
+                                Body = JToken.FromObject(new object[]
+                                {
+                                    new
+                                    {
+                                        text = "${dialog.name} is ${dialog.age}",
+                                        age = "=dialog.age"
+                                    },
+                                    new
+                                    {
+                                        text = "text",
+                                        age = 11
+                                    }
+                                })
+                            },
+                            new SendActivity("${turn.lastresult.content}"),
+                            new HttpRequest()
+                            {
                                 Url = "http://foo.com/image",
                                 Method = HttpRequest.HttpMethod.GET,
                                 ResponseType = HttpRequest.ResponseTypes.Binary
@@ -668,6 +733,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                     .AssertReply("string")
                     .AssertReply("object")
                     .AssertReply("array")
+                    .AssertReply("put:string")
+                    .AssertReply("put:object")
+                    .AssertReply("put:array")
                     .AssertReply("VGVzdEltYWdl")
                     .AssertReply("test")
                     .AssertReply("testtest")


### PR DESCRIPTION
Fixes #5610

## Description
PUT method attempts to reference request.Content before setting it causing a NullReferenceExeption.

## Specific Changes
Move the request.Content assignment to a line before it is referenced.

## Testing
Added unit tests for PUT method. All succeed after this change.

![image](https://user-images.githubusercontent.com/44449640/120911866-75693300-c63f-11eb-82de-e4fa8c2292b6.png)

