### PR TITLE
[Part 2] Increase Microsoft.Bot.Schema.Teams code coverage

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/FileConsentCardResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FileConsentCardResponse.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// action.</param>
         /// <param name="uploadInfo">If the user accepted the file, contains
         /// information about the file to be uploaded.</param>
-        public FileConsentCardResponse(string action = default(string), object context = default(object), FileUploadInfo uploadInfo = default(FileUploadInfo))
+        public FileConsentCardResponse(string action = default, object context = default, FileUploadInfo uploadInfo = default)
         {
             Action = action;
             Context = context;

--- a/libraries/Microsoft.Bot.Schema/Teams/FileDownloadInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FileDownloadInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="uniqueId">Unique Id for the file.</param>
         /// <param name="fileType">Type of file.</param>
         /// <param name="etag">ETag for the file.</param>
-        public FileDownloadInfo(string downloadUrl = default(string), string uniqueId = default(string), string fileType = default(string), object etag = default(object))
+        public FileDownloadInfo(string downloadUrl = default, string uniqueId = default, string fileType = default, object etag = default)
         {
             DownloadUrl = downloadUrl;
             UniqueId = uniqueId;

--- a/libraries/Microsoft.Bot.Schema/Teams/FileInfoCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FileInfoCard.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="uniqueId">Unique Id for the file.</param>
         /// <param name="fileType">Type of file.</param>
         /// <param name="etag">ETag for the file.</param>
-        public FileInfoCard(string uniqueId = default(string), string fileType = default(string), object etag = default(object))
+        public FileInfoCard(string uniqueId = default, string fileType = default, object etag = default)
         {
             UniqueId = uniqueId;
             FileType = fileType;

--- a/libraries/Microsoft.Bot.Schema/Teams/FileUploadInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/FileUploadInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="uniqueId">ID that uniquely identifies the
         /// file.</param>
         /// <param name="fileType">Type of the file.</param>
-        public FileUploadInfo(string name = default(string), string uploadUrl = default(string), string contentUrl = default(string), string uniqueId = default(string), string fileType = default(string))
+        public FileUploadInfo(string name = default, string uploadUrl = default, string contentUrl = default, string uniqueId = default, string fileType = default)
         {
             Name = name;
             UploadUrl = uploadUrl;

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="role">Role of the participant in the current meeting.</param>
         /// <param name="inMeeting">True, if the participant is in the meeting.</param>
-        public MeetingParticipantInfo(string role = default(string), bool? inMeeting = null)
+        public MeetingParticipantInfo(string role = default, bool? inMeeting = null)
         { 
             Role = role;
             InMeeting = inMeeting;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayload.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessageActionsPayload.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="mentions">List of entities mentioned in the
         /// message.</param>
         /// <param name="reactions">Reactions for the message.</param>
-        public MessageActionsPayload(string id = default(string), string replyToId = default(string), string messageType = default(string), string createdDateTime = default(string), string lastModifiedDateTime = default(string), bool? deleted = default(bool?), string subject = default(string), string summary = default(string), string importance = default(string), string locale = default(string), MessageActionsPayloadFrom from = default(MessageActionsPayloadFrom), MessageActionsPayloadBody body = default(MessageActionsPayloadBody), string attachmentLayout = default(string), IList<MessageActionsPayloadAttachment> attachments = default(IList<MessageActionsPayloadAttachment>), IList<MessageActionsPayloadMention> mentions = default(IList<MessageActionsPayloadMention>), IList<MessageActionsPayloadReaction> reactions = default(IList<MessageActionsPayloadReaction>))
+        public MessageActionsPayload(string id = default, string replyToId = default, string messageType = default, string createdDateTime = default, string lastModifiedDateTime = default, bool? deleted = default, string subject = default, string summary = default, string importance = default, string locale = default, MessageActionsPayloadFrom from = default, MessageActionsPayloadBody body = default, string attachmentLayout = default, IList<MessageActionsPayloadAttachment> attachments = default, IList<MessageActionsPayloadMention> mentions = default, IList<MessageActionsPayloadReaction> reactions = default)
         {
             Id = id;
             ReplyToId = replyToId;

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/FileConsentCardResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/FileConsentCardResponseTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class FileConsentCardResponseTests
+    {
+        [Fact]
+        public void FileConsentCardResponseInits()
+        {
+            var action = "accept";
+            var context = "some context around the action";
+            var uploadInfo = new FileUploadInfo("pandas.txt", "https://example.com", "https://url-to-the-file.com", "unique-panda-file-id", ".txt");
+            var fileConsentCardResponse = new FileConsentCardResponse(action, context, uploadInfo);
+
+            Assert.NotNull(fileConsentCardResponse);
+            Assert.IsType<FileConsentCardResponse>(fileConsentCardResponse);
+            Assert.Equal(action, fileConsentCardResponse.Action);
+            Assert.Equal(context, fileConsentCardResponse.Context);
+            Assert.Equal(uploadInfo, fileConsentCardResponse.UploadInfo);
+        }
+
+        [Fact]
+        public void FileConsentCardResponseInitsWithNoArgs()
+        {
+            var fileConsentCardResponse = new FileConsentCardResponse();
+
+            Assert.NotNull(fileConsentCardResponse);
+            Assert.IsType<FileConsentCardResponse>(fileConsentCardResponse);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/FileDownloadInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/FileDownloadInfoTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class FileDownloadInfoTests
+    {
+        [Fact]
+        public void FileDownloadInfoInits()
+        {
+            var downloadUrl = "https://example-download-url.com";
+            var uniqueId = "file-unique-id-123";
+            var fileType = ".txt";
+            var etag = "etag123";
+
+            var fileDownloadInfo = new FileDownloadInfo(downloadUrl, uniqueId, fileType, etag);
+
+            Assert.NotNull(fileDownloadInfo);
+            Assert.IsType<FileDownloadInfo>(fileDownloadInfo);
+            Assert.Equal(downloadUrl, fileDownloadInfo.DownloadUrl);
+            Assert.Equal(uniqueId, fileDownloadInfo.UniqueId);
+            Assert.Equal(fileType, fileDownloadInfo.FileType);
+            Assert.Equal(etag, fileDownloadInfo.Etag);
+        }
+        
+        [Fact]
+        public void FileDownloadInfoInitsWithNoArgs()
+        {
+            var fileDownloadInfo = new FileDownloadInfo();
+
+            Assert.NotNull(fileDownloadInfo);
+            Assert.IsType<FileDownloadInfo>(fileDownloadInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/FileInfoCardTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/FileInfoCardTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class FileInfoCardTests
+    {
+        [Fact]
+        public void FileInfoCardInits()
+        {
+            var uniqueId = "unique-file-id-123";
+            var fileType = ".txt";
+            var etag = "etag123";
+
+            var fileInfoCard = new FileInfoCard(uniqueId, fileType, etag);
+
+            Assert.NotNull(fileInfoCard);
+            Assert.IsType<FileInfoCard>(fileInfoCard);
+            Assert.Equal(uniqueId, fileInfoCard.UniqueId);
+            Assert.Equal(fileType, fileInfoCard.FileType);
+            Assert.Equal(etag, fileInfoCard.Etag);
+        }
+        
+        [Fact]
+        public void FileInfoCardInitsWithNoArgs()
+        {
+            var fileInfoCard = new FileInfoCard();
+
+            Assert.NotNull(fileInfoCard);
+            Assert.IsType<FileInfoCard>(fileInfoCard);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/FileUploadInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/FileUploadInfoTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class FileUploadInfoTests
+    {
+        [Fact]
+        public void FileUploadInfoInits()
+        {
+            var name = "pandas";
+            var uploadUrl = "https://example-happy-panda.com";
+            var contentUrl = "https://example-url-to-pandas-content";
+            var uniqueId = "uniqueId-pandas123";
+            var fileType = ".png";
+
+            var fileUploadInfo = new FileUploadInfo(name, uploadUrl, contentUrl, uniqueId, fileType);
+
+            Assert.NotNull(fileUploadInfo);
+            Assert.IsType<FileUploadInfo>(fileUploadInfo);
+            Assert.Equal(name, fileUploadInfo.Name);
+            Assert.Equal(uploadUrl, fileUploadInfo.UploadUrl);
+            Assert.Equal(contentUrl, fileUploadInfo.ContentUrl);
+            Assert.Equal(uniqueId, fileUploadInfo.UniqueId);
+            Assert.Equal(fileType, fileUploadInfo.FileType);
+        }
+        
+        [Fact]
+        public void FileUploadInfoInitsWithNoArgs()
+        {
+            var fileUploadInfo = new FileUploadInfo();
+
+            Assert.NotNull(fileUploadInfo);
+            Assert.IsType<FileUploadInfo>(fileUploadInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantInfoTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MeetingParticipantInfoTests
+    {
+        [Fact]
+        public void MeetingParticipantInfoInits()
+        {
+            var role = "organizer";
+            var inMeeting = true;
+
+            var meetingParticipantInfo = new MeetingParticipantInfo(role, inMeeting);
+
+            Assert.NotNull(meetingParticipantInfo);
+            Assert.IsType<MeetingParticipantInfo>(meetingParticipantInfo);
+            Assert.Equal(role, meetingParticipantInfo.Role);
+            Assert.Equal(inMeeting, meetingParticipantInfo.InMeeting);
+        }
+        
+        [Fact]
+        public void MeetingParticipantInfoInitsWithNoArgs()
+        {
+            var meetingParticipantInfo = new MeetingParticipantInfo();
+
+            Assert.NotNull(meetingParticipantInfo);
+            Assert.IsType<MeetingParticipantInfo>(meetingParticipantInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessageActionsPayloadTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessageActionsPayloadTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
         [Fact]
         public void TestMessageActionsPayloadConstructorWithArguments()
         {
-            var payload = CreateActionPayload();
+            var payload = new MessageActionsPayload(_id, _replyId, _messageType, _date, _date, _deleted, _subject, _summary, _importance, _locale, _from, _body, _attachmentLayout, _attachments, _mentions, _reactions);
 
             Assert.Equal(_id, payload.Id);
             Assert.Equal(_replyId, payload.ReplyToId);


### PR DESCRIPTION
Fixes #5626 

___

## Description
Part 2 of 8.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 6.23%
![image](https://user-images.githubusercontent.com/35248895/117715883-bc255380-b18d-11eb-93c5-6bea84d936c2.png)

Coverage Raised to with this Chunk: 15.79%
![image](https://user-images.githubusercontent.com/35248895/121090694-cdb64700-c79d-11eb-9498-9244eb73965c.png)

