### PR TITLE
[Part 4] Increase Microsoft.Bot.Schema.Teams code coverage

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAction.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -37,7 +35,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="botActivityPreview">A collection of bot activities.</param>
         /// <param name="messagePayload">Message content sent as part of the
         /// command request.</param>
-        public MessagingExtensionAction(object data = default(object), TaskModuleRequestContext context = default(TaskModuleRequestContext), string commandId = default(string), string commandContext = default(string), string botMessagePreviewAction = default(string), IList<Activity> botActivityPreview = default(IList<Activity>), MessageActionsPayload messagePayload = default(MessageActionsPayload))
+        public MessagingExtensionAction(object data = default, TaskModuleRequestContext context = default, string commandId = default, string commandContext = default, string botMessagePreviewAction = default, IList<Activity> botActivityPreview = default, MessageActionsPayload messagePayload = default)
             : base(data, context)
         {
             CommandId = commandId;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionActionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionActionResponse.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="task">The JSON for the Adaptive card to appear in the
         /// task module.</param>
         /// <param name="composeExtension">A <see cref="MessagingExtensionResult"/> that initializes the current object's ComposeExension property.</param>
-        public MessagingExtensionActionResponse(TaskModuleResponseBase task = default(TaskModuleResponseBase), MessagingExtensionResult composeExtension = default(MessagingExtensionResult))
+        public MessagingExtensionActionResponse(TaskModuleResponseBase task = default, MessagingExtensionResult composeExtension = default)
         {
             Task = task;
             ComposeExtension = composeExtension;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAttachment.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionAttachment.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="name">(OPTIONAL) The name of the attachment.</param>
         /// <param name="thumbnailUrl">(OPTIONAL) Thumbnail associated with attachment.</param>
         /// <param name="preview">A preview attachment.</param>
-        public MessagingExtensionAttachment(string contentType = default(string), string contentUrl = default(string), object content = default(object), string name = default(string), string thumbnailUrl = default(string), Attachment preview = default(Attachment))
+        public MessagingExtensionAttachment(string contentType = default, string contentUrl = default, object content = default, string name = default, string thumbnailUrl = default, Attachment preview = default)
             : base(contentType, contentUrl, content, name, thumbnailUrl)
         {
             Preview = preview;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionParameter.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionParameter.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -24,7 +23,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="name">Name of the parameter.</param>
         /// <param name="value">Value of the parameter.</param>
-        public MessagingExtensionParameter(string name = default(string), object value = default(object))
+        public MessagingExtensionParameter(string name = default, object value = default)
         {
             Name = name;
             Value = value;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQuery.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="parameters">Parameters for the query.</param>
         /// <param name="queryOptions">The query options.</param>
         /// <param name="state">State parameter passed back to the bot after authentication/configuration flow.</param>
-        public MessagingExtensionQuery(string commandId = default(string), IList<MessagingExtensionParameter> parameters = default(IList<MessagingExtensionParameter>), MessagingExtensionQueryOptions queryOptions = default(MessagingExtensionQueryOptions), string state = default(string))
+        public MessagingExtensionQuery(string commandId = default, IList<MessagingExtensionParameter> parameters = default, MessagingExtensionQueryOptions queryOptions = default, string state = default)
         {
             CommandId = commandId;
             Parameters = parameters;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQueryOptions.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionQueryOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="skip">Number of entities to skip.</param>
         /// <param name="count">Number of entities to fetch.</param>
-        public MessagingExtensionQueryOptions(int? skip = default(int?), int? count = default(int?))
+        public MessagingExtensionQueryOptions(int? skip = default, int? count = default)
         {
             Skip = skip;
             Count = count;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResponse.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the <see cref="MessagingExtensionResponse"/> class.
         /// </summary>
         /// <param name="composeExtension">A <see cref="MessagingExtensionResult"/> that initializes the current object's ComposeExension property.</param>
-        public MessagingExtensionResponse(MessagingExtensionResult composeExtension = default(MessagingExtensionResult))
+        public MessagingExtensionResponse(MessagingExtensionResult composeExtension = default)
         {
             ComposeExtension = composeExtension;
             CustomInit();

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResult.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionResult.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="suggestedActions">The message extension suggested actions.</param>
         /// <param name="text">(Only when type is message) Text.</param>
         /// <param name="activityPreview">(Only when type is botMessagePreview) Message activity to preview.</param>
-        public MessagingExtensionResult(string attachmentLayout = default(string), string type = default(string), IList<MessagingExtensionAttachment> attachments = default(IList<MessagingExtensionAttachment>), MessagingExtensionSuggestedAction suggestedActions = default(MessagingExtensionSuggestedAction), string text = default(string), Activity activityPreview = default(Activity))
+        public MessagingExtensionResult(string attachmentLayout = default, string type = default, IList<MessagingExtensionAttachment> attachments = default, MessagingExtensionSuggestedAction suggestedActions = default, string text = default, Activity activityPreview = default)
         {
             AttachmentLayout = attachmentLayout;
             Type = type;

--- a/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MessagingExtensionSuggestedAction.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionActionResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionActionResponseTests.cs
@@ -9,5 +9,32 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 {
     public class MessagingExtensionActionResponseTests
     {
+        [Fact]
+        public void MessagingExtensionActionResponseInits()
+        {
+            var task = new TaskModuleResponseBase("message");
+            var composeExtension = new MessagingExtensionResult("list", "message", null, null, "with a personality like sunshine");
+            var cacheInfo = new CacheInfo();
+
+            var msgExtActionResponse = new MessagingExtensionActionResponse(task, composeExtension)
+            { 
+                CacheInfo = cacheInfo
+            };
+
+            Assert.NotNull(msgExtActionResponse);
+            Assert.IsType<MessagingExtensionActionResponse>(msgExtActionResponse);
+            Assert.Equal(task, msgExtActionResponse.Task);
+            Assert.Equal(composeExtension, msgExtActionResponse.ComposeExtension);
+            Assert.Equal(cacheInfo, msgExtActionResponse.CacheInfo);
+        }
+        
+        [Fact]
+        public void MessagingExtensionActionResponseInitsWithNoArgs()
+        {
+            var msgExtActionResponse = new MessagingExtensionActionResponse();
+
+            Assert.NotNull(msgExtActionResponse);
+            Assert.IsType<MessagingExtensionActionResponse>(msgExtActionResponse);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionActionResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionActionResponseTests.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionActionResponseTests
+    {
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionActionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionActionTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionActionTests
+    {
+        [Fact]
+        public void MessagingExtensionActionInits()
+        {
+            var data = new Dictionary<string, string>() { { "key", "value" } };
+            var context = new TaskModuleRequestContext("theme");
+            var commandId = "commandId";
+            var commandContext = "message";
+            var botMessagePreviewAction = "send";
+            var botActivityPreview = new List<Activity>() { new Activity(text: "hi"), new Activity(text: "yo yo yo") };
+            var messagePayload = new MessageActionsPayload("msgId", "1234", "message");
+            var state = "secureOAuthState1234";
+
+            var msgExtAction = new MessagingExtensionAction(data, context, commandId, commandContext, botMessagePreviewAction, botActivityPreview, messagePayload)
+            { 
+                State = state
+            };
+
+            Assert.NotNull(msgExtAction);
+            Assert.IsType<MessagingExtensionAction>(msgExtAction);
+            Assert.Equal(data, msgExtAction.Data);
+            Assert.Equal(context, msgExtAction.Context);
+            Assert.Equal(commandId, msgExtAction.CommandId);
+            Assert.Equal(commandContext, msgExtAction.CommandContext);
+            Assert.Equal(botMessagePreviewAction, msgExtAction.BotMessagePreviewAction);
+            Assert.Equal(botActivityPreview, msgExtAction.BotActivityPreview);
+            Assert.Equal(messagePayload, msgExtAction.MessagePayload);
+            Assert.Equal(state, msgExtAction.State);
+        }
+        
+        [Fact]
+        public void MessagingExtensionActionInitsNoArgs()
+        {
+            var msgExtAction = new MessagingExtensionAction();
+
+            Assert.NotNull(msgExtAction);
+            Assert.IsType<MessagingExtensionAction>(msgExtAction);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionAttachmentTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionAttachmentTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionAttachmentTests
+    {
+        [Fact]
+        public void MessagingExtensionAttachmentInits()
+        {
+            var contentType = "text/plain";
+            var contentUrl = "https://example.com";
+            var content = "some content";
+            var name = "super-plain-attachment";
+            var thumbnailUrl = "https://url-to-thumbnail.com";
+            var preview = new Attachment();
+
+            var msgExtAttachment = new MessagingExtensionAttachment(contentType, contentUrl, content, name, thumbnailUrl, preview);
+
+            Assert.NotNull(msgExtAttachment);
+            Assert.IsType<MessagingExtensionAttachment>(msgExtAttachment);
+            Assert.Equal(contentType, msgExtAttachment.ContentType);
+            Assert.Equal(contentUrl, msgExtAttachment.ContentUrl);
+            Assert.Equal(content, msgExtAttachment.Content);
+            Assert.Equal(name, msgExtAttachment.Name);
+            Assert.Equal(thumbnailUrl, msgExtAttachment.ThumbnailUrl);
+            Assert.Equal(preview, msgExtAttachment.Preview);
+        }
+
+        [Fact]
+        public void MessagingExtensionAttachmentInitsWithNoArgs()
+        {
+            var msgExtAttachment = new MessagingExtensionAttachment();
+
+            Assert.NotNull(msgExtAttachment);
+            Assert.IsType<MessagingExtensionAttachment>(msgExtAttachment);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionAttachmentTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionAttachmentTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using Microsoft.Bot.Schema.Teams;
 using Xunit;
 

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionParametersTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionParametersTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionParametersTests
+    {
+        [Fact]
+        public void MessagingExtensionParametersInits()
+        {
+            var name = "pandaCount";
+            var value = 3;
+
+            var msgExtParams = new MessagingExtensionParameter(name, value);
+
+            Assert.NotNull(msgExtParams);
+            Assert.IsType<MessagingExtensionParameter>(msgExtParams);
+            Assert.Equal(name, msgExtParams.Name);
+            Assert.Equal(value, msgExtParams.Value);
+        }
+        
+        [Fact]
+        public void MessagingExtensionParametersInitsWithNoArgs()
+        {
+            var msgExtParams = new MessagingExtensionParameter();
+
+            Assert.NotNull(msgExtParams);
+            Assert.IsType<MessagingExtensionParameter>(msgExtParams);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionQueryOptionsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionQueryOptionsTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionQueryOptionsTests
+    {
+        [Fact]
+        public void MessagingExtensionQueryOptionsInits()
+        {
+            var skip = 0;
+            var count = 2;
+
+            var msgExtQueryOptions = new MessagingExtensionQueryOptions(skip, count);
+
+            Assert.NotNull(msgExtQueryOptions);
+            Assert.IsType<MessagingExtensionQueryOptions>(msgExtQueryOptions);
+            Assert.Equal(skip, msgExtQueryOptions.Skip);
+            Assert.Equal(count, msgExtQueryOptions.Count);
+        }
+        
+        [Fact]
+        public void MessagingExtensionQueryOptionsInitsWithNoArgs()
+        {
+            var msgExtQueryOptions = new MessagingExtensionQueryOptions();
+
+            Assert.NotNull(msgExtQueryOptions);
+            Assert.IsType<MessagingExtensionQueryOptions>(msgExtQueryOptions);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionQueryTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionQueryTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionQueryTests
+    {
+        [Fact]
+        public void MessagingExtensionQueryInits()
+        {
+            var commandId = "commandId123";
+            var parameters = new List<MessagingExtensionParameter>() { new MessagingExtensionParameter("pandaCount", 5) };
+            var queryOptions = new MessagingExtensionQueryOptions(0, 1);
+            var state = "secureAuthStateValue123";
+
+            var msgExtQuery = new MessagingExtensionQuery(commandId, parameters, queryOptions, state);
+
+            Assert.NotNull(msgExtQuery);
+            Assert.IsType<MessagingExtensionQuery>(msgExtQuery);
+            Assert.Equal(commandId, msgExtQuery.CommandId);
+            Assert.Equal(parameters, msgExtQuery.Parameters);
+            Assert.Equal(queryOptions, msgExtQuery.QueryOptions);
+            Assert.Equal(state, msgExtQuery.State);
+        }
+        
+        [Fact]
+        public void MessagingExtensionQueryInitsWithNoArgs()
+        {
+            var msgExtQuery = new MessagingExtensionQuery();
+
+            Assert.NotNull(msgExtQuery);
+            Assert.IsType<MessagingExtensionQuery>(msgExtQuery);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionResponseTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionResponseTests
+    {
+        [Fact]
+        public void MessagingExtensionResponseInits()
+        {
+            var composeExtension = new MessagingExtensionResult("list", "message", null, null, "happy dance");
+            var cacheInfo = new CacheInfo();
+
+            var msgExtResponse = new MessagingExtensionResponse(composeExtension)
+            { 
+                CacheInfo = cacheInfo
+            };
+
+            Assert.NotNull(msgExtResponse);
+            Assert.IsType<MessagingExtensionResponse>(msgExtResponse);
+            Assert.Equal(composeExtension, msgExtResponse.ComposeExtension);
+            Assert.Equal(cacheInfo, msgExtResponse.CacheInfo);
+        }
+        
+        [Fact]
+        public void MessagingExtensionResponseInitsWithNoArgs()
+        {
+            var msgExtResponse = new MessagingExtensionResponse();
+
+            Assert.NotNull(msgExtResponse);
+            Assert.IsType<MessagingExtensionResponse>(msgExtResponse);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionResultTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionResultTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionResultTests
+    {
+        [Fact]
+        public void MessagingExtensionResultInits()
+        {
+            var attachmentLayout = "list";
+            var type = "message";
+            var attachments = new List<MessagingExtensionAttachment>() { new MessagingExtensionAttachment() };
+            var suggestedActions = new MessagingExtensionSuggestedAction(
+                new List<CardAction>()
+                { 
+                    new CardAction("showImage"),
+                    new CardAction("openUrl"),
+                });
+            var text = "my cup runneth over";
+            var activityPreview = new Activity();
+
+            var msgExtResult = new MessagingExtensionResult(attachmentLayout, type, attachments, suggestedActions, text, activityPreview);
+
+            Assert.NotNull(msgExtResult);
+            Assert.IsType<MessagingExtensionResult>(msgExtResult);
+            Assert.Equal(attachmentLayout, msgExtResult.AttachmentLayout);
+            Assert.Equal(type, msgExtResult.Type);
+            Assert.Equal(attachments, msgExtResult.Attachments);
+            Assert.Equal(suggestedActions, msgExtResult.SuggestedActions);
+            Assert.Equal(text, msgExtResult.Text);
+            Assert.Equal(activityPreview, msgExtResult.ActivityPreview);
+        }
+        
+        [Fact]
+        public void MessagingExtensionResultInitsWithNoArgs()
+        {
+            var msgExtResult = new MessagingExtensionResult();
+
+            Assert.NotNull(msgExtResult);
+            Assert.IsType<MessagingExtensionResult>(msgExtResult);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionSuggestedActionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MessagingExtensionSuggestedActionTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MessagingExtensionSuggestedActionTests
+    {
+        [Fact]
+        public void MessagingExtensionSuggestedActionInits()
+        {
+            var cardActions = new List<CardAction>()
+            {
+                new CardAction("openUrl"),
+                new CardAction("imBack"),
+                new CardAction("postBack"),
+            };
+            
+            var msgExtSuggestedAction = new MessagingExtensionSuggestedAction(cardActions);
+
+            Assert.NotNull(msgExtSuggestedAction);
+            Assert.IsType<MessagingExtensionSuggestedAction>(msgExtSuggestedAction);
+            Assert.Equal(cardActions, msgExtSuggestedAction.Actions);
+            Assert.Equal(cardActions.Count, msgExtSuggestedAction.Actions.Count);
+        }
+        
+        [Fact]
+        public void MessagingExtensionSuggestedActionInitsWithNoArgs()
+        {
+            var msgExtSuggestedAction = new MessagingExtensionSuggestedAction();
+
+            Assert.NotNull(msgExtSuggestedAction);
+            Assert.IsType<MessagingExtensionSuggestedAction>(msgExtSuggestedAction);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5645 

___

## Description
Part 4 of 8.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 6.23%
![image](https://user-images.githubusercontent.com/35248895/117715883-bc255380-b18d-11eb-93c5-6bea84d936c2.png)

Coverage Raised to with this Chunk: 22.56%
![image](https://user-images.githubusercontent.com/35248895/121426410-67116480-c928-11eb-95d1-962f0d92d501.png)
