### PR TITLE
[Part 5] Increase Microsoft.Bot.Schema.Teams code coverage

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/NotificationInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/NotificationInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="alert">true if notification is to be sent to the user,
         /// false otherwise.</param>
-        public NotificationInfo(bool? alert = default(bool?))
+        public NotificationInfo(bool? alert = default)
         {
             Alert = alert;
             CustomInit();

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCard.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="sections">Set of sections for the current card.</param>
         /// <param name="potentialAction">Set of actions for the current
         /// card.</param>
-        public O365ConnectorCard(string title = default(string), string text = default(string), string summary = default(string), string themeColor = default(string), IList<O365ConnectorCardSection> sections = default(IList<O365ConnectorCardSection>), IList<O365ConnectorCardActionBase> potentialAction = default(IList<O365ConnectorCardActionBase>))
+        public O365ConnectorCard(string title = default, string text = default, string summary = default, string themeColor = default, IList<O365ConnectorCardSection> sections = default, IList<O365ConnectorCardActionBase> potentialAction = default)
         {
             Title = title;
             Text = text;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionBase.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="name">Name of the action that will be used as button
         /// title.</param>
         /// <param name="id">Action Id.</param>
-        public O365ConnectorCardActionBase(string type = default(string), string name = default(string), string id = default(string))
+        public O365ConnectorCardActionBase(string type = default, string name = default, string id = default)
         {
             Type = type;
             Name = name;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionCard.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// whose each item can be in any subtype of
         /// O365ConnectorCardActionBase except O365ConnectorCardActionCard, as
         /// nested ActionCard is forbidden.</param>
-        public O365ConnectorCardActionCard(string type = default(string), string name = default(string), string id = default(string), IList<O365ConnectorCardInputBase> inputs = default(IList<O365ConnectorCardInputBase>), IList<O365ConnectorCardActionBase> actions = default(IList<O365ConnectorCardActionBase>))
+        public O365ConnectorCardActionCard(string type = default, string name = default, string id = default, IList<O365ConnectorCardInputBase> inputs = default, IList<O365ConnectorCardActionBase> actions = default)
             : base(type, name, id)
         {
             Inputs = inputs;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionQuery.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -27,7 +26,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="actionId">Action Id associated with the HttpPOST
         /// action button triggered, defined in
         /// O365ConnectorCardActionBase.</param>
-        public O365ConnectorCardActionQuery(string body = default(string), string actionId = default(string))
+        public O365ConnectorCardActionQuery(string body = default, string actionId = default)
         {
             Body = body;
             ActionId = actionId;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardDateInput.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardDateInput.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="value">Default value for this input field.</param>
         /// <param name="includeTime">Include time input field. Default value
         /// is false (date only).</param>
-        public O365ConnectorCardDateInput(string type = default(string), string id = default(string), bool? isRequired = default(bool?), string title = default(string), string value = default(string), bool? includeTime = default(bool?))
+        public O365ConnectorCardDateInput(string type = default, string id = default, bool? isRequired = default, string title = default, string value = default, bool? includeTime = default)
             : base(type, id, isRequired, title, value)
         {
             IncludeTime = includeTime;

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/NotificationInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/NotificationInfoTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class NotificationInfoTests
+    {
+        [Fact]
+        public void NotificationInfoInits()
+        {
+            var alert = true;
+            var externalResourceUrl = "https://example.com";
+
+            var notificationInfo = new NotificationInfo(alert)
+            {
+                AlertInMeeting = true,
+                ExternalResourceUrl = externalResourceUrl,
+            };
+
+            Assert.NotNull(notificationInfo);
+            Assert.IsType<NotificationInfo>(notificationInfo);
+            Assert.True(notificationInfo.Alert);
+            Assert.True(notificationInfo.AlertInMeeting);
+            Assert.Equal(externalResourceUrl, notificationInfo.ExternalResourceUrl);
+        }
+        
+        [Fact]
+        public void NotificationInfoInitsWithNoArgs()
+        {
+            var notificationInfo = new NotificationInfo();
+
+            Assert.NotNull(notificationInfo);
+            Assert.IsType<NotificationInfo>(notificationInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionBaseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionBaseTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardActionBaseTests
+    {
+        [Fact]
+        public void O365ConnectorCardActionBaseInits()
+        {
+            var type = "HttpPOST";
+            var name = "OK";
+            var id = "confirmation";
+
+            var o365ConnectorCardActionBase = new O365ConnectorCardActionBase(type, name, id);
+
+            Assert.NotNull(o365ConnectorCardActionBase);
+            Assert.IsType<O365ConnectorCardActionBase>(o365ConnectorCardActionBase);
+            Assert.Equal(type, o365ConnectorCardActionBase.Type);
+            Assert.Equal(name, o365ConnectorCardActionBase.Name);
+            Assert.Equal(id, o365ConnectorCardActionBase.Id);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardActionBaseInitsWithNoArgs()
+        {
+            var o365ConnectorCardActionBase = new O365ConnectorCardActionBase();
+
+            Assert.NotNull(o365ConnectorCardActionBase);
+            Assert.IsType<O365ConnectorCardActionBase>(o365ConnectorCardActionBase);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionBaseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionBaseTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using Microsoft.Bot.Schema.Teams;
 using Xunit;
 

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionCardTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionCardTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardActionCardTests
+    {
+        [Fact]
+        public void O365ConnectorCardActionCardInits()
+        {
+            var name = "Set due date";
+            var id = "dueDate";
+            var inputs = new List<O365ConnectorCardInputBase>() { new O365ConnectorCardInputBase("dateInput") };
+            var actions = new List<O365ConnectorCardActionBase>() { new O365ConnectorCardActionBase("ActionCard") };
+
+            var o365ConnectorCardActionCard = new O365ConnectorCardActionCard("ActionCard", name, id, inputs, actions);
+
+            Assert.NotNull(o365ConnectorCardActionCard);
+            Assert.IsType<O365ConnectorCardActionCard>(o365ConnectorCardActionCard);
+            Assert.Equal(name, o365ConnectorCardActionCard.Name);
+            Assert.Equal(id, o365ConnectorCardActionCard.Id);
+            Assert.Equal(inputs, o365ConnectorCardActionCard.Inputs);
+            Assert.Equal(actions, o365ConnectorCardActionCard.Actions);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardActionCardInitsWithNoArgs()
+        {
+            var o365ConnectorCardActionCard = new O365ConnectorCardActionCard();
+
+            Assert.NotNull(o365ConnectorCardActionCard);
+            Assert.IsType<O365ConnectorCardActionCard>(o365ConnectorCardActionCard);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionQueryTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardActionQueryTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardActionQueryTests
+    {
+        [Fact]
+        public void O365ConnectorCardActionQueryInits()
+        {
+            var body = "body";
+            var actionId = "ActionCard";
+
+            var actionQuery = new O365ConnectorCardActionQuery(body, actionId);
+
+            Assert.NotNull(actionQuery);
+            Assert.IsType<O365ConnectorCardActionQuery>(actionQuery);
+            Assert.Equal(body, actionQuery.Body);
+            Assert.Equal(actionId, actionQuery.ActionId);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardActionQueryInitsWithNoArgs()
+        {
+            var actionQuery = new O365ConnectorCardActionQuery();
+
+            Assert.NotNull(actionQuery);
+            Assert.IsType<O365ConnectorCardActionQuery>(actionQuery);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardDateInputTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardDateInputTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardDateInputTests
+    {
+        [Fact]
+        public void O365ConnectorCardDateInputInits()
+        {
+            var type = "dateInput";
+            var id = "dateInput123";
+            var isRequired = true;
+            var title = "Enter Date";
+            var value = "2009-06-15T13:45:30";
+            var includeTime = false;
+
+            var dateInput = new O365ConnectorCardDateInput(type, id, isRequired, title, value, includeTime);
+
+            Assert.NotNull(dateInput);
+            Assert.IsType<O365ConnectorCardDateInput>(dateInput);
+            Assert.Equal(id, dateInput.Id);
+            Assert.Equal(isRequired, dateInput.IsRequired);
+            Assert.Equal(title, dateInput.Title);
+            Assert.Equal(value, dateInput.Value);
+            Assert.Equal(includeTime, dateInput.IncludeTime);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardDateInputInitsWithNoArgs()
+        {
+            var dateInput = new O365ConnectorCardDateInput();
+
+            Assert.NotNull(dateInput);
+            Assert.IsType<O365ConnectorCardDateInput>(dateInput);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardTests
+    {
+        [Fact]
+        public void O365ConnectorCardInits()
+        {
+            var title = "Grand Title";
+            var text = "A grand adventure awaits!";
+            var summary = "A card that details harrowing tails of our grand adventurer";
+            var themeColor = "0078D7";
+            var sections = new List<O365ConnectorCardSection>() { new O365ConnectorCardSection("David Claux") };
+            var potentialAction = new List<O365ConnectorCardActionBase>() { new O365ConnectorCardActionBase("ActionCard") };
+
+            var o365ConnectorCard = new O365ConnectorCard(title, text, summary, themeColor, sections, potentialAction);
+
+            Assert.NotNull(o365ConnectorCard);
+            Assert.IsType<O365ConnectorCard>(o365ConnectorCard);
+            Assert.Equal(title, o365ConnectorCard.Title);
+            Assert.Equal(text, o365ConnectorCard.Text);
+            Assert.Equal(summary, o365ConnectorCard.Summary);
+            Assert.Equal(themeColor, o365ConnectorCard.ThemeColor);
+            Assert.Equal(sections, o365ConnectorCard.Sections);
+            Assert.Equal(potentialAction, o365ConnectorCard.PotentialAction);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardInitsWithNoArgs()
+        {
+            var o365ConnectorCard = new O365ConnectorCard();
+
+            Assert.NotNull(o365ConnectorCard);
+            Assert.IsType<O365ConnectorCard>(o365ConnectorCard);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5647 

___

## Description
Part 3 of 8.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 6.23%
![image](https://user-images.githubusercontent.com/35248895/117715883-bc255380-b18d-11eb-93c5-6bea84d936c2.png)

Coverage Raised to with this Chunk: 18.58%
![image](https://user-images.githubusercontent.com/35248895/121445146-b914b300-c945-11eb-8764-a3b009a99488.png)
