### PR TITLE
[Part 6] Increase Microsoft.Bot.Schema.Teams code coverage

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardFact.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardFact.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="name">Display name of the fact.</param>
         /// <param name="value">Display value for the fact.</param>
-        public O365ConnectorCardFact(string name = default(string), string value = default(string))
+        public O365ConnectorCardFact(string name = default, string value = default)
         {
             Name = name;
             Value = value;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardHttpPOST.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardHttpPOST.cs
@@ -24,12 +24,10 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="type">Type of the action. Possible values include:
         /// 'ViewAction', 'OpenUri', 'HttpPOST', 'ActionCard'.</param>
-        /// <param name="name">Name of the action that will be used as button
-        /// title.</param>
+        /// <param name="name">Name of the action that will be used as button title.</param>
         /// <param name="id">Action Id.</param>
-        /// <param name="body">Content to be posted back to bots via
-        /// invoke.</param>
-        public O365ConnectorCardHttpPOST(string type = default(string), string name = default(string), string id = default(string), string body = default(string))
+        /// <param name="body">Content to be posted back to bots via invoke.</param>
+        public O365ConnectorCardHttpPOST(string type = default, string name = default, string id = default, string body = default)
             : base(type, name, id)
         {
             Body = body;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardImage.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardImage.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="image">URL for the image.</param>
         /// <param name="title">Alternative text for the image.</param>
-        public O365ConnectorCardImage(string image = default(string), string title = default(string))
+        public O365ConnectorCardImage(string image = default, string title = default)
         {
             Image = image;
             Title = title;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardInputBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardInputBase.cs
@@ -24,14 +24,11 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="type">Input type name. Possible values include:
         /// 'textInput', 'dateInput', 'multichoiceInput'.</param>
-        /// <param name="id">Input Id. It must be unique per entire O365
-        /// connector card.</param>
-        /// <param name="isRequired">Define if this input is a required field.
-        /// Default value is false.</param>
-        /// <param name="title">Input title that will be shown as the
-        /// placeholder.</param>
+        /// <param name="id">Input Id. It must be unique per entire O365 connector card.</param>
+        /// <param name="isRequired">Define if this input is a required field. Default value is false.</param>
+        /// <param name="title">Input title that will be shown as the placeholder.</param>
         /// <param name="value">Default value for this input field.</param>
-        public O365ConnectorCardInputBase(string type = default(string), string id = default(string), bool? isRequired = default(bool?), string title = default(string), string value = default(string))
+        public O365ConnectorCardInputBase(string type = default, string id = default, bool? isRequired = default, string title = default, string value = default)
         {
             Type = type;
             Id = id;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInput.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInput.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -26,20 +24,14 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="type">Input type name. Possible values include:
         /// 'textInput', 'dateInput', 'multichoiceInput'.</param>
-        /// <param name="id">Input Id. It must be unique per entire O365
-        /// connector card.</param>
-        /// <param name="isRequired">Define if this input is a required field.
-        /// Default value is false.</param>
-        /// <param name="title">Input title that will be shown as the
-        /// placeholder.</param>
+        /// <param name="id">Input Id. It must be unique per entire O365 connector card.</param>
+        /// <param name="isRequired">Define if this input is a required field. Default value is false.</param>
+        /// <param name="title">Input title that will be shown as the placeholder.</param>
         /// <param name="value">Default value for this input field.</param>
-        /// <param name="choices">Set of choices whose each item can be in any
-        /// subtype of O365ConnectorCardMultichoiceInputChoice.</param>
-        /// <param name="style">Choice item rendering style. Default value is
-        /// 'compact'. Possible values include: 'compact', 'expanded'.</param>
-        /// <param name="isMultiSelect">Define if this input field allows
-        /// multiple selections. Default value is false.</param>
-        public O365ConnectorCardMultichoiceInput(string type = default(string), string id = default(string), bool? isRequired = default(bool?), string title = default(string), string value = default(string), IList<O365ConnectorCardMultichoiceInputChoice> choices = default(IList<O365ConnectorCardMultichoiceInputChoice>), string style = default(string), bool? isMultiSelect = default(bool?))
+        /// <param name="choices">Set of choices whose each item can be in any subtype of O365ConnectorCardMultichoiceInputChoice.</param>
+        /// <param name="style">Choice item rendering style. Default value is 'compact'. Possible values include: 'compact', 'expanded'.</param>
+        /// <param name="isMultiSelect">Define if this input field allows multiple selections. Default value is false.</param>
+        public O365ConnectorCardMultichoiceInput(string type = default, string id = default, bool? isRequired = default, string title = default, string value = default, IList<O365ConnectorCardMultichoiceInputChoice> choices = default, string style = default, bool? isMultiSelect = default)
             : base(type, id, isRequired, title, value)
         {
             Choices = choices;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInputChoice.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInputChoice.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="display">The text rendered on ActionCard.</param>
         /// <param name="value">The value received as results.</param>
-        public O365ConnectorCardMultichoiceInputChoice(string display = default(string), string value = default(string))
+        public O365ConnectorCardMultichoiceInputChoice(string display = default, string value = default)
         {
             Display = display;
             Value = value;

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardFactTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardFactTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardFactTests
+    {
+        [Fact]
+        public void O365ConnectorCardFactInits()
+        {
+            var name = "BugId";
+            var value = "1234";
+
+            var fact = new O365ConnectorCardFact(name, value);
+
+            Assert.NotNull(fact);
+            Assert.IsType<O365ConnectorCardFact>(fact);
+            Assert.Equal(name, fact.Name);
+            Assert.Equal(value, fact.Value);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardFactInitsWithNoArgs()
+        {
+            var fact = new O365ConnectorCardFact();
+
+            Assert.NotNull(fact);
+            Assert.IsType<O365ConnectorCardFact>(fact);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardHttpPOSTTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardHttpPOSTTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardHttpPOSTTests
+    {
+        [Fact]
+        public void O365ConnectorCardHttpPOSTInits()
+        {
+            var type = "HttpPOST";
+            var name = "Order Yoga Pants";
+            var id = "orderYogaPants";
+            var body = new JObject() { { "color", "red" } }.ToString();
+
+            var httpPOST = new O365ConnectorCardHttpPOST(type, name, id, body);
+
+            Assert.NotNull(httpPOST);
+            Assert.IsType<O365ConnectorCardHttpPOST>(httpPOST);
+            Assert.Equal(name, httpPOST.Name);
+            Assert.Equal(id, httpPOST.Id);
+            Assert.Equal(body, httpPOST.Body);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardHttpPOSTInitsWithNoArgs()
+        {
+            var httpPOST = new O365ConnectorCardHttpPOST();
+
+            Assert.NotNull(httpPOST);
+            Assert.IsType<O365ConnectorCardHttpPOST>(httpPOST);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardImageTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardImageTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardImageTests
+    {
+        [Fact]
+        public void O365ConnectorCardImageInits()
+        {
+            var image = "http://example-image.com";
+            var title = "Happy Pandas";
+
+            var cardImage = new O365ConnectorCardImage(image, title);
+
+            Assert.NotNull(cardImage);
+            Assert.IsType<O365ConnectorCardImage>(cardImage);
+            Assert.Equal(image, cardImage.Image);
+            Assert.Equal(title, cardImage.Title);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardImageInitsWithNoArgs()
+        {
+            var cardImage = new O365ConnectorCardImage();
+
+            Assert.NotNull(cardImage);
+            Assert.IsType<O365ConnectorCardImage>(cardImage);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardInputBaseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardInputBaseTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardInputBaseTests
+    {
+        [Fact]
+        public void O365ConnectorCardInputBaseInits()
+        {
+            var type = "textInput";
+            var id = "firstName";
+            var isRequired = true;
+            var title = "Profile";
+            var value = "First Name";
+
+            var inputBase = new O365ConnectorCardInputBase(type, id, isRequired, title, value);
+
+            Assert.NotNull(inputBase);
+            Assert.IsType<O365ConnectorCardInputBase>(inputBase);
+            Assert.Equal(type, inputBase.Type);
+            Assert.Equal(id, inputBase.Id);
+            Assert.Equal(isRequired, inputBase.IsRequired);
+            Assert.Equal(title, inputBase.Title);
+            Assert.Equal(value, inputBase.Value);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardInputBaseInitsWithNoArgs()
+        {
+            var inputBase = new O365ConnectorCardInputBase();
+
+            Assert.NotNull(inputBase);
+            Assert.IsType<O365ConnectorCardInputBase>(inputBase);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardMultichoiceInputChoiceTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardMultichoiceInputChoiceTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardMultichoiceInputChoiceTests
+    {
+        [Fact]
+        public void O365ConnectorCardMultichoiceInputChoiceInits()
+        {
+            var display = "C# in Depth";
+            var value = "csharpInDepth";
+
+            var choice = new O365ConnectorCardMultichoiceInputChoice(display, value);
+
+            Assert.NotNull(choice);
+            Assert.IsType<O365ConnectorCardMultichoiceInputChoice>(choice);
+            Assert.Equal(display, choice.Display);
+            Assert.Equal(value, choice.Value);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardMultichoiceInputChoiceInitsWithNoArgs()
+        {
+            var choice = new O365ConnectorCardMultichoiceInputChoice();
+
+            Assert.NotNull(choice);
+            Assert.IsType<O365ConnectorCardMultichoiceInputChoice>(choice);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardMultichoiceInputTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardMultichoiceInputTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardMultichoiceInputTests
+    {
+        [Fact]
+        public void O365ConnectorCardMultichoiceInputInits()
+        {
+            var type = "multichoiceInput";
+            var id = "bookChoice";
+            var isRequired = true;
+            var title = "Books";
+            var value = "No Book Selected";
+            var choices = new List<O365ConnectorCardMultichoiceInputChoice>()
+            { 
+                new O365ConnectorCardMultichoiceInputChoice("C# In Depth"),
+                new O365ConnectorCardMultichoiceInputChoice("C# in a Nutshell"), 
+            };
+            var style = "expanded";
+            var isMultiSelect = true;
+
+            var multichoiceInput = new O365ConnectorCardMultichoiceInput(type, id, isRequired, title, value, choices, style, isMultiSelect);
+
+            Assert.NotNull(multichoiceInput);
+            Assert.IsType<O365ConnectorCardMultichoiceInput>(multichoiceInput);
+            Assert.Equal(id, multichoiceInput.Id);
+            Assert.Equal(isRequired, multichoiceInput.IsRequired);
+            Assert.Equal(title, multichoiceInput.Title);
+            Assert.Equal(value, multichoiceInput.Value);
+            Assert.Equal(choices, multichoiceInput.Choices);
+            Assert.Equal(2, multichoiceInput.Choices.Count);
+            Assert.Equal(style, multichoiceInput.Style);
+            Assert.Equal(isMultiSelect, multichoiceInput.IsMultiSelect);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardMultichoiceInputInitsWithNoArgs()
+        {
+            var multichoiceInput = new O365ConnectorCardMultichoiceInput();
+
+            Assert.NotNull(multichoiceInput);
+            Assert.IsType<O365ConnectorCardMultichoiceInput>(multichoiceInput);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5661

___

## Description
Part 6 of 8.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 6.23%
![image](https://user-images.githubusercontent.com/35248895/117715883-bc255380-b18d-11eb-93c5-6bea84d936c2.png)

Coverage Raised to with this Chunk: 14.93%
![image](https://user-images.githubusercontent.com/35248895/121733973-02c9de80-caa9-11eb-8714-03ff60d69e0b.png)
