### PR TITLE
[Part 7] [Unit Tests - Code Coverage]: Microsoft.Bot.Schema.Teams

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUri.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUri.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -30,7 +28,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// title.</param>
         /// <param name="id">Action Id.</param>
         /// <param name="targets">Target os / urls.</param>
-        public O365ConnectorCardOpenUri(string type = default(string), string name = default(string), string id = default(string), IList<O365ConnectorCardOpenUriTarget> targets = default(IList<O365ConnectorCardOpenUriTarget>))
+        public O365ConnectorCardOpenUri(string type = default, string name = default, string id = default, IList<O365ConnectorCardOpenUriTarget> targets = default)
             : base(type, name, id)
         {
             Targets = targets;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUriTarget.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUriTarget.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="os">Target operating system. Possible values include:
         /// 'default', 'iOS', 'android', 'windows'.</param>
         /// <param name="uri">Target url.</param>
-        public O365ConnectorCardOpenUriTarget(string os = default(string), string uri = default(string))
+        public O365ConnectorCardOpenUriTarget(string os = default, string uri = default)
         {
             Os = os;
             Uri = uri;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardSection.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardSection.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -30,15 +28,12 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="activitySubtitle">Activity subtitle.</param>
         /// <param name="activityText">Activity text.</param>
         /// <param name="activityImage">Activity image.</param>
-        /// <param name="activityImageType">Describes how Activity image is
-        /// rendered. Possible values include: 'avatar', 'article'.</param>
-        /// <param name="markdown">Use markdown for all text contents. Default
-        /// value is true.</param>
+        /// <param name="activityImageType">Describes how Activity image is rendered. Possible values include: 'avatar', 'article'.</param>
+        /// <param name="markdown">Use markdown for all text contents. Default value is true.</param>
         /// <param name="facts">Set of facts for the current section.</param>
         /// <param name="images">Set of images for the current section.</param>
-        /// <param name="potentialAction">Set of actions for the current
-        /// section.</param>
-        public O365ConnectorCardSection(string title = default(string), string text = default(string), string activityTitle = default(string), string activitySubtitle = default(string), string activityText = default(string), string activityImage = default(string), string activityImageType = default(string), bool? markdown = default(bool?), IList<O365ConnectorCardFact> facts = default(IList<O365ConnectorCardFact>), IList<O365ConnectorCardImage> images = default(IList<O365ConnectorCardImage>), IList<O365ConnectorCardActionBase> potentialAction = default(IList<O365ConnectorCardActionBase>))
+        /// <param name="potentialAction">Set of actions for the current section.</param>
+        public O365ConnectorCardSection(string title = default, string text = default, string activityTitle = default, string activitySubtitle = default, string activityText = default, string activityImage = default, string activityImageType = default, bool? markdown = default, IList<O365ConnectorCardFact> facts = default, IList<O365ConnectorCardImage> images = default, IList<O365ConnectorCardActionBase> potentialAction = default)
         {
             Title = title;
             Text = text;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardTextInput.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardTextInput.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -24,18 +23,13 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="type">Input type name. Possible values include:
         /// 'textInput', 'dateInput', 'multichoiceInput'.</param>
-        /// <param name="id">Input Id. It must be unique per entire O365
-        /// connector card.</param>
-        /// <param name="isRequired">Define if this input is a required field.
-        /// Default value is false.</param>
-        /// <param name="title">Input title that will be shown as the
-        /// placeholder.</param>
+        /// <param name="id">Input Id. It must be unique per entire O365 connector card.</param>
+        /// <param name="isRequired">Define if this input is a required field. Default value is false.</param>
+        /// <param name="title">Input title that will be shown as the placeholder.</param>
         /// <param name="value">Default value for this input field.</param>
-        /// <param name="isMultiline">Define if text input is allowed for
-        /// multiple lines. Default value is false.</param>
-        /// <param name="maxLength">Maximum length of text input. Default value
-        /// is unlimited.</param>
-        public O365ConnectorCardTextInput(string type = default(string), string id = default(string), bool? isRequired = default(bool?), string title = default(string), string value = default(string), bool? isMultiline = default(bool?), double? maxLength = default(double?))
+        /// <param name="isMultiline">Define if text input is allowed for multiple lines. Default value is false.</param>
+        /// <param name="maxLength">Maximum length of text input. Default value is unlimited.</param>
+        public O365ConnectorCardTextInput(string type = default, string id = default, bool? isRequired = default, string title = default, string value = default, bool? isMultiline = default, double? maxLength = default)
             : base(type, id, isRequired, title, value)
         {
             IsMultiline = isMultiline;

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardViewAction.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardViewAction.cs
@@ -3,9 +3,7 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -26,12 +24,10 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="type">Type of the action. Possible values include:
         /// 'ViewAction', 'OpenUri', 'HttpPOST', 'ActionCard'.</param>
-        /// <param name="name">Name of the action that will be used as button
-        /// title.</param>
+        /// <param name="name">Name of the action that will be used as button title.</param>
         /// <param name="id">Action Id.</param>
-        /// <param name="target">Target urls, only the first url effective for
-        /// card button.</param>
-        public O365ConnectorCardViewAction(string type = default(string), string name = default(string), string id = default(string), IList<string> target = default(IList<string>))
+        /// <param name="target">Target urls, only the first url effective for card button.</param>
+        public O365ConnectorCardViewAction(string type = default, string name = default, string id = default, IList<string> target = default)
             : base(type, name, id)
         {
             Target = target;

--- a/libraries/Microsoft.Bot.Schema/Teams/SigninStateVerificationQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/SigninStateVerificationQuery.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="state"> The state string originally received when the
         /// signin web flow is finished with a state posted back to client via
         /// tab SDK microsoftTeams.authentication.notifySuccess(state).</param>
-        public SigninStateVerificationQuery(string state = default(string))
+        public SigninStateVerificationQuery(string state = default)
         {
             State = state;
             CustomInit();

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardOpenUriTargetTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardOpenUriTargetTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardOpenUriTargetTests
+    {
+        [Fact]
+        public void O365ConnectorCardOpenUriTargetInits()
+        {
+            var os = "default";
+            var uri = "www.bing.com";
+
+            var openUriTarget = new O365ConnectorCardOpenUriTarget(os, uri);
+
+            Assert.NotNull(openUriTarget);
+            Assert.IsType<O365ConnectorCardOpenUriTarget>(openUriTarget);
+            Assert.Equal(os, openUriTarget.Os);
+            Assert.Equal(uri, openUriTarget.Uri);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardOpenUriTargetInitsWithNoArgs()
+        {
+            var openUriTarget = new O365ConnectorCardOpenUriTarget();
+
+            Assert.NotNull(openUriTarget);
+            Assert.IsType<O365ConnectorCardOpenUriTarget>(openUriTarget);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardOpenUriTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardOpenUriTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardOpenUriTests
+    {
+        [Fact]
+        public void O365ConnectorCardOpenUriInits()
+        {
+            var type = "OpenUri";
+            var name = "Go to Bing";
+            var id = "goToBing";
+            var targets = new List<O365ConnectorCardOpenUriTarget>() { new O365ConnectorCardOpenUriTarget("default", "www.bing.com") };
+
+            var openUri = new O365ConnectorCardOpenUri(type, name, id, targets);
+
+            Assert.NotNull(openUri);
+            Assert.IsType<O365ConnectorCardOpenUri>(openUri);
+            Assert.Equal(name, openUri.Name);
+            Assert.Equal(id, openUri.Id);
+            Assert.Equal(targets, openUri.Targets);
+            Assert.Equal(1, openUri.Targets.Count);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardOpenUriInitsWithNoArgs()
+        {
+            var openUri = new O365ConnectorCardOpenUri();
+
+            Assert.NotNull(openUri);
+            Assert.IsType<O365ConnectorCardOpenUri>(openUri);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardSectionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardSectionTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardSectionTests
+    {
+        [Fact]
+        public void O365ConnectorCardSectionInits()
+        {
+            var title = "Donut Selection";
+            var text = "Choose a Donut";
+            var activityTitle = "Donut";
+            var activitySubtitle = "Select an image below.";
+            var activityText = "Select the image of the donut you wish to order.";
+            var activityImage = "https://example-of-donut.com";
+            var activityImageType = "article";
+            var markdown = false;
+            var facts = new List<O365ConnectorCardFact>()
+            {
+                new O365ConnectorCardFact("jelly"),
+                new O365ConnectorCardFact("powdered"),
+            };
+            var images = new List<O365ConnectorCardImage>()
+            { 
+                new O365ConnectorCardImage("https://jelly.com"),
+                new O365ConnectorCardImage("https://powdered.com") 
+            };
+            var potentialAction = new List<O365ConnectorCardActionBase>() { new O365ConnectorCardActionBase("OpenUri") };
+
+            var section = new O365ConnectorCardSection(title, text, activityTitle, activitySubtitle, activityText, activityImage, activityImageType, markdown, facts, images, potentialAction);
+
+            Assert.NotNull(section);
+            Assert.IsType<O365ConnectorCardSection>(section);
+            Assert.Equal(title, section.Title);
+            Assert.Equal(text, section.Text);
+            Assert.Equal(activityTitle, section.ActivityTitle);
+            Assert.Equal(activitySubtitle, section.ActivitySubtitle);
+            Assert.Equal(activityText, section.ActivityText);
+            Assert.Equal(activityImage, section.ActivityImage);
+            Assert.Equal(activityImageType, section.ActivityImageType);
+            Assert.Equal(markdown, section.Markdown);
+            Assert.Equal(facts, section.Facts);
+            Assert.Equal(2, section.Facts.Count);
+            Assert.Equal(images, section.Images);
+            Assert.Equal(2, section.Images.Count);
+            Assert.Equal(potentialAction, section.PotentialAction);
+            Assert.Equal(1, section.PotentialAction.Count);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardSectionInitsWithNoArgs()
+        {
+            var section = new O365ConnectorCardSection();
+
+            Assert.NotNull(section);
+            Assert.IsType<O365ConnectorCardSection>(section);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardTextInputTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardTextInputTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardTextInputTests
+    {
+        [Fact]
+        public void O365ConnectorCardTextInputInits()
+        {
+            var type = "textInput";
+            var id = "firstName";
+            var isRequired = true;
+            var title = "Profile";
+            var value = "First Name";
+            var isMultiline = false;
+            var maxLength = 250;
+
+            var textInput = new O365ConnectorCardTextInput(type, id, isRequired, title, value, isMultiline, maxLength);
+
+            Assert.NotNull(textInput);
+            Assert.IsType<O365ConnectorCardTextInput>(textInput);
+            Assert.Equal(id, textInput.Id);
+            Assert.Equal(isRequired, textInput.IsRequired);
+            Assert.Equal(title, textInput.Title);
+            Assert.Equal(value, textInput.Value);
+            Assert.Equal(isMultiline, textInput.IsMultiline);
+            Assert.Equal(maxLength, textInput.MaxLength);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardTextInputInitsWithNoArgs()
+        {
+            var textInput = new O365ConnectorCardTextInput();
+
+            Assert.NotNull(textInput);
+            Assert.IsType<O365ConnectorCardTextInput>(textInput);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardViewActionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardViewActionTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class O365ConnectorCardViewActionTests
+    {
+        [Fact]
+        public void O365ConnectorCardViewActionInits()
+        {
+            var type = "ViewAction";
+            var name = "Custom Action";
+            var id = "customAction";
+            var target = new List<string>() { "https://example.com" };
+
+            var viewAction = new O365ConnectorCardViewAction(type, name, id, target);
+
+            Assert.NotNull(viewAction);
+            Assert.IsType<O365ConnectorCardViewAction>(viewAction);
+            Assert.Equal(name, viewAction.Name);
+            Assert.Equal(id, viewAction.Id);
+            Assert.Equal(target, viewAction.Target);
+            Assert.Equal(1, viewAction.Target.Count);
+        }
+        
+        [Fact]
+        public void O365ConnectorCardViewActionInitsWithNoArgs()
+        {
+            var viewAction = new O365ConnectorCardViewAction();
+
+            Assert.NotNull(viewAction);
+            Assert.IsType<O365ConnectorCardViewAction>(viewAction);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/SigninStateVerificationQueryTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/SigninStateVerificationQueryTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class SigninStateVerificationQueryTests
+    {
+        [Fact]
+        public void SigninStateVerificationQueryInits()
+        {
+            var state = "OK";
+            
+            var verificationQuery = new SigninStateVerificationQuery(state);
+
+            Assert.NotNull(verificationQuery);
+            Assert.IsType<SigninStateVerificationQuery>(verificationQuery);
+            Assert.Equal(state, verificationQuery.State);
+        }
+        
+        [Fact]
+        public void SigninStateVerificationQueryInitsWithNoArgs()
+        {
+            var verificationQuery = new SigninStateVerificationQuery();
+
+            Assert.NotNull(verificationQuery);
+            Assert.IsType<SigninStateVerificationQuery>(verificationQuery);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5663 

___

## Description
Part 7 of 8.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 6.23%
![image](https://user-images.githubusercontent.com/35248895/117715883-bc255380-b18d-11eb-93c5-6bea84d936c2.png)

Coverage Raised to with this Chunk: 19.12%
![image](https://user-images.githubusercontent.com/35248895/121749093-f18bcc80-cabe-11eb-83a2-ebbc7ff02b1b.png)
