### PR TITLE
Adds missing required 'user' property to PostMessageAsync method

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -171,6 +171,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
                 ["channel"] = message.Channel,
                 ["text"] = message.Text,
                 ["thread_ts"] = message.ThreadTs,
+                ["user"] = message.User,
             };
 
             if (message.Blocks != null)

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackHelperTests.cs
@@ -53,6 +53,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         public void ActivityToSlackShouldReturnMessageFromChannelData()
         {
             const string messageText = "Hello from message";
+            const string ephemeralValue = "testEphemeral";
+            const string channelId = "channelId";
+            const string userId = "testRecipientId";
 
             var activity = new Activity
             {
@@ -62,7 +65,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
                 ChannelData = new NewSlackMessage
                 {
                     Text = messageText,
-                    Ephemeral = "testEphemeral"
+                    Ephemeral = ephemeralValue,
+                    Channel = channelId,
+                    User = userId,
                 },
                 Conversation = new ConversationAccount(id: "testId"),
             };
@@ -70,6 +75,9 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
             var message = SlackHelper.ActivityToSlack(activity);
 
             Assert.Equal(messageText, message.Text);
+            Assert.Equal(ephemeralValue, message.Ephemeral);
+            Assert.Equal(channelId, message.Channel);
+            Assert.Equal(userId, message.User);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #5602 

## Description
For an ephemeral message to be posted in Slack, the Slack message must contain, at a minimum, the `channel`, `text`, and `user` properties. Currently, the `user` property is not being assigned to the Slack `message` object resulting in a failed post. This PR fixes the issue allowing ephemeral messages to successfully post in Slack.

## Specific Changes
- In SlackClientWrapper.cs, added the `user` property to the `data` object sent to Slack's `api/chat.postEphemeral` endpoint.
- In SlackHelperTests.cs:
    - Changed hard-coded string literals to constants
    - Added the `Channel` and `User` properties to ChannelData
    - Added asserts to test the `ephemeral`, `channel`, and `user` properties

## Testing
![image](https://user-images.githubusercontent.com/18403946/121749483-96a6a500-cabf-11eb-9e22-dbc10f81de0e.png)
