### PR TITLE
Fix Path for merge tests.schema output directory

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 File.Delete(schemaPath);
 
                 // Merge all schema files,
-                var mergeCommand = $"/C bf dialog:merge ../../libraries/**/*.schema ../../libraries/**/*.uischema ../**/*.schema !../**/testbot.schema -o {schemaPath}";
+                var mergeCommand = $"/C bf dialog:merge ../../libraries/**/*.schema ../../libraries/**/*.uischema ../**/*.schema !../**/testbot.schema -o \"{schemaPath}\"";
                 var error = RunCommand(mergeCommand);
 
                 // Check if there were any errors or if the new schema file has changed.


### PR DESCRIPTION
Fixes #5668 

## Description
I just added double quotation to the name of output directory

## Specific Changes
  - Microsoft.Bot.Builder.Dialogs.Declarative.Tests.SchemaTestsFixture
  
![image](https://user-images.githubusercontent.com/25031218/121861001-1623b680-cd02-11eb-859d-665d0c270ead.png)

