### PR TITLE
Fix warning on pushing a package to nuget.org

### DIFF
--- a/build/FixLicenseInNuspecFiles.ps1
+++ b/build/FixLicenseInNuspecFiles.ps1
@@ -5,7 +5,7 @@
 # nuget.org. It compensates for a bug in Visual Studio's .nuspec file generation 
 # dating from when <licenseUrl> was deprecated in 2018. 6/15/2021
 #
-$path = "$(System.DefaultWorkingDirectory)/signing/*/*.nuspec";
+$path = "./signing/*/*.nuspec";
 $find = "licenseUrl>";
 $replace = "license>";
 

--- a/build/FixLicenseInNuspecFiles.ps1
+++ b/build/FixLicenseInNuspecFiles.ps1
@@ -5,12 +5,18 @@
 # nuget.org. It compensates for a bug in Visual Studio's .nuspec file generation 
 # dating from when <licenseUrl> was deprecated in 2018. 6/15/2021
 #
-$path = "$(Build.SourcesDirectory)/libraries/*/package.json/signing/*/*.nuspec";
+param
+( 
+    [string]$pathRoot,
+)
+pushd $pathRoot
+
+$relativePath = "./*/*.nuspec";
 $find = "licenseUrl>";
 $replace = "license>";
 
 function GoReplace() {
-    Get-ChildItem -Path "$path" | % {
+    Get-ChildItem -Path "$relativePath" | % {
         $_.FullName; 
         $content = Get-Content -Raw $_.FullName;
 

--- a/build/FixLicenseInNuspecFiles.ps1
+++ b/build/FixLicenseInNuspecFiles.ps1
@@ -1,0 +1,22 @@
+#
+# Replace "licenseUrl>" with "license>" in .nuspec files. 
+# Designed to be run after unpacking and before signing .nupkg file contents.
+# It eliminates "WARNING: The <licenseUrl> element is deprecated" when pushing to 
+# nuget.org. It compensates for a bug in Visual Studio's .nuspec file generation 
+# dating from when <licenseUrl> was deprecated in 2018. 6/15/2021
+#
+$path = "$(System.DefaultWorkingDirectory)/signing/*/*.nuspec";
+$find = "licenseUrl>";
+$replace = "license>";
+
+function GoReplace() {
+    Get-ChildItem -Path "$path" | % {
+        $_.FullName; 
+        $content = Get-Content -Raw $_.FullName;
+
+        $content -Replace "$find", "$replace" | Set-Content $_.FullName;
+        '-------------'; get-content $_.FullName; '===================';
+    }
+}
+
+GoReplace;

--- a/build/FixLicenseInNuspecFiles.ps1
+++ b/build/FixLicenseInNuspecFiles.ps1
@@ -7,7 +7,7 @@
 #
 param
 ( 
-    [string]$pathRoot,
+    [string]$pathRoot
 )
 pushd $pathRoot
 

--- a/build/FixLicenseInNuspecFiles.ps1
+++ b/build/FixLicenseInNuspecFiles.ps1
@@ -5,7 +5,7 @@
 # nuget.org. It compensates for a bug in Visual Studio's .nuspec file generation 
 # dating from when <licenseUrl> was deprecated in 2018. 6/15/2021
 #
-$path = "./signing/*/*.nuspec";
+$path = "$(Build.SourcesDirectory)/libraries/*/package.json/signing/*/*.nuspec";
 $find = "licenseUrl>";
 $replace = "license>";
 

--- a/build/yaml/sign-steps.yml
+++ b/build/yaml/sign-steps.yml
@@ -17,6 +17,12 @@ steps:
     filePath: ./build/ExtractCompressNuGet.ps1
     arguments: '$(Build.ArtifactStagingDirectory)\Signing  -Extract'
 
+- task: PowerShell@2
+  displayName: 'Fix license in .nuspec files'
+  inputs:
+    targetType: filePath
+    filePath: ./build/FixLicenseInNuspecFiles.ps1
+
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP Signing - strong name (CP-233863-SN)'
   inputs:

--- a/build/yaml/sign-steps.yml
+++ b/build/yaml/sign-steps.yml
@@ -22,6 +22,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: ./build/FixLicenseInNuspecFiles.ps1
+    arguments: '$(Build.ArtifactStagingDirectory)\Signing'
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP Signing - strong name (CP-233863-SN)'


### PR DESCRIPTION
Fixes #5557

## Description
The warning originates from the deprecated licenseUrl element in the .nuspec file in each Nuget package.
That .nuspec file is autogenerated by Visual Studio when it does the packaging in the build. There appears to be no way to get VS to use the modern XML tag "license".

## Specific Changes
This fix does a postfix on the .nuspec files after unpacking the packages and before signing by running the powershell script FixLicenseInNuspecFiles.ps1. In each file it changes the tag "licenseUrl" to "license".
