### PR TITLE
fix: Add automaticDecompression for httpRequest to avoid garbled code

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpResponseMock.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpResponseMock.cs
@@ -28,7 +28,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
             /// <summary>
             /// Byte array response. The content should be the base64 string of the byte array.
             /// </summary>
-            ByteArray
+            ByteArray,
+
+            /// <summary>
+            /// String content with GZip format.
+            /// </summary>
+            GZipString
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpResponseMockContent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/HttpRequestMocks/HttpResponseMockContent.cs
@@ -72,23 +72,24 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.HttpRequestMocks
 
         private byte[] CompressToGZip(string content)
         {
-            var byteArray = Encoding.Default.GetBytes(content);
+            var from = Encoding.Default.GetBytes(content);
 
-            using var memory = new MemoryStream();
-            using (var gzip = new GZipStream(memory, CompressionMode.Compress, true))
+            using var to = new MemoryStream();
+            using (var gzipStream = new GZipStream(to, CompressionMode.Compress))
             {
-                gzip.Write(byteArray, 0, byteArray.Length);
+                gzipStream.Write(from, 0, from.Length);
+                gzipStream.Close();
             }
 
-            return memory.ToArray();
+            return to.ToArray();
         }
 
         private string DecompressFromGZip(byte[] content)
         {
             using var from = new MemoryStream(content);
             using var to = new MemoryStream();
-            using var gZipStream = new GZipStream(from, CompressionMode.Decompress);
-            gZipStream.CopyTo(to);
+            using var gzipStream = new GZipStream(from, CompressionMode.Decompress);
+            gzipStream.CopyTo(to);
             return Encoding.Default.GetString(to.ToArray());
         }
     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Schemas/Microsoft.Test.HttpRequestSequenceMock.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Schemas/Microsoft.Test.HttpRequestSequenceMock.schema
@@ -149,7 +149,8 @@
                         "description": "Content type of response.",
                         "enum": [
                             "String",
-                            "ByteArray"
+                            "ByteArray",
+                            "GZipString"
                         ],
                         "examples": [
                             "String"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
@@ -236,7 +237,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
                 //Note: this should also be analyzed once we start using HttpClientFactory.
 #pragma warning disable CA2000 // Dispose objects before losing scope
-                client = new HttpClient();
+                var handler = new HttpClientHandler();
+                if (handler.SupportsAutomaticDecompression)
+                {
+                    handler.AutomaticDecompression = DecompressionMethods.GZip |
+                                                     DecompressionMethods.Deflate;
+                }
+
+                client = new HttpClient(handler);
 #pragma warning restore CA2000 // Dispose objects before losing scope
             }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/HttpRequestMock/httpgzip.mock.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/HttpRequestMock/httpgzip.mock.dialog
@@ -1,0 +1,15 @@
+﻿{
+    "$schema": "../../../../tests.schema",
+    "$kind": "Microsoft.Test.HttpRequestSequenceMock",
+    "method": "POST",
+    "url": "http://127.0.0.1",
+    "body": "gzip body",
+    "matchType": "Exact",
+    "responses": [
+        {
+            "contentType": "GZipString",
+            // CompressToGZip(content);
+            "content": "string response with gzip format"
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_HttpRequestMock.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/TestScriptTests/TestScriptTests_HttpRequestMock.test.dialog
@@ -4,6 +4,7 @@
     "description": "Test HttpRequestMock",
     "httpRequestMocks": [
         "httpexact.mock",
+        "httpgzip.mock",
         "httppartial.mock",
         "get.mock",
         "all.mock"
@@ -158,6 +159,18 @@
                     {
                         "$kind": "Microsoft.SendActivity",
                         "activity": "${dialog.result.content}"
+                    },
+                    {
+                        "$kind": "Microsoft.HttpRequest",
+                        "responseType": "Json",
+                        "method": "POST",
+                        "body": "gzip body",
+                        "url": "http://127.0.0.1",
+                        "resultProperty": "dialog.result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${dialog.result.content}"
                     }
                 ]
             }
@@ -219,6 +232,10 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "exact match"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "string response with gzip format"
         }
     ]
 }

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -9348,7 +9348,8 @@
                                 "description": "Content type of response.",
                                 "enum": [
                                     "String",
-                                    "ByteArray"
+                                    "ByteArray",
+                                    "GZipString"
                                 ],
                                 "examples": [
                                     "String"

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -9363,7 +9363,8 @@
                 "description": "Content type of response.",
                 "enum": [
                   "String",
-                  "ByteArray"
+                  "ByteArray",
+                  "GZipString"
                 ],
                 "examples": [
                   "String"


### PR DESCRIPTION
fixes  https://github.com/MicrosoftDocs/composer-docs/issues/128

## Description
If you use your HTTP client to call another website, then by default it does not advertise that it supports compression. Which is a shame as it can reduce the payload of the response considerably. Most web servers will compress the response body when the request contains a header called Accept-Encoding. The value of this header specifies what kind of encodings are supported by the calling client. For example:
```
GET https://www.example.com
Accept: application/xml
Accept-Encoding: gzip, deflate
```

The server can respond with a compressed body:
```
200 OK
content-encoding: gzip
content-length: 17800
content-type: application/xml

<compressed>
```

The client now needs to decompress the body and return the contents. Your browser will by default do this for you, however a HttpClient won’t.