### PR TITLE
Fix: add cache for luis recognizer result to avoid extra requests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingBotComponent.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/AdaptiveTestingBotComponent.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertReplyActivity>(AssertReplyActivity.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertNoActivity>(AssertNoActivity.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<MemoryAssertions>(MemoryAssertions.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<AssertTelemetryContains>(AssertTelemetryContains.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<HttpRequestSequenceMock>(HttpRequestSequenceMock.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<UserTokenBasicMock>(UserTokenBasicMock.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<SetProperties>(SetProperties.Kind));

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Mocks/MockLuisRecognizer.cs
@@ -49,9 +49,17 @@ namespace Microsoft.Bot.Builder.AI.Luis.Testing
         public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Activity activity, CancellationToken cancellationToken = default, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             HttpClientHandler newHandler = null, oldHandler = _recognizer.HttpClient;
-
+            
             // Used for ResponsePath
             var recognizer = _recognizer.RecognizerOptions(dialogContext);
+            foreach (var middware in dialogContext.Context.Adapter.MiddlewareSet)
+            {
+                if (middware is TelemetryLoggerMiddleware telemetryMiddleware)
+                {
+                    _recognizer.TelemetryClient = telemetryMiddleware.TelemetryClient;
+                }
+            }
+
             recognizer.IncludeAPIResults = true;
 
             var middleware = dialogContext.Context.TurnState.Get<MockHttpRequestMiddleware>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Schemas/Microsoft.Test.AssertTelemetryContains.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/Schemas/Microsoft.Test.AssertTelemetryContains.schema
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+    "$role": "implements(Microsoft.Test.ITestAction)",
+    "title": "Assert telemetry contains",
+    "description": "Checks whether telemetry log contsain specific events.",
+    "type": "object",
+    "required": [
+        "events"
+    ],
+    "properties": {
+        "events": {
+            "type": "array",
+            "title": "Events name should be included in telemetry log",
+            "description": "A string array contains event names.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "description": {
+            "type": "string",
+            "title": "Description",
+            "description": "The description of which events should be included"
+        }
+    }
+}
+

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertTelemetryContains.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertTelemetryContains.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using AdaptiveExpressions;
 using Microsoft.Bot.Builder.Adapters;
 using Moq;
 using Newtonsoft.Json;
@@ -14,7 +13,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 {
     /// <summary>
-    /// Run assertions against memory.
+    /// Checks whether telemetry log contsain specific events.
     /// </summary>
     [DebuggerDisplay("AssertTelemetryContains")]
     public class AssertTelemetryContains : TestAction
@@ -37,18 +36,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
         }
 
         /// <summary>
-        /// Gets or sets the description of this assertion.
+        /// Gets or sets the description of this check.
         /// </summary>
-        /// <value>Description of what this assertion is.</value>
+        /// <value>Description of what this check is.</value>
         [JsonProperty("description")]
         public string Description { get; set; }
 
         /// <summary>
-        /// Gets the assertions.
+        /// Gets the events should be contained.
         /// </summary>
-        /// <value>The assertion expressions.</value>
-        [JsonProperty("contains")]
-        public List<string> Contains { get; } = new List<string>();
+        /// <value>The events names.</value>
+        [JsonProperty("events")]
+        public List<string> Events { get; } = new List<string>();
 
         /// <inheritdoc/>
         public override Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback, Inspector inspector = null)
@@ -69,9 +68,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 msgs.Add(invocation.Arguments[0].ToString());
             }
 
-            foreach (var contain in Contains)
+            foreach (var eve in Events)
             {
-                if (!msgs.Contains(contain))
+                if (!msgs.Contains(eve))
                 {
                     flag = false;
                     break;
@@ -80,7 +79,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
 
             if (flag == false)
             {
-                throw new InvalidOperationException($"{Description} {Contains} AssertTelemetryContains failed");
+                throw new InvalidOperationException($"{Description} {string.Join(",", Events)} AssertTelemetryContains failed");
             }
 
             return Task.FromResult(flag);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertTelemetryContains.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertTelemetryContains.cs
@@ -1,0 +1,89 @@
+﻿// Copyright(c) Microsoft Corporation.All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using AdaptiveExpressions;
+using Microsoft.Bot.Builder.Adapters;
+using Moq;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
+{
+    /// <summary>
+    /// Run assertions against memory.
+    /// </summary>
+    [DebuggerDisplay("AssertTelemetryContains")]
+    public class AssertTelemetryContains : TestAction
+    {
+        /// <summary>
+        /// Kind for the serialization.
+        /// </summary>
+        [JsonProperty("$kind")]
+        public const string Kind = "Microsoft.Test.AssertTelemetryContains";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertTelemetryContains"/> class.
+        /// </summary>
+        /// <param name="path">Path to source.</param>
+        /// <param name="line">Line number in source.</param>
+        [JsonConstructor]
+        public AssertTelemetryContains([CallerFilePath] string path = "", [CallerLineNumber] int line = 0)
+        {
+            RegisterSourcePath(path, line);
+        }
+
+        /// <summary>
+        /// Gets or sets the description of this assertion.
+        /// </summary>
+        /// <value>Description of what this assertion is.</value>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the assertions.
+        /// </summary>
+        /// <value>The assertion expressions.</value>
+        [JsonProperty("contains")]
+        public List<string> Contains { get; } = new List<string>();
+
+        /// <inheritdoc/>
+        public override Task ExecuteAsync(TestAdapter adapter, BotCallbackHandler callback, Inspector inspector = null)
+        {
+            var flag = true;
+            IBotTelemetryClient telemetryClient = null;
+            foreach (var middware in adapter.MiddlewareSet)
+            {
+                if (middware is TelemetryLoggerMiddleware telemetryMiddleware)
+                {
+                    telemetryClient = telemetryMiddleware.TelemetryClient;
+                }
+            }
+
+            var msgs = new List<string>();
+            foreach (var invocation in Mock.Get(telemetryClient).Invocations)
+            {
+                msgs.Add(invocation.Arguments[0].ToString());
+            }
+
+            foreach (var contain in Contains)
+            {
+                if (!msgs.Contains(contain))
+                {
+                    flag = false;
+                    break;
+                }
+            }
+
+            if (flag == false)
+            {
+                throw new InvalidOperationException($"{Description} {Contains} AssertTelemetryContains failed");
+            }
+
+            return Task.FromResult(flag);
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
@@ -15,6 +15,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.UserTokenMocks;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
+using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -194,8 +195,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 
             adapter.EnableTrace = EnableTrace;
             adapter.Locale = Locale;
+            var mockTelemetryClient = new Mock<IBotTelemetryClient>();
             adapter.Use(new MockHttpRequestMiddleware(HttpRequestMocks));
             adapter.Use(new MockSettingsMiddleware(SettingMocks));
+            adapter.Use(new TelemetryLoggerMiddleware(mockTelemetryClient.Object, logPersonalInformation: true));
 
             foreach (var userToken in UserTokenMocks)
             {

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("test"));
             Assert.Equal("testvalue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["test"]);
@@ -448,7 +448,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.Equal(8, ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
@@ -495,7 +495,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.Equal(7, ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
@@ -547,7 +547,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(2, telemetryClient.Invocations.Count);
+            Assert.Equal(3, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("MyImportantProperty"));
             Assert.Equal("myImportantValue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["MyImportantProperty"]);
@@ -605,7 +605,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(2, telemetryClient.Invocations.Count);
+            Assert.Equal(3, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("MyImportantProperty"));
             Assert.Equal("myImportantValue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["MyImportantProperty"]);
@@ -658,7 +658,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent"));
@@ -702,7 +702,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent"));
@@ -757,7 +757,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("test"));
             Assert.Equal("testvalue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["test"]);

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("test"));
             Assert.Equal("testvalue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["test"]);
@@ -419,7 +419,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
 
             // Assert.IsTrue(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count == 8);
@@ -467,7 +467,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).Count == 7);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
@@ -519,7 +519,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(2, telemetryClient.Invocations.Count);
+            Assert.Equal(3, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("MyImportantProperty"));
             Assert.Equal("myImportantValue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["MyImportantProperty"]);
@@ -577,7 +577,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(2, telemetryClient.Invocations.Count);
+            Assert.Equal(3, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("MyImportantProperty"));
             Assert.Equal("myImportantValue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["MyImportantProperty"]);
@@ -630,7 +630,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent"));
@@ -674,7 +674,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("applicationId"));
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("intent"));
@@ -729,7 +729,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Single(telemetryClient.Invocations);
+            Assert.Equal(2, telemetryClient.Invocations.Count);
             Assert.Equal("LuisResult", telemetryClient.Invocations[0].Arguments[0].ToString());
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("test"));
             Assert.Equal("testvalue", ((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1])["test"]);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AskTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AskTests.cs
@@ -44,5 +44,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
+
+        [Fact]
+        public async Task CacheLuisRecognizer()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskName.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskName.dialog
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../tests.schema",
   "$kind": "Microsoft.AdaptiveDialog",
   "recognizer": {
     "$kind": "Microsoft.LuisRecognizer",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskName.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/AskName.dialog
@@ -1,0 +1,30 @@
+{
+  "$kind": "Microsoft.AdaptiveDialog",
+  "recognizer": {
+    "$kind": "Microsoft.LuisRecognizer",
+    "applicationId": "00000000-0000-0000-0000-000000000000",
+    "endpointKey": "00000000000000000000000000000000",
+    "endpoint": "https://westus.api.cognitive.microsoft.com",
+    "predictionOptions": {
+      "IncludeAPIResults": true
+    }
+  },
+  "triggers": [
+    {
+      "$kind": "Microsoft.OnBeginDialog",
+      "actions": [
+        {
+          "$kind": "Microsoft.TextInput",
+          "disabled": false,
+          "maxTurnCount": 3,
+          "alwaysPrompt": false,
+          "allowInterruptions": true,
+          "unrecognizedPrompt": "",
+          "invalidPrompt": "",
+          "prompt": "What is your name?"
+        }
+      ]
+    }
+  ],
+  "id": "AskName"
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/CacheLuisRecognizer.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/CacheLuisRecognizer.test.dialog
@@ -75,25 +75,12 @@
       "text": "Bread?"
     },
     {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "$retries == 0"
-      ],
-      "description": "Ensure retries is initialized"
-    },
-    {
       "$kind": "Microsoft.Test.UserSays",
       "text": "no entities"
     },
     {
       "$kind": "Microsoft.Test.AssertReply",
       "text": "Bread?"
-    },
-    {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "$retries == 1"
-      ]
     },
     {
       "$kind": "Microsoft.Test.UserSays",
@@ -108,10 +95,12 @@
       "text": "rye"
     },
     {
-      "$kind": "Microsoft.Test.MemoryAssertions",
-      "assertions": [
-        "!$retries"
-      ]
+      "$kind": "Microsoft.Test.AssertTelemetryContains",
+      "contains": [
+        "Luis result cached",
+        "Read from cached Luis result"
+      ],
+      "description": "Ensure telemetry log contains cached Luis info"
     }
   ]
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/CacheLuisRecognizer.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/CacheLuisRecognizer.test.dialog
@@ -96,7 +96,7 @@
     },
     {
       "$kind": "Microsoft.Test.AssertTelemetryContains",
-      "contains": [
+      "events": [
         "Luis result cached",
         "Read from cached Luis result"
       ],

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/CacheLuisRecognizer.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AskTests/CacheLuisRecognizer.test.dialog
@@ -1,0 +1,117 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "description": "Test retries from Ask with DeleteProperties",
+  "httpRequestMocks": [
+    "LuisNoEntities.mock",
+    "LuisBreadEntity.mock"
+  ],
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "recognizer": {
+      "$kind": "Microsoft.LuisRecognizer",
+      "applicationId": "00000000-0000-0000-0000-000000000000",
+      "endpointKey": "00000000000000000000000000000000",
+      "endpoint": "https://westus.api.cognitive.microsoft.com",
+      "predictionOptions": {
+        "IncludeAPIResults": true
+      }
+    },
+    "schema": "oneProperty.json",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnBeginDialog",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "welcome"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnEndOfActions",
+        "condition": "=!$Bread",
+        "priority": 0,
+        "actions": [
+          {
+            "$kind": "Microsoft.Ask",
+            "activity": "Bread?",
+            "expectedProperties": [
+              "Bread"
+            ]
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnAssignEntity",
+        "operation": "Add()",
+        "property": "Bread",
+        "value": "BreadEntity",
+        "actions": [
+          {
+            "$kind": "Microsoft.BeginDialog",
+            "options": {},
+            "dialog": "AskName"
+          }
+        ]
+      }
+    ]
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [
+        "Bot",
+        "User"
+      ],
+      "membersRemoved": []
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "welcome"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Bread?"
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "$retries == 0"
+      ],
+      "description": "Ensure retries is initialized"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "no entities"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Bread?"
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "$retries == 1"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "rye"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "What is your name?"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "rye"
+    },
+    {
+      "$kind": "Microsoft.Test.MemoryAssertions",
+      "assertions": [
+        "!$retries"
+      ]
+    }
+  ]
+}

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -350,6 +350,9 @@
       "$ref": "#/definitions/Microsoft.Test.AssertReplyOneOf"
     },
     {
+      "$ref": "#/definitions/Microsoft.Test.AssertTelemetryContains"
+    },
+    {
       "$ref": "#/definitions/Microsoft.Test.CustomEvent"
     },
     {
@@ -9163,6 +9166,50 @@
         }
       }
     },
+    "Microsoft.Test.AssertTelemetryContains": {
+      "$role": "implements(Microsoft.Test.ITestAction)",
+      "title": "Assert telemetry contains",
+      "description": "Checks whether telemetry log contsain specific events.",
+      "type": "object",
+      "required": [
+        "events",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "title": "Events name should be included in telemetry log",
+          "description": "A string array contains event names.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "The description of which events should be included"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.Test.AssertTelemetryContains"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
     "Microsoft.Test.CustomEvent": {
       "$role": "implements(Microsoft.Test.ITestAction)",
       "title": "User event",
@@ -9462,6 +9509,9 @@
         },
         {
           "$ref": "#/definitions/Microsoft.Test.AssertReplyOneOf"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.Test.AssertTelemetryContains"
         },
         {
           "$ref": "#/definitions/Microsoft.Test.CustomEvent"


### PR DESCRIPTION
closes #5593 
In order to avoid two LUIS network calls from the child dialog for the same user query when interruptions are enabled. 
In this PR, Luis Recognizer would cache the luis result for each turn, using endpoint combines with application id as the key.
