### PR TITLE
Add AllowedSkillsClaimsValidator for Issue 5285

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -77,14 +77,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
 
         internal static void AddBotRuntimeSkills(this IServiceCollection services, IConfiguration configuration)
         {
+            // We only support being a skill or a skill consumer currently (not both).
+            // See https://github.com/microsoft/botbuilder-dotnet/issues/5738 for feature request to allow both in the future.
             var skillSettings = configuration.GetSection(SkillSettings.SkillSettingsKey).Get<SkillSettings>();
             var settings = configuration.GetSection(SkillConfigurationEntry.SkillSettingsKey).Get<List<SkillConfigurationEntry>>();
             if (settings?.Count > 0)
             {
+                // If the config entry for SkillConfigurationEntry.SkillSettingsKey is present then we are a consumer
+                // and the entries under SkillSettings.SkillSettingsKey are ignored
                 services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(settings.Select(x => x.MsAppId).ToList()) });
             }
             else
             {
+                // If the config entry for SkillSettings.SkillSettingsKey contains entries, then we are a skill
+                // and we validate caller against this list
                 services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(skillSettings?.AllowedCallers) });
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -78,8 +78,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
         internal static void AddBotRuntimeSkills(this IServiceCollection services, IConfiguration configuration)
         {
             var skillSettings = configuration.GetSection(SkillSettings.SkillSettingsKey).Get<SkillSettings>();
+            List<SkillConfigurationEntry> settings = configuration.GetSection("skill").Get<List<SkillConfigurationEntry>>();
+            if (settings?.Count > 0)
+            {
+                services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(settings.Select(x => x.MsAppId).ToList()) });
+            }
+            else
+            {
+                services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(skillSettings?.AllowedCallers) });
+            }
 
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedCallersClaimsValidator(skillSettings?.AllowedCallers) });
             services.TryAddSingleton<ChannelServiceHandlerBase, CloudSkillHandler>();
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
         internal static void AddBotRuntimeSkills(this IServiceCollection services, IConfiguration configuration)
         {
             var skillSettings = configuration.GetSection(SkillSettings.SkillSettingsKey).Get<SkillSettings>();
-            List<SkillConfigurationEntry> settings = configuration.GetSection("skill").Get<List<SkillConfigurationEntry>>();
+            var settings = configuration.GetSection(SkillConfigurationEntry.SkillSettingsKey).Get<List<SkillConfigurationEntry>>();
             if (settings?.Count > 0)
             {
                 services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(settings.Select(x => x.MsAppId).ToList()) });

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/SkillConfigurationEntry.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/SkillConfigurationEntry.cs
@@ -9,6 +9,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings
     public class SkillConfigurationEntry
     {
         /// <summary>
+        /// Gets the configuration key for <see cref="SkillConfigurationEntry"/>.
+        /// </summary>
+        /// <value>
+        /// Configuration key for <see cref="SkillConfigurationEntry"/>.
+        /// </value>
+        public static string SkillSettingsKey => "skill";
+
+        /// <summary>
         /// Gets or sets of sets the MSAppId for the entry.
         /// </summary>
         /// <value>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/SkillConfigurationEntry.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/SkillConfigurationEntry.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings
+{
+    /// <summary>
+    /// Definition of a skill entry in the appsettings.json file.
+    /// </summary>
+    public class SkillConfigurationEntry
+    {
+        /// <summary>
+        /// Gets or sets of sets the MSAppId for the entry.
+        /// </summary>
+        /// <value>
+        /// The MSAppId for the entry.
+        /// </value>
+        public string MsAppId { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/SkillConfigurationEntry.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Settings/SkillConfigurationEntry.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings
 {

--- a/libraries/Microsoft.Bot.Connector/Authentication/AllowedSkillsClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AllowedSkillsClaimsValidator.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Bot.Connector.Authentication
     /// </summary>
     public class AllowedSkillsClaimsValidator : ClaimsValidator
     {
-        private readonly List<string> _allowedSkills;
+        private readonly IList<string> _allowedSkills;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AllowedSkillsClaimsValidator"/> class.
         /// </summary>
         /// <param name="allowedSkillAppIds">List of allowed callers referenced by appId.</param>
-        public AllowedSkillsClaimsValidator(List<string> allowedSkillAppIds)
+        public AllowedSkillsClaimsValidator(IList<string> allowedSkillAppIds)
         {
             _allowedSkills = allowedSkillAppIds ?? new List<string>();
         }

--- a/libraries/Microsoft.Bot.Connector/Authentication/AllowedSkillsClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AllowedSkillsClaimsValidator.cs
@@ -19,15 +19,10 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <summary>
         /// Initializes a new instance of the <see cref="AllowedSkillsClaimsValidator"/> class.
         /// </summary>
-        /// <param name="allowedAppIds">List of allowed callers referenced by appId.</param>
-        public AllowedSkillsClaimsValidator(List<string> allowedAppIds)
+        /// <param name="allowedSkillAppIds">List of allowed callers referenced by appId.</param>
+        public AllowedSkillsClaimsValidator(List<string> allowedSkillAppIds)
         {
-            if (allowedAppIds == null)
-            {
-                throw new ArgumentNullException(nameof(allowedAppIds));
-            }
-
-            _allowedSkills = allowedAppIds;
+            _allowedSkills = allowedSkillAppIds ?? new List<string>();
         }
 
         /// <inheritdoc/>

--- a/libraries/Microsoft.Bot.Connector/Authentication/AllowedSkillsClaimsValidator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AllowedSkillsClaimsValidator.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// A claims validator that loads an allowed list from a provided list of allowed AppIds
+    /// and checks that responses are coming from configured skills.
+    /// </summary>
+    public class AllowedSkillsClaimsValidator : ClaimsValidator
+    {
+        private readonly List<string> _allowedSkills;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AllowedSkillsClaimsValidator"/> class.
+        /// </summary>
+        /// <param name="allowedAppIds">List of allowed callers referenced by appId.</param>
+        public AllowedSkillsClaimsValidator(List<string> allowedAppIds)
+        {
+            if (allowedAppIds == null)
+            {
+                throw new ArgumentNullException(nameof(allowedAppIds));
+            }
+
+            _allowedSkills = allowedAppIds;
+        }
+
+        /// <inheritdoc/>
+        public override Task ValidateClaimsAsync(IList<Claim> claims)
+        {
+            if (SkillValidation.IsSkillClaim(claims))
+            {
+                // Check that the appId claim in the skill request is in the list of skills configured for this bot.
+                var appId = JwtTokenValidation.GetAppIdFromClaims(claims);
+                if (!_allowedSkills.Contains(appId))
+                {
+                    throw new UnauthorizedAccessException($"Received a request from an application with an appID of \"{appId}\". To enable requests from this skill, add the skill to your configuration file.");
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/AllowedSkillsClaimsValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/AllowedSkillsClaimsValidationTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests.Authentication
+{
+    public class AllowedSkillsClaimsValidationTests
+    {
+        private const string _version = "1.0";
+
+        private readonly string audienceClaim = Guid.NewGuid().ToString();
+
+        public static IEnumerable<object[]> GetConfigureServicesSucceedsData()
+        {
+            string primaryAppId = Guid.NewGuid().ToString();
+            string secondaryAppId = Guid.NewGuid().ToString();
+
+            // Null allowed callers
+            yield return new object[]
+            {
+                null,
+                null
+            };
+
+            // Null configuration with attempted caller
+            yield return new object[]
+            {
+                primaryAppId,
+                null
+            };
+
+            // Empty allowed callers array
+            yield return new object[]
+            {
+                (string)null,
+                new string[0]
+            };
+
+            // Specify allowed caller
+            yield return new object[]
+            {
+                primaryAppId,
+                new string[] { $"{primaryAppId}" }
+            };
+
+            // Specify multiple callers
+            yield return new object[]
+            {
+                primaryAppId,
+                new string[] { $"{primaryAppId}", $"{secondaryAppId}" }
+            };
+
+            // Blocked caller throws exception
+            yield return new object[]
+            {
+                primaryAppId,
+                new string[] { $"{secondaryAppId}" }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetConfigureServicesSucceedsData))]
+
+        public async Task AcceptAllowedCallersArray(string allowedCallerClaimId, IList<string> allowList)
+        {
+            var validator = new AllowedSkillsClaimsValidator(allowList);
+
+            if (allowedCallerClaimId != null)
+            {
+                var claims = CreateCallerClaims(allowedCallerClaimId);
+
+                if (allowList != null)
+                {
+                    if (allowList.Contains(allowedCallerClaimId) || allowList.Contains("*"))
+                    {
+                        await validator.ValidateClaimsAsync(claims);
+                    }
+                    else
+                    {
+                        await ValidateUnauthorizedAccessException(allowedCallerClaimId, validator, claims);
+                    }
+                }
+                else
+                {
+                    await ValidateUnauthorizedAccessException(allowedCallerClaimId, validator, claims);
+                }
+            }
+        }
+
+        private static async Task ValidateUnauthorizedAccessException(string allowedCallerClaimId, AllowedSkillsClaimsValidator validator, List<Claim> claims)
+        {
+            Exception ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => validator.ValidateClaimsAsync(claims));
+
+            Assert.Contains(allowedCallerClaimId, ex.Message);
+        }
+
+        private List<Claim> CreateCallerClaims(string appId)
+        {
+            return new List<Claim>()
+            {
+                new Claim(AuthenticationConstants.AppIdClaim, appId),
+                new Claim(AuthenticationConstants.VersionClaim, _version),
+                new Claim(AuthenticationConstants.AudienceClaim, audienceClaim),
+            };
+        }
+    }
+}

--- a/tests/Skills/Bot1/Startup.cs
+++ b/tests/Skills/Bot1/Startup.cs
@@ -38,7 +38,7 @@ namespace Bot1
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotBuilderSamples.SimpleRootBot.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.

--- a/tests/Skills/Bot2/Startup.cs
+++ b/tests/Skills/Bot2/Startup.cs
@@ -38,7 +38,7 @@ namespace Bot2
             services.AddSingleton<SkillsConfiguration>();
 
             // Register AuthConfiguration to enable custom claim validation.
-            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
+            services.AddSingleton(sp => new AuthenticationConfiguration { ClaimsValidator = new Microsoft.BotBuilderSamples.SimpleRootBot.Authentication.AllowedSkillsClaimsValidator(sp.GetService<SkillsConfiguration>()) });
 
             // Register the Bot Framework Adapter with error handling enabled.
             // Note: some classes use the base BotAdapter so we add an extra registration that pulls the same instance.


### PR DESCRIPTION
Fixes #5285 

## Description
Added AllowedSkillsClaimsValidator as needed to support skills in the AdaptiveRuntime so that allowedCallers are inferred correctly and validated from the configured skills.

## Specific Changes
Added AllowedSkillsClaimsValidator and add it as a singleton as an AuthenticationConfiguration in AddBotRunTimeSkills in ServiceCollectionExtensions.cs. 

Because AllowedSkillsClaimsValidator originally was part of the samples/test code and not part of the SDK this meant that there was now an ambiguous reference which had to be handled in the test code, and will need to be updated in the samples as well. It is possible to update the samples/test code to no longer have their own copies of the AllowedSkillsClaimsValidator and have them use the SDK version by having them instantiate the SDK version and pass in a list of allowed callers which could be extracted from the current SkillsConfiguration class that they use (also defined locally to the sample/test). It seems when the AllowedCallersClaimsValidator was added to the SDK that the samples/tests were just updated to use the new SDK class, is that what we want to do here as well?

## Testing
Tested with bot projects created from Composer that were configured to use the modified SDK code.