### PR TITLE
Update package license handling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
 
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
 
-    <!-- Per rules,this must be *EXACTLY* "Microsoft. Otherwise Nuget.org will reject the packages."  -->
+    <!-- Per rules,this must be *EXACTLY* "Microsoft. Otherwise Nuget.org will reject the packages." -->
 
     <Authors>Microsoft</Authors>
     <Product>Microsoft Bot Builder SDK</Product>
@@ -60,11 +60,10 @@
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
     <PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png</PackageIconUrl>
-    <PackageLicenseExpression>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/Microsoft/botbuilder-dotnet</RepositoryUrl>
-    <LicenseUrl>https://github.com/Microsoft/BotBuilder-dotnet/blob/master/LICENSE</LicenseUrl>
     <PackageTags>bots;ai;botframework;botbuilder</PackageTags>
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -60,7 +60,7 @@
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
     <PackageProjectUrl>https://github.com/Microsoft/botbuilder-dotnet</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryUrl>https://github.com/Microsoft/botbuilder-dotnet</RepositoryUrl>


### PR DESCRIPTION
Fixes #5557

## Description
This fixes "WARNING: The licenseUrl element is deprecated" on package pushes to Nuget.org. The licenseUrl element is in the .nuspec file in each Nuget package. The .nuspec file is autogenerated by Visual Studio when it does the packaging in the build.

This implements the recommended new way to handle licenses: reference them in licenses.nuget.org. (Or physically include them in the package.) Ours is the MIT license.

## Specific Changes
Update Directory.Build.props replacing PackageLicenseUrl with PackageLicenseExpression.
