### PR TITLE
Fix OAuth prompt should store in turn.token, not dialog.token

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.OAuthInput.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Dialogs/Microsoft.OAuthInput.schema
@@ -51,7 +51,7 @@
             "description": "Property to store the OAuth token result. WARNING: Changing this location is not recommended as you should call OAuthInput immediately before each use of the token.",
             "default":  "turn.token",
             "examples": [
-                "dialog.token"
+                "turn.token"
             ]
         },
         "invalidPrompt": {

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -5569,7 +5569,7 @@
                     "title": "Token property",
                     "description": "Property to store the OAuth token result.",
                     "examples": [
-                        "dialog.token"
+                        "turn.token"
                     ]
                 },
                 "invalidPrompt": {

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -5386,7 +5386,7 @@
           "description": "Property to store the OAuth token result. WARNING: Changing this location is not recommended as you should call OAuthInput immediately before each use of the token.",
           "default": "turn.token",
           "examples": [
-            "dialog.token"
+            "turn.token"
           ]
         },
         "invalidPrompt": {


### PR DESCRIPTION
Fixes:
- Composer docs [issue 121](https://github.com/MicrosoftDocs/composer-docs/issues/121)
- Related Composer [issue 6767](https://github.com/microsoft/BotFramework-Composer/issues/6767).
Also see Jonathan's [pr 5660](https://github.com/microsoft/botbuilder-dotnet/pull/5660)

## Description
This fixes the tests covering Jonathan Fingold's patch in the file Microsoft.OAuthInput.schema. He changed "dialog.token" to "turn.token". #minor

## Specific Changes
The same change made in tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema and tests/tests.schema.
