### PR TITLE
Log Warning during BotComponentDefinition.Load

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Http;
@@ -19,6 +20,8 @@ using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.EventLog;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
 {
@@ -34,6 +37,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
         /// <param name="configuration">The application configuration.</param>
         public static void AddBotRuntime(this IServiceCollection services, IConfiguration configuration)
         {
+            AddBotRuntime(services, configuration, (builder) => ConfigureLoggerFactory(builder, configuration));
+        }
+
+        /// <summary>
+        /// Adds bot runtime-related services to the application's service collection.
+        /// </summary>
+        /// <param name="services">The application's collection of registered services.</param>
+        /// <param name="configuration">The application configuration.</param>
+        /// <param name="configureLoggerFactory">Action used to configure <see cref="ILoggerFactory"/> instance.</param>
+        public static void AddBotRuntime(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            Action<ILoggingBuilder> configureLoggerFactory)
+        {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
@@ -44,35 +61,54 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            // Ensure the IConfiguration is available. (Azure Functions don't do this.)
-            services.TryAddSingleton(configuration);
+            if (configureLoggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(configureLoggerFactory));
+            }
 
-            // All things auth
-            services.TryAddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+            // To enable logging within the scope of ServiceCollectionExtensions.AddBotRuntime, we need to create an
+            // ILoggerFactory instance from which we can create an ILogger. Per MSDN documentation:
+            //
+            // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1#create-logs-in-startup
+            //
+            // Default usage of ILogger is dependent upon DI, and therefore cannot be done by anything in the scope of
+            // Startup.ConfigureServices, which is where this function is invoked. To be as consistent as possible with
+            // Microsoft.Extensions.Hosting.HostBuilder, callers may optionally supply a configure action to configure the
+            // created ILoggerFactory object here (the same format as using IHostBuilder.ConfigureLogging), or may otherwise
+            // default to our own provided implementation of the configure action, which follows the same implementation defined
+            // in Microsoft.Extensions.Hosting.
+            using (ILoggerFactory loggerFactory = LoggerFactory.Create(configureLoggerFactory))
+            {
+                // Ensure the IConfiguration is available. (Azure Functions don't do this.)
+                services.TryAddSingleton(configuration);
 
-            // IBot
-            services.TryAddSingleton<IBot, ConfigurationAdaptiveDialogBot>();
+                // All things auth
+                services.TryAddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
-            // Resource explorer
-            services.TryAddSingleton<ResourceExplorer, ConfigurationResourceExplorer>();
+                // IBot
+                services.TryAddSingleton<IBot, ConfigurationAdaptiveDialogBot>();
 
-            // Language policy
-            services.TryAddSingleton<LanguagePolicy, ConfigurationLanguagePolicy>();
+                // Resource explorer
+                services.TryAddSingleton<ResourceExplorer, ConfigurationResourceExplorer>();
 
-            // CoreBotAdapter registration
-            services.AddSingleton<CoreBotAdapter>();
-            services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
+                // Language policy
+                services.TryAddSingleton<LanguagePolicy, ConfigurationLanguagePolicy>();
 
-            // Needed for SkillsHttpClient which depends on BotAdapter
-            services.AddSingleton<BotAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
+                // CoreBotAdapter registration
+                services.AddSingleton<CoreBotAdapter>();
+                services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
 
-            // Runtime set up
-            services.AddBotRuntimeSkills(configuration);
-            services.AddBotRuntimeStorage();
-            services.AddBotRuntimeTelemetry(configuration);
-            services.AddBotRuntimeTranscriptLogging(configuration);
-            services.AddBotRuntimeFeatures(configuration);
-            services.AddBotRuntimeComponents(configuration);
+                // Needed for SkillsHttpClient which depends on BotAdapter
+                services.AddSingleton<BotAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
+
+                // Runtime set up
+                services.AddBotRuntimeSkills(configuration);
+                services.AddBotRuntimeStorage();
+                services.AddBotRuntimeTelemetry(configuration);
+                services.AddBotRuntimeTranscriptLogging(configuration);
+                services.AddBotRuntimeFeatures(configuration);
+                services.AddBotRuntimeComponents(configuration, loggerFactory);
+            }
         }
 
         internal static void AddBotRuntimeSkills(this IServiceCollection services, IConfiguration configuration)
@@ -91,8 +127,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
             services.TryAddSingleton<SkillConversationIdFactoryBase, SkillConversationIdFactory>();
         }
 
-        internal static void AddBotRuntimeComponents(this IServiceCollection services, IConfiguration configuration)
+        internal static void AddBotRuntimeComponents(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            ILoggerFactory loggerFactory)
         {
+            ILogger logger = loggerFactory.CreateLogger<BotComponentDefinition>();
+
             var componentDefinitions = configuration
                 .GetSection($"{ConfigurationConstants.RuntimeSettingsKey}:components")
                 .Get<List<BotComponentDefinition>>() ?? Enumerable.Empty<BotComponentDefinition>();
@@ -106,7 +147,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
             {
                 try
                 {
-                    component.Load(componentEnumerator, services, configuration);
+                    component.Load(componentEnumerator, services, configuration, logger);
                 }
 #pragma warning disable CA1031 // Do not catch general exception types. We want to capture all exceptions from components and throw them all at once.
                 catch (Exception ex)
@@ -207,6 +248,43 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
                     featureSettings.SetSpeak.VoiceFontName,
                     featureSettings.SetSpeak.FallbackToTextForSpeechIfEmpty));
             }
+        }
+
+        private static void ConfigureLoggerFactory(ILoggingBuilder builder, IConfiguration configuration)
+        {
+            // This function follows the same implementation defined in Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.ConfigureDefaults:
+            // https://github.com/dotnet/runtime/blob/5e63c7891687b8656182aa7083bc6191c76fd774/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs#L226-L257
+
+            bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+            // IMPORTANT: This needs to be added *before* configuration is loaded, this lets
+            // the defaults be overridden by the configuration.
+            if (isWindows)
+            {
+                // Default the EventLogLoggerProvider to warning or above
+                builder.AddFilter<EventLogLoggerProvider>(level => level >= LogLevel.Warning);
+            }
+
+            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddConsole();
+            builder.AddDebug();
+            builder.AddEventSourceLogger();
+
+            if (isWindows)
+            {
+                // Add the EventLogLoggerProvider on windows machines
+                builder.AddEventLog();
+            }
+
+#if NETSTANDARD2_0
+            builder.Configure(options =>
+            {
+                options.ActivityTrackingOptions =
+                    ActivityTrackingOptions.SpanId |
+                    ActivityTrackingOptions.TraceId |
+                    ActivityTrackingOptions.ParentId;
+            });
+#endif
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -29,17 +29,24 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- Explicitly set to 5.0.1 for those built against 2.0-->
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/RuntimeComponentTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/RuntimeComponentTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -9,6 +10,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Component;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.Components.TestComponents;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Dialogs.Memory;
@@ -18,6 +20,7 @@ using Microsoft.Bot.Builder.Runtime.Tests.Components.Implementations;
 using Microsoft.Bot.Builder.Runtime.Tests.Components.TestComponents;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
@@ -70,7 +73,7 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
             services.AddSingleton<IConfiguration>(configuration);
 
             // Test
-            services.AddBotRuntimeComponents(configuration);
+            services.AddBotRuntimeComponents(configuration, new TestLoggerFactory());
 
             // Assert 
             var provider = services.BuildServiceProvider();
@@ -174,6 +177,24 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
             {
                 byte[] byteArray = Encoding.UTF8.GetBytes(_json);
                 return Task.FromResult<Stream>(new MemoryStream(byteArray));
+            }
+        }
+
+        internal class TestLoggerFactory : ILoggerFactory
+        {
+            public void AddProvider(ILoggerProvider provider)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return new TestLogger();
+            }
+
+            public void Dispose()
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/TestLogger.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/TestLogger.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests
+{
+    public class TestLogger : ILogger
+    {
+        public TestLogger()
+        {
+            this.LogAction = null;
+        }
+
+        public Action<LogLevel, EventId, object, Exception> LogAction { get; set; }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            this.LogAction?.Invoke(logLevel, eventId, state, exception);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5674.

## Description
During startup of the runtime, we attempt to load BotComponent definitions from external assemblies referenced in the application settings. We can end up in cases where assemblies which do not contain any components are referenced, adding unnecessary overhead to startup time. This change handles logging warnings when this happens to help direct developers to clean up the list of components in their application settings.

## Specific Changes
  - Enabling logging in ServiceCollectionExtensions.AddBotRuntime by manually instantiating ILoggerFactory, following the same defaults used by Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.
  - Log a warning in BotComponentDefinition if the component enumerator returns 0 components to be loaded.

## Testing
Unit test coverage exercising this case.