### PR TITLE
Add component governance detection to ci build.

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -68,6 +68,7 @@ stages:
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
 
 - stage: API_Compatibility_Validation
   condition: ne(variables['DisableApiCompatibityValidation'], 'true')

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -60,6 +60,7 @@ stages:
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
   - job: Release_Windows_Configuration_31
     variables:
       BuildConfiguration: Release-Windows

--- a/build/yaml/ci-component-detection-steps.yml
+++ b/build/yaml/ci-component-detection-steps.yml
@@ -1,0 +1,8 @@
+steps:
+- task: ComponentGovernanceComponentDetection@0
+  displayName: Component Detection
+  inputs:
+    scanType: "Register"
+    verbosity: "Verbose"
+    alertWarningLevel: "High"
+    failOnAlert: true


### PR DESCRIPTION
Fixes #5354

## Description
Add Component Governance Detection (CGD) to the BotBuilder-DotNet-CI-PR-yaml build.

## Specific Changes
Add ci-component-detection-steps.yml.
Modify botbuilder-dotnet-ci.yml: Add CGD to the Release_Windows_Configuration_31 and the Release_Windows_Configuration_21 build jobs.


