### PR TITLE
[#5166] Add unit tests for Microsoft.Bot.Connector.Authentication.UserTokenClientImpl 

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClientImpl.cs
@@ -5,12 +5,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest;
+
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Connector.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Connector.Tests")]
+#endif
 
 namespace Microsoft.Bot.Connector.Authentication
 {

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Bot.Connector.Tests.Authentication
@@ -47,9 +51,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             //var httpClientFactory = new Mock<IHttpClientFactory>();
             //httpClientFactory.Setup(x => x.CreateClient()).Returns(new HttpClient());
 
-            var credentials = new BotAccessTokenStub("token");
-
-            // var credentials = new TestCredentials();
+            var credentials = new TestCredentials();
 
             Assert.NotNull(new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null));
         }
@@ -95,17 +97,20 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             });
         }
 
-        [Fact]
-        public async Task GetUserTokenAsyncShouldReturnToken()
-        {
-            var credentials = new BotAccessTokenStub("token");
+        //[Fact]
+        //public async Task GetUserTokenAsyncShouldReturnToken()
+        //{
+        //    var credentials = new TestCredentials();
 
-            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+        //    //var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+        //    //var userToken = new UserTokenClientImplMockedClient(AppId, credentials, OauthEndpoint, null, null);
+        //    var userToken = new Mock<UserTokenClientImpl>();
+        //    userToken.SetupGet(x => x._client).Returns();
 
-            var token = await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
+        //    var token = await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
 
-            Assert.NotNull(token);
-        }
+        //    Assert.NotNull(token);
+        //}
 
         [Fact]
         public async Task GetSignInResourceAsyncOfDisposedTokenShouldThrow()
@@ -330,4 +335,45 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 #pragma warning restore SA1402 // File may only contain a single type
     {
     }
+
+//#pragma warning disable SA1402 // File may only contain a single type
+//    internal class UserTokenClientImplMockedClient : UserTokenClientImpl
+//#pragma warning restore SA1402 // File may only contain a single type
+//    {
+//        private static string _appId;
+//        private static ServiceClientCredentials _credentials;
+//        private static string _oauthEndpoint;
+//        private static OAuthClient _client;
+//        private static ILogger _logger;
+//        private static HttpClient _httpClient;
+
+//        public UserTokenClientImplMockedClient()
+//        : base(_appId, _credentials, _oauthEndpoint, _httpClient, _logger)
+//        {
+//            _appId = "appId";
+//            _credentials = new TestCredentials();
+//            _oauthEndpoint = "oauthEndpoint";
+//            _httpClient = new HttpClient();
+//            ConnectorClient.AddDefaultRequestHeaders(_httpClient);
+
+//            var tokenResponse = new TokenResponse
+//            {
+//                Token = "1234"
+//            };
+
+//            var userToken = new Mock<UserToken>();
+//            userToken.Setup(x => x.GetTokenAsync(
+//                It.IsAny<string>(),
+//                It.IsAny<string>(),
+//                It.IsAny<string>(),
+//                It.IsAny<string>(),
+//                It.IsAny<CancellationToken>())).ReturnsAsync(tokenResponse);
+
+//            var client = new Mock<OAuthClient>();
+//            client.SetupGet(x => x.UserToken).Returns(userToken.Object);
+
+//            _client = client.Object;
+//            _logger = NullLogger.Instance;
+//        }
+//    }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
     public class UserTokenClientImplTests
     {
         private const string AppId = "test-app-id";
-        private const string ToChannelFromBotOAuthScope = "oauth-scope";
         private const string OauthEndpoint = "https://test.endpoint";
         private const string UserId = "userId";
         private const string ConnectionName = "connection-name";

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
@@ -1,0 +1,333 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Rest;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests.Authentication
+{
+    public class UserTokenClientImplTests
+    {
+        private const string AppId = "test-app-id";
+        private const string ToChannelFromBotOAuthScope = "oauth-scope";
+        private const string OauthEndpoint = "https://test.endpoint";
+        private const string UserId = "userId";
+        private const string ConnectionName = "connection-name";
+        private const string ChannelId = "channel-id";
+        private const string MagicCode = "magic-code";
+
+        [Fact]
+        public void ConstructorWithNullCredentialsShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>(() => new UserTokenClientImpl(AppId, null, OauthEndpoint, null, null));
+        }
+
+        [Fact]
+        public void ConstructorShouldWork()
+        {
+            // Arrange
+            //string fromBotId = "from-bot-id";
+            //string toBotId = "to-bot-id";
+            //string loginUrl = AuthenticationConstants.ToChannelFromBotLoginUrlTemplate;
+            //Uri toUrl = new Uri("http://test1.com/test");
+
+            //var credentialFactoryMock = new Mock<ServiceClientCredentialsFactory>();
+            //credentialFactoryMock.Setup(cssf => cssf.CreateCredentialsAsync(
+            //    It.Is<string>(v => v == fromBotId),
+            //    It.Is<string>(v => v == toBotId),
+            //    It.Is<string>(v => v == loginUrl),
+            //    It.IsAny<bool>(),
+            //    It.IsAny<CancellationToken>())).ReturnsAsync(MicrosoftAppCredentials.Empty);
+
+            //var httpClientFactory = new Mock<IHttpClientFactory>();
+            //httpClientFactory.Setup(x => x.CreateClient()).Returns(new HttpClient());
+
+            var credentials = new BotAccessTokenStub("token");
+
+            // var credentials = new TestCredentials();
+
+            Assert.NotNull(new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null));
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncOfDisposedTokenShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncWithNullUserIdShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetUserTokenAsync(null, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncWithNullConnectionNameShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetUserTokenAsync(UserId, null, ChannelId, MagicCode, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetUserTokenAsyncShouldReturnToken()
+        {
+            var credentials = new BotAccessTokenStub("token");
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            var token = await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
+
+            Assert.NotNull(token);
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsyncOfDisposedTokenShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetSignInResourceAsync(ConnectionName, new Activity(), "final-redirect", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsyncWithNullConnectionNameShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetSignInResourceAsync(null, new Activity(), "final-redirect", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetSignInResourceAsyncWithNullActivityShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetSignInResourceAsync(ConnectionName, null, "final-redirect", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task SignOutUserAsyncOfDisposedTokenShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.SignOutUserAsync(UserId, ConnectionName, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task SignOutUserAsyncWithNullUserIdShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.SignOutUserAsync(null, ConnectionName, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task SignOutUserAsyncWithNullConnectionNameShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.SignOutUserAsync(UserId, null, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsyncOfDisposedTokenShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetTokenStatusAsync(UserId, ConnectionName, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsyncWithNullUserIdShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetTokenStatusAsync(null, ChannelId, "filter", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetTokenStatusAsyncWithNullChannelIdShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetTokenStatusAsync(UserId, null, "filter", CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsyncOfDisposedTokenShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+            
+            string[] resourceUrls = { "https://test.url" };
+            
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.GetAadTokensAsync(UserId, ConnectionName, resourceUrls, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsyncWithNullUserIdShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            string[] resourceUrls = { "https://test.url" };
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetAadTokensAsync(null, ChannelId, resourceUrls, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task GetAadTokensAsyncWithNullConnectionNameShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            string[] resourceUrls = { "https://test.url" };
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.GetAadTokensAsync(UserId, null, resourceUrls, ChannelId, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task ExchangeTokenAsyncOfDisposedTokenShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            var tokenExchange = new TokenExchangeRequest();
+
+            userToken.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            {
+                await userToken.ExchangeTokenAsync(UserId, ConnectionName, ChannelId, tokenExchange, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task ExchangeTokenAsyncWithNullUserIdShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            var tokenExchange = new TokenExchangeRequest();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.ExchangeTokenAsync(null, ChannelId, ChannelId, tokenExchange, CancellationToken.None);
+            });
+        }
+
+        [Fact]
+        public async Task ExchangeTokenAsyncWithNullConnectionNameShouldThrow()
+        {
+            var credentials = new TestCredentials();
+
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+
+            var tokenExchange = new TokenExchangeRequest();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await userToken.ExchangeTokenAsync(UserId, null, ChannelId, tokenExchange, CancellationToken.None);
+            });
+        }
+    }
+
+#pragma warning disable SA1402 // File may only contain a single type
+    public class TestCredentials : ServiceClientCredentials
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+    }
+}

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/UserTokenClientImplTests.cs
@@ -2,15 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Rest;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Bot.Connector.Tests.Authentication
@@ -34,23 +30,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         [Fact]
         public void ConstructorShouldWork()
         {
-            // Arrange
-            //string fromBotId = "from-bot-id";
-            //string toBotId = "to-bot-id";
-            //string loginUrl = AuthenticationConstants.ToChannelFromBotLoginUrlTemplate;
-            //Uri toUrl = new Uri("http://test1.com/test");
-
-            //var credentialFactoryMock = new Mock<ServiceClientCredentialsFactory>();
-            //credentialFactoryMock.Setup(cssf => cssf.CreateCredentialsAsync(
-            //    It.Is<string>(v => v == fromBotId),
-            //    It.Is<string>(v => v == toBotId),
-            //    It.Is<string>(v => v == loginUrl),
-            //    It.IsAny<bool>(),
-            //    It.IsAny<CancellationToken>())).ReturnsAsync(MicrosoftAppCredentials.Empty);
-
-            //var httpClientFactory = new Mock<IHttpClientFactory>();
-            //httpClientFactory.Setup(x => x.CreateClient()).Returns(new HttpClient());
-
             var credentials = new TestCredentials();
 
             Assert.NotNull(new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null));
@@ -96,21 +75,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 await userToken.GetUserTokenAsync(UserId, null, ChannelId, MagicCode, CancellationToken.None);
             });
         }
-
-        //[Fact]
-        //public async Task GetUserTokenAsyncShouldReturnToken()
-        //{
-        //    var credentials = new TestCredentials();
-
-        //    //var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
-        //    //var userToken = new UserTokenClientImplMockedClient(AppId, credentials, OauthEndpoint, null, null);
-        //    var userToken = new Mock<UserTokenClientImpl>();
-        //    userToken.SetupGet(x => x._client).Returns();
-
-        //    var token = await userToken.GetUserTokenAsync(UserId, ConnectionName, ChannelId, MagicCode, CancellationToken.None);
-
-        //    Assert.NotNull(token);
-        //}
 
         [Fact]
         public async Task GetSignInResourceAsyncOfDisposedTokenShouldThrow()
@@ -241,9 +205,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             var credentials = new TestCredentials();
 
             var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
-            
+
             string[] resourceUrls = { "https://test.url" };
-            
+
             userToken.Dispose();
 
             await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
@@ -328,52 +292,18 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 await userToken.ExchangeTokenAsync(UserId, null, ChannelId, tokenExchange, CancellationToken.None);
             });
         }
+
+        [Fact]
+        public void DisposeOfDisposedTokenShouldReturn()
+        {
+            var credentials = new TestCredentials();
+            var userToken = new UserTokenClientImpl(AppId, credentials, OauthEndpoint, null, null);
+            userToken.Dispose();
+            userToken.Dispose();
+        }
+
+        private class TestCredentials : ServiceClientCredentials
+        {
+        }
     }
-
-#pragma warning disable SA1402 // File may only contain a single type
-    public class TestCredentials : ServiceClientCredentials
-#pragma warning restore SA1402 // File may only contain a single type
-    {
-    }
-
-//#pragma warning disable SA1402 // File may only contain a single type
-//    internal class UserTokenClientImplMockedClient : UserTokenClientImpl
-//#pragma warning restore SA1402 // File may only contain a single type
-//    {
-//        private static string _appId;
-//        private static ServiceClientCredentials _credentials;
-//        private static string _oauthEndpoint;
-//        private static OAuthClient _client;
-//        private static ILogger _logger;
-//        private static HttpClient _httpClient;
-
-//        public UserTokenClientImplMockedClient()
-//        : base(_appId, _credentials, _oauthEndpoint, _httpClient, _logger)
-//        {
-//            _appId = "appId";
-//            _credentials = new TestCredentials();
-//            _oauthEndpoint = "oauthEndpoint";
-//            _httpClient = new HttpClient();
-//            ConnectorClient.AddDefaultRequestHeaders(_httpClient);
-
-//            var tokenResponse = new TokenResponse
-//            {
-//                Token = "1234"
-//            };
-
-//            var userToken = new Mock<UserToken>();
-//            userToken.Setup(x => x.GetTokenAsync(
-//                It.IsAny<string>(),
-//                It.IsAny<string>(),
-//                It.IsAny<string>(),
-//                It.IsAny<string>(),
-//                It.IsAny<CancellationToken>())).ReturnsAsync(tokenResponse);
-
-//            var client = new Mock<OAuthClient>();
-//            client.SetupGet(x => x.UserToken).Returns(userToken.Object);
-
-//            _client = client.Object;
-//            _logger = NullLogger.Instance;
-//        }
-//    }
 }


### PR DESCRIPTION
Fixes #5166

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR adds unit tests for the `UserTokenClientImpl.cs` to increase the code coverage from 15% to 65%

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Add unit tests in `UserTokenClientImplTests.cs` covering code from `UserTokenClientImpl.cs`.
  - Add assembly IntervalVisibleTo tag to `UserTokenClientImpl.cs` to be available for the test class.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
![image](https://user-images.githubusercontent.com/38112957/122118255-35a00980-cdfe-11eb-8cb1-dc826b7a8d3b.png)