### PR TITLE
Docs: Update Orchestrator description and ProjectURL for Composer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/Microsoft.Bot.Builder.AI.Orchestrator.csproj
@@ -13,10 +13,11 @@
     <!-- TODO: Change TargetFramework to netstandard2.0 once Orchestrator supports it -->
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Microsoft.Bot.Builder.AI.Orchestrator</PackageId>
-    <Description>This library implements .NET support for Orchestrator</Description>
+    <Description>The Orchestrator package contains Bot Framework recognizer for detecting and routing user intents.</Description>
     <Summary>This library implements .NET support for Orchestrator</Summary>
     <ContentTargetFolders>content</ContentTargetFolders>
     <PackageTags>msbot-component;msbot-recognizer</PackageTags>
+    <PackageProjectUrl>https://aka.ms/bf-orchestrator-package-readme</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #5704

## Description
Update the description and project URL for the Orchestrator Recognizer package (which show up in Composer)

## Specific Changes
- `Description` text for Composer's Package Manager.  Text was copied from [js](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder-ai-orchestrator/README.md) repo added by @scheyal
- `PackageProjectUrl` for the `View documentation` link in Package Manager.
 