### PR TITLE
[#5620] Upgrade Microsoft.Recognizers to 1.3.2

### DIFF
--- a/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
+++ b/libraries/AdaptiveExpressions/AdaptiveExpressions.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.9" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive.csproj
@@ -47,11 +47,11 @@
     <PackageReference Include="AdaptiveExpressions" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.2.9" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.2.9" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.9" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.2.9" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Sequence" Version="1.2.9" />
+    <PackageReference Include="Microsoft.Recognizers.Text" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Sequence" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs.csproj
@@ -26,8 +26,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
-    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.2.9" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.9" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot.Shared/Microsoft.Bot.Builder.TestBot.Shared.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Shared/Microsoft.Bot.Builder.TestBot.Shared.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.9" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.9" />
+    <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses #5620
#minor

## Description
This PR upgrades Recognizers-Text packages to version [1.3.2](https://www.nuget.org/packages/Microsoft.Recognizers.Text/1.3.2). This is the latest version compatible with NetCore2.1. Once we drop support for NetCore2.1, we'll be able to upgrade to the latest version of Recognizers-Text ([1.7.0](https://www.nuget.org/packages/Microsoft.Recognizers.Text/1.7.0))

## Specific Changes
Updated the following projects to use version 1.3.2 of Recognizers-Text packages.
- libraries/AdaptiveExpressions/AdaptiveExpressions
- libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Microsoft.Bot.Builder.Dialogs.Adaptive
- libraries/Microsoft.Bot.Builder.Dialogs/Microsoft.Bot.Builder.Dialogs
- tests/Microsoft.Bot.Builder.TestBot.Shared/Microsoft.Bot.Builder.TestBot.Shared
- tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot

## Testing
This image shows the CI pipeline passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/122450402-593d8e00-cf7d-11eb-8f89-a7c1b1a5e0e9.png)