### PR TITLE
[Part 8] [Unit Tests - Code Coverage]: Microsoft.Bot.Schema.Teams

### DIFF
--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabContextTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabContextTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Bot.Schema.Teams;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
 using Xunit;
 
 namespace Microsoft.Bot.Schema.Tests.Teams

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabContextTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabContextTests.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabContextTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("hi")]
+        public void TabContextInits(string theme)
+        {
+            var tabContext = new TabContext()
+            {
+                Theme = theme
+            };
+
+            Assert.NotNull(tabContext);
+            Assert.IsType<TabContext>(tabContext);
+            Assert.Equal(theme, tabContext.Theme);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabEntityContextTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabEntityContextTests.cs
@@ -1,10 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
 
 namespace Microsoft.Bot.Schema.Tests.Teams
 {
-    class TabEntityContextTests
+    public class TabEntityContextTests
     {
+        [Theory]
+        [InlineData("files")]
+        [InlineData(null)]
+        public void TabEntityContextInits(string tabEntityId)
+        {
+            var tabEntityContext = new TabEntityContext()
+            {
+                TabEntityId = tabEntityId
+            };
+
+            Assert.NotNull(tabEntityContext);
+            Assert.IsType<TabEntityContext>(tabEntityContext);
+            Assert.Equal(tabEntityId, tabEntityContext.TabEntityId);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabEntityContextTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabEntityContextTests.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    class TabEntityContextTests
+    {
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabRequestTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabRequestTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabRequestTests
+    {
+        [Theory]
+        [ClassData(typeof(TabRequestTestData))]
+        public void TabRequestInits(TabEntityContext tabEntityContext, TabContext tabContext, string state)
+        {
+            var tabRequest = new TabRequest()
+            {
+                TabEntityContext = tabEntityContext,
+                Context = tabContext,
+                State = state,
+            };
+
+            Assert.NotNull(tabRequest);
+            Assert.IsType<TabRequest>(tabRequest);
+            Assert.Equal(tabEntityContext, tabRequest.TabEntityContext);
+            Assert.Equal(tabContext, tabRequest.Context);
+            Assert.Equal(state, tabRequest.State);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseCardTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseCardTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabResponseCardTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("testResponseCard")]
+        public void TabResponseCardInits(object card)
+        {
+            var responseCard = new TabResponseCard()
+            {
+                Card = card
+            };
+
+            Assert.NotNull(responseCard);
+            Assert.IsType<TabResponseCard>(responseCard);
+            Assert.Equal(card, responseCard.Card);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseCardsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseCardsTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabResponseCardsTests
+    {
+        [Theory]
+        [ClassData(typeof(TabResponseCardsTestData))]
+        public void TabResponseCardsInits(IList<TabResponseCard> cards)
+        {
+            var responseCards = new TabResponseCards()
+            {
+                Cards = cards
+            };
+
+            Assert.NotNull(responseCards);
+            Assert.IsType<TabResponseCards>(responseCards);
+            Assert.Equal(cards, responseCards.Cards);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponsePayloadTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponsePayloadTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabResponsePayloadTests
+    {
+        [Theory]
+        [ClassData(typeof(TabResponsePayloadTestData))]
+        public void TabResponsePayloadInits(string tabType, TabResponseCards value, TabSuggestedActions suggestedActions)
+        {
+            var resPayload = new TabResponsePayload()
+            {
+                Type = tabType,
+                Value = value,
+                SuggestedActions = suggestedActions
+            };
+
+            Assert.NotNull(resPayload);
+            Assert.IsType<TabResponsePayload>(resPayload);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabResponseTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabResponseTests
+    {
+        [Theory]
+        [ClassData(typeof(TabResponseTestData))]
+        public void TabResponseInits(TabResponsePayload tab)
+        {
+            var tabResponse = new TabResponse()
+            {
+                Tab = tab
+            };
+
+            Assert.NotNull(tabResponse);
+            Assert.IsType<TabResponse>(tabResponse);
+            Assert.Equal(tab, tabResponse.Tab);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabSubmitDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabSubmitDataTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabSubmitDataTests
+    {
+        [Theory]
+        [ClassData(typeof(TabSubmitDataTestData))]
+        public void TabSubmitDataInits(string tabType, JObject properties)
+        {
+            var submitData = new TabSubmitData()
+            {
+                Type = tabType,
+                Properties = properties
+            };
+
+            Assert.NotNull(submitData);
+            Assert.IsType<TabSubmitData>(submitData);
+            Assert.Equal(tabType, submitData.Type);
+
+            var dataProps = submitData.Properties;
+            Assert.Equal(properties, dataProps);
+            if (dataProps != null)
+            {
+                Assert.Equal(properties.Count, submitData.Properties.Count);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabSubmitTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabSubmitTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabSubmitTests
+    {
+        [Theory]
+        [ClassData(typeof(TabSubmitTestData))]
+        public void TabSubmitInits(TabEntityContext tabEntityContext, TabContext tabContext, TabSubmitData tabSubmitData)
+        {
+            var submit = new TabSubmit()
+            {
+                TabEntityContext = tabEntityContext,
+                Context = tabContext,
+                Data = tabSubmitData,
+            };
+
+            Assert.NotNull(submit);
+            Assert.IsType<TabSubmit>(submit);
+            Assert.Equal(tabEntityContext, submit.TabEntityContext);
+            Assert.Equal(tabContext, submit.Context);
+            Assert.Equal(tabSubmitData, submit.Data);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabSuggestedActionsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabSuggestedActionsTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+using static Microsoft.Bot.Schema.Tests.Teams.TabsTestData;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TabSuggestedActionsTests
+    {
+        [Theory]
+        [ClassData(typeof(TabSuggestedActionsTestData))]
+        public void TabSuggestedActionsInits(IList<CardAction> actions)
+        {
+            var suggestedActions = new TabSuggestedActions()
+            {
+                Actions = actions
+            };
+
+            Assert.NotNull(suggestedActions);
+            Assert.IsType<TabSuggestedActions>(suggestedActions);
+            Assert.Equal(actions, suggestedActions.Actions);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -30,5 +30,16 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        internal class TabResponseTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { null };
+                yield return new object[] { new TabResponsePayload() };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -121,5 +121,23 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        internal class TabSuggestedActionsTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { null };
+                yield return new object[]
+                { 
+                    new List<CardAction>()
+                    { 
+                        new CardAction(),
+                        new CardAction(),
+                    } 
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    internal class TabsTestData
+    {
+        internal class TabRequestTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[]
+                {
+                    new TabEntityContext(),
+                    new TabContext(),
+                    "oAuthStateMagicCode",
+                };
+
+                yield return new object[]
+                {
+                    null,
+                    null,
+                    null,
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -59,5 +59,27 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        internal class TabResponsePayloadTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[]
+                {
+                    null,
+                    null,
+                    null
+                };
+
+                yield return new object[]
+                {
+                    "docx",
+                    new TabResponseCards(),
+                    new TabSuggestedActions(),
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -41,5 +41,23 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        internal class TabResponseCardsTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { null };
+                yield return new object[]
+                {
+                    new List<TabResponseCard>()
+                    {
+                        new TabResponseCard(),
+                        new TabResponseCard(),
+                    } 
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Schema.Tests.Teams
 {
@@ -99,6 +100,22 @@ namespace Microsoft.Bot.Schema.Tests.Teams
                     new TabEntityContext(),
                     new TabContext(),
                     new TabSubmitData(),
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        internal class TabSubmitDataTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // string tabType, JObject properties
+                yield return new object[] { null, null };
+                yield return new object[]
+                {
+                    "pdf",
+                    new JObject() { { "key", "value" } },
                 };
             }
 

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TabsTestData.cs
@@ -81,5 +81,28 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
+
+        internal class TabSubmitTestData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // TabEntityContext tabEntityContext, TabContext tabContext, TabSubmitData tabSubmitData
+                yield return new object[]
+                {
+                    null,
+                    null,
+                    null,
+                };
+
+                yield return new object[]
+                {
+                    new TabEntityContext(),
+                    new TabContext(),
+                    new TabSubmitData(),
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
     }
 }


### PR DESCRIPTION
Fixes #5708 

___

## Description
Part 8 of 10.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 71.40%
![image](https://user-images.githubusercontent.com/35248895/122624972-970ee500-d057-11eb-9aff-a744ab52072e.png)

Coverage Raised to with this Chunk: 77.31%
![image](https://user-images.githubusercontent.com/35248895/122624990-b3128680-d057-11eb-966b-214640641be9.png)
