### PR TITLE
[Part 9] [Unit Tests - Code Coverage]: Microsoft.Bot.Schema.Teams

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleContinueResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleContinueResponse.cs
@@ -22,9 +22,8 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleContinueResponse"/> class.
         /// </summary>
-        /// <param name="value">The JSON for the Adaptive card to appear in the
-        /// task module.</param>
-        public TaskModuleContinueResponse(TaskModuleTaskInfo value = default(TaskModuleTaskInfo))
+        /// <param name="value">The JSON for the Adaptive card to appear in the task module.</param>
+        public TaskModuleContinueResponse(TaskModuleTaskInfo value = default)
             : base("continue")
         {
             Value = value;
@@ -32,8 +31,7 @@ namespace Microsoft.Bot.Schema.Teams
         }
 
         /// <summary>
-        /// Gets or sets the JSON for the Adaptive card to appear in the task
-        /// module.
+        /// Gets or sets the JSON for the Adaptive card to appear in the task module.
         /// </summary>
         /// <value>The JSON for the adaptive card to appear in the task module.</value>
         [JsonProperty(PropertyName = "value")]

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleMessageResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleMessageResponse.cs
@@ -22,9 +22,8 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleMessageResponse"/> class.
         /// </summary>
-        /// <param name="value">Teams will display the value of value in a
-        /// popup message box.</param>
-        public TaskModuleMessageResponse(string value = default(string))
+        /// <param name="value">Teams will display the value of value in a popup message box.</param>
+        public TaskModuleMessageResponse(string value = default)
             : base("message")
         {
             Value = value;

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequest.cs
@@ -22,10 +22,9 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleRequest"/> class.
         /// </summary>
-        /// <param name="data">User input data. Free payload with key-value
-        /// pairs.</param>
+        /// <param name="data">User input data. Free payload with key-value pairs.</param>
         /// <param name="context">Current user context, i.e., the current theme.</param>
-        public TaskModuleRequest(object data = default(object), TaskModuleRequestContext context = default(TaskModuleRequestContext))
+        public TaskModuleRequest(object data = default, TaskModuleRequestContext context = default)
         {
             Data = data;
             Context = context;

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequestContext.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequestContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the <see cref="TaskModuleRequestContext"/> class.
         /// </summary>
         /// <param name="theme">The theme.</param>
-        public TaskModuleRequestContext(string theme = default(string))
+        public TaskModuleRequestContext(string theme = default)
         {
             Theme = theme;
             CustomInit();

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponse.cs
@@ -22,9 +22,8 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleResponse"/> class.
         /// </summary>
-        /// <param name="task">The JSON for the Adaptive card to appear in the
-        /// task module.</param>
-        public TaskModuleResponse(TaskModuleResponseBase task = default(TaskModuleResponseBase))
+        /// <param name="task">The JSON for the Adaptive card to appear in the task module.</param>
+        public TaskModuleResponse(TaskModuleResponseBase task = default)
         {
             Task = task;
             CustomInit();
@@ -39,8 +38,7 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleResponseBase Task { get; set; }
 
         /// <summary>
-        /// Gets or sets the CacheInfo for this <see cref="TaskModuleResponse"/>.
-        /// module.
+        /// Gets or sets the CacheInfo for this <see cref="TaskModuleResponse"/> module.
         /// </summary>
         /// <value>The CacheInfo for this <see cref="TaskModuleResponse"/>.</value>
         [JsonProperty(PropertyName = "cacheInfo")]

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponseBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponseBase.cs
@@ -22,10 +22,8 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleResponseBase"/> class.
         /// </summary>
-        /// <param name="type">Choice of action options when responding to the
-        /// task/submit message. Possible values include: 'message',
-        /// 'continue'.</param>
-        public TaskModuleResponseBase(string type = default(string))
+        /// <param name="type">Choice of action options when responding to the task/submit message. Possible values include: 'message', 'continue'.</param>
+        public TaskModuleResponseBase(string type = default)
         {
             Type = type;
             CustomInit();

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleActionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleActionTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleActionTests
+    {
+        [Theory]
+        [InlineData("NullValueButton", null)]
+        [InlineData("StringValueButton", "{}")]
+        [InlineData("JObjectValueButton", "makeJObject")]
+        public void TaskModuleActionInits(string title, object value)
+        {
+            if ((string)value == "makeJObject")
+            {
+                value = new JObject();
+            }
+
+            var action = new TaskModuleAction(title, value);
+            var expectedKey = "type";
+            var expectedVal = "task/fetch";
+
+            Assert.NotNull(action);
+            Assert.IsType<TaskModuleAction>(action);
+            Assert.Equal(title, action.Title);
+            var valAsObj = JObject.Parse(action.Value as string);
+            Assert.True(valAsObj.ContainsKey(expectedKey));
+            Assert.Equal(expectedVal, valAsObj[expectedKey]);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleCardResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleCardResponseTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleCardResponseTests
+    {
+        [Fact]
+        public void TaskModuleCardResponseInits()
+        {
+            var value = new TabResponse();
+            var cardResponse = new TaskModuleCardResponse(value);
+
+            Assert.NotNull(cardResponse);
+            Assert.IsType<TaskModuleCardResponse>(cardResponse);
+            Assert.Equal(value, cardResponse.Value);
+        }
+        
+        [Fact]
+        public void TaskModuleCardResponseInitsWithNoArgs()
+        {
+            var cardResponse = new TaskModuleCardResponse();
+
+            Assert.NotNull(cardResponse);
+            Assert.IsType<TaskModuleCardResponse>(cardResponse);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleContinueResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleContinueResponseTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleContinueResponseTests
+    {
+        [Fact]
+        public void TaskModuleContinueResponseInits()
+        {
+            var value = new TaskModuleTaskInfo();
+
+            var continueResponse = new TaskModuleContinueResponse(value);
+
+            Assert.NotNull(continueResponse);
+            Assert.IsType<TaskModuleContinueResponse>(continueResponse);
+            Assert.Equal(value, continueResponse.Value);
+        }
+        
+        [Fact]
+        public void TaskModuleContinueResponseInitsWithNoArgs()
+        {
+            var continueResponse = new TaskModuleContinueResponse();
+
+            Assert.NotNull(continueResponse);
+            Assert.IsType<TaskModuleContinueResponse>(continueResponse);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleMessageResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleMessageResponseTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleMessageResponseTests
+    {
+        [Fact]
+        public void TaskModuleMessageResponseInits()
+        {
+            var value = "message value for Teams popup";
+
+            var messageResponse = new TaskModuleMessageResponse(value);
+
+            Assert.NotNull(messageResponse);
+            Assert.IsType<TaskModuleMessageResponse>(messageResponse);
+            Assert.Equal(value, messageResponse.Value);
+        }
+        
+        [Fact]
+        public void TaskModuleMessageResponseInitsWithNoArgs()
+        {
+            var messageResponse = new TaskModuleMessageResponse();
+
+            Assert.NotNull(messageResponse);
+            Assert.IsType<TaskModuleMessageResponse>(messageResponse);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleRequestContextTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleRequestContextTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleRequestContextTests
+    {
+        [Fact]
+        public void TaskModuleRequestContextInits()
+        {
+            var theme = "chat";
+
+            var requestContext = new TaskModuleRequestContext(theme);
+
+            Assert.NotNull(requestContext);
+            Assert.IsType<TaskModuleRequestContext>(requestContext);
+            Assert.Equal(theme, requestContext.Theme);
+        }
+        
+        [Fact]
+        public void TaskModuleRequestContextInitsWithNoArgs()
+        {
+            var requestContext = new TaskModuleRequestContext();
+
+            Assert.NotNull(requestContext);
+            Assert.IsType<TaskModuleRequestContext>(requestContext);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleRequestContextTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleRequestContextTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Bot.Schema.Teams;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Bot.Schema.Tests.Teams

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleRequestTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleRequestTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleRequestTests
+    {
+        [Fact]
+        public void TaskModuleRequestInits()
+        {
+            var data = new JObject() { { "key", "value" } };
+            var context = new TaskModuleRequestContext();
+            var tabEntityContext = new TabEntityContext();
+
+            var request = new TaskModuleRequest(data, context)
+            {
+                TabEntityContext = tabEntityContext
+            };
+
+            Assert.NotNull(request);
+            Assert.IsType<TaskModuleRequest>(request);
+            Assert.Equal(data, request.Data);
+            Assert.Equal(context, request.Context);
+            Assert.Equal(tabEntityContext, request.TabEntityContext);
+        }
+        
+        [Fact]
+        public void TaskModuleRequestInitsWithNoArgs()
+        {
+            var request = new TaskModuleRequest();
+
+            Assert.NotNull(request);
+            Assert.IsType<TaskModuleRequest>(request);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleResponseBaseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleResponseBaseTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleResponseBaseTests
+    {
+        [Fact]
+        public void TaskModuleResponseBaseInits()
+        {
+            var type = "message";
+
+            var responseBase = new TaskModuleResponseBase(type);
+
+            Assert.NotNull(responseBase);
+            Assert.IsType<TaskModuleResponseBase>(responseBase);
+            Assert.Equal(type, responseBase.Type);
+        }
+        
+        [Fact]
+        public void TaskModuleResponseBaseInitsWithNoArgs()
+        {
+            var responseBase = new TaskModuleResponseBase();
+
+            Assert.NotNull(responseBase);
+            Assert.IsType<TaskModuleResponseBase>(responseBase);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleResponseTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleResponseTests
+    {
+        [Fact]
+        public void TaskModuleResponseInits()
+        {
+            var task = new TaskModuleResponseBase();
+            var cacheInfo = new CacheInfo();
+
+            var response = new TaskModuleResponse(task)
+            {
+                CacheInfo = cacheInfo
+            };
+
+            Assert.NotNull(response);
+            Assert.IsType<TaskModuleResponse>(response);
+            Assert.Equal(task, response.Task);
+            Assert.Equal(cacheInfo, response.CacheInfo);
+        }
+        
+        [Fact]
+        public void TaskModuleResponseInitsWithNoArgs()
+        {
+            var response = new TaskModuleResponse();
+
+            Assert.NotNull(response);
+            Assert.IsType<TaskModuleResponse>(response);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5714 
___

## Description
Part 9 of 10.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 71.40%
![image](https://user-images.githubusercontent.com/35248895/122624972-970ee500-d057-11eb-9aff-a744ab52072e.png)

Coverage Raised to with this Chunk: 78.18%
![image](https://user-images.githubusercontent.com/35248895/122808318-9a85b480-d281-11eb-9e8f-abc987c2a336.png)

