### PR TITLE
[Part 10] Increase Microsoft.Bot.Schema.Teams code coverage

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleTaskInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleTaskInfo.cs
@@ -22,25 +22,15 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleTaskInfo"/> class.
         /// </summary>
-        /// <param name="title">Appears below the app name and to the right of
-        /// the app icon.</param>
-        /// <param name="height">This can be a number, representing the task
-        /// module's height in pixels, or a string, one of: small, medium,
-        /// large.</param>
-        /// <param name="width">This can be a number, representing the task
-        /// module's width in pixels, or a string, one of: small, medium,
-        /// large.</param>
-        /// <param name="url">The URL of what is loaded as an iframe inside the
-        /// task module. One of url or card is required.</param>
-        /// <param name="card">The JSON for the Adaptive card to appear in the
-        /// task module.</param>
-        /// <param name="fallbackUrl">If a client does not support the task
-        /// module feature, this URL is opened in a browser tab.</param>
-        /// <param name="completionBotId">Specifies a bot App ID to send the
-        /// result of the user's interaction with the task module to. If
-        /// specified, the bot will receive a task/submit invoke event with
-        /// a JSON object in the event payload.</param>
-        public TaskModuleTaskInfo(string title = default(string), object height = default(object), object width = default(object), string url = default(string), Attachment card = default(Attachment), string fallbackUrl = default(string), string completionBotId = default(string))
+        /// <param name="title">Appears below the app name and to the right of the app icon.</param>
+        /// <param name="height">This can be a number, representing the task module's height in pixels, or a string, one of: small, medium, large.</param>
+        /// <param name="width">This can be a number, representing the task module's width in pixels, or a string, one of: small, medium, large.</param>
+        /// <param name="url">The URL of what is loaded as an iframe inside the task module. One of url or card is required.</param>
+        /// <param name="card">The JSON for the Adaptive card to appear in the task module.</param>
+        /// <param name="fallbackUrl">If a client does not support the task module feature, this URL is opened in a browser tab.</param>
+        /// <param name="completionBotId">Specifies a bot App ID to send the result of the user's interaction with the task module to.
+        /// If specified, the bot will receive a task/submit invoke event with a JSON object in the event payload.</param>
+        public TaskModuleTaskInfo(string title = default, object height = default, object width = default, string url = default, Attachment card = default, string fallbackUrl = default, string completionBotId = default(string))
         {
             Title = title;
             Height = height;

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamDetails.cs
@@ -24,10 +24,9 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="id">Unique identifier representing a team.</param>
         /// <param name="name">Name of team.</param>
-        /// <param name="aadGroupId">Azure Active Directory (AAD) Group Id for.
-        /// </param>
+        /// <param name="aadGroupId">Azure Active Directory (AAD) Group Id.</param>
         [Obsolete("Use the parameter initialization method instead.")]
-        public TeamDetails(string id = default(string), string name = default(string), string aadGroupId = default(string))
+        public TeamDetails(string id = default, string name = default, string aadGroupId = default)
         {
             Id = id;
             Name = name;

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="id">Unique identifier representing a team.</param>
         /// <param name="name">Name of team.</param>
-        public TeamInfo(string id = default(string), string name = default(string))
+        public TeamInfo(string id = default, string name = default)
         {
             Id = id;
             Name = name;

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelAccount.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelAccount.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -31,7 +30,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="userPrincipalName">Unique user principal name.</param>
         /// <param name="tenantId">TenantId of the user.</param>
         /// <param name="userRole">UserRole of the user.</param>
-        public TeamsChannelAccount(string id = default(string), string name = default(string), string givenName = default(string), string surname = default(string), string email = default(string), string userPrincipalName = default(string), string tenantId = default(string), string userRole = default(string))
+        public TeamsChannelAccount(string id = default, string name = default, string givenName = default, string surname = default, string email = default, string userPrincipalName = default, string tenantId = default, string userRole = default)
             : base(id, name)
         {
             GivenName = givenName;
@@ -53,7 +52,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="surname">Surname part of the user name.</param>
         /// <param name="email">Email Id of the user.</param>
         /// <param name="userPrincipalName">Unique user principal name.</param>
-        public TeamsChannelAccount(string id = default(string), string name = default(string), string givenName = default(string), string surname = default(string), string email = default(string), string userPrincipalName = default(string))
+        public TeamsChannelAccount(string id = default, string name = default, string givenName = default, string surname = default, string email = default, string userPrincipalName = default)
             : this(id, name, givenName, surname, email, userPrincipalName, string.Empty, string.Empty)
         {
         }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelAccountEx.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelAccountEx.cs
@@ -16,15 +16,9 @@ namespace Microsoft.Bot.Schema.Teams
         [JsonProperty(PropertyName = "objectId")]
         private string ObjectId
         {
-            get
-            {
-                return this.AadObjectId;
-            }
+            get => AadObjectId;
 
-            set
-            {
-                this.AadObjectId = value;
-            }
+            set => AadObjectId = value;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -21,16 +21,13 @@ namespace Microsoft.Bot.Schema.Teams
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsChannelData"/> class.
         /// </summary>
-        /// <param name="channel">Information about the channel in which the
-        /// message was sent.</param>
+        /// <param name="channel">Information about the channel in which the message was sent.</param>
         /// <param name="eventType">Type of event.</param>
-        /// <param name="team">Information about the team in which the message
-        /// was sent.</param>
-        /// <param name="notification">Notification settings for the
-        /// message.</param>
+        /// <param name="team">Information about the team in which the message was sent.</param>
+        /// <param name="notification">Notification settings for the message.</param>
         /// <param name="tenant">Information about the tenant in which the
         /// message was sent.</param>
-        public TeamsChannelData(ChannelInfo channel = default(ChannelInfo), string eventType = default(string), TeamInfo team = default(TeamInfo), NotificationInfo notification = default(NotificationInfo), TenantInfo tenant = default(TenantInfo))
+        public TeamsChannelData(ChannelInfo channel = default, string eventType = default, TeamInfo team = default, NotificationInfo notification = default, TenantInfo tenant = default)
         {
             Channel = channel;
             EventType = eventType;

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingInfo.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the <see cref="TeamsMeetingInfo"/> class.
         /// </summary>
         /// <param name="id">Unique identifier representing a teams meeting.</param>
-        public TeamsMeetingInfo(string id = default(string))
+        public TeamsMeetingInfo(string id = default)
         {
             Id = id;
             CustomInit();

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsPagedMembersResult.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// </summary>
         /// <param name="continuationToken">A paging token.</param>
         /// <param name="members">A list of channel accounts.</param>
-        public TeamsPagedMembersResult(string continuationToken = default(string), IList<ChannelAccount> members = default(IList<ChannelAccount>))
+        public TeamsPagedMembersResult(string continuationToken = default, IList<ChannelAccount> members = default)
         {
             ContinuationToken = continuationToken;
             var teamsChannelAccounts = members.Select(channelAccount => JObject.FromObject(channelAccount).ToObject<TeamsChannelAccount>());

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsParticipantChannelAccount.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsParticipantChannelAccount.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <param name="meetingRole">Role of the participant in the current meeting.</param>
         /// <param name="inMeeting">True, if the participant is in the meeting.</param>
         /// <param name="conversation">Conversation Account for the meeting.</param>
-        public TeamsParticipantChannelAccount(string id = default(string), string name = default(string), string givenName = default(string), string surname = default(string), string email = default(string), string userPrincipalName = default(string), string tenantId = default(string), string userRole = default(string), string meetingRole = default(string), bool inMeeting = default(bool), ConversationAccount conversation = null)
+        public TeamsParticipantChannelAccount(string id = default, string name = default, string givenName = default, string surname = default, string email = default, string userPrincipalName = default, string tenantId = default, string userRole = default, string meetingRole = default, bool inMeeting = default, ConversationAccount conversation = null)
             : base(id, name, givenName, surname, email, userPrincipalName, tenantId, userRole)
         {
             MeetingRole = meetingRole;

--- a/libraries/Microsoft.Bot.Schema/Teams/TenantInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TenantInfo.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// Initializes a new instance of the <see cref="TenantInfo"/> class.
         /// </summary>
         /// <param name="id">Unique identifier representing a tenant.</param>
-        public TenantInfo(string id = default(string))
+        public TenantInfo(string id = default)
         {
             Id = id;
             CustomInit();

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleTaskInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleTaskInfoTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TaskModuleTaskInfoTests
+    {
+        [Fact]
+        public void TaskModuleTaskInfoInits()
+        {
+            var title = "chatty";
+            var height = "medium";
+            var width = "large";
+            var url = "https://example.com";
+            var card = new Attachment();
+            var fallbackUrl = "https://fallback-url-of-example.com";
+            var completionBotId = "0000-0000-0000-0000-0000";
+
+            var taskInfo = new TaskModuleTaskInfo(title, height, width, url, card, fallbackUrl, completionBotId);
+
+            Assert.NotNull(taskInfo);
+            Assert.IsType<TaskModuleTaskInfo>(taskInfo);
+            Assert.Equal(title, taskInfo.Title);
+            Assert.Equal(height, taskInfo.Height);
+            Assert.Equal(width, taskInfo.Width);
+            Assert.Equal(url, taskInfo.Url);
+            Assert.Equal(card, taskInfo.Card);
+            Assert.Equal(fallbackUrl, taskInfo.FallbackUrl);
+            Assert.Equal(completionBotId, taskInfo.CompletionBotId);
+        }
+        
+        [Fact]
+        public void TaskModuleTaskInfoInitsWithNoArgs()
+        {
+            var taskInfo = new TaskModuleTaskInfo();
+
+            Assert.NotNull(taskInfo);
+            Assert.IsType<TaskModuleTaskInfo>(taskInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamDetailsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamDetailsTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamDetailsTests
+    {
+        [Fact]
+        public void TeamDetailsInits()
+        {
+            var id = "supportEngineers";
+            var name = "Support Engineers";
+            var aadGroupId = "0000-0000-0000-0000-0000-0000";
+
+            var teamDetails = new TeamDetails(id, name, aadGroupId);
+
+            Assert.NotNull(teamDetails);
+            Assert.IsType<TeamDetails>(teamDetails);
+            Assert.Equal(id, teamDetails.Id);
+            Assert.Equal(name, teamDetails.Name);
+            Assert.Equal(aadGroupId, teamDetails.AadGroupId);
+        }
+        
+        [Fact]
+        public void TeamDetailsInitsWithNoArgs()
+        {
+            var teamDetails = new TeamDetails();
+
+            Assert.NotNull(teamDetails);
+            Assert.IsType<TeamDetails>(teamDetails);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamDetailsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamDetailsTests.cs
@@ -14,14 +14,22 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             var id = "supportEngineers";
             var name = "Support Engineers";
             var aadGroupId = "0000-0000-0000-0000-0000-0000";
+            var channelCount = 1;
+            var memberCount = 2;
 
-            var teamDetails = new TeamDetails(id, name, aadGroupId);
+            var teamDetails = new TeamDetails(id, name, aadGroupId)
+            {
+                ChannelCount = channelCount,
+                MemberCount = memberCount,
+            };
 
             Assert.NotNull(teamDetails);
             Assert.IsType<TeamDetails>(teamDetails);
             Assert.Equal(id, teamDetails.Id);
             Assert.Equal(name, teamDetails.Name);
             Assert.Equal(aadGroupId, teamDetails.AadGroupId);
+            Assert.Equal(channelCount, teamDetails.ChannelCount);
+            Assert.Equal(memberCount, teamDetails.MemberCount);
         }
         
         [Fact]

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamInfoTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamInfoTests
+    {
+        [Fact]
+        public void TeamInfoInits()
+        {
+            var id = "supportEngineers";
+            var name = "Support Engineers";
+
+            var teamInfo = new TeamInfo(id, name);
+
+            Assert.NotNull(teamInfo);
+            Assert.IsType<TeamInfo>(teamInfo);
+            Assert.Equal(id, teamInfo.Id);
+            Assert.Equal(name, teamInfo.Name);
+        }
+
+        [Fact]
+        public void TeamInfoInitsWithNoArgs()
+        {
+            var teamInfo = new TeamInfo();
+
+            Assert.NotNull(teamInfo);
+            Assert.IsType<TeamInfo>(teamInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelAccountTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelAccountTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamsChannelAccountTests
+    {
+        [Fact]
+        public void TeamChannelAccountInits()
+        {
+            var id = "john@smith.com";
+            var name = "John Smith";
+            var givenName = "John";
+            var surname = "Smith";
+            var email = "john@smith.com";
+            var userPrincipalName = "johnUserPrincipal";
+
+            var teamsChannelAccount = new TeamsChannelAccount(id, name, givenName, surname, email, userPrincipalName);
+
+            Assert.NotNull(teamsChannelAccount);
+            Assert.IsType<TeamsChannelAccount>(teamsChannelAccount);
+            Assert.Equal(id, teamsChannelAccount.Id);
+            Assert.Equal(name, teamsChannelAccount.Name);
+            Assert.Equal(givenName, teamsChannelAccount.GivenName);
+            Assert.Equal(surname, teamsChannelAccount.Surname);
+            Assert.Equal(email, teamsChannelAccount.Email);
+            Assert.Equal(userPrincipalName, teamsChannelAccount.UserPrincipalName);
+        }
+        
+        [Fact]
+        public void TeamChannelAccountInitsWithAllOptions()
+        {
+            var id = "john@smith.com";
+            var name = "John Smith";
+            var givenName = "John";
+            var surname = "Smith";
+            var email = "john@smith.com";
+            var userPrincipalName = "johnUserPrincipal";
+            var tenantId = "0000-0000-0000-0000-0000-0000";
+            var userRole = "contributor";
+            var objectId = "abcdefgh-ijkl-mnop-qrst-uvwxyz123456";
+
+            var teamsChannelAccount = new TeamsChannelAccount(id, name, givenName, surname, email, userPrincipalName, tenantId, userRole)
+            {
+                AadObjectId = objectId
+            };
+
+            Assert.NotNull(teamsChannelAccount);
+            Assert.IsType<TeamsChannelAccount>(teamsChannelAccount);
+            Assert.Equal(id, teamsChannelAccount.Id);
+            Assert.Equal(name, teamsChannelAccount.Name);
+            Assert.Equal(givenName, teamsChannelAccount.GivenName);
+            Assert.Equal(surname, teamsChannelAccount.Surname);
+            Assert.Equal(email, teamsChannelAccount.Email);
+            Assert.Equal(userPrincipalName, teamsChannelAccount.UserPrincipalName);
+            Assert.Equal(tenantId, teamsChannelAccount.TenantId);
+            Assert.Equal(userRole, teamsChannelAccount.UserRole);
+            Assert.Equal(objectId, teamsChannelAccount.AadObjectId);
+        }
+        
+        [Fact]
+        public void TeamChannelAccountInitsWithNoArgs()
+        {
+            var teamsChannelAccount = new TeamsChannelAccount();
+
+            Assert.NotNull(teamsChannelAccount);
+            Assert.IsType<TeamsChannelAccount>(teamsChannelAccount);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsChannelDataTests.cs
@@ -9,6 +9,40 @@ namespace Microsoft.Bot.Schema.Tests.Teams
     public class TeamsChannelDataTests
     {
         [Fact]
+        public void TeamsChannelDataInits()
+        {
+            var channel = new ChannelInfo("general", "General");
+            var eventType = "eventType";
+            var team = new TeamInfo("supportEngineers", "Support Engineers");
+            var notification = new NotificationInfo(true);
+            var tenant = new TenantInfo("uniqueTenantId");
+            var meeting = new TeamsMeetingInfo("BFSE Stand Up");
+
+            var channelData = new TeamsChannelData(channel, eventType, team, notification, tenant)
+            {
+                Meeting = meeting
+            };
+
+            Assert.NotNull(channelData);
+            Assert.IsType<TeamsChannelData>(channelData);
+            Assert.Equal(channel, channelData.Channel);
+            Assert.Equal(eventType, channelData.EventType);
+            Assert.Equal(team, channelData.Team);
+            Assert.Equal(notification, channelData.Notification);
+            Assert.Equal(tenant, channelData.Tenant);
+            Assert.Equal(meeting, channelData.Meeting);
+        }
+        
+        [Fact]
+        public void TeamsChannelDataInitsWithNoArgs()
+        {
+            var channelData = new TeamsChannelData();
+
+            Assert.NotNull(channelData);
+            Assert.IsType<TeamsChannelData>(channelData);
+        }
+
+        [Fact]
         public void GetAadGroupId()
         {
             // Arrange

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsMeetingInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsMeetingInfoTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamsMeetingInfoTests
+    {
+        [Fact]
+        public void TeamsMeetingInfoInits()
+        {
+            var id = "BFSE Stand Up";
+
+            var meetingInfo = new TeamsMeetingInfo(id);
+
+            Assert.NotNull(meetingInfo);
+            Assert.IsType<TeamsMeetingInfo>(meetingInfo);
+            Assert.Equal(id, meetingInfo.Id);
+        }
+        
+        [Fact]
+        public void TeamsMeetingInfoInitsWithNoArgs()
+        {
+            var meetingInfo = new TeamsMeetingInfo();
+
+            Assert.NotNull(meetingInfo);
+            Assert.IsType<TeamsMeetingInfo>(meetingInfo);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsMeetingParticipantTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsMeetingParticipantTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamsMeetingParticipantTests
+    {
+        [Fact]
+        public void TeamsMeetingParticipantInits()
+        {
+            var user = new TeamsChannelAccount("joe@smith.com", "Joe", "Joe", "Smith", "joe@smith.com", "joePrincipalName");
+            var conversation = new ConversationAccount(true);
+            var meeting = new MeetingParticipantInfo("owner", true);
+
+            var participant = new TeamsMeetingParticipant(user, conversation, meeting);
+
+            Assert.NotNull(participant);
+            Assert.IsType<TeamsMeetingParticipant>(participant);
+            Assert.Equal(user, participant.User);
+            Assert.Equal(conversation, participant.Conversation);
+            Assert.Equal(meeting, participant.Meeting);
+        }
+        
+        [Fact]
+        public void TeamsMeetingParticipantInitsWithNoArgs()
+        {
+            var participant = new TeamsMeetingParticipant();
+
+            Assert.NotNull(participant);
+            Assert.IsType<TeamsMeetingParticipant>(participant);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsPagedMembersResultTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsPagedMembersResultTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamsPagedMembersResultTests
+    {
+        [Fact]
+        public void TeamsPagedMemberResultInits()
+        {
+            var continuationToken = "myContinuationToken";
+            var channel1Id = "Channel1";
+            var channel2Id = "Channel2";
+            var members = new List<ChannelAccount>()
+            {
+                new ChannelAccount(channel1Id),
+                new ChannelAccount(channel2Id),
+            };
+
+            var result = new TeamsPagedMembersResult(continuationToken, members);
+
+            Assert.NotNull(result);
+            Assert.IsType<TeamsPagedMembersResult>(result);
+            Assert.Equal(continuationToken, result.ContinuationToken);
+            var resultMembers = result.Members;
+            Assert.IsType<List<TeamsChannelAccount>>(resultMembers);
+            Assert.Equal(2, resultMembers.Count);
+            Assert.Equal(channel1Id, resultMembers[0].Id);
+            Assert.Equal(channel2Id, resultMembers[1].Id);
+        }
+        
+        [Fact]
+        public void TeamsPagedMemberResultInitsWithNoArgs()
+        {
+            var result = new TeamsPagedMembersResult();
+
+            Assert.NotNull(result);
+            Assert.IsType<TeamsPagedMembersResult>(result);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsParticipantChannelAccountTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsParticipantChannelAccountTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TeamsParticipantChannelAccountTests
+    {
+        [Fact]
+        public void TeamsParticipantChannelAccountInits()
+        {
+            var id = "joe@smith.com";
+            var name = "Joe Smith";
+            var givenName = "Joe";
+            var surname = "Smith";
+            var email = "joe@smith.com";
+            var userPrincipalName = "joeUserPrincipalName";
+            var tenantId = "123456-7890-abcd-efgh-ijklmnop";
+            var userRole = "owner";
+            var meetingRole = "owner";
+            var inMeeting = true;
+            var conversation = new ConversationAccount(true);
+
+            var participantAccount = new TeamsParticipantChannelAccount(id, name, givenName, surname, email, userPrincipalName, tenantId, userRole, meetingRole, inMeeting, conversation);
+
+            Assert.NotNull(participantAccount);
+            Assert.IsType<TeamsParticipantChannelAccount>(participantAccount);
+            Assert.Equal(id, participantAccount.Id);
+            Assert.Equal(name, participantAccount.Name);
+            Assert.Equal(givenName, participantAccount.GivenName);
+            Assert.Equal(surname, participantAccount.Surname);
+            Assert.Equal(email, participantAccount.Email);
+            Assert.Equal(userPrincipalName, participantAccount.UserPrincipalName);
+            Assert.Equal(tenantId, participantAccount.TenantId);
+            Assert.Equal(userRole, participantAccount.UserRole);
+            Assert.Equal(meetingRole, participantAccount.MeetingRole);
+            Assert.Equal(inMeeting, participantAccount.InMeeting);
+            Assert.Equal(conversation, participantAccount.Conversation);
+        }
+        
+        [Fact]
+        public void TeamsParticipantChannelAccountInitsWithNoArgs()
+        {
+            var participantAccount = new TeamsParticipantChannelAccount();
+
+            Assert.NotNull(participantAccount);
+            Assert.IsType<TeamsParticipantChannelAccount>(participantAccount);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsParticipantChannelAccountTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TeamsParticipantChannelAccountTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using Microsoft.Bot.Schema.Teams;
 using Xunit;
 

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TenantInfoTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TenantInfoTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class TenantInfoTests
+    {
+        [Fact]
+        public void TenantInfoInits()
+        {
+            var id = "123456-7890-abcd-efgh-ijklmno";
+            
+            var tenantInfo = new TenantInfo(id);
+
+            Assert.NotNull(tenantInfo);
+            Assert.IsType<TenantInfo>(tenantInfo);
+            Assert.Equal(id, tenantInfo.Id);
+        }
+        
+        [Fact]
+        public void TenantInfoInitsWithNoArgs()
+        {
+            var tenantInfo = new TenantInfo();
+
+            Assert.NotNull(tenantInfo);
+            Assert.IsType<TenantInfo>(tenantInfo);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5725 

___

## Description
Part 10 of 10.
Write unit tests to bring `Microsoft.Bot.Schema.Teams` to 100% code coverage 🎊🥳🎉

___
Original `Microsoft.Bot.Schema.Teams` Coverage: 71.40%
![image](https://user-images.githubusercontent.com/35248895/122624972-970ee500-d057-11eb-9aff-a744ab52072e.png)

Coverage Raised to with this Chunk: 87.51%
![image](https://user-images.githubusercontent.com/35248895/123139954-9d141580-d40b-11eb-9b98-683230c0dcc5.png)
