### PR TITLE
Remove Azure.Queues.dll from CC report

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -23,7 +23,7 @@
                 <ModulePath>.*\Microsoft.Bot.Builder.ApplicationInsights.dll$</ModulePath>
                 <!--<ModulePath>.*\Microsoft.Bot.Builder.Azure.dll$</ModulePath>-->
                 <!--<ModulePath>.*\Microsoft.Bot.Builder.Azure.Blobs.dll$</ModulePath>-->
-                <ModulePath>.*\Microsoft.Bot.Builder.Azure.Queues.dll$</ModulePath>
+                <!--<ModulePath>.*\Microsoft.Bot.Builder.Azure.Queues.dll$</ModulePath>-->
                 <ModulePath>.*\Microsoft.Bot.Builder.Dialogs.dll$</ModulePath>
                 <ModulePath>.*\Microsoft.Bot.Builder.Dialogs.Adaptive.dll$</ModulePath>
                 <ModulePath>.*\Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.dll$</ModulePath>


### PR DESCRIPTION
Fixes #5703

## Description
This is a follow-on to PR #5723

## Specific Changes
Remove Azure.Queues.dll from CodeCoverage.runsettings CodeCoverage Include list.
