### PR TITLE
Add conversation id header in skill requests

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -85,6 +85,8 @@ namespace Microsoft.Bot.Connector.Authentication
                     httpRequestMessage.RequestUri = toUrl;
                     httpRequestMessage.Content = jsonContent;
 
+                    httpRequestMessage.Headers.Add("x-ms-conversation-id", conversationId);
+
                     // Add the auth header to the HTTP request.
                     await credentials.ProcessHttpRequestAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     httpRequestMessage.RequestUri = toUrl;
                     httpRequestMessage.Content = jsonContent;
 
-                    httpRequestMessage.Headers.Add("x-ms-conversation-id", conversationId);
+                    httpRequestMessage.Headers.Add(ConversationConstants.ConversationIdHttpHeaderName, conversationId);
 
                     // Add the auth header to the HTTP request.
                     await credentials.ProcessHttpRequestAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Connector/ConversationConstants.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationConstants.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Connector
+{
+    /// <summary>
+    /// Values and constants used for Conversation specific info.
+    /// </summary>
+    public static class ConversationConstants
+    {
+        /// <summary>
+        /// The name of Http Request Header to add Conversation Id to skills requests.
+        /// </summary>
+        public const string ConversationIdHttpHeaderName = "x-ms-conversation-id";
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Conversations.cs
+++ b/libraries/Microsoft.Bot.Connector/Conversations.cs
@@ -1251,7 +1251,7 @@ namespace Microsoft.Bot.Connector
                 }
             }
 
-            httpRequest.Headers.Add("x-ms-conversation-id", conversationId);
+            httpRequest.Headers.Add(ConversationConstants.ConversationIdHttpHeaderName, conversationId);
 
             // Serialize Request
             string requestContent = null;

--- a/libraries/Microsoft.Bot.Connector/Conversations.cs
+++ b/libraries/Microsoft.Bot.Connector/Conversations.cs
@@ -1251,6 +1251,8 @@ namespace Microsoft.Bot.Connector
                 }
             }
 
+            httpRequest.Headers.Add("x-ms-conversation-id", conversationId);
+
             // Serialize Request
             string requestContent = null;
             if (activity != null)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -236,6 +236,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                         httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
                     }
 
+                    httpRequestMessage.Headers.Add(ConversationConstants.ConversationIdHttpHeaderName, activity.Conversation.Id);
+
                     httpRequestMessage.Content = jsonContent;
                     using (var response = await HttpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false))
                     {

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpClientTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/BotFrameworkHttpClientTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Moq;
@@ -52,6 +53,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         {
             var httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
             {
+                Assert.Equal("NewConversationId", request.Headers.GetValues(ConversationConstants.ConversationIdHttpHeaderName).FirstOrDefault());
                 var sentActivity = JsonConvert.DeserializeObject<Activity>(request.Content.ReadAsStringAsync().Result);
                 Assert.Equal(RoleTypes.Skill, sentActivity.Recipient.Role);
 
@@ -110,6 +112,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 // Assert the request properties
                 Assert.Equal(new Uri("https://skillbot.com/api/messages"), request.RequestUri);
+                Assert.Equal("NewConversationId", request.Headers.GetValues(ConversationConstants.ConversationIdHttpHeaderName).FirstOrDefault());
 
                 // Assert expected values are in the activity being sent.
                 var sentActivity = JsonConvert.DeserializeObject<Activity>(request.Content.ReadAsStringAsync().Result);
@@ -166,6 +169,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             var activity = new Activity { Conversation = new ConversationAccount(id: Guid.NewGuid().ToString()) };
             var httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
             {
+                Assert.Equal(activity.Conversation.Id, request.Headers.GetValues(ConversationConstants.ConversationIdHttpHeaderName).FirstOrDefault());
                 var sentActivity = JsonConvert.DeserializeObject<Activity>(request.Content.ReadAsStringAsync().Result);
 
                 // Assert the activity we are sending is what we passed in.
@@ -193,6 +197,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             var activity = new Activity { Conversation = new ConversationAccount(id: Guid.NewGuid().ToString()) };
             var httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
             {
+                Assert.Equal(activity.Conversation.Id, request.Headers.GetValues(ConversationConstants.ConversationIdHttpHeaderName).FirstOrDefault());
                 var sentActivity = JsonConvert.DeserializeObject<Activity>(request.Content.ReadAsStringAsync().Result);
 
                 // Assert the activity we are sending is what we passed in.


### PR DESCRIPTION
Fixes #5592

## Description
PVA team needs ConversationId in the header of skills requests, bot Host to Skill, and Skill to Host. This change adds the header to these Http requests.

## Testing
Updated existing tests to assert the new header.