### PR TITLE
[#5192] Add unit tests for SendHandoffActivity

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -516,6 +516,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_SendHandoffActivity()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_HttpRequest()
         {
             var handler = new MockHttpMessageHandler();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SendHandoffActivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SendHandoffActivity.test.dialog
@@ -1,0 +1,46 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "$context",
+                      "value": "={\"context\": \"test-context\"}"
+                    },{
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "$transcript",
+                      "value": "={\"activities\": [{\"id\": \"activity1\"}, {\"id\": \"activity2\"}]}"
+                    },
+                    {
+                      "$kind": "Microsoft.SendHandoffActivity",
+                      "context": "=$context",
+                      "transcript":  "=$transcript", 
+                      "activity": {
+                        "type": "event"
+                      }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserConversationUpdate"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'event'",
+                "value.context == 'test-context'",
+                "attachments[0].name == 'Transcript'",
+                "attachments[0].content.activities[0].id == 'activity1'"
+            ]
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaMergeTests.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
             var omit = new List<string>
             {
                 "Action_SendActivity.test.dialog",
+                "Action_SendHandoffActivity.test.dialog",
                 "Action_BeginSkill.test.dialog",
                 "Action_BeginSkillEndDialog.test.dialog",
                 "TestScriptTests_OAuthInputLG.test.dialog"


### PR DESCRIPTION
Fixes #5192

## Description
This PR adds unit tests for the [SendHandoffActivity](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendHandoffActivity.cs) class reaching 100% code coverage.

## Specific Changes
- Added Action_SendHandoffActivity.test.dialog script file.
- Added `Action_SendHandoffActivity` in ActionTests class.
- Added schema to the omitted list in `SchemaMergeTests` as it fails with the same [issue](https://stackoverflow.com/questions/63493078/why-does-validation-fail-in-code-but-work-in-newtonsoft-web-validator) that affects _Action_SendActivity.test.dialog_.

## Testing
These images show the new test passing and the coverage for the class.
![image](https://user-images.githubusercontent.com/44245136/123853683-220f9b00-d8f4-11eb-8237-1bb94152f415.png)