### PR TITLE
Disable code coverage reporting for netcoreapp 2.1

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -56,7 +56,7 @@ stages:
     variables:
       BuildConfiguration: Release-Windows
       BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
-      PublishCoverage: true
+      PublishCoverage: false
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml


### PR DESCRIPTION
Fixes #5756 

With both 2.1 and 3.1 reports uploading to coveralls.io, the last to be uploaded overwrites the first. Which one wins is random.