### PR TITLE
Add legacy component registration to DialogStateManager

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs
@@ -46,14 +46,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Memory
             {
                 Configuration = new DialogStateManagerConfiguration();
 
-                // Legacy memory scopes from static ComponentRegistration which is now obsolete.
-                var memoryScopes = ComponentRegistration.Components
-                    .OfType<IComponentMemoryScopes>()
-                    .SelectMany(c => c.GetMemoryScopes())
-                    .ToList();
-
                 // Merge new registrations from turn state
+                var memoryScopes = new List<MemoryScope>();
+
                 memoryScopes.AddRange(dc.Context.TurnState.Get<IEnumerable<MemoryScope>>() ?? Enumerable.Empty<MemoryScope>());
+
+                if (memoryScopes.Count == 0)
+                {
+                    ComponentRegistration.Add(new DialogsComponentRegistration());
+                    
+                    // Legacy memory scopes from static ComponentRegistration which is now obsolete.
+                    memoryScopes = ComponentRegistration.Components
+                        .OfType<IComponentMemoryScopes>()
+                        .SelectMany(c => c.GetMemoryScopes())
+                        .ToList();
+                }
 
                 // Get all of the component memory scopes.
                 foreach (var scope in memoryScopes)


### PR DESCRIPTION
#minor

## Description
Static ComponentRegistration was removed from DialogStateManager in favor of a new registration model that gets memory scopes from the turn state. This change brings back the legacy memory scopes for bots that have not been updated. 

The issue was first reported in [https://github.com/microsoft/BotBuilder-Samples/issues/3194](https://github.com/microsoft/BotBuilder-Samples/issues/3194)