### PR TITLE
Ensure the results of Orchestrator scoring are not readonly

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
             if ((results != null) && results.Any())
             {
                 // Add full recognition result as a 'result' property
-                recognizerResult.Properties.Add(ResultProperty, results);
+                recognizerResult.Properties.Add(ResultProperty, results.ToList());
 
                 var topScore = results[0].Score;
 

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -156,12 +156,12 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
             }
 
             // Score with orchestrator
-            var results = _resolver.Score(text);
+            var results = _resolver.Score(text).ToList();
 
             if ((results != null) && results.Any())
             {
                 // Add full recognition result as a 'result' property
-                recognizerResult.Properties.Add(ResultProperty, results.ToList());
+                recognizerResult.Properties.Add(ResultProperty, results);
 
                 var topScore = results[0].Score;
 

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
             }
 
             // Score with orchestrator
-            var results = _resolver.Score(text).ToList();
+            var results = _resolver.Score(text)?.ToList();
 
             if ((results != null) && results.Any())
             {

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorAdaptiveRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorAdaptiveRecognizerTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
                 Label = new Label { Name = "mockLabel" }
             };
 
-            var mockScore = new List<Result> { mockResult };
+            var mockScore = new List<Result> { mockResult }.AsReadOnly();
             var mockResolver = new MockResolver(mockScore);
             var recognizer = new OrchestratorRecognizer(string.Empty, string.Empty, mockResolver)
             {
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
                 Label = new Label { Name = "mockLabel2" }
             };
 
-            var mockScore = new List<Result> { mockResult1, mockResult2 };
+            var mockScore = new List<Result> { mockResult1, mockResult2 }.AsReadOnly();
             var mockResolver = new MockResolver(mockScore);
             var telemetryClient = new Mock<IBotTelemetryClient>();
             var recognizer = new OrchestratorRecognizer(string.Empty, string.Empty, mockResolver)
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
                 Label = new Label { Name = "FOOBAR", Type = LabelType.Intent },
             };
 
-            var mockScore = new List<Result> { mockResult1 };
+            var mockScore = new List<Result> { mockResult1 }.AsReadOnly();
             var mockResolver = new MockResolver(mockScore);
             var telemetryClient = new Mock<IBotTelemetryClient>();
             var recognizer = new OrchestratorRecognizer(string.Empty, string.Empty, mockResolver)
@@ -153,14 +153,14 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
                 Label = new Label { Name = "mockLabel" }
             };
 
-            var mockScore = new List<Result> { mockResult };
+            var mockScore = new List<Result> { mockResult }.AsReadOnly();
             var mockEntityResult = new Result
             {
                 Score = 0.75,
                 Label = new Label { Name = "mockEntityLabel", Type = LabelType.Entity, Span = new Span { Offset = 17, Length = 7 } },
             };
 
-            var mockEntityScore = new List<Result> { mockEntityResult };
+            var mockEntityScore = new List<Result> { mockEntityResult }.AsReadOnly();
             var mockResolver = new MockResolver(mockScore, mockEntityScore);
             var recognizer = new OrchestratorRecognizer(string.Empty, string.Empty, mockResolver)
             {
@@ -207,7 +207,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
             {
                 mockResult1,
                 mockResult2
-            };
+            }.AsReadOnly();
             var mockResolver = new MockResolver(mockScore);
             var recognizer = new OrchestratorRecognizer(string.Empty, string.Empty, mockResolver)
             {


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/5762

This should maybe be cherry-picked to 4.14, and patched.