### PR TITLE
Remove .NetApp 2.1 framework in Adaptive.Tests project file

### DIFF
--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp21'">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <!-- The MockHttp package isn't signed, so supress the warning. -->


### PR DESCRIPTION
In this PR, the dotnetApp 2.1 framework has been removed. 
Thus, it would only generate dotnetcore 3.1 app in bin folder and only run the tests under dotnetcore 3.1 framework.
![image](https://user-images.githubusercontent.com/17074777/124883578-0c8d2600-e004-11eb-9fc1-30597f8e8a05.png)
<img width="433" alt="Screen Shot 2021-07-08 at 3 50 54 PM" src="https://user-images.githubusercontent.com/17074777/124883877-5aa22980-e004-11eb-93c0-fcc0a2ea6fae.png">

#minor
