### PR TITLE
fix: Fix the case issue that would block the building in linux system

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -61,7 +61,7 @@
   <ItemGroup>
     <ProjectReference Include="..\integration\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core\Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj" />
     <ProjectReference Include="..\integration\Microsoft.Bot.Builder.Integration.AspNet.Core\Microsoft.Bot.Builder.Integration.AspNet.Core.csproj" />
-    <ProjectReference Include="..\Microsoft.Bot.Builder.AI.Luis\Microsoft.Bot.Builder.AI.Luis.csproj" />
+    <ProjectReference Include="..\Microsoft.Bot.Builder.AI.LUIS\Microsoft.Bot.Builder.AI.Luis.csproj" />
     <ProjectReference Include="..\Microsoft.Bot.Builder.AI.QnA\Microsoft.Bot.Builder.AI.QnA.csproj" />
     <ProjectReference Include="..\Microsoft.Bot.Builder.ApplicationInsights\Microsoft.Bot.Builder.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Microsoft.Bot.Builder.Azure\Microsoft.Bot.Builder.Azure.csproj" />


### PR DESCRIPTION
#minor
Small fix.
Change `Microsoft.Bot.Builder.AI.Luis` folder name to `Microsoft.Bot.Builder.AI.LUIS`

Attach the original error in ubuntu:
```
 error NU1603: Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime depends on Microsoft.Bot.Builder.AI.Luis (>= 4.11.0-local) but Microsoft.Bot.Builder.AI.Luis 4.11.0-local was not found. An approximate best match of Microsoft.Bot.Builder.AI.Luis 4.11.0 was resolved.
```