### PR TITLE
Added dialogs property of AdaptiveDialog to the hidden list

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Microsoft.AdaptiveDialog.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Microsoft.AdaptiveDialog.uischema
@@ -12,7 +12,8 @@
             "triggers",
             "generator",
             "selector",
-            "schema"
+            "schema",
+            "dialogs"
         ],
         "properties": {
             "recognizer": {


### PR DESCRIPTION
Fixes #5566 
## Description
Hide the dialogs property of AdaptiveDialog in the Composer UI by adding it to the hidden list in the AdaptiveDialog.uischema file. 

Note that as of today this change will not be used by Composer, it is using a local copy of a uischema file that drives it's behavior, so another Issue and PR were created for this in the Composer repo:

[AdaptiveDialog has dialogs property added in declarative schema and that property should be hidden.](https://github.com/microsoft/BotFramework-Composer/issues/8387)

[fix: Added dialogs to hidden list for AdaptiveDialog in index.ts file](https://github.com/microsoft/BotFramework-Composer/pull/8388)

The change was also added here so that once Composer stops using the local file this change will already be reflected in the SDK AdaptiveDialog.uischema file.

## Specific Changes
Added "dialogs" property to the AdaptiveDialog.uischema file.

## Testing
This can't be tested yet today as Composer is not using the properties in the SDK uischema file yet, but the change was done in a consistent manner as the other hidden properties in the AdaptiveDialog.uischema were also done.