### PR TITLE
check whether Metadata contains Timestamp

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobTranscriptStore.cs
@@ -180,6 +180,11 @@ namespace Microsoft.Bot.Builder.Azure
 
                 foreach (var blob in segment.Results.Cast<CloudBlockBlob>())
                 {
+                    if (!blob.Metadata.ContainsKey("Timestamp"))
+                    {
+                        continue;
+                    }
+
                     if (DateTime.Parse(blob.Metadata["Timestamp"], CultureInfo.InvariantCulture).ToUniversalTime() >= startDate)
                     {
                         if (continuationToken != null)


### PR DESCRIPTION
Fixes #5787 

## Description
We check whether `blob.Metadata.ContainsKey("Timestamp")` before calling `blob.Metadata["Timestamp"]` to avoid key not found exception.
Please let me know if the "skip if not exist" behavior is good or not.

## Specific Changes
  - skip if `blob.Metadata.ContainsKey("Timestamp")` is False in GetTranscriptActivitiesAsync
