### PR TITLE
Streaming: Surface exceptions like other paths to allow error handling in upper layers.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Bot.Builder.Streaming
             }
             else
             {
-                throw new Exception($"Failed tosend request through streaming transport. Status code: {serverResponse.StatusCode}.");
+                throw new Exception($"Failed to send request through streaming transport. Status code: {serverResponse.StatusCode}.");
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/5793

When we send outgoing activities in the adapter for http flows, if they fail, we let the exception get thrown so that it reaches the top level adapter. Cloud adapter+  streaming also does not catch, so that errors flow to the handlers. 

However, outgoing activities on streaming when using the BotFrameworkHttpAdapter, we do catch the exceptions, log them and return null. The result is negative in a number of ways:

1- Errors are swallowed 
2- Callers cannot retry or handler errors in code
3- Developers expect OnError trigger to get called but when using streaming it does not (OneVoice ran in to this)

This change makes all outgoing activities treat errors consistently (by not hiding them) and solve the problems above.