### PR TITLE
feat: add MultiplexingAdapter

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -24,9 +24,9 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook
 {
-     /// <summary>
-     /// BotAdapter to allow for handling Facebook App payloads and responses via the Facebook API.
-     /// </summary>
+    /// <summary>
+    /// BotAdapter to allow for handling Facebook App payloads and responses via the Facebook API.
+    /// </summary>
     public class FacebookAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
         private const string HubModeSubscribe = "subscribe";
@@ -190,6 +190,12 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
             {
                 await RunPipelineAsync(context, logic, cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        /// <inheritdoc/>
+        public override async Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            await ContinueConversationAsync(reference, callback, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -245,6 +245,12 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
             }
         }
 
+        /// <inheritdoc/>
+        public override async Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            await ContinueConversationAsync(reference, callback, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Accept an incoming webhook request and convert it into a TurnContext which can be processed by the bot's logic.
         /// </summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -234,6 +234,12 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
             }
         }
 
+        /// <inheritdoc/>
+        public override async Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            await ContinueConversationAsync(reference, callback, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Sends a proactive message from the bot to a conversation.
         /// </summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -195,6 +195,12 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
             }
         }
 
+        /// <inheritdoc/>
+        public override async Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            await ContinueConversationAsync(reference, callback, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Sends a proactive message from the bot to a conversation.
         /// </summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Adapters/MultiplexingAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Adapters/MultiplexingAdapter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// </remarks>
     public class MultiplexingAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
-        private readonly Dictionary<string, IBotFrameworkHttpAdapter> _adapters = new ();
+        private readonly Dictionary<string, IBotFrameworkHttpAdapter> _adapters = new Dictionary<string, IBotFrameworkHttpAdapter>();
         private readonly IConfiguration _configuration;
         private readonly ILogger _logger;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Adapters/MultiplexingAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Adapters/MultiplexingAdapter.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+{
+    /// <summary>
+    /// A multiplexing bot adapter that can select the appropriate IbotFrameworkHttpAdapter based on the incoming
+    /// request's route or the activity's ChannelId.
+    /// </summary>
+    /// <remarks>
+    /// To use this adapter properly, the api/{route} must match the Activity.ChannelId to map the appropriate adapter.
+    /// Otherwise, you may override the BuildAdapterMap() method.
+    /// </remarks>
+    public class MultiplexingAdapter : BotAdapter, IBotFrameworkHttpAdapter
+    {
+        private readonly Dictionary<string, IBotFrameworkHttpAdapter> _adapters = new ();
+        private readonly IConfiguration _configuration;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiplexingAdapter"/> class.
+        /// </summary>
+        /// <param name="configuration">An <see cref="IConfiguration"/> instance.</param>
+        /// <param name="adapters">The array of adapters used in multiplexing.</param>
+        /// /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        public MultiplexingAdapter(IConfiguration configuration, IEnumerable<IBotFrameworkHttpAdapter> adapters, ILogger logger = null)
+        {
+            _configuration = configuration;
+            _logger = logger ?? NullLogger.Instance;
+
+            Initialize(adapters);
+        }
+
+        /// <inheritdoc/>
+        public Task ProcessAsync(HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default)
+        {
+            var routeAsChannelId = httpRequest.Path.ToString().Split('/').LastOrDefault();
+            return (GetAppropriateAdapter(routeAsChannelId) as IBotFrameworkHttpAdapter).ProcessAsync(httpRequest, httpResponse, bot, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(turnContext.Activity.ChannelId).DeleteActivityAsync(turnContext, reference, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(turnContext.Activity.ChannelId).SendActivitiesAsync(turnContext, activities, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(turnContext.Activity.ChannelId).UpdateActivityAsync(turnContext, activity, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ContinueConversationAsync(string botId, Activity continuationActivity, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(continuationActivity.ChannelId).ContinueConversationAsync(botId, continuationActivity, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ContinueConversationAsync(string botId, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(reference.ChannelId).ContinueConversationAsync(botId, reference, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, Activity continuationActivity, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(continuationActivity.ChannelId).ContinueConversationAsync(claimsIdentity, continuationActivity, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, Activity continuationActivity, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(continuationActivity.ChannelId).ContinueConversationAsync(claimsIdentity, continuationActivity, audience, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(reference.ChannelId).ContinueConversationAsync(claimsIdentity, reference, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, ConversationReference reference, string audience, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(reference.ChannelId).ContinueConversationAsync(claimsIdentity, reference, audience, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task CreateConversationAsync(string botAppId, string channelId, string serviceUrl, string audience, ConversationParameters conversationParameters, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(channelId).CreateConversationAsync(botAppId, channelId, serviceUrl, audience, conversationParameters, callback, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override Task<InvokeResponse> ProcessActivityAsync(ClaimsIdentity claimsIdentity, Activity activity, BotCallbackHandler callback, CancellationToken cancellationToken)
+        {
+            return GetAppropriateAdapter(activity.ChannelId).ProcessActivityAsync(claimsIdentity, activity, callback, cancellationToken);
+        }
+
+        /// <summary>
+        /// Maps the incoming ChannelId or route (api/{route}) to the correct adapter. By default, this uses the AdapterSettings specified in appsettings.json.
+        /// Override this method to customize the mapping behavior.
+        /// </summary>
+        /// <param name="adapters">The adapters to map the routes to.</param>
+        protected virtual void BuildAdapterMap(IEnumerable<IBotFrameworkHttpAdapter> adapters)
+        {
+            var adapterSettings = _configuration.GetSection(AdapterSettings.AdapterSettingsKey).Get<List<AdapterSettings>>() ?? new List<AdapterSettings>();
+            var messagesAdapter = adapterSettings.FirstOrDefault(s => s.Route == "messages");
+            if (messagesAdapter == null)
+            {
+                adapterSettings.Add(AdapterSettings.CoreBotAdapterSettings);
+            }
+
+            foreach (var adapter in adapters ?? throw new ArgumentNullException(nameof(adapters)))
+            {
+                var settings = adapterSettings.FirstOrDefault(s => s.Enabled && s.Type == adapter.GetType().FullName.Split('.').Last());
+
+                if (settings != null)
+                {
+                    // Map route/ChannelId to adapter.
+                    _adapters.Add(settings.Route, adapter);
+
+                    // Add the adapter handling the messages route as the default adapter.
+                    if (settings.Route == "messages")
+                    {
+                        _adapters.Add("default", adapter);
+                    }
+                }
+            }
+        }
+
+        private void Initialize(IEnumerable<IBotFrameworkHttpAdapter> adapters)
+        {
+            BuildAdapterMap(adapters);
+        }
+
+        private BotAdapter GetAppropriateAdapter(string channelId)
+        {
+            if (_adapters.TryGetValue(channelId, out var adapter))
+            {
+                return adapter as BotAdapter;
+            }
+
+            if (_adapters.TryGetValue("default", out var defaultAdapter))
+            {
+                _logger.LogWarning($"Unable to find router for channelId {channelId}. Using default adapter {nameof(defaultAdapter)}. You may need to ensure your appsettings.json has an adapter with the Route property that matches the ChannelId of the adapter.");
+                return defaultAdapter as BotAdapter;
+            }
+
+            throw new ArgumentException($"No adapter available for channelId/route '{channelId}' and no default adapter exists");
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs
@@ -101,7 +101,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions
             services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
 
             // Needed for SkillsHttpClient which depends on BotAdapter
-            services.AddSingleton<BotAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
+            services.AddSingleton<MultiplexingAdapter>();
+            services.AddSingleton<BotAdapter>(sp => sp.GetRequiredService<MultiplexingAdapter>());
 
             // Runtime set up
             services.AddBotRuntimeSkills(configuration);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Adapters/MultiplexingAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Adapters/MultiplexingAdapterTests.cs
@@ -1,0 +1,231 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.Runtime.Tests;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.Adapters
+{
+    public class MultiplexingAdapterTests
+    {
+        [Fact]
+        public void MultiplexingAdapterRegistered()
+        {
+            // Setup
+            IServiceCollection services = new ServiceCollection();
+            IConfiguration configuration = new ConfigurationBuilder().Build();
+
+            // We do this here since in asp.net core world this is done for us, but here we need to do it manually.
+            services.AddSingleton(configuration);
+
+            // Test
+            services.AddBotRuntime(configuration);
+
+            // Assert
+            var provider = services.BuildServiceProvider();
+
+            // Core adapter should be register for as IBotFrameworkHttpAdapter for controllers.
+            Assertions.AssertService<IBotFrameworkHttpAdapter, CoreBotAdapter>(services, provider, ServiceLifetime.Singleton);
+
+            // Multiplexing adapter should be register as BotAdapter for SkillHandler.
+            Assertions.AssertService<BotAdapter, MultiplexingAdapter>(services, provider, ServiceLifetime.Singleton);
+        }
+
+        [Fact]
+        public async Task ProperlyRoutesPathBasedOnAdapterSettings()
+        {
+            // Setup
+            IServiceCollection services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("Adapters/Resources/appSettingsSomeRoute.json")
+                .Build();
+
+            var someRouteAdapter = new SomeRouteAdapter();
+            var adapter = new MultiplexingAdapter(configuration, new List<IBotFrameworkHttpAdapter> { someRouteAdapter });
+            
+            var req = new Mock<HttpRequest>();
+            req.Setup(mock => mock.Path).Returns("/api/someRoute");
+            var res = new Mock<HttpResponse>().Object;
+            var bot = new Mock<IBot>().Object;
+
+            // Test
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+        }
+
+        [Fact]
+        public async Task ProperlyRoutesPathWithMultipleAdaptersAndDefaults()
+        {
+            // Setup
+            IServiceCollection services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("Adapters/Resources/appSettingsMultipleRoutes.json")
+                .Build();
+
+            var someRouteAdapter = new SomeRouteAdapter();
+            var someOtherRouteAdapter = new SomeOtherRouteAdapter();
+            var defaultAndMessagesAdapter = new DefaultAndMessagesAdapter();
+            var adapter = new MultiplexingAdapter(configuration, new List<IBotFrameworkHttpAdapter> { someRouteAdapter, someOtherRouteAdapter, defaultAndMessagesAdapter });
+
+            var req = new Mock<HttpRequest>();
+            req.Setup(mock => mock.Path).Returns("/api/someRoute");
+            var res = new Mock<HttpResponse>().Object;
+            var bot = new Mock<IBot>().Object;
+
+            // Test api/someRoute
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(0, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(0, defaultAndMessagesAdapter.ProcessCalls);
+
+            // Test api/someOtherRoute
+            req.Setup(mock => mock.Path).Returns("/api/someOtherRoute");
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(1, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(0, defaultAndMessagesAdapter.ProcessCalls);
+
+            // Test api/messages
+            req.Setup(mock => mock.Path).Returns("/api/messages");
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(1, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(1, defaultAndMessagesAdapter.ProcessCalls);
+
+            // Test api/unlistedRoute
+            req.Setup(mock => mock.Path).Returns("/api/unlistedRoute");
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(1, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(2, defaultAndMessagesAdapter.ProcessCalls);
+        }
+
+        [Fact]
+        public async void OverriddenBuildAdapterMapAllowsCustomAdapterMapping()
+        {
+            // Setup
+            IServiceCollection services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("Adapters/Resources/appSettingsMultipleRoutes.json")
+                .Build();
+
+            var someRouteAdapter = new SomeRouteAdapter();
+            var someOtherRouteAdapter = new SomeOtherRouteAdapter();
+            var defaultAndMessagesAdapter = new DefaultAndMessagesAdapter();
+            var adapter = new OverriddenMultiplexingAdapter(configuration, new List<IBotFrameworkHttpAdapter> { someRouteAdapter, someOtherRouteAdapter, defaultAndMessagesAdapter });
+
+            var req = new Mock<HttpRequest>();
+            req.Setup(mock => mock.Path).Returns("/api/someRoute");
+            var res = new Mock<HttpResponse>().Object;
+            var bot = new Mock<IBot>().Object;
+
+            // Test api/someRoute
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(0, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(0, defaultAndMessagesAdapter.ProcessCalls);
+
+            // Test api/someOtherRoute
+            req.Setup(mock => mock.Path).Returns("/api/someOtherRoute");
+            var ex = await Assert.ThrowsAsync<System.ArgumentException>(async () => await adapter.ProcessAsync(req.Object, res, bot));
+            Assert.Equal("No adapter available for channelId/route 'someOtherRoute' and no default adapter exists", ex.Message);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(0, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(0, defaultAndMessagesAdapter.ProcessCalls);
+
+            // Test api/messages
+            req.Setup(mock => mock.Path).Returns("/api/messages");
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(0, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(1, defaultAndMessagesAdapter.ProcessCalls);
+
+            // Test api/unlistedRoute
+            req.Setup(mock => mock.Path).Returns("/api/unlistedRoute");
+            await adapter.ProcessAsync(req.Object, res, bot);
+
+            // Assert
+            Assert.Equal(1, someRouteAdapter.ProcessCalls);
+            Assert.Equal(0, someOtherRouteAdapter.ProcessCalls);
+            Assert.Equal(2, defaultAndMessagesAdapter.ProcessCalls);
+        }
+
+        internal class SomeRouteAdapter : BotAdapter, IBotFrameworkHttpAdapter
+        {
+            internal SomeRouteAdapter()
+            {
+                ProcessCalls = 0;
+            }
+
+            public int ProcessCalls { get; private set; }
+
+            public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public Task ProcessAsync(HttpRequest httpRequest, HttpResponse httpResponse, IBot bot, CancellationToken cancellationToken = default)
+            {
+                ProcessCalls++;
+                return Task.FromResult(nameof(SomeRouteAdapter));
+            }
+
+            public override Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, Activity[] activities, CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, Activity activity, CancellationToken cancellationToken)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        internal class SomeOtherRouteAdapter : SomeRouteAdapter 
+        {
+        }
+
+        internal class DefaultAndMessagesAdapter : SomeRouteAdapter
+        {
+        }
+
+        internal class OverriddenMultiplexingAdapter : MultiplexingAdapter
+        {
+            internal OverriddenMultiplexingAdapter(IConfiguration configuration, IEnumerable<IBotFrameworkHttpAdapter> adapters)
+                : base(configuration, adapters)
+            {
+            }
+
+            protected override void BuildAdapterMap(IEnumerable<IBotFrameworkHttpAdapter> adapters)
+            {
+                Adapters.Add("someRoute", adapters.First());
+                Adapters.Add("messages", adapters.Last());
+                Adapters.Add("unlistedRoute", adapters.Last());
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Adapters/Resources/appSettingsMultipleRoutes.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Adapters/Resources/appSettingsMultipleRoutes.json
@@ -1,0 +1,24 @@
+﻿{
+  "runtimeSettings": {
+    "adapters": [
+      {
+        "name": "SomeRouteAdapter",
+        "type": "SomeRouteAdapter",
+        "route": "someRoute",
+        "enabeld": true
+      },
+      {
+        "name": "SomeOtherRouteAdapter",
+        "type": "SomeOtherRouteAdapter",
+        "route": "someOtherRoute",
+        "enabeld": true
+      },
+      {
+        "name": "DefaultAndMessagesAdapter",
+        "type": "DefaultAndMessagesAdapter",
+        "route": "messages",
+        "enabeld": true
+      }
+    ]
+  }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Adapters/Resources/appSettingsSomeRoute.json
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Adapters/Resources/appSettingsSomeRoute.json
@@ -1,0 +1,12 @@
+﻿{
+  "runtimeSettings": {
+    "adapters": [
+      {
+        "name": "SomeRouteAdapter",
+        "type": "SomeRouteAdapter",
+        "route": "someRoute",
+        "enabeld": true
+      }
+    ]
+  }
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/AdapterRegistrationTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Extensions/AdapterRegistrationTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,9 +33,6 @@ namespace Microsoft.Bot.Builder.Runtime.Tests.Extensions
 
             // Core adapter should be register for as IBotFrameworkHttpAdapter for controllers
             Assertions.AssertService<IBotFrameworkHttpAdapter, CoreBotAdapter>(services, provider, ServiceLifetime.Singleton);
-
-            // Core adapter should be register for as BotAdapter for Skill HttpClient
-            Assertions.AssertService<BotAdapter, CoreBotAdapter>(services, provider, ServiceLifetime.Singleton);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -32,6 +33,12 @@
 
   <ItemGroup>
     <None Update="Extensions\ConfigurationBuilderExtensionsFiles\**\*.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Adapters\Resources\**\*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Fixes #5606 

## Description

Adds a MultiplexingAdapter which allows several 3P adapters (Slack, Facebook, etc) to be used easily, and to work with skills.

See issue linked above for why 3P Adapters weren't previously working with skills.

## Specific Changes

  - Add `MultiplexingAdapter` class
  - Add `ContinueConversation()` overload used by `SkillHandlerImpl` to 3P adapters
  - Use MutliplexingAdapter by default in Runtime

## Scenarios Tested

* All adapters
* Runtime and non-runtime bots
* With mix of 3P adapters and 3P channels
* Proactive
* Skills

## To Use in a Bot

### Controller

```csharp
namespace Microsoft.BotBuilderSamples
{
    [ApiController]
	// It's important to put the `Route()` here instead of above PostAsync() so that routing can still be passed off to SkillController, if needed.
    [Route("api/{route}")]
    public class BotController : ControllerBase
    {
        // I *think* this needs to be changed from IBotFrameworkHttpAdapter (like used in the samples)
        // The default IBotFrameworkHttpAdapter is usually AdapterWithErrorHandler or CloudAdapter, but
        // there may be another way to set this up. Just haven't had time to toy with ideas here, yet.
        private readonly MultiplexingAdapter _adapter;
        private readonly IBot _bot;

        public BotController(MultiplexingAdapter adapter, IBot bot)
        {
            _adapter = adapter;
            _bot = bot;
        }

        // We cannot have `PostAsync(string route)` as done in `Components/generators` because it removes or
        // prematurely reads Request.Body from Twilio messages. I was unable to find a workaround other than
        // removing the `route` argument from this method.
        public async Task PostAsync()
        {
            await _adapter.ProcessAsync(Request, Response, _bot).ConfigureAwait(false);
        }
    }
}

```

### Startup.cs for non-Runtime bots

```csharp
services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>();
services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>();
services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>();
services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>();

services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();

// Note that because MultiplexingAdapter adds all the adapters through DI, it MUST come last.
// We register it as the `BotAdapter` for skills.
services.AddSingleton<MultiplexingAdapter>();
services.AddSingleton<BotAdapter>(sp => sp.GetRequiredService<MultiplexingAdapter>());
```

### Startup.cs for Runtime bots

```csharp
services.AddSingleton<IBotFrameworkHttpAdapter, SlackAdapter>();
services.AddSingleton<IBotFrameworkHttpAdapter, FacebookAdapter>();
services.AddSingleton<IBotFrameworkHttpAdapter, WebexAdapter>();
services.AddSingleton<IBotFrameworkHttpAdapter, TwilioAdapter>();

// MultiplexingAdapter is added to by inside `AddBotRuntime` so we just need to make sure we add all of the other adapters first.
services.AddBotRuntime(Configuration);
```

### appsettings.json

```json
"runtimeSettings": {
    "adapters": [
      {
        "name": "AdapterWithErrorHandler",
        "type": "AdapterWithErrorHandler",
        "route": "messages",
        "enabeld": true
      },
      {
        "name": "AdapterWithErrorHandler",
        "type": "AdapterWithErrorHandler",
        "route": "notify",
        "enabeld": true
      },
      {
        "name": "SlackAdapter",
        "type": "SlackAdapter",
        "route": "slack",
        "enabeld": true
      },
      {
        "name": "FacebookAdapter",
        "type": "FacebookAdapter",
        "route": "facebook",
        "enabeld": true
      },
      {
        "name": "TwilioAdapter",
        "type": "TwilioAdapter",
        "route": "twilio-sms",
        "enabeld": true
      },
      {
        "name": "WebexAdapter",
        "type": "WebexAdapter",
        "route": "webex",
        "enabeld": true
      }
    ]
  },
  "SlackVerificationToken": "<>",
  "SlackBotToken": "<>",
  "SlackClientSigningSecret": "<>",
  "FacebookVerifyToken": "<>",
  "FacebookAppSecret": "<>",
  "FacebookAccessToken": "<>",
  "TwilioNumber": "<>",
  "TwilioAccountSid": "<>",
  "TwilioAuthToken": "<>",
  "TwilioValidationUrl": "https://<>/api/twilio-sms",
  "WebexPublicAddress": "https://<>/api/webex",
  "WebexAccessToken": "<>",
  "WebexSecret": "<>",
  "WebexWebhookName": "<>",
```