### PR TITLE
feat: add support for meeting participants added/removed events

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -82,10 +82,10 @@ namespace Microsoft.Bot.Builder.Teams
 
                         case "task/submit":
                             return CreateInvokeResponse(await OnTeamsTaskModuleSubmitAsync(turnContext, SafeCast<TaskModuleRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
-                        
+
                         case "tab/fetch":
                             return CreateInvokeResponse(await OnTeamsTabFetchAsync(turnContext, SafeCast<TabRequest>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
-                        
+
                         case "tab/submit":
                             return CreateInvokeResponse(await OnTeamsTabSubmitAsync(turnContext, SafeCast<TabSubmit>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
 
@@ -638,7 +638,7 @@ namespace Microsoft.Bot.Builder.Teams
         {
             return Task.CompletedTask;
         }
-        
+
         /// <summary>
         /// Invoked when a Channel Restored event activity is received from the connector.
         /// Channel Restored correspond to the user restoring a previously deleted channel.
@@ -759,6 +759,10 @@ namespace Microsoft.Bot.Builder.Teams
                         return OnTeamsMeetingStartAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingStartEventDetails>(), turnContext, cancellationToken);
                     case "application/vnd.microsoft.meetingEnd":
                         return OnTeamsMeetingEndAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingEndEventDetails>(), turnContext, cancellationToken);
+                    case "application/vnd.microsoft.meetingParticipantsAdded":
+                        return OnTeamsMeetingParticipantsAddedAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingParticipantsAddedEventDetails>(), turnContext, cancellationToken);
+                    case "application/vnd.microsoft.meetingParticipantsRemoved":
+                        return OnTeamsMeetingParticipantsRemovedAsync(JObject.FromObject(turnContext.Activity.Value).ToObject<MeetingParticipantsRemovedEventDetails>(), turnContext, cancellationToken);
                 }
             }
 
@@ -789,6 +793,34 @@ namespace Microsoft.Bot.Builder.Teams
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         protected virtual Task OnTeamsMeetingEndAsync(MeetingEndEventDetails meeting, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a Teams Participants Added event activity is received from the connector.
+        /// Override this in a derived class to provide logic for when meeting participants are added.
+        /// </summary>
+        /// <param name="meeting">The details of the meeting.</param>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMeetingParticipantsAddedAsync(MeetingParticipantsAddedEventDetails meeting, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a Teams Participants Removed event activity is received from the connector.
+        /// Override this in a derived class to provide logic for when meeting participants are removed.
+        /// </summary>
+        /// <param name="meeting">The details of the meeting.</param>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMeetingParticipantsRemovedAsync(MeetingParticipantsRemovedEventDetails meeting, ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsAddedEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsAddedEventDetails.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specific details of a Teams meeting participants added event.
+    /// </summary>
+    public partial class MeetingParticipantsAddedEventDetails : MeetingEventDetails
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsAddedEventDetails"/> class.
+        /// </summary>
+        public MeetingParticipantsAddedEventDetails()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsAddedEventDetails"/> class.
+        /// </summary>
+        /// <param name="id">The meeting's Id, encoded as a BASE64 string.</param>
+        /// <param name="joinUrl">The URL used to join the meeting.</param>
+        /// <param name="title">The title of the meeting.</param>
+        /// <param name="meetingType">The meeting's type.</param>
+        /// <param name="participantsAdded">The added participant accounts.</param>
+        public MeetingParticipantsAddedEventDetails(
+            string id,
+            Uri joinUrl = null,
+            string title = null,
+            string meetingType = "Scheduled",
+            IList<TeamsChannelAccount> participantsAdded = default)
+            : base(id, joinUrl, title, meetingType)
+        {
+            ParticipantsAdded = participantsAdded;
+
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the added meeting participants.
+        /// </summary>
+        /// <value>
+        /// The added participant accounts.
+        /// </value>
+        [JsonProperty(PropertyName = "ParticipantsAdded")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
+        public IList<TeamsChannelAccount> ParticipantsAdded { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsRemovedEventDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingParticipantsRemovedEventDetails.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specific details of a Teams meeting participants removed event.
+    /// </summary>
+    public partial class MeetingParticipantsRemovedEventDetails : MeetingEventDetails
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsRemovedEventDetails"/> class.
+        /// </summary>
+        public MeetingParticipantsRemovedEventDetails()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingParticipantsRemovedEventDetails"/> class.
+        /// </summary>
+        /// <param name="id">The meeting's Id, encoded as a BASE64 string.</param>
+        /// <param name="joinUrl">The URL used to join the meeting.</param>
+        /// <param name="title">The title of the meeting.</param>
+        /// <param name="meetingType">The meeting's type.</param>
+        /// <param name="participantsRemoved">The removed participant accounts.</param>
+        public MeetingParticipantsRemovedEventDetails(
+            string id,
+            Uri joinUrl = null,
+            string title = null,
+            string meetingType = "Scheduled",
+            IList<TeamsChannelAccount> participantsRemoved = default)
+            : base(id, joinUrl, title, meetingType)
+        {
+            ParticipantsRemoved = participantsRemoved;
+
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the removed meeting participants.
+        /// </summary>
+        /// <value>
+        /// The removed participant accounts.
+        /// </value>
+        [JsonProperty(PropertyName = "ParticipantsRemoved")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
+        public IList<TeamsChannelAccount> ParticipantsRemoved { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsAddedEventDetailsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsAddedEventDetailsTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MeetingParticipantsAddedEventDetailsTests
+    {
+        [Fact]
+        public void MeetingParticipantsAddedEventDetailsInits()
+        {
+            // Arrange
+            var meetingId = "meetingId";
+            var meetingJoinUrl = new Uri("http://meetingJoinUrl");
+            var meetingTitle = "meetingTitle";
+            var meetingType = "meetingType";
+            var participant = new TeamsChannelAccount("id", "name", "givenName", "surname", "email", "userPrincipalName");
+            var participantsAdded = new List<TeamsChannelAccount>() { participant };
+
+            // Act
+            var meeting = new MeetingParticipantsAddedEventDetails(meetingId, meetingJoinUrl, meetingTitle, meetingType, participantsAdded);
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsAddedEventDetails>(meeting);
+            Assert.Equal(meetingId, meeting.Id);
+            Assert.Equal(meetingJoinUrl, meeting.JoinUrl);
+            Assert.Equal(meetingTitle, meeting.Title);
+            Assert.Equal(meetingType, meeting.MeetingType);
+            Assert.StrictEqual(participantsAdded, meeting.ParticipantsAdded);
+        }
+
+        [Fact]
+        public void MeetingParticipantsAddedEventDetailsInitsWithNoArgs()
+        {
+            // Act
+            var meeting = new MeetingParticipantsAddedEventDetails();
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsAddedEventDetails>(meeting);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsRemovedEventDetailsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/MeetingParticipantsRemovedEventDetailsTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class MeetingParticipantsRemovedEventDetailsTests
+    {
+        [Fact]
+        public void MeetingParticipantsRemovedEventDetailsInits()
+        {
+            // Arrange
+            var meetingId = "meetingId";
+            var meetingJoinUrl = new Uri("http://meetingJoinUrl");
+            var meetingTitle = "meetingTitle";
+            var meetingType = "meetingType";
+            var participant = new TeamsChannelAccount("id", "name", "givenName", "surname", "email", "userPrincipalName");
+            var participantsRemoved = new List<TeamsChannelAccount>() { participant };
+
+            // Act
+            var meeting = new MeetingParticipantsRemovedEventDetails(meetingId, meetingJoinUrl, meetingTitle, meetingType, participantsRemoved);
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsRemovedEventDetails>(meeting);
+            Assert.Equal(meetingId, meeting.Id);
+            Assert.Equal(meetingJoinUrl, meeting.JoinUrl);
+            Assert.Equal(meetingTitle, meeting.Title);
+            Assert.Equal(meetingType, meeting.MeetingType);
+            Assert.StrictEqual(participantsRemoved, meeting.ParticipantsRemoved);
+        }
+
+        [Fact]
+        public void MeetingParticipantsRemovedEventDetailsInitsWithNoArgs()
+        {
+            // Act
+            var meeting = new MeetingParticipantsRemovedEventDetails();
+
+            // Assert
+            Assert.NotNull(meeting);
+            Assert.IsType<MeetingParticipantsRemovedEventDetails>(meeting);
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Adds support to TeamsActivityHandler for meeting participants added/removed events.

## Specific Changes
<!-- Please list the changes in a concise manner. -->
- Added support for 2 new activity types - `application/vnd.microsoft.meetingParticipantsAdded` and `application/vnd.microsoft.meetingParticipantsRemoved`
- Added functions to register handlers for when teams meeting participants are added/removed.
- Added unit tests.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
To be added.