### PR TITLE
Create pipelines to unlist deprecated packages on 4 feeds

### DIFF
--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -73,14 +73,14 @@ foreach ($packageName in $packageNames) {
         #$url = "$feedApiUrl$packageName/versions/$version";
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version";
-            "npm unpublish $packageName@$version";
-            npm unpublish $packageName@$version
+            "npm unpublish $packageName@v$version";
+            npm unpublish $packageName@v$version
             #Invoke-RestMethod -Uri $url -Method Delete -ContentType "application/json"
             #"nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
             #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive;
         } else {
             "What-if: Unlisting $version"
-            "npm unpublish $packageName@$version";
+            "npm unpublish $packageName@v$version";
             #"nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
         }
     }

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -69,11 +69,11 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version"
-            "npm unpublish $packageName@$version --registry=$feedApiUrl"
-            npm unpublish $packageName@$version --registry=$feedApiUrl
+            "npm unpublish $packageName@$version"
+            npm unpublish $packageName@$version
         } else {
             "What-if: Unlisting $version"
-            "npm unpublish $packageName@$version --registry=$feedApiUrl"
+            "npm unpublish $packageName@$version"
         }
     }
 }

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -50,7 +50,8 @@ foreach ($packageName in $packageNames) {
     #$package.versions | Select -Last 30;
 
     [string]$unsortedVersions = $package.versions | %{ $_ + "`r`n" };
-
+    "----unsortedVersions--------------------------"
+    $unsortedVersions
     $sortedVersions = Sort-Versions $unsortedVersions;
 
     #Get versions equal to or older than $versionToUnlist

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -67,17 +67,21 @@ foreach ($packageName in $packageNames) {
     "------------------------";
 
     # Do the unlisting
+    npm config set registry https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/
+
     foreach ($version in $versionsToUnlist) {
         #$url = "$feedApiUrl$packageName/versions/$version";
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version";
-            #npm unpublish $packageName@$version
+            "npm unpublish $packageName@$version";
+            npm unpublish $packageName@$version
             #Invoke-RestMethod -Uri $url -Method Delete -ContentType "application/json"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
-            nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive;
+            #"nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
+            #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive;
         } else {
             "What-if: Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
+            "npm unpublish $packageName@$version";
+            #"nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
         }
     }
 }

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -55,10 +55,11 @@ foreach ($packageName in $packageNames) {
         $sortedVersions = Sort-Versions $unsortedVersions;
 
         #Set index to $versionToUnlist
-        $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+        #$index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+        $index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
 
         if ($index -ne $Null) {
-            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[0] + 1);
         }
     } else {
         [string[]]$versionsToUnlist = $packageInfo.versions.Where({$_ -eq $versionToUnlist});

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -12,7 +12,7 @@ param
 )
 
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
-$feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/api/v3/index.json";
+$feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/npm/";
 
 Function Sort-Versions
 {
@@ -50,6 +50,7 @@ foreach ($packageName in $packageNames) {
     #$package.versions | Select -Last 30;
 
     [string]$unsortedVersions = $package.versions | %{ $_ + "`r`n" };
+
     $sortedVersions = Sort-Versions $unsortedVersions;
 
     #Get versions equal to or older than $versionToUnlist
@@ -68,11 +69,11 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
-            nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
+            "npm unpublish $packageName@$version --registry=$feedApiUrl"
+            npm unpublish $packageName@$version --registry=$feedApiUrl
         } else {
             "What-if: Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
+            "npm unpublish $packageName@$version --registry=$feedApiUrl"
         }
     }
 }

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -1,6 +1,6 @@
 #
 # Shows but cannot unlist npm package versions on MyGet.org lower than or equal to $versionToUnlist.
-# Cannot unlist because per MyGet support, "we do not support the npm unpublish command".
+# Cannot unlist because per MyGet support, "we do not support the npm unpublish command". Unlisting must be done in the UI.
 # 
 param
 ( 

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -34,6 +34,8 @@ Function Sort-Versions
 }
 
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
+"----result--------------------------"
+$result
 
 "unlistPackagesForReal: " + $unlistPackagesForReal;
 "Target version: " + $versionToUnlist;
@@ -46,6 +48,8 @@ foreach ($packageName in $packageNames) {
     "========================";
 
     $package = $result.packages | Where-Object {$_.id -eq $packageName};
+    "----package--------------------------"
+    $package
 
     #$package.versions | Select -Last 30;
 

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -67,13 +67,16 @@ foreach ($packageName in $packageNames) {
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
+        #$url = "$feedApiUrl$packageName/versions/$version";
         if ($unlistPackagesForReal -eq "true") {
-            "Unlisting $version"
-            "npm unpublish $packageName@$version"
-            npm unpublish $packageName@$version
+            "Unlisting $version";
+            #npm unpublish $packageName@$version
+            #Invoke-RestMethod -Uri $url -Method Delete -ContentType "application/json"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
+            nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive;
         } else {
             "What-if: Unlisting $version"
-            "npm unpublish $packageName@$version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
         }
     }
 }

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -12,7 +12,8 @@ param
 )
 
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
-$feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/npm/";
+#$feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/npm/";
+$feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/api/v3/index.json";
 
 Function Sort-Versions
 {

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -33,12 +33,7 @@ Function Sort-Versions
     return $Q.TrimEnd(".");
 }
 
-"----packageNames--------------------------"
-$packageNames
-
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
-"----result--------------------------"
-$result
 
 "unlistPackagesForReal: " + $unlistPackagesForReal;
 "Target version: " + $versionToUnlist;
@@ -51,15 +46,11 @@ foreach ($packageName in $packageNames) {
     "========================";
 
     $package = $result.packages | Where-Object {$_.id -eq $packageName};
-    "----package--------------------------"
-    $package
 
     #$package.versions | Select -Last 30;
 
     [string]$unsortedVersions = $package.versions | %{ $_ + "`r`n" };
-    "----unsortedVersions--------------------------"
-    $unsortedVersions
-    #$sortedVersions = Sort-Versions $unsortedVersions;
+    $sortedVersions = Sort-Versions $unsortedVersions;
 
     #Get versions equal to or older than $versionToUnlist
     $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -35,12 +35,13 @@ Function Sort-Versions
     return $Q.TrimEnd(".");
 }
 
-$result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
-
+"versionToUnlist: " + $versionToUnlist;
+"unlistOlderVersionsAlso: " + $unlistOlderVersionsAlso;
 "unlistPackagesForReal: " + $unlistPackagesForReal;
-"Target version: " + $versionToUnlist;
 " ";
-"Package versions to unlist:";
+"Package versions to unlist:"
+
+$result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
 
 npm config set registry https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/;
 

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -1,0 +1,79 @@
+#
+# Unlists npm package versions on MyGet.org lower than or equal to $versionToUnlist.
+# Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
+#
+param
+( 
+    [string]$versionToUnlist = "v4.13.4",
+    [string[]]$packageNames = @( "adaptive-expressions","botbuilder","botbuilder-dialogs-adaptive-runtime-core" ),
+    [string]$myGetFeedName = "botbuilder-v4-js-daily",
+    [string]$myGetPersonalAccessToken,
+    [string]$unlistPackagesForReal = "false"
+)
+
+$feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
+$feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/api/v3/index.json";
+
+Function Sort-Versions
+{
+    param ( [string]$versions );
+
+    New-Item -Path .\xxx.csv -ItemType "file" -Value $versions -Force | Out-Null;
+
+    $Header = 'Major', 'Minor', 'Build', 'Revision', 'p5', 'p6';
+
+    $P = Import-Csv -Path .\xxx.csv -Delimiter . -Header $Header;
+    $P | % { $_.Major = [int]$_.Major };
+    $P | % { $_.Minor = [int]$_.Minor };
+    $P = $P | Sort -Property Major,Minor,Build,Revision;
+    #$P | Format-Table;
+
+    $Q = $P | % {  ($_.PSObject.Properties | % { $_.Value }) -join '.'};
+
+    return $Q.TrimEnd(".");
+}
+
+$result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
+
+"unlistPackagesForReal: " + $unlistPackagesForReal;
+"Target version: " + $versionToUnlist;
+" ";
+"Package versions to unlist:"
+
+foreach ($packageName in $packageNames) {
+    "========================";
+    $packageName;
+    "========================";
+
+    $package = $result.packages | Where-Object {$_.id -eq $packageName};
+
+    #$package.versions | Select -Last 30;
+
+    [string]$unsortedVersions = $package.versions | %{ $_ + "`r`n" };
+
+    $sortedVersions = Sort-Versions $unsortedVersions;
+
+    #Get versions equal to or older than $versionToUnlist
+    $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+
+    if ($index -ne $Null) {
+        $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        $versionsToUnlist;
+    } else {
+        $versionsToUnlist = $null;
+        "[none]";
+    }
+    "------------------------";
+
+    # Do the unlisting
+    foreach ($version in $versionsToUnlist) {
+        if ($unlistPackagesForReal -eq "true") {
+            "Deleting $version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
+            nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
+        } else {
+            "What-if: Deleting $version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
+        }
+    }
+}

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -33,6 +33,9 @@ Function Sort-Versions
     return $Q.TrimEnd(".");
 }
 
+"----packageNames--------------------------"
+$packageNames
+
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
 "----result--------------------------"
 $result
@@ -56,7 +59,7 @@ foreach ($packageName in $packageNames) {
     [string]$unsortedVersions = $package.versions | %{ $_ + "`r`n" };
     "----unsortedVersions--------------------------"
     $unsortedVersions
-    $sortedVersions = Sort-Versions $unsortedVersions;
+    #$sortedVersions = Sort-Versions $unsortedVersions;
 
     #Get versions equal to or older than $versionToUnlist
     $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};

--- a/build/UnlistNpmPackagesOnMyGet.ps1
+++ b/build/UnlistNpmPackagesOnMyGet.ps1
@@ -4,7 +4,7 @@
 #
 param
 ( 
-    [string]$versionToUnlist = "v4.13.4",
+    [string]$versionToUnlist = "4.0.5-1500",
     [string[]]$packageNames = @( "adaptive-expressions","botbuilder","botbuilder-dialogs-adaptive-runtime-core" ),
     [string]$myGetFeedName = "botbuilder-v4-js-daily",
     [string]$myGetPersonalAccessToken,
@@ -68,11 +68,11 @@ foreach ($packageName in $packageNames) {
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
-            "Deleting $version"
+            "Unlisting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
             nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
         } else {
-            "What-if: Deleting $version"
+            "What-if: Unlisting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
         }
     }

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -1,5 +1,5 @@
 #
-# Unlists NuGet package versions on NuGet.org lower than or equal to $versionToUnlist.
+# Unlists NuGet package versions on Azure ConversationalAI feed  lower than or equal to $versionToUnlist.
 # Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
 # See: https://stackoverflow.com/questions/34958908/where-can-i-find-documentation-for-the-nuget-v3-api
 #
@@ -7,7 +7,7 @@ param
 ( 
     [string]$versionToUnlist = "1.0.2",
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
-    [string]$nuGetPersonalAccessToken,
+    [string]$adoPersonalAccessToken,
     [string]$unlistPackagesForReal = "false"
 )
 
@@ -53,11 +53,11 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive"
-            nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $adoPersonalAccessToken -NonInteractive"
+            nuget delete $packageName $version -Source $feedApiUrl -apikey $adoPersonalAccessToken -NonInteractive
         } else {
             "What-if: Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $adoPersonalAccessToken -NonInteractive"
         }
     }
 }

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -24,7 +24,7 @@ Function Get-Versions-From-Azure
     return $versions
 }
 
-"deletePackagesForReal: " + $unlistPackagesForReal;
+"unlistPackagesForReal: " + $unlistPackagesForReal;
 "Target version: " + $versionToUnlist;
 " ";
 "Package versions to unlist:"

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -11,13 +11,12 @@ param
     [string]$unlistPackagesForReal = "false"
 )
 
-$feedApiUrl = "https://api.nuget.org/v3/index.json";
+$RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json";
 
 Function Get-Versions-From-Azure 
 {
     param ( [string]$packageName );
 
-    $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
     $result = nuget list $packageName -Source "$RegistryUrlSource" -PreRelease -AllVersions | Where-Object { $_ -like "$packageName *" };
     $versions = $result | % { $_.Split(" ")[-1] };
 
@@ -53,11 +52,11 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $adoPersonalAccessToken -NonInteractive"
-            nuget delete $packageName $version -Source $feedApiUrl -apikey $adoPersonalAccessToken -NonInteractive
+            "nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive"
+            nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive
         } else {
             "What-if: Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $adoPersonalAccessToken -NonInteractive"
+            "nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive"
         }
     }
 }

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -5,7 +5,7 @@
 #
 param
 ( 
-    [string]$versionToUnlist = "4.7.0",
+    [string]$versionToUnlist = "4.11.2",
     [string]$unlistOlderVersionsAlso = "false",
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$adoPersonalAccessToken,

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -31,18 +31,25 @@ Function Get-Versions-From-Azure
 "Package versions to unlist:"
 
 foreach ($packageName in $packageNames) {
-    $versionsToUnlist = $null;
+    $versionsToUnlist = $Null;
+    $index = -1;
 
     $sortedVersions = Get-Versions-From-Azure $packageName;
 
     [array]::Reverse($sortedVersions);
 
     if ($unlistOlderVersionsAlso -eq "true") {
-        #Set index to $versionToUnlist
-        $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+        for ([int]$i = 0; $i -lt $sortedVersions.Count; $i++)
+        {
+            if ($sortedVersions[$i] -ge $versionToUnlist) {
+                $index = $i;
+                if ($sortedVersions[$i] -gt $versionToUnlist) { $index--; }
+                break;
+            }
+        }
 
-        if ($index -ne $Null) {
-            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        if ($index -ne $Null -and $index -ge 0) {
+            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index + 1);
         }
     } else {
         [string[]]$versionsToUnlist = $sortedVersions.Where({$_ -eq $versionToUnlist});
@@ -55,12 +62,13 @@ foreach ($packageName in $packageNames) {
 
         foreach ($version in $versionsToUnlist) {
             if ($unlistPackagesForReal -eq "true") {
-                "    Unlisting $version"
-                "    nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive"
-                nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive
+                "    Unlisting $version";
+                "    nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive";
+                nuget delete $packageName $version -Source $RegistryUrlSource -apikey $adoPersonalAccessToken -NonInteractive;
             } else {
-                "    $version"
+                "    $version";
             }
         }
     }
 }
+"-----------------------------------------";

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -47,6 +47,7 @@ foreach ($packageName in $packageNames) {
         $versionsToUnlist = $null;
         "[none]";
     }
+    "------------------------";
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -1,5 +1,5 @@
 #
-# Unlists NuGet package versions on Azure ConversationalAI feed  lower than or equal to $versionToUnlist.
+# Unlists NuGet package versions on Azure ConversationalAI feed lower than or equal to $versionToUnlist.
 # Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
 # See: https://stackoverflow.com/questions/34958908/where-can-i-find-documentation-for-the-nuget-v3-api
 #

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -1,0 +1,63 @@
+#
+# Unlists NuGet package versions on NuGet.org lower than or equal to $versionToUnlist.
+# Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
+# See: https://stackoverflow.com/questions/34958908/where-can-i-find-documentation-for-the-nuget-v3-api
+#
+param
+( 
+    [string]$versionToUnlist = "1.0.2",
+    [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
+    [string]$nuGetPersonalAccessToken,
+    [string]$unlistPackagesForReal = "false"
+)
+
+$feedApiUrl = "https://api.nuget.org/v3/index.json";
+
+Function Get-Versions-From-Azure 
+{
+    param ( [string]$packageName );
+
+    $RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
+    $result = nuget list $packageName -Source "$RegistryUrlSource" -PreRelease -AllVersions | Where-Object { $_ -like "$packageName *" };
+    $versions = $result | % { $_.Split(" ")[-1] };
+
+    return $versions
+}
+
+"deletePackagesForReal: " + $unlistPackagesForReal;
+"Target version: " + $versionToUnlist;
+" ";
+"Package versions to unlist:"
+
+foreach ($packageName in $packageNames) {
+    "========================";
+    $packageName;
+    "========================";
+
+    $sortedVersions = Get-Versions-From-Azure $packageName;
+
+    [array]::Reverse($sortedVersions);
+
+    #Get versions equal to or older than $versionToUnlist
+    $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+
+    if ($index -ne $Null) {
+        $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        $versionsToUnlist;
+    } else {
+        $versionsToUnlist = $null;
+        "[none]";
+    }
+
+    # Do the unlisting
+    foreach ($version in $versionsToUnlist) {
+        if ($unlistPackagesForReal -eq "true") {
+            "Unlisting $version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive"
+            nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive
+        } else {
+            "What-if: Unlisting $version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive"
+        }
+    }
+}

--- a/build/UnlistPackagesOnAzure.ps1
+++ b/build/UnlistPackagesOnAzure.ps1
@@ -5,7 +5,7 @@
 #
 param
 ( 
-    [string]$versionToUnlist = "1.0.2",
+    [string]$versionToUnlist = "4.11.0",
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$adoPersonalAccessToken,
     [string]$unlistPackagesForReal = "false"

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -43,7 +43,8 @@ Function Sort-Versions
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
 
 foreach ($packageName in $packageNames) {
-    $versionsToUnlist = $null;
+    $versionsToUnlist = $Null;
+    $index = $Null;
 
     $packageInfo = $result.packages | Where-Object {$_.id -eq $packageName};
 

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -1,6 +1,6 @@
 #
 # Unlists NuGet package versions on MyGet.org lower than or equal to $versionToUnlist.
-# Run this first with $deletePackagesForReal = false (default) to verify what versions will be affected.
+# Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
 #
 param
 ( 
@@ -8,7 +8,7 @@ param
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
-    [string]$deletePackagesForReal = "false"
+    [string]$unlistPackagesForReal = "false"
 )
 
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
@@ -35,7 +35,7 @@ Function Sort-Versions
 
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
 
-"deletePackagesForReal: " + $deletePackagesForReal;
+"unlistPackagesForReal: " + $unlistPackagesForReal;
 "Target version: " + $versionToUnlist;
 " ";
 "Package versions to unlist:"
@@ -66,7 +66,7 @@ foreach ($packageName in $packageNames) {
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
-        if ($deletePackagesForReal -eq "true") {
+        if ($unlistPackagesForReal -eq "true") {
             "Deleting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
             nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -68,11 +68,11 @@ foreach ($packageName in $packageNames) {
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
-            "Deleting $version"
+            "Unlisting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
             nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
         } else {
-            "What-if: Deleting $version"
+            "What-if: Unlisting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
         }
     }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -5,7 +5,7 @@
 param
 ( 
     [string]$versionToUnlist = "4.7.2-",
-    [string]$packageNames = "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core",
+    [string]$packageNames = "AdaptiveExpressions",
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
     [switch]$deletePackagesForReal = $false

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -70,10 +70,10 @@ foreach ($packageName in $packageNames) {
         foreach ($version in $versionsToUnlist) {
             if ($unlistPackagesForReal -eq "true") {
                 "    Unlisting $version";
-                "    nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
-                nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
+                "    nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive";
+                nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive;
             } else {
-                "    $version"
+                "    $version";
             }
         }
     }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -5,7 +5,7 @@
 param
 ( 
     [string]$versionToUnlist = "4.7.2-",
-    [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
+    [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
     [string]$deletePackagesForReal = "false"

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -14,7 +14,7 @@ param
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 $feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/api/v3/index.json";
 
-Set-PSDebug -Trace 1;
+#Set-PSDebug -Trace 1;
 
 Function Sort-Versions
 {
@@ -80,5 +80,5 @@ foreach ($packageName in $packageNames) {
         }
     }
 
-    Set-PSDebug -Trace 0;
+    #Set-PSDebug -Trace 0;
 }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -57,6 +57,11 @@ foreach ($packageName in $packageNames) {
         #$index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
         $index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
 
+        "sortedVersions = ";
+        $sortedVersions;
+        "sortedVersions.Count = " + $sortedVersions.Count;
+        "index = " + $index;
+
         if ($index -ne $Null) {
             [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[0] + 1);
         }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -44,7 +44,7 @@ $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "applica
 
 foreach ($packageName in $packageNames) {
     $versionsToUnlist = $Null;
-    $index = $Null;
+    $index = -1;
 
     $packageInfo = $result.packages | Where-Object {$_.id -eq $packageName};
 
@@ -55,18 +55,27 @@ foreach ($packageName in $packageNames) {
 
         #Set index to $versionToUnlist
         #$index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
-        $index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
+        #$index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
+
+        for (int i = 0; i -lt $sortedVersions.Count; i++)
+        {
+            if ($sortedVersions[i] -ge $versionToUnlist) {
+                $index = i;
+                if ($sortedVersions[i] -gt $versionToUnlist) { $index--; }
+                break;
+            }
+        }
 
         "sortedVersions = ";
         $sortedVersions;
         "sortedVersions.Count = " + $sortedVersions.Count;
         "index = " + $index;
 
-        if ($index -ne $Null) {
-            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[0] + 1);
+        if ($index -ne $Null && $index -ge 0) {
+            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index + 1);
         }
     } else {
-        [string[]]$versionsToUnlist = $packageInfo.versions.Where({$_ -eq $versionToUnlist});
+        [string[]]$versionsToUnlist = $sortedVersions.Where({$_ -eq $versionToUnlist});
     }
 
     if ($versionsToUnlist.Count -gt 0) {

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -1,10 +1,11 @@
 #
-# Unlists NuGet package versions on MyGet.org lower than or equal to $versionToUnlist.
+# Unlists NuGet packages on MyGet.org with the specified version number. Option to unlist all older packages as well.
 # Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
 #
 param
 ( 
     [string]$versionToUnlist = "4.7.2-",
+    [string]$unlistAllOlderPackagesAlso = "false",
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
@@ -53,11 +54,15 @@ foreach ($packageName in $packageNames) {
 
     $sortedVersions = Sort-Versions $unsortedVersions;
 
-    #Get versions equal to or older than $versionToUnlist
+    #Set index to $versionToUnlist
     $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
 
     if ($index -ne $Null) {
-        $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        if ($unlistAllOlderPackagesAlso == "true") {
+            $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        } else {
+            $versionsToUnlist = @($sortedVersions[$index]);
+        }
         $versionsToUnlist;
     } else {
         $versionsToUnlist = $null;

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -68,12 +68,11 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($deletePackagesForReal -eq "true") {
             "Deleting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey myGetPersonalAccessToken -NonInteractive"
-            #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
+            nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
         } else {
             "What-if: Deleting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey myGetPersonalAccessToken -NonInteractive"
-            #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
         }
     }
 }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -1,11 +1,11 @@
 #
-# Unlists NuGet packages on MyGet.org with the specified version number. Option to unlist all older packages as well.
+# Unlists NuGet packages on MyGet.org with the specified version number. Option to unlist all older versions as well.
 # Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
 #
 param
 ( 
     [string]$versionToUnlist = "4.7.2-",
-    [string]$unlistAllOlderPackagesAlso = "false",
+    [string]$unlistAllOlderVersionsAlso = "false",
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
@@ -37,7 +37,8 @@ Function Sort-Versions
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
 
 "unlistPackagesForReal: " + $unlistPackagesForReal;
-"Target version: " + $versionToUnlist;
+"versionToUnlist: " + $versionToUnlist;
+"unlistAllOlderVersionsAlso: " + $unlistAllOlderVersionsAlso;
 " ";
 "Package versions to unlist:"
 
@@ -58,7 +59,7 @@ foreach ($packageName in $packageNames) {
     $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
 
     if ($index -ne $Null) {
-        if ($unlistAllOlderPackagesAlso == "true") {
+        if ($unlistAllOlderVersionsAlso -eq "true") {
             $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
         } else {
             $versionsToUnlist = @($sortedVersions[$index]);

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -8,7 +8,7 @@ param
     [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
-    [string]$deletePackagesForReal = false
+    [string]$deletePackagesForReal = "false"
 )
 
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -69,7 +69,7 @@ foreach ($packageName in $packageNames) {
 
         foreach ($version in $versionsToUnlist) {
             if ($unlistPackagesForReal -eq "true") {
-                "    Unlisting $version"
+                "    Unlisting $version";
                 "    nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
                 nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
             } else {

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -53,13 +53,7 @@ foreach ($packageName in $packageNames) {
 
         $sortedVersions = Sort-Versions $unsortedVersions;
 
-        #"sortedVersions = ";
-        #$sortedVersions;
         "sortedVersions.Count = " + $sortedVersions.Count;
-
-        #Set index to $versionToUnlist
-        #$index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
-        #$index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
 
         for ([int]$i = 0; $i -lt $sortedVersions.Count; $i++)
         {
@@ -69,8 +63,6 @@ foreach ($packageName in $packageNames) {
                 break;
             }
         }
-
-        "index = " + $index;
 
         if ($index -ne $Null -and $index -ge 0) {
             [string[]]$versionsToUnlist = $sortedVersions | select -First ($index + 1);

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -5,7 +5,7 @@
 param
 ( 
     [string]$versionToUnlist = "4.7.2-",
-    [string]$packageNames = "AdaptiveExpressions",
+    [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
     [switch]$deletePackagesForReal = $false

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -14,8 +14,6 @@ param
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 $feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/api/v3/index.json";
 
-#Set-PSDebug -Trace 1;
-
 Function Sort-Versions
 {
     param ( [string]$versions );
@@ -41,9 +39,9 @@ $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "applica
 "Target version: " + $versionToUnlist;
 " ";
 "Package versions to unlist:"
-"========================";
 
 foreach ($packageName in $packageNames) {
+    "========================";
     $packageName;
     "========================";
 
@@ -65,8 +63,6 @@ foreach ($packageName in $packageNames) {
         $versionsToUnlist = $null;
         "[none]";
     }
-    " ";
-    "========================";
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
@@ -80,6 +76,4 @@ foreach ($packageName in $packageNames) {
             #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
         }
     }
-
-    #Set-PSDebug -Trace 0;
 }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -53,10 +53,11 @@ foreach ($packageName in $packageNames) {
         $sortedVersions = Sort-Versions $unsortedVersions;
 
         #Set index to $versionToUnlist
-        $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+        #$index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+        $index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
 
         if ($index -ne $Null) {
-            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[0] + 1);
         }
     } else {
         [string[]]$versionsToUnlist = $packageInfo.versions.Where({$_ -eq $versionToUnlist});

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -37,6 +37,7 @@ Function Sort-Versions
 
 $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "application/json";
 
+"deletePackagesForReal: " + $deletePackagesForReal;
 "Target version: " + $versionToUnlist;
 " ";
 "Package versions to unlist:"

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -8,7 +8,7 @@ param
     [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
-    [boolean]$deletePackagesForReal = $false
+    [string]$deletePackagesForReal = false
 )
 
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
@@ -69,7 +69,7 @@ foreach ($packageName in $packageNames) {
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
-        if ($deletePackagesForReal -eq $true) {
+        if ($deletePackagesForReal -eq true) {
             "Deleting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey myGetPersonalAccessToken -NonInteractive"
             #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -63,6 +63,7 @@ foreach ($packageName in $packageNames) {
         $versionsToUnlist = $null;
         "[none]";
     }
+    "------------------------";
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -4,8 +4,8 @@
 #
 param
 ( 
-    [string]$versionToUnlist = "4.7.0",
-    [string]$unlistOlderVersionsAlso = "false",
+    [string]$versionToUnlist = "4.6.1-preview",
+    [string]$unlistOlderVersionsAlso = "true",
     [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
@@ -53,25 +53,26 @@ foreach ($packageName in $packageNames) {
 
         $sortedVersions = Sort-Versions $unsortedVersions;
 
+        #"sortedVersions = ";
+        #$sortedVersions;
+        "sortedVersions.Count = " + $sortedVersions.Count;
+
         #Set index to $versionToUnlist
         #$index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
         #$index = (($sortedVersions.Count-1)..0) | where {$sortedVersions[$_] -le $versionToUnlist};
 
-        for (int i = 0; i -lt $sortedVersions.Count; i++)
+        for ([int]$i = 0; $i -lt $sortedVersions.Count; $i++)
         {
-            if ($sortedVersions[i] -ge $versionToUnlist) {
-                $index = i;
-                if ($sortedVersions[i] -gt $versionToUnlist) { $index--; }
+            if ($sortedVersions[$i] -ge $versionToUnlist) {
+                $index = $i;
+                if ($sortedVersions[$i] -gt $versionToUnlist) { $index--; }
                 break;
             }
         }
 
-        "sortedVersions = ";
-        $sortedVersions;
-        "sortedVersions.Count = " + $sortedVersions.Count;
         "index = " + $index;
 
-        if ($index -ne $Null && $index -ge 0) {
+        if ($index -ne $Null -and $index -ge 0) {
             [string[]]$versionsToUnlist = $sortedVersions | select -First ($index + 1);
         }
     } else {

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -69,7 +69,7 @@ foreach ($packageName in $packageNames) {
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
-        if ($deletePackagesForReal -eq true) {
+        if ($deletePackagesForReal -eq "true") {
             "Deleting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey myGetPersonalAccessToken -NonInteractive"
             #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -69,7 +69,7 @@ foreach ($packageName in $packageNames) {
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {
-        if ($deletePackagesForReal) {
+        if ($deletePackagesForReal -eq $true) {
             "Deleting $version"
             "nuget delete $packageName $version -Source $feedApiUrl -apikey myGetPersonalAccessToken -NonInteractive"
             #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -8,7 +8,7 @@ param
     [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
     [string]$myGetFeedName = "botbuilder-v4-dotnet-daily",
     [string]$myGetPersonalAccessToken,
-    [switch]$deletePackagesForReal = $false
+    [boolean]$deletePackagesForReal = $false
 )
 
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -14,6 +14,8 @@ param
 $feedStateUrl = "https://botbuilder.myget.org/F/$myGetFeedName/auth/$myGetPersonalAccessToken/api/v2/feed-state";
 $feedApiUrl = "https://botbuilder.myget.org/F/$myGetFeedName/api/v3/index.json";
 
+Set-PSDebug -Trace 1;
+
 Function Sort-Versions
 {
     param ( [string]$versions );
@@ -77,4 +79,6 @@ foreach ($packageName in $packageNames) {
             #nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
         }
     }
+
+    Set-PSDebug -Trace 0;
 }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -48,11 +48,11 @@ foreach ($packageName in $packageNames) {
 
     $packageInfo = $result.packages | Where-Object {$_.id -eq $packageName};
 
+    [string]$unsortedVersions = $packageInfo.versions | %{ $_ + "`r`n" };
+
+    $sortedVersions = Sort-Versions $unsortedVersions;
+
     if ($unlistOlderVersionsAlso -eq "true") {
-        [string]$unsortedVersions = $packageInfo.versions | %{ $_ + "`r`n" };
-
-        $sortedVersions = Sort-Versions $unsortedVersions;
-
         for ([int]$i = 0; $i -lt $sortedVersions.Count; $i++)
         {
             if ($sortedVersions[$i] -ge $versionToUnlist) {

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -1,6 +1,6 @@
 #
 # Unlists MyGet package versions lower than or equal to $versionToUnlist.
-# Run this first with $deletePackagesForReal = false to verify what versions will be unlisted.
+# Run this first with $deletePackagesForReal = false (default) to verify what versions will be affected.
 #
 param
 ( 

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -43,10 +43,6 @@ $result = Invoke-RestMethod -Uri $feedStateUrl -Method Get -ContentType "applica
 "Package versions to unlist:"
 
 foreach ($packageName in $packageNames) {
-    "========================";
-    $packageName;
-    "========================";
-
     $package = $result.packages | Where-Object {$_.id -eq $packageName};
 
     #$package.versions | Select -Last 30;
@@ -59,27 +55,24 @@ foreach ($packageName in $packageNames) {
     $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
 
     if ($index -ne $Null) {
+        "==================";
+        $packageName;
+        "==================";
+
         if ($unlistAllOlderVersionsAlso -eq "true") {
             $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
         } else {
             $versionsToUnlist = @($sortedVersions[$index]);
         }
-        $versionsToUnlist;
-    } else {
-        $versionsToUnlist = $null;
-        "[none]";
-    }
-    "------------------------";
 
-    # Do the unlisting
-    foreach ($version in $versionsToUnlist) {
-        if ($unlistPackagesForReal -eq "true") {
-            "Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
-            nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
-        } else {
-            "What-if: Unlisting $version"
-            "nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
+        foreach ($version in $versionsToUnlist) {
+            if ($unlistPackagesForReal -eq "true") {
+                "    Unlisting $version"
+                "    nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive"
+                nuget delete $packageName $version -Source $feedApiUrl -apikey $myGetPersonalAccessToken -NonInteractive
+            } else {
+                "    $version"
+            }
         }
     }
 }

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -1,5 +1,5 @@
 #
-# Unlists MyGet package versions lower than or equal to $versionToUnlist.
+# Unlists NuGet package versions on MyGet.org lower than or equal to $versionToUnlist.
 # Run this first with $deletePackagesForReal = false (default) to verify what versions will be affected.
 #
 param

--- a/build/UnlistPackagesOnMyGet.ps1
+++ b/build/UnlistPackagesOnMyGet.ps1
@@ -53,8 +53,6 @@ foreach ($packageName in $packageNames) {
 
         $sortedVersions = Sort-Versions $unsortedVersions;
 
-        "sortedVersions.Count = " + $sortedVersions.Count;
-
         for ([int]$i = 0; $i -lt $sortedVersions.Count; $i++)
         {
             if ($sortedVersions[$i] -ge $versionToUnlist) {

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -51,8 +51,8 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version"
-            "npm unpublish $packageName@$version";
-            npm unpublish $packageName@$version
+            "npm unpublish @microsoft/$packageName@$version --loglevel verbose";
+            npm unpublish @microsoft/$packageName@$version --loglevel verbose;
         } else {
             "What-if: Unlisting $version"
             "npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose";

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -6,7 +6,7 @@ param
 ( 
     [string]$versionToUnlist = "0.6.0",
     [string[]]$packageNames = @( "adaptive-expressions","botbuilder","botbuilder-dialogs-adaptive-runtime-core" ),
-    [string]$npmPersonalAccessToken,
+    [string]$npmPersonalAccessToken, # Not currently used.
     [string]$unlistPackagesForReal = "false"
 )
 

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -51,12 +51,16 @@ foreach ($packageName in $packageNames) {
     foreach ($version in $versionsToUnlist) {
         if ($unlistPackagesForReal -eq "true") {
             "Unlisting $version"
-            "npm unpublish @microsoft/$packageName@$version --loglevel verbose";
-            npm unpublish @microsoft/$packageName@$version --loglevel verbose;
+            "npm unpublish $packageName@$version --loglevel verbose";
+            npm unpublish $packageName@$version --loglevel verbose;
+            #"npm unpublish @microsoft/$packageName@$version --loglevel verbose";
+            #npm unpublish @microsoft/$packageName@$version --loglevel verbose;
         } else {
             "What-if: Unlisting $version"
-            "npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose";
-            npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose;
+            "npm unpublish $packageName@$version --dry-run --loglevel verbose";
+            npm unpublish $packageName@$version --dry-run --loglevel verbose;
+            #"npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose";
+            #npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose;
         }
     }
 }

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -6,7 +6,7 @@ param
 ( 
     [string]$versionToUnlist = "0.6.0",
     [string[]]$packageNames = @( "adaptive-expressions","botbuilder","botbuilder-dialogs-adaptive-runtime-core" ),
-    [string]$adoPersonalAccessToken,
+    [string]$npmPersonalAccessToken,
     [string]$unlistPackagesForReal = "false"
 )
 

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -1,0 +1,62 @@
+#
+# Unlists package versions on npm feed lower than or equal to $versionToUnlist.
+# Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
+#
+param
+( 
+    [string]$versionToUnlist = "0.6.0",
+    [string[]]$packageNames = @( "adaptive-expressions","botbuilder","botbuilder-dialogs-adaptive-runtime-core" ),
+    [string]$adoPersonalAccessToken,
+    [string]$unlistPackagesForReal = "false"
+)
+
+$RegistryUrlSource = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/npm/registry/";
+
+Function Get-Versions-From-Npm 
+{
+    param ( [string]$packageName );
+
+    $result = npm view $packageName versions
+    $versions = $result | ConvertFrom-Json;
+
+    return $versions;
+}
+
+"unlistPackagesForReal: " + $unlistPackagesForReal;
+"Target version: " + $versionToUnlist;
+" ";
+"Package versions to unlist:"
+
+foreach ($packageName in $packageNames) {
+    "========================";
+    $packageName;
+    "========================";
+
+    $versions = Get-Versions-From-Npm $packageName;
+    $versionsArray = $versions -split " " | Where-Object {$_};
+
+    #Get versions equal to or older than $versionToUnlist
+    $index = (0..($versionsArray.Count-1)) | where {$versionsArray[$_].StartsWith($versionToUnlist)};
+
+    if ($index -ne $Null) {
+        $versionsToUnlist = $versionsArray | select -First ($index[-1] + 1);
+        $versionsToUnlist;
+    } else {
+        $versionsToUnlist = $null;
+        "[none]";
+    }
+    "------------------------";
+
+    # Do the unlisting
+    foreach ($version in $versionsToUnlist) {
+        if ($unlistPackagesForReal -eq "true") {
+            "Unlisting $version"
+            "npm unpublish $packageName@$version";
+            npm unpublish $packageName@$version
+        } else {
+            "What-if: Unlisting $version"
+            "npm unpublish $packageName@$version --dry-run";
+            npm unpublish $packageName@$version --dry-run
+        }
+    }
+}

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -4,7 +4,7 @@
 #
 param
 ( 
-    [string]$versionToUnlist = "0.6.0",
+    [string]$versionToUnlist = "0.6.2",
     [string]$unlistOlderVersionsAlso = "false",
     [string[]]$packageNames = @( "adaptive-expressions","botbuilder","botbuilder-dialogs-adaptive-runtime-core" ),
     [string]$npmPersonalAccessToken, # Not currently used.

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -55,8 +55,8 @@ foreach ($packageName in $packageNames) {
             npm unpublish $packageName@$version
         } else {
             "What-if: Unlisting $version"
-            "npm unpublish $packageName@$version --dry-run --loglevel verbose";
-            npm unpublish $packageName@$version --dry-run --loglevel verbose;
+            "npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose";
+            npm unpublish @microsoft/$packageName@$version --dry-run --loglevel verbose;
         }
     }
 }

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -56,7 +56,7 @@ foreach ($packageName in $packageNames) {
         } else {
             "What-if: Unlisting $version"
             "npm unpublish $packageName@$version --dry-run";
-            npm unpublish $packageName@$version --dry-run
+            npm unpublish $packageName@$version --dry-run --loglevel verbose;
         }
     }
 }

--- a/build/UnlistPackagesOnNpm.ps1
+++ b/build/UnlistPackagesOnNpm.ps1
@@ -55,7 +55,7 @@ foreach ($packageName in $packageNames) {
             npm unpublish $packageName@$version
         } else {
             "What-if: Unlisting $version"
-            "npm unpublish $packageName@$version --dry-run";
+            "npm unpublish $packageName@$version --dry-run --loglevel verbose";
             npm unpublish $packageName@$version --dry-run --loglevel verbose;
         }
     }

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -1,0 +1,63 @@
+#
+# Unlists NuGet package versions lower than or equal to $versionToUnlist.
+# Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
+#
+param
+( 
+    [string]$versionToUnlist = "1.0.2",
+    [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
+    [string]$nuGetPersonalAccessToken,
+    [string]$unlistPackagesForReal = "false"
+)
+
+$feedApiUrl = "https://api.nuget.org/v3/index.json";
+
+Function Get-Versions-From-Nuget
+{
+    param ( [string]$packageName );
+
+    $packageBaseAddress = "https://api.nuget.org/v3-flatcontainer/";
+    $versionsUri = $packageBaseAddress + $packageName + "/index.json";
+
+    $response2 = Invoke-RestMethod -Uri $versionsUri
+
+    $versions = $response2.versions;
+
+    return $versions;
+}
+
+"deletePackagesForReal: " + $unlistPackagesForReal;
+"Target version: " + $versionToUnlist;
+" ";
+"Package versions to unlist:"
+
+foreach ($packageName in $packageNames) {
+    "========================";
+    $packageName;
+    "========================";
+
+    $sortedVersions = Get-Versions-From-Nuget $packageName;
+
+    #Get versions equal to or older than $versionToUnlist
+    $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+
+    if ($index -ne $Null) {
+        $versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        $versionsToUnlist;
+    } else {
+        $versionsToUnlist = $null;
+        "[none]";
+    }
+
+    # Do the unlisting
+    foreach ($version in $versionsToUnlist) {
+        if ($unlistPackagesForReal -eq "true") {
+            "Unlisting $version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive"
+            nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive
+        } else {
+            "What-if: Unlisting $version"
+            "nuget delete $packageName $version -Source $feedApiUrl -apikey $nuGetPersonalAccessToken -NonInteractive"
+        }
+    }
+}

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -35,16 +35,23 @@ Function Get-Versions-From-Nuget
 "Package versions to unlist:"
 
 foreach ($packageName in $packageNames) {
-    $versionsToUnlist = $null;
+    $versionsToUnlist = $Null;
+    $index = -1;
 
     $sortedVersions = Get-Versions-From-Nuget $packageName;
 
     if ($unlistOlderVersionsAlso -eq "true") {
-        #Set index to $versionToUnlist
-        $index = (0..($sortedVersions.Count-1)) | where {$sortedVersions[$_].StartsWith($versionToUnlist)};
+        for ([int]$i = 0; $i -lt $sortedVersions.Count; $i++)
+        {
+            if ($sortedVersions[$i] -ge $versionToUnlist) {
+                $index = $i;
+                if ($sortedVersions[$i] -gt $versionToUnlist) { $index--; }
+                break;
+            }
+        }
 
-        if ($index -ne $Null) {
-            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
+        if ($index -ne $Null -and $index -ge 0) {
+            [string[]]$versionsToUnlist = $sortedVersions | select -First ($index + 1);
         }
     } else {
         [string[]]$versionsToUnlist = $sortedVersions.Where({$_ -eq $versionToUnlist});

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -1,5 +1,5 @@
 #
-# Unlists NuGet package versions lower than or equal to $versionToUnlist.
+# Unlists NuGet package versions on NuGet.org lower than or equal to $versionToUnlist.
 # Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
 #
 param

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -49,6 +49,7 @@ foreach ($packageName in $packageNames) {
         $versionsToUnlist = $null;
         "[none]";
     }
+    "------------------------";
 
     # Do the unlisting
     foreach ($version in $versionsToUnlist) {

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -1,6 +1,7 @@
 #
 # Unlists NuGet package versions on NuGet.org lower than or equal to $versionToUnlist.
 # Run this first with $unlistPackagesForReal = false (default) to verify what versions will be affected.
+# See: https://stackoverflow.com/questions/34958908/where-can-i-find-documentation-for-the-nuget-v3-api
 #
 param
 ( 

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -27,7 +27,7 @@ Function Get-Versions-From-Nuget
     return $versions;
 }
 
-"deletePackagesForReal: " + $unlistPackagesForReal;
+"unlistPackagesForReal: " + $unlistPackagesForReal;
 "Target version: " + $versionToUnlist;
 " ";
 "Package versions to unlist:"

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -5,7 +5,7 @@
 param
 ( 
     [string]$versionToUnlist = "1.0.2",
-    [string[]]$packageNames = { "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" },
+    [string[]]$packageNames = @( "AdaptiveExpressions","Microsoft.Bot.Builder","Microsoft.Bot.Builder.Integration.AspNet.Core" ),
     [string]$nuGetPersonalAccessToken,
     [string]$unlistPackagesForReal = "false"
 )

--- a/build/UnlistPackagesOnNuGet.ps1
+++ b/build/UnlistPackagesOnNuGet.ps1
@@ -19,7 +19,7 @@ Function Get-Versions-From-Nuget
     param ( [string]$packageName );
 
     $packageBaseAddress = "https://api.nuget.org/v3-flatcontainer/";
-    $versionsUri = $packageBaseAddress + $packageName + "/index.json";
+    [string]$versionsUri = $packageBaseAddress + $packageName + "/index.json";
 
     $response2 = Invoke-RestMethod -Uri $versionsUri
 
@@ -47,7 +47,7 @@ foreach ($packageName in $packageNames) {
             [string[]]$versionsToUnlist = $sortedVersions | select -First ($index[-1] + 1);
         }
     } else {
-        [string[]]$versionsToUnlist = $packageInfo.versions.Where({$_ -eq $versionToUnlist});
+        [string[]]$versionsToUnlist = $sortedVersions.Where({$_ -eq $versionToUnlist});
     }
 
     if ($versionsToUnlist.Count -gt 0) {


### PR DESCRIPTION
Fixes #5818

## Description
Feeds are MyGet, NuGet, Azure, npm.

Pipelines are:
[Unlist-DotNet-Packages-On-Azure](https://dev.azure.com/FuseLabs/SDK_v4/_release?definitionId=197&view=mine&_a=releases)
[Unlist-DotNet-Packages-On-MyGet](https://dev.azure.com/FuseLabs/SDK_v4/_release?definitionId=196&view=mine&_a=releases)
[Unlist-DotNet-Packages-On-NuGet](https://dev.azure.com/FuseLabs/SDK_v4/_release?definitionId=199&view=mine&_a=releases)
[Unlist-Packages-On-Npm](https://dev.azure.com/FuseLabs/SDK_v4/_release?definitionId=198&view=mine&_a=releases)
[View-Npm-Package-Versions-On-MyGet](https://dev.azure.com/FuseLabs/SDK_v4/_release?definitionId=200&view=mine&_a=releases) ("Unlist" is not supported. "View" is.)

The pipelines are currently configured to  not actually unlist, for safety. They can be activated at any time.

Unlisting DotNet on Azure is not tested because lacking authorization.
Unlisting DotNet on NuGet is not tested because lacking authorization.
Unlisting JS on npm is not tested because lacking authorization.

## Specific Changes
5 yaml files created
