### PR TITLE
Make StreamingRequestHandler methods virtual

### DIFF
--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.3.0-rc2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,7 +26,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.3.0-rc2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />


### PR DESCRIPTION
Fixes #5816 

## Description
Changes method signatures in StreamingRequestHandler to 'virtual' to allow overrides:

- public async Task ListenAsync() -> public virtual async Task ListenAsync()
- public async Task<ResourceResponse> SendActivityAsync -> public virtual async Task<ResourceResponse> SendActivityAsync
- private void Server_Disconnected -> protected virtual void ServerDisconnected

## Testing
New unit test creates class **BotFrameworkHttpAdapterSub** that inherits from **BotFrameworkHttpAdapter** and overrides method **CreateStreamingRequestHandler**. 
Class **StreamingRequestHandlerSub** inherits from **StreamingRequestHandler** and overrides **ListenAsync** and **ServerDisconnected**.
The test verifies these methods are called by the subclasses.
