### PR TITLE
[#5838][Part 2] Increase Microsoft.Bot.Streaming code coverage

### DIFF
--- a/tests/Microsoft.Bot.Streaming.Tests/ContentStreamTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ContentStreamTests.cs
@@ -24,8 +24,10 @@ namespace Microsoft.Bot.Streaming.UnitTests
             var id = Guid.NewGuid();
             var assembler = new PayloadStreamAssembler(null, id);
             var c = new ContentStream(id, assembler);
+            var stream = assembler.GetPayloadAsStream();
 
             Assert.Equal(id, c.Id);
+            Assert.Equal(stream, c.Stream);
 
             c.Cancel();
         }
@@ -43,6 +45,21 @@ namespace Microsoft.Bot.Streaming.UnitTests
             Assert.Equal(type, c.ContentType);
 
             c.Cancel();
+        }
+
+        [Fact]
+        public void ContentStream_Length()
+        {
+            var id = Guid.NewGuid();
+            var assembler = new PayloadStreamAssembler(null, id);
+            var content = new ContentStream(id, assembler);
+            var length = 3;
+
+            content.Length = 3;
+
+            Assert.Equal(length, content.Length);
+
+            content.Cancel();
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTests.cs
@@ -54,5 +54,76 @@ namespace Microsoft.Bot.Streaming.UnitTests
                 writeStream.Dispose();
             }
         }
+
+        [Fact]
+        public void NamedPipeClient_ctor_With_Empty_BaseName()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NamedPipeClient(string.Empty));
+        }
+
+        [Fact]
+        public async void NamedPipeClient_SendAsync_With_No_Message()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            var pipe = new NamedPipeClient(pipeName);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pipe.SendAsync(null));
+        }
+
+        [Fact]
+        public async void NamedPipeClient_SendAsync_With_No_Connected_Client()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            var pipe = new NamedPipeClient(pipeName);
+            var message = new StreamingRequest();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => pipe.SendAsync(message));
+        }
+
+        [Fact]
+        public void NamedPipeServer_IsConnected()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            var requestHandler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), pipeName);
+            var pipe = new NamedPipeServer(pipeName, requestHandler);
+
+            Assert.False(pipe.IsConnected);
+        }
+
+        [Fact]
+        public void NamedPipeServer_ctor_With_Empty_BaseName()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            var requestHandler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), pipeName);
+            Assert.Throws<ArgumentNullException>(() => new NamedPipeServer(string.Empty, requestHandler));
+        }
+
+        [Fact]
+        public void NamedPipeServer_ctor_With_No_RequestHandler()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            Assert.Throws<ArgumentNullException>(() => new NamedPipeServer(pipeName, null));
+        }
+
+        [Fact]
+        public async void NamedPipeServer_SendAsync_With_No_Message()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            var requestHandler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), pipeName);
+            var pipe = new NamedPipeServer(pipeName, requestHandler);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => pipe.SendAsync(null));
+        }
+
+        [Fact]
+        public async void NamedPipeServer_SendAsync_With_No_Connected_Client()
+        {
+            var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
+            var requestHandler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), pipeName);
+            var pipe = new NamedPipeServer(pipeName, requestHandler);
+            var message = new StreamingRequest();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => pipe.SendAsync(message));
+        }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTransportTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTransportTests.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
+        public async void ReceiveAsync_With_Null_Stream()
+        {
+            var pipe = new NamedPipeTransport(null);
+            var result = await pipe.ReceiveAsync(new byte[0], 0, 0);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
         public void ClosedStream_Not_IsConnected()
         {
             var pipeName = Guid.NewGuid().ToString();

--- a/tests/Microsoft.Bot.Streaming.Tests/TransportDisconnectedExceptionTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/TransportDisconnectedExceptionTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Bot.Streaming.PayloadTransport;
+using Xunit;
+
+namespace Microsoft.Bot.Streaming.UnitTests
+{
+    public class TransportDisconnectedExceptionTests
+    {
+        [Fact]
+
+        public void TransportDisconnectedException_ctor()
+        {
+            var exception = new TransportDisconnectedException();
+
+            Assert.NotNull(exception.Reason);
+        }
+
+        [Fact]
+
+        public void TransportDisconnectedException_ctor_With_InnerException()
+        {
+            var innerException = new Exception("inner-exception");
+            var exception = new TransportDisconnectedException("exception", innerException);
+
+            Assert.Equal(innerException, exception.InnerException);
+            Assert.Equal("exception", exception.Reason);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Streaming.Tests/WebSocketTransportTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/WebSocketTransportTests.cs
@@ -60,6 +60,44 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
+        public void WebSocketServer_ctor_With_No_Socket()
+        {
+            var requestHandlerMock = new Mock<RequestHandler>();
+
+            Assert.Throws<ArgumentNullException>(() => new WebSocketServer(null, requestHandlerMock.Object));
+        }
+
+        [Fact]
+        public void WebSocketServer_ctor_With_No_RequestHandler()
+        {
+            var requestHandlerMock = new Mock<RequestHandler>();
+            var socketMock = new Mock<WebSocket>();
+
+            Assert.Throws<ArgumentNullException>(() => new WebSocketServer(socketMock.Object, null));
+        }
+
+        [Fact]
+        public async void WebSocketServer_SendAsync_With_No_Message()
+        {
+            var socketMock = new Mock<WebSocket>();
+            var requestHandlerMock = new Mock<RequestHandler>();
+            var server = new WebSocketServer(socketMock.Object, requestHandlerMock.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => server.SendAsync(null));
+        }
+
+        [Fact]
+        public async void WebSocketServer_SendAsync_With_No_Connected_Client()
+        {
+            var socketMock = new Mock<WebSocket>();
+            var requestHandlerMock = new Mock<RequestHandler>();
+            var server = new WebSocketServer(socketMock.Object, requestHandlerMock.Object);
+            var message = new StreamingRequest();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendAsync(message));
+        }
+
+        [Fact]
         public async Task WebSocketClient_ThrowsOnEmptyUrl()
         {
             Exception result = null;
@@ -74,6 +112,23 @@ namespace Microsoft.Bot.Streaming.UnitTests
             }
 
             Assert.IsType<ArgumentNullException>(result);
+        }
+
+        [Fact]
+        public async void WebSocketClient_SendAsync_With_No_Message()
+        {
+            var client = new WebSocketClient("url");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SendAsync(null));
+        }
+
+        [Fact]
+        public async void WebSocketClient_SendAsync_With_No_Connected_Client()
+        {
+            var client = new WebSocketClient("url");
+            var message = new StreamingRequest();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(message));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #5838

## Description
This PR increases the code coverage for the `Microsoft.Bot.Streaming` from **63%** up to **84%**, the changes are divided in two parts, see PR #5839 for Part 1.

## Specific Changes
- Added unit tests for:
  - ConcurrentStream
  - ContentStream
  - NamedPipe
  - NamedPipTransport
  - Request
  - Response
  - SendOperations
  - TransportDisconnected
  - WebSocketTransport

## Testing
The following image shows the before and after the changes that increased the code coverage.
![imagen](https://user-images.githubusercontent.com/62260472/127224473-770d1e5a-65e5-4555-bb65-55e3ffcb38d2.png)