### PR TITLE
Soumyak/removecortanafix

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 case Connector.Channels.Directline:
                 case Connector.Channels.DirectlineSpeech:
                 case Connector.Channels.Webchat:
-                case Connector.Channels.Cortana:
                     return buttonCnt <= 100;
 
                 default:
@@ -86,11 +85,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <returns>True if the Channel has a Message Feed, False if it does not.</returns>
         public static bool HasMessageFeed(string channelId)
         {
+            // The removed 'cortana' channel was the only channel that returned false.
+            // This channel is no longer available for bot developers and was removed from
+            // the Channels enum while addressing issues #3603, #5671
+            // Since this is publically available but not documented in the official reference docs, the method is retained.
             switch (channelId)
-            {
-                case Connector.Channels.Cortana:
-                    return false;
-
+            { 
                 default:
                     return true;
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -49,13 +49,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             var supportsSuggestedActions = Channel.SupportsSuggestedActions(channelId, list.Count);
             var supportsCardActions = Channel.SupportsCardActions(channelId, list.Count);
             var maxActionTitleLength = Channel.MaxActionTitleLength(channelId);
-            var hasMessageFeed = Channel.HasMessageFeed(channelId);
             var longTitles = maxTitleLength > maxActionTitleLength;
 
             if (!longTitles && !supportsSuggestedActions && supportsCardActions)
             {
                 // SuggestedActions is the preferred approach, but for channels that don't
-                // support them (e.g. Teams, Cortana) we should use a HeroCard with CardActions
+                // support them (e.g. Teams) we should use a HeroCard with CardActions
                 return HeroCard(list, text, speak);
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -590,7 +590,6 @@ namespace Microsoft.Bot.Builder.Dialogs
         {
             switch (channelId)
             {
-                case Channels.Cortana:
                 case Channels.Skype:
                 case Channels.Skypeforbusiness:
                     return false;

--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -20,12 +20,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Console channel.
         /// </summary>
-        public const string Console = "console";
-
-        /// <summary>
-        /// Cortana channel.
-        /// </summary>
-        public const string Cortana = "cortana";
+        public const string Console = "console";       
 
         /// <summary>
         /// Direct Line channel.

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
     public class ChoiceFactoryTests
     {
         private static List<Choice> colorChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue") };
-        private static List<Choice> extraChoices = new List<Choice> { new Choice("red"), new Choice("green"), new Choice("blue"), new Choice("alpha") };
         private static List<Choice> choicesWithActions = new List<Choice>
         {
             new Choice("ImBack") { Action = new CardAction(ActionTypes.ImBack, "ImBack Action", value: "ImBack Value") },
@@ -99,28 +98,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
             Assert.Equal("blue", activity.SuggestedActions.Actions[2].Value);
             Assert.Equal("blue", activity.SuggestedActions.Actions[2].Title);
-        }
-
-        [Fact]
-        public void ShouldChooseCorrectStylesForCortana()
-        {
-            var activity = ChoiceFactory.ForChannel(Channels.Cortana, colorChoices, "select from:");
-
-            Assert.NotNull(activity.Attachments);
-
-            var heroCard = (HeroCard)activity.Attachments.First().Content;
-
-            Assert.Equal(3, heroCard.Buttons.Count);
-            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[0].Type);
-            Assert.Equal("red", heroCard.Buttons[0].Value);
-            Assert.Equal("red", heroCard.Buttons[0].Title);
-            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[1].Type);
-            Assert.Equal("green", heroCard.Buttons[1].Value);
-            Assert.Equal("green", heroCard.Buttons[1].Title);
-            Assert.Equal(ActionTypes.ImBack, heroCard.Buttons[2].Type);
-            Assert.Equal("blue", heroCard.Buttons[2].Value);
-            Assert.Equal("blue", heroCard.Buttons[2].Title);
-        }
+        }        
 
         [Fact]
         public void ShouldChooseCorrectStylesForTeams()

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
@@ -95,14 +95,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var supports = Channel.SupportsCardActions(Channels.Line, 100);
             Assert.False(supports);
         }
-
-        [Fact]
-        public void ShouldReturnTrueForSupportsCardActionsWithCortanaAnd100()
-        {
-            var supports = Channel.SupportsCardActions(Channels.Cortana, 100);
-            Assert.True(supports);
-        }
-
+       
         [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithSlackAnd100()
         {
@@ -125,10 +118,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
-        public void ShouldReturnFalseForHasMessageFeedWithCortana()
+        public void ShouldReturnTrueForHasMessageFeedWithAllChannels()
         {
-            var supports = Channel.HasMessageFeed(Channels.Cortana);
-            Assert.False(supports);
+            var supports = Channel.HasMessageFeed(Channels.Directline);
+            Assert.True(supports);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Tests/Adapters/TestAdapterTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Adapters/TestAdapterTests.cs
@@ -567,7 +567,6 @@ namespace Microsoft.Bot.Builder.Tests.Adapters
         [InlineData(Channels.Emulator)]
         [InlineData(Channels.Msteams)]
         [InlineData(Channels.Webchat)]
-        [InlineData(Channels.Cortana)]
         [InlineData(Channels.Directline)]
         [InlineData(Channels.Facebook)]
         [InlineData(Channels.Slack)]

--- a/tests/Microsoft.Bot.Builder.Tests/MentionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MentionTests.cs
@@ -104,13 +104,7 @@ namespace Microsoft.Bot.Builder.Tests
         public void Mention_Email()
         {
             // TODO: for now: Email mentions not included in Activity.Text?
-        }
-
-        [Fact]
-        public void Mention_Cortana()
-        {
-            // TODO: no-op for now: Cortana mentions unknown at this time
-        }
+        }        
 
         [Fact]
         public void Mention_Kik()


### PR DESCRIPTION
Fixes #5671 

## Description
The changes in fix: remove Cortana from Channels enum (#3730)  are being ported dotnet to maintain parity with microsoft/botbuilder-js.

## Specific Changes
- Remove Cortana from Channels enum 
- Public method hasMessageFeed() always returns true (no change on visibility in declarations)
- Channel.SupportsCardActions() no longer has Channels.Cortana 
- OAuthPrompt.ChannelSupportsOAuthCard() no longer has Channels.Cortana.
- Removed and Updated Cortana specific tests 
