### PR TITLE
Corrected GetConversationMembers to use TeamsInfo helper class rather…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Teams;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
@@ -74,13 +75,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            var bfAdapter = dc.Context.Adapter as BotFrameworkAdapter;
-            if (bfAdapter == null)
-            {
-                throw new InvalidOperationException("GetConversationMembersAsync() only works with BotFrameworkAdapter");
-            }
-
-            var result = await bfAdapter.GetConversationMembersAsync(dc.Context, cancellationToken).ConfigureAwait(false);
+            var result = await TeamsInfo.GetMembersAsync(dc.Context, cancellationToken).ConfigureAwait(false);
 
             if (this.Property != null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/GetConversationMembers.cs
@@ -77,8 +77,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
-            var conversationId = dc.Context.Activity?.Conversation?.Id;
-            var result = await GetMembersAsync(GetConnectorClient(dc.Context), conversationId, cancellationToken).ConfigureAwait(false);
+            var result = await GetMembersAsync(dc.Context, cancellationToken).ConfigureAwait(false);
 
             if (this.Property != null)
             {
@@ -94,20 +93,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             return $"{GetType().Name}[{this.Property?.ToString() ?? string.Empty}]";
         }
 
-        private static async Task<IEnumerable<ChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
+        private static async Task<IEnumerable<ChannelAccount>> GetMembersAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
+            var conversationId = turnContext.Activity?.Conversation?.Id;
             if (conversationId == null)
             {
                 throw new InvalidOperationException("The GetMembersAsync operation needs a valid conversation Id.");
             }
 
+            var connectorClient = turnContext.TurnState.Get<IConnectorClient>() ?? throw new InvalidOperationException("This method requires a connector client.");
+
             var teamMembers = await connectorClient.Conversations.GetConversationMembersAsync(conversationId, cancellationToken).ConfigureAwait(false);
             return teamMembers;
-        }
-
-        private static IConnectorClient GetConnectorClient(ITurnContext turnContext)
-        {
-            return turnContext.TurnState.Get<IConnectorClient>() ?? throw new InvalidOperationException("This method requires a connector client.");
         }
     }
 }


### PR DESCRIPTION
… than rely on BotFrameworkAdapter directly.

Fixes #5873 

## Description
Corrected GetConversationMembers in Adaptive.Runtime to use TeamsInfo helper class rather than rely on BotFrameworkAdapter functions that aren't available now that CoreBotAdapter derives from CloudAdapter and not BotFrameworkAdapter

## Specific Changes
Remove check for BotFrameworkAdapter and call to it for GetConversationMembersAsync and now use TeamsInfo and call GetMembersAsync.

## Testing
Tested against a Composer created bot using the updated SDK to make sure all the changes were correct.