### PR TITLE
Added outlook and searchassistant channels to Channels List, made duplicated twilio channel obsolete.

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
             {
                 Id = twilioMessage.MessageSid,
                 Timestamp = DateTime.UtcNow,
-                ChannelId = Channels.Twilio,
+                ChannelId = Channels.Sms,
                 Conversation = new ConversationAccount()
                 {
                     Id = twilioMessage.From ?? twilioMessage.Author,

--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Connector
 {
     /// <summary>
@@ -110,6 +112,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Twilio channel.
         /// </summary>
+        [Obsolete("This is a duplicate and will be deprecated. Please use Channels.Sms instead.", true)]
         public const string Twilio = "twilio-sms";
 
         /// <summary>
@@ -121,5 +124,15 @@ namespace Microsoft.Bot.Connector
         /// Omni channel.
         /// </summary>
         public const string Omni = "omnichannel";
+
+        /// <summary>
+        /// Outlook channel.
+        /// </summary>
+        public const string Outlook = "outlook";
+
+        /// <summary>
+        /// SearchAssistant channel.
+        /// </summary>
+        public const string SearchAssistant = "searchassistant";
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Files/Activities.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Files/Activities.json
@@ -6,7 +6,7 @@
       "localTimestamp":null,
       "localTimezone":null,
       "serviceUrl":null,
-      "channelId":"twilio-sms",
+      "channelId":"sms",
       "from":{  
          "id":"redacted",
          "name":null,


### PR DESCRIPTION


Fixes #5678 

## Description
Currently there are duplicate entries for twilio sms channel in Microsoft.Bot.Connector.Channels. Made Channels.Twilio obsolete and added comment to use Channels.Sms instead.
Added outlook and searchassistant channels to Microsoft.Bot.Connector.Channels list.
