### PR TITLE
Move IAdaptiveDialogDependencies to Adaptive library

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ReplaceDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ReplaceDialog.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         /// Enumerate child dialog dependencies required to be exposed for parent containers dialogset.
         /// </summary>
         /// <returns>dialog enumeration.</returns>
-        public virtual IEnumerable<Dialog> GetExternalDependencies()
+        public IEnumerable<Dialog> GetExternalDependencies()
         {
             return this.GetDependencies();
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/IAdaptiveDialogDependencies.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/IAdaptiveDialogDependencies.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// <summary>
     /// Defines Dialog Dependencies interface for enumerating child dialogs should exposed for parent.
     /// </summary>
-    public interface IAdaptiveDialogDependencies
+    internal interface IAdaptiveDialogDependencies
     {
         /// <summary>
         /// Enumerate child dialog dependencies required to be exposed for parent containers dialogset.


### PR DESCRIPTION
Fixes #5624 

## Description
Adds change requested in #5656 by @carlosscastro 

- Moves new interface IAdaptiveDialogDependencies to Adaptive library
- Makes the new interface "internal"
- Makes the implementation method in "ReplaceDialog" non-virtual.
