### PR TITLE
[#5898] Increase Microsoft.Bot.Builder.Azure.Queues code coverage

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueTests.cs
@@ -68,5 +68,17 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 Assert.Equal(JsonConvert.SerializeObject(cr), JsonConvert.SerializeObject(cr2));
             }
         }
+
+        [Fact]
+        public void AzureQueueStorageNullConnectionString()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AzureQueueStorage(null, "test-queue"));
+        }
+
+        [Fact]
+        public void AzureQueueStorageNullQueueName()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AzureQueueStorage(ConnectionString, null));
+        }
     }
 }


### PR DESCRIPTION
Fixes #5898

## Description
This PR increases the code coverage for the `Microsoft.Bot.Builder.Azure.Queues` from **82%** to **100%**.
Originally the coverage was **82%**, but these tests are skipped in the CI pipeline as they require the [AzureStorageEmulator](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator).

## Specific Changes
Added unit tests for:
- AzureQueueStorage

## Testing
The following images show the tests passing and the new code coverage.
![image](https://user-images.githubusercontent.com/44245136/134926912-ead48ed7-4c32-4b69-b1ca-dba047b51473.png)
