### PR TITLE
Set up new pipelines for vNextPrototype branch.

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -19,7 +19,7 @@ variables:
   BotBuilderDll: Microsoft.Bot.Builder.AI.Luis,Microsoft.Bot.Builder.AI.QnA,Microsoft.Bot.Builder.ApplicationInsights,Microsoft.Bot.Builder.Azure,Microsoft.Bot.Builder.Dialogs,Microsoft.Bot.Builder.Integration.ApplicationInsights.Core,Microsoft.Bot.Builder.Integration.AspNet.Core,Microsoft.Bot.Builder.TemplateManager,Microsoft.Bot.Builder.Testing,Microsoft.Bot.Builder,Microsoft.Bot.Configuration,Microsoft.Bot.Connector,Microsoft.Bot.Schema,Microsoft.Bot.Streaming
   BuildConfiguration: Debug-Windows
   BuildPlatform: any cpu
-  IsBuildServer: true # This activates package versioning in the projects in Microsoft.Bot.Builder.sln.
+  IsBuildServer: true # This is consumed by tests\Microsoft.Bot.Builder.Dialogs.Declarative.Tests\SchemaTestsFixture.cs.
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   Parameters.solution: Microsoft.Bot.Builder.sln
   PreviewPackageVersion: 4.9.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.

--- a/build/yaml/vnextprototype/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/vnextprototype/botbuilder-dotnet-ci-mac.yml
@@ -1,0 +1,65 @@
+#
+# Replaces the classic BotBuilder-DotNet-master-CI-PR-(MacLinux)
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+
+pool:
+    vmImage: 'macOS-10.14'
+
+trigger: none # ci trigger is set in ADO
+pr: none # pr trigger is set in ADO
+
+variables:
+  BuildConfiguration: debug
+
+steps:
+# Note: Template ci-build-steps.yml is not supported in macOS because it calls VSBuild@1 in order to build the Windows-only ASP.NET Desktop assemblies.
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 2.1.x'
+  inputs:
+    version: 2.1.x
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 3.1.101'
+  inputs:
+    version: 3.1.101
+
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
+
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
+
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  inputs:
+    restoreSolution: Microsoft.Bot.Builder-Standard.sln
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    projects: Microsoft.Bot.Builder.sln
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+     
+    arguments: '-v n  --configuration $(BuildConfiguration) --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests&TestCategory!=WindowsOnly" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: build folder'
+  inputs:
+    PathtoPublish: build
+    ArtifactName: build
+
+- powershell: |
+   cd ..
+   ls -R
+  displayName: 'Dir workspace'
+  continueOnError: true
+  condition: succeededOrFailed()

--- a/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
+++ b/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
@@ -17,7 +17,7 @@ pr: none # pr trigger is set in ADO
 variables:
   BuildConfiguration: Debug-Windows
   BuildPlatform: any cpu
-  IsBuildServer: true # This activates package versioning in the projects in Microsoft.Bot.Builder.sln.
+  IsBuildServer: true # This is consumed by tests\Microsoft.Bot.Builder.Dialogs.Declarative.Tests\SchemaTestsFixture.cs.
   MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
   Parameters.solution: Microsoft.Bot.Builder.sln
   PreviewPackageVersion: 5.0.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.

--- a/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
+++ b/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
@@ -1,0 +1,70 @@
+#
+# Replaces the classic BotBuilder-DotNet-master-CI-PR
+#
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+
+pool:
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  demands:
+  - msbuild
+  - visualstudio
+
+trigger: none # ci trigger is set in ADO
+pr: none # pr trigger is set in ADO
+
+variables:
+  BuildConfiguration: Debug-Windows
+  BuildPlatform: any cpu
+  IsBuildServer: true # This activates package versioning in the projects in Microsoft.Bot.Builder.sln.
+  MSBuildArguments: -p:SignAssembly=false -p:delaySign=false
+  Parameters.solution: Microsoft.Bot.Builder.sln
+  PreviewPackageVersion: 5.0.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
+  ReleasePackageVersion: 5.0.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
+  runCodesignValidationInjection: false # Disables unnecessary CodeSign Validation step
+#  Not used: DotNetCoverallsToken: define this in Azure
+#  Not used: GitHubCommentApiKey: define this in Azure
+#  Not used: ApiCompatExcludeClasses: (optional) define this in Azure
+#  Not used: DisableApiCompatibityValidation: (optional) define this in Azure
+
+# The following 2 stages run multi-configuration, multi-agent parallel jobs.
+# Debug-Windows/Release-Windows => Builds everything in Debug/Release + the ASP.NET Desktop.
+# Debug/Release => would build all .NET Standard libs and test them.
+# The .NET 4.X asp.net integrations libraries do not build and test on non-windows boxes.
+# If we drop support for .NET 4.x then we can drop to just Debug/Release.
+stages:
+- stage: Build
+  jobs:
+  - job: Debug_Windows_Configuration_21
+    variables:
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+  - job: Debug_Windows_Configuration_31
+    variables:
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+  - job: Release_Windows_Configuration_21
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
+      PublishCoverage: false
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    #- template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_31
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+      PublishCoverage: false
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    #- template: ci-component-detection-steps.yml

--- a/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
+++ b/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
@@ -23,6 +23,7 @@ variables:
   PreviewPackageVersion: 5.0.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
   ReleasePackageVersion: 5.0.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
   runCodesignValidationInjection: false # Disables unnecessary CodeSign Validation step
+  skipComponentGovernanceDetection: true
 #  Not used: DotNetCoverallsToken: define this in Azure
 #  Not used: GitHubCommentApiKey: define this in Azure
 #  Not used: ApiCompatExcludeClasses: (optional) define this in Azure

--- a/build/yaml/vnextprototype/ci-build-steps.yml
+++ b/build/yaml/vnextprototype/ci-build-steps.yml
@@ -1,0 +1,31 @@
+steps:
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
+
+# Variables ReleasePackageVersion and PreviewPackageVersion are consumed by projects in Microsoft.Bot.Builder.sln.
+# For the signed build, they should be settable at queue time. To set that up, define the variables in Azure on the Variables tab.
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet '
+
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  inputs:
+    restoreSolution: '$(Parameters.solution)'
+
+- task: VSBuild@1
+  displayName: 'Build solution Microsoft.Bot.Builder.sln'
+  inputs:
+    solution: '$(Parameters.solution)'
+    vsVersion: 16.0
+    msbuildArgs: '$(MSBuildArguments)'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    maximumCpuCount: true
+    logProjectEvents: false
+
+- script: |
+   cd ..
+   dir *.* /s
+  displayName: 'Dir workspace'
+  continueOnError: true
+  condition: succeededOrFailed()

--- a/build/yaml/vnextprototype/ci-test-steps.yml
+++ b/build/yaml/vnextprototype/ci-test-steps.yml
@@ -1,0 +1,104 @@
+#variables:
+#  DotNetCoverallsToken: define this in Azure
+#  PublishCoverage: (optional) set to true in the calling template.
+steps:
+- powershell: |
+   Remove-Item CodeCoverage -Force -Recurse -ErrorAction Ignore
+   New-Item CodeCoverage -ItemType Directory -Force
+  displayName: 'Create Code Coverage directory'
+
+# - task: petergroenewegen.PeterGroenewegen-Xpirit-Vsts-Build-InlinePowershell.Xpirit-Vsts-Build-InlinePowershell.InlinePowershell@1
+#   displayName: 'Start CosmosDB Emulator'
+#   inputs:
+#     Script: |
+#         Write-Host "Starting CosmosDB Emulator on Windows"
+#         Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
+#         Start-CosmosDbEmulator
+
+- task: Npm@1
+  displayName: 'install botframework-cli to set up for Schema merge tests.'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'install -g @microsoft/botframework-cli@next'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 2.1'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+     !Tests/**/Microsoft.Bot.Builder.TestBot.Tests.csproj
+     !Tests/**/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+     
+    arguments: '-v n  -f netcoreapp2.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp21'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 3.1'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+     !Tests/**/*21.Tests.csproj
+
+    arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+
+- powershell: |
+   # This task copies the code coverage file created by dotnet test into a well known location. In all
+   # checks I've done, dotnet test ALWAYS outputs the coverage file to the temp directory. 
+   # My attempts to override this and have it go directly to the CodeCoverage directory have
+   # all failed, so I'm just doing the copy here.  (cmullins)
+   
+   Get-ChildItem -Path "D:\a\_temp" -Include "*.coverage" -Recurse | Copy-Item -Destination CodeCoverage
+  displayName: 'Copy .coverage Files to CodeCoverage folder'
+  condition: eq(variables['BuildConfiguration'],'Release-Windows')
+
+- powershell: 'echo ''##vso[task.setvariable variable=CoverallsToken]$(DotNetCoverallsToken)'''
+  displayName: 'Set CoverallsToken for PublishToCoveralls.ps1 if token exists'
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+
+- task: PowerShell@2
+  displayName: 'Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
+    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish build artifact CodeCoverage'
+  inputs:
+    PathtoPublish: CodeCoverage
+    ArtifactName: CodeCoverage
+  enabled: false
+
+- powershell: |
+   New-Item -ItemType directory -Path "outputLibraries\" -Force
+   
+   $buildTarget = $env:BuildConfiguration.Split("-")[0];
+   
+   $env:BotBuilderDll.Split(",") | ForEach {
+       $library = $_.Trim()
+       Write-Host $library
+   
+       Get-ChildItem -Path "*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
+       Get-ChildItem -Path "*/*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
+   }
+  displayName: 'Copy DLLs to outputLibraries folder'
+
+- task: PublishPipelineArtifact@0
+  displayName: 'Publish Microsoft.Bot.Builder DLLs artifact'
+  inputs:
+    artifactName: 'BotBuilderDLLs-$(BuildConfiguration)-$(BuildTarget)'
+    targetPath: outputLibraries
+
+- script: |
+   cd ..
+   dir *.* /s
+  displayName: 'Dir workspace'
+  continueOnError: true
+  condition: succeededOrFailed()

--- a/build/yaml/vnextprototype/ci-test-steps.yml
+++ b/build/yaml/vnextprototype/ci-test-steps.yml
@@ -76,28 +76,6 @@ steps:
     ArtifactName: CodeCoverage
   enabled: false
 
-#- powershell: |
-#   New-Item -ItemType directory -Path "outputLibraries\" -Force
-   
-#   $buildTarget = $env:BuildConfiguration.Split("-")[0];
-   
-#   $env:BotBuilderDll.Split(",") | ForEach {
-#       $library = $_.Trim()
-#       Write-Host $library
-   
-#       Get-ChildItem -Path "*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
-#       Get-ChildItem -Path "*/*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
-#   }
-#  displayName: 'Copy DLLs to outputLibraries folder'
-#  enabled: false
-
-#- task: PublishPipelineArtifact@0
-#  displayName: 'Publish Microsoft.Bot.Builder DLLs artifact'
-#  inputs:
-#    artifactName: 'BotBuilderDLLs-$(BuildConfiguration)-$(BuildTarget)'
-#    targetPath: outputLibraries
-#  enabled: false
-
 - script: |
    cd ..
    dir *.* /s

--- a/build/yaml/vnextprototype/ci-test-steps.yml
+++ b/build/yaml/vnextprototype/ci-test-steps.yml
@@ -76,25 +76,27 @@ steps:
     ArtifactName: CodeCoverage
   enabled: false
 
-- powershell: |
-   New-Item -ItemType directory -Path "outputLibraries\" -Force
+#- powershell: |
+#   New-Item -ItemType directory -Path "outputLibraries\" -Force
    
-   $buildTarget = $env:BuildConfiguration.Split("-")[0];
+#   $buildTarget = $env:BuildConfiguration.Split("-")[0];
    
-   $env:BotBuilderDll.Split(",") | ForEach {
-       $library = $_.Trim()
-       Write-Host $library
+#   $env:BotBuilderDll.Split(",") | ForEach {
+#       $library = $_.Trim()
+#       Write-Host $library
    
-       Get-ChildItem -Path "*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
-       Get-ChildItem -Path "*/*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
-   }
-  displayName: 'Copy DLLs to outputLibraries folder'
+#       Get-ChildItem -Path "*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
+#       Get-ChildItem -Path "*/*/$library/bin/$buildTarget/netstandard2.0/$library.dll" -Recurse | Copy-Item -Destination 'outputLibraries\' -Force
+#   }
+#  displayName: 'Copy DLLs to outputLibraries folder'
+#  enabled: false
 
-- task: PublishPipelineArtifact@0
-  displayName: 'Publish Microsoft.Bot.Builder DLLs artifact'
-  inputs:
-    artifactName: 'BotBuilderDLLs-$(BuildConfiguration)-$(BuildTarget)'
-    targetPath: outputLibraries
+#- task: PublishPipelineArtifact@0
+#  displayName: 'Publish Microsoft.Bot.Builder DLLs artifact'
+#  inputs:
+#    artifactName: 'BotBuilderDLLs-$(BuildConfiguration)-$(BuildTarget)'
+#    targetPath: outputLibraries
+#  enabled: false
 
 - script: |
    cd ..

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.Contains("Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.LUISRuntimeClient", userAgent);
 
             // And that we added the bot.builder package details.
-            Assert.Contains("microsoft.bot.builder.ai.luis/4", userAgent.ToLower());
+            Assert.Contains("microsoft.bot.builder.ai.luis/5", userAgent.ToLower());
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -337,7 +337,17 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.Contains("Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.LUISRuntimeClient", userAgent);
 
             // And that we added the bot.builder package details.
-            Assert.Contains("microsoft.bot.builder.ai.luis/5", userAgent.ToLower());
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+            {
+                // In Windows we get v5.
+                Assert.Contains("microsoft.bot.builder.ai.luis/5", userAgent.ToLower());
+            }
+            else
+            {
+                // In MacLinux we get v4.
+                Assert.Contains("microsoft.bot.builder.ai.luis/4", userAgent.ToLower());
+            }
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var userAgent = clientHandler.UserAgent;
 
             // And that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/4", userAgent);
+            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/5", userAgent);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -311,7 +311,17 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var userAgent = clientHandler.UserAgent;
 
             // And that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/5", userAgent);
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+            {
+                // In Windows we get v5.
+                Assert.Contains("microsoft.bot.builder.ai.luis/5", userAgent.ToLower());
+            }
+            else
+            {
+                // In MacLinux we get v4.
+                Assert.Contains("microsoft.bot.builder.ai.luis/4", userAgent.ToLower());
+            }
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
                 },
                 new QnAMakerOptions
                 {
-                   Top = 5,
+                    Top = 5,
                 });
 
             var results = await qna.GetAnswersAsync(GetContext("Q11"));
@@ -408,7 +408,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             mockHttp = new MockHttpMessageHandler();
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
                 .Respond("application/json", GetResponse("QnaMaker_TopNAnswer_DisableActiveLearning.json"));
-           
+
             results = await qna.GetAnswersAsync(GetContext("Q11"));
             Assert.NotNull(results);
             Assert.Equal(4, results.Length);
@@ -732,11 +732,14 @@ namespace Microsoft.Bot.Builder.AI.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new QnAMaker(
                 new QnAMakerEndpoint
                 {
-                    KnowledgeBaseId = _knowledgeBaseId, EndpointKey = _endpointKey, Host = _hostname,
+                    KnowledgeBaseId = _knowledgeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = _hostname,
                 },
                 new QnAMakerOptions
                 {
-                    Top = -1, ScoreThreshold = 0.5F,
+                    Top = -1,
+                    ScoreThreshold = 0.5F,
                 }));
         }
 
@@ -750,7 +753,9 @@ namespace Microsoft.Bot.Builder.AI.Tests
                 new QnAMaker(
                     new QnAMakerEndpoint
                     {
-                        KnowledgeBaseId = string.Empty, EndpointKey = _endpointKey, Host = _hostname,
+                        KnowledgeBaseId = string.Empty,
+                        EndpointKey = _endpointKey,
+                        Host = _hostname,
                     });
             });
         }
@@ -763,7 +768,9 @@ namespace Microsoft.Bot.Builder.AI.Tests
             Assert.Throws<ArgumentException>(() => new QnAMaker(
                 new QnAMakerEndpoint
                 {
-                    KnowledgeBaseId = _knowledgeBaseId, EndpointKey = string.Empty, Host = _hostname,
+                    KnowledgeBaseId = _knowledgeBaseId,
+                    EndpointKey = string.Empty,
+                    Host = _hostname,
                 }));
         }
 
@@ -775,7 +782,9 @@ namespace Microsoft.Bot.Builder.AI.Tests
             Assert.Throws<ArgumentException>(() => new QnAMaker(
                 new QnAMakerEndpoint
                 {
-                    KnowledgeBaseId = _knowledgeBaseId, EndpointKey = _endpointKey, Host = string.Empty,
+                    KnowledgeBaseId = _knowledgeBaseId,
+                    EndpointKey = _endpointKey,
+                    Host = string.Empty,
                 }));
         }
 
@@ -810,7 +819,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             Assert.StartsWith("BaseCamp: You can use a damp rag to clean around the Power Pack", results[0].Answer);
 
             // Verify that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.QnA/4", interceptHttp.UserAgent);
+            Assert.Contains("Microsoft.Bot.Builder.AI.QnA/5", interceptHttp.UserAgent);
         }
 
         [Fact]
@@ -873,7 +882,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
 
             var options = new QnAMakerOptions
             {
-               Top = 1,
+                Top = 1,
             };
 
             var results = await qna.GetAnswersAsync(GetContext("who loves me?"), options);
@@ -1142,7 +1151,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
 
                                 Host = _hostname,
                             }, oneFilteredOption);
-            
+
             var context = GetContext("up");
             var noFilterResults1 = await qna.GetAnswersAsync(context, oneFilteredOption);
             var requestContent1 = JsonConvert.DeserializeObject<CapturedRequest>(interceptHttp.Content);
@@ -1631,7 +1640,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
                     await dc.Context.SendActivityAsync("Yippee ki-yay!");
                     return EndOfTurn;
                 }
-                
+
                 return await dc.BeginDialogAsync("qnaDialog");
             }
 
@@ -1843,6 +1852,6 @@ namespace Microsoft.Bot.Builder.AI.Tests
             public Metadata[] MetadataBoost { get; set; }
 
             public float ScoreThreshold { get; set; }
-           }
+        }
     }
 }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -819,7 +819,17 @@ namespace Microsoft.Bot.Builder.AI.Tests
             Assert.StartsWith("BaseCamp: You can use a damp rag to clean around the Power Pack", results[0].Answer);
 
             // Verify that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.QnA/5", interceptHttp.UserAgent);
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+            {
+                // In Windows we get v5.
+                Assert.Contains("microsoft.bot.builder.ai.qna/5", interceptHttp.UserAgent.ToLower());
+            }
+            else
+            {
+                // In MacLinux we get v4.
+                Assert.Contains("microsoft.bot.builder.ai.qna/4", interceptHttp.UserAgent.ToLower());
+            }
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
@@ -299,7 +299,17 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             var userAgent = clientHandler.UserAgent;
 
             // And that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/5", userAgent);
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+            {
+                // In Windows we get v5.
+                Assert.Contains("microsoft.bot.builder.ai.luis/5", userAgent.ToLower());
+            }
+            else
+            {
+                // In MacLinux we get v4.
+                Assert.Contains("microsoft.bot.builder.ai.luis/4", userAgent.ToLower());
+            }
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
                 {
                     var traceActivity = activity as ITraceActivity;
                     Assert.NotNull(traceActivity);
-                    #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0612 // Type or member is obsolete
                     Assert.Equal(LuisRecognizer.LuisTraceType, traceActivity.ValueType);
                     Assert.Equal(LuisRecognizer.LuisTraceLabel, traceActivity.Label);
 
@@ -299,7 +299,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             var userAgent = clientHandler.UserAgent;
 
             // And that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/4", userAgent);
+            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/5", userAgent);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -52,21 +52,22 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
                 Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
             bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
 
-            Assert.True(false, $"Debug: FrameworkDescription={System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+            // Assert.True(false, $"Debug: FrameworkDescription={System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
 
             if (!onBuildAgent || winNtOnAgent || netCore46)
             {
-                Assert.True(false, $"Top: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
+                // Assert.True(false, $"Top: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
 
                 // In 1) Windows and 2) MacLinux .NET Core 4.6 the second connection throws an exception.
                 Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
             }
             else
             {
-                Assert.True(false, $"Bottom: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
+                // Assert.True(false, $"Bottom: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
 
                 // In MacLinux .NET Core 3.1 the second connection does not throw.
-                receiver.Connect(transport);
+                // receiver.Connect(transport);
+                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
             }
         }
     }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -37,13 +37,12 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public void PayloadReceiver_Connect_ShouldFail()
+        public void PayloadReceiver_Connect_ShouldFail_In_Windows()
         {
             var buffer = new byte[20];
 
             var transport = new MockTransportReceiver(buffer);
             var receiver = new PayloadReceiver();
-            receiver.Connect(transport);
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
                 Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
@@ -54,6 +53,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             else
             {
                 // MacLinux environment does not throw.
+                receiver.Connect(transport);
             }
 
         }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -47,8 +47,21 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             // First connection succeeds.
             receiver.Connect(transport);
 
-            // The second connection throws an exception.
-            Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            bool onBuildAgent = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS"));
+            bool winNtOnAgent = onBuildAgent &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
+            bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
+
+            if (!onBuildAgent || winNtOnAgent || !netCore46)
+            {
+                // In 1) Windows and 2) MacLinux .NET Core 3.1 the second connection throws an exception.
+                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            }
+            else
+            {
+                // In MacLinux .NET Core 4.6 the second connection does not throw.
+                receiver.Connect(transport);
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
                 Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
             bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
 
+            Assert.True(false, $"Debug: FrameworkDescription={System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
+
             if (!onBuildAgent || winNtOnAgent || netCore46)
             {
                 Assert.True(false, $"Top: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -47,21 +47,23 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             // First connection succeeds.
             receiver.Connect(transport);
 
-            bool onBuildAgent = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS"));
-            bool winNtOnAgent = onBuildAgent &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
-            bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
+            Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
 
-            if (!onBuildAgent || winNtOnAgent || !netCore46)
-            {
-                // In 1) Windows and 2) MacLinux .NET Core 3.1 the second connection throws an exception.
-                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
-            }
-            else
-            {
-                // In MacLinux .NET Core 4.6 the second connection does not throw.
-                receiver.Connect(transport);
-            }
+            // bool onBuildAgent = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS"));
+            // bool winNtOnAgent = onBuildAgent &&
+            //     Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
+            // bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
+
+            // if (!onBuildAgent || winNtOnAgent || !netCore46)
+            // {
+            //     // In 1) Windows and 2) MacLinux .NET Core 3.1 the second connection throws an exception.
+            //     Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            // }
+            // else
+            // {
+            //     // In MacLinux .NET Core 4.6 the second connection does not throw.
+            //     receiver.Connect(transport);
+            // }
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -55,12 +55,14 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             if (!onBuildAgent || winNtOnAgent || netCore46)
             {
                 Assert.True(false, $"Top: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
+
                 // In 1) Windows and 2) MacLinux .NET Core 4.6 the second connection throws an exception.
                 Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
             }
             else
             {
                 Assert.True(false, $"Bottom: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
+
                 // In MacLinux .NET Core 3.1 the second connection does not throw.
                 receiver.Connect(transport);
             }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public void PayloadReceiver_Connect_ShouldFail_In_Windows()
+        public void PayloadReceiver_Connect_ShouldFail()
         {
             var buffer = new byte[20];
 
@@ -47,28 +47,8 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             // First connection succeeds.
             receiver.Connect(transport);
 
-            bool onBuildAgent = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS"));
-            bool winNtOnAgent = onBuildAgent &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
-            bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
-
-            // Assert.True(false, $"Debug: FrameworkDescription={System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
-
-            if (!onBuildAgent || winNtOnAgent || netCore46)
-            {
-                // Assert.True(false, $"Top: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
-
-                // In 1) Windows and 2) MacLinux .NET Core 4.6 the second connection throws an exception.
-                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
-            }
-            else
-            {
-                // Assert.True(false, $"Bottom: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
-
-                // In MacLinux .NET Core 3.1 the second connection does not throw.
-                // receiver.Connect(transport);
-                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
-            }
+            // Second connection throws an exception.
+            Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -47,23 +47,21 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             // First connection succeeds.
             receiver.Connect(transport);
 
-            Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            bool onBuildAgent = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS"));
+            bool winNtOnAgent = onBuildAgent &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
+            bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
 
-            // bool onBuildAgent = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS"));
-            // bool winNtOnAgent = onBuildAgent &&
-            //     Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT");
-            // bool netCore46 = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.Contains("Core 4.6");
-
-            // if (!onBuildAgent || winNtOnAgent || !netCore46)
-            // {
-            //     // In 1) Windows and 2) MacLinux .NET Core 3.1 the second connection throws an exception.
-            //     Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
-            // }
-            // else
-            // {
-            //     // In MacLinux .NET Core 4.6 the second connection does not throw.
-            //     receiver.Connect(transport);
-            // }
+            if (!onBuildAgent || winNtOnAgent || netCore46)
+            {
+                // In 1) Windows and 2) MacLinux .NET Core 4.6 the second connection throws an exception.
+                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            }
+            else
+            {
+                // In MacLinux .NET Core 3.1 the second connection does not throw.
+                receiver.Connect(transport);
+            }
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -54,11 +54,13 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             if (!onBuildAgent || winNtOnAgent || netCore46)
             {
+                Assert.True(false, $"Top: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
                 // In 1) Windows and 2) MacLinux .NET Core 4.6 the second connection throws an exception.
                 Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
             }
             else
             {
+                Assert.True(false, $"Bottom: onBuildAgent={onBuildAgent}; winNtOnAgent={winNtOnAgent}; netCore46={netCore46}");
                 // In MacLinux .NET Core 3.1 the second connection does not throw.
                 receiver.Connect(transport);
             }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -45,7 +45,17 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             var receiver = new PayloadReceiver();
             receiver.Connect(transport);
 
-            Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+            {
+                // Windows environment throws an exception.
+                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
+            }
+            else
+            {
+                // MacLinux environment does not throw.
+            }
+
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -43,16 +43,18 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             var transport = new MockTransportReceiver(buffer);
             var receiver = new PayloadReceiver();
+            // First connection succeeds.
+            receiver.Connect(transport);
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
                 Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
             {
-                // Windows environment throws an exception.
+                // In Windows the second connection throws an exception.
                 Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
             }
             else
             {
-                // MacLinux environment does not throw.
+                // In MacLinux the second connection does not throw.
                 receiver.Connect(transport);
             }
         }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             var transport = new MockTransportReceiver(buffer);
             var receiver = new PayloadReceiver();
+
             // First connection succeeds.
             receiver.Connect(transport);
 

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -47,17 +47,8 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             // First connection succeeds.
             receiver.Connect(transport);
 
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
-            {
-                // In Windows the second connection throws an exception.
-                Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
-            }
-            else
-            {
-                // In MacLinux the second connection does not throw.
-                receiver.Connect(transport);
-            }
+            // The second connection throws an exception.
+            Assert.Throws<InvalidOperationException>(() => receiver.Connect(transport));
         }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadReceiverTests.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
                 // MacLinux environment does not throw.
                 receiver.Connect(transport);
             }
-
         }
     }
 }


### PR DESCRIPTION
Fixes #minor

Adapt pipelines for vNextPrototype branch.

Fix tests to look for Microsoft.Bot.Builder.AI.Luis/5 in Windows instead of Microsoft.Bot.Builder.AI.Luis/4. MacLinux still uses v4, which is odd.

Fix test to expect Microsoft.Bot.Builder.AI.QnA/5 instead of v4. MacLinux still uses v4, which is odd.

Miscellaneous formatting fixes were made by an automated process.