### PR TITLE
fix: Component Governance: CVE-2021-31957

### DIFF
--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.20" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #minor

## Description
Component Governance: CVE-2021-31957, severity high
https://dev.azure.com/FuseLabs/SDK_Public/_componentGovernance/143548/alert/5891813?typeId=2307558
"a vulnerability in .NET 5.0 and .NET Core 3.1...A denial of service vulnerability exists when ASP.NET Core improperly handles client disconnect."
"If you're using .NET 5.0, you should download and install Runtime 5.0.7 or SDK 5.0.204 (for Visual Studio 2019 v16.8) or SDK 5.0.301 (for Visual Studio 2019 16.10)

If you're using .NET Core 3.1, you should download and install Runtime 3.1.16 or SDK 3.1.116 (for Visual Studio 2019 v16.4) or 3.1.410 (for Visual Studio 2019 v16.5 or later)"

/s/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
..was showing: Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1"
I updated it to Version="3.1.20".

## Specific Changes
Update reference "Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" to Version="3.1.20".