### PR TITLE
Fix comparison policy of string in adaptive expressions

### DIFF
--- a/libraries/AdaptiveExpressions/FunctionUtils.cs
+++ b/libraries/AdaptiveExpressions/FunctionUtils.cs
@@ -917,7 +917,7 @@ namespace AdaptiveExpressions
                 }
                 else if (instance is JObject jobj)
                 {
-                    value = jobj.GetValue(property, StringComparison.CurrentCultureIgnoreCase);
+                    value = jobj.GetValue(property, StringComparison.OrdinalIgnoreCase);
                     isPresent = value != null;
                 }
                 else

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1100,6 +1100,8 @@ namespace AdaptiveExpressions.Tests
             Test("getProperty('bag').index", 3),
             Test("getProperty('a:b')", "stringa:b"),
             Test("getProperty(concat('he', 'llo'))", "hello"),
+            Test("getProperty({IncidentCaptionNormal: \"value\"}, \"IncidentCaptionNormal\")", "value"),
+            Test("{IncidentCaptionNormal: \"value\"}.IncidentCaptionNormal", "value"),
             Test("items[2]", "two", new HashSet<string> { "items[2]" }),
             Test("bag.list[bag.index - 2]", "blue", new HashSet<string> { "bag.list", "bag.index" }),
             Test("items[nestedItems[1].x]", "two", new HashSet<string> { "items", "nestedItems[1].x" }),
@@ -1273,7 +1275,7 @@ namespace AdaptiveExpressions.Tests
         [MemberData(nameof(Data))]
         public void EvaluateInOtherCultures(string input, object expected, HashSet<string> expectedRefs)
         {
-            var cultureList = new List<string>() { "de-DE", "fr-FR", "es-ES" };
+            var cultureList = new List<string>() { "de-DE", "fr-FR", "es-ES", "tr-TR" };
             foreach (var newCultureInfo in cultureList)
             {
                 var originalCulture = Thread.CurrentThread.CurrentCulture;


### PR DESCRIPTION
Fixes #5917

## Description
Fix comparison policy of string in adaptive expressions to avoid the special case of different cultures.

## Testing
Add "tr-TR" culture test