### PR TITLE
Add support for referral property in Facebook messaging_referrals event

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookReferral.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookReferral.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
         /// Gets or sets the type parameter in the referral event.
         /// </summary>
         /// <value>The identifier for the referral. For referrals coming from m.me links, it will always be "OPEN_THREAD".</value>
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
     }
 }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookReferral.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookReferral.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
+{
+    /// <summary>
+    /// Represents the referral parameter in the messaging_referrals event.
+    /// </summary>
+    public class FacebookReferral
+    {
+        /// <summary>
+        /// Gets or sets the ref parameter in the referral event.
+        /// </summary>
+        /// <value>The arbitrary data that was originally passed in the ref param added to the m.me link.</value>
+        [JsonProperty(PropertyName = "ref")]
+        public string Ref { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source parameter in the referral event.
+        /// </summary>
+        /// <value>The source of this referral. For m.me links, the value of source is “SHORTLINK”. For referrals from Messenger Conversation Ads, the value of source is "ADS".</value>
+        [JsonProperty(PropertyName = "source")]
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type parameter in the referral event.
+        /// </summary>
+        /// <value>The identifier for the referral. For referrals coming from m.me links, it will always be "OPEN_THREAD".</value>
+        public string Type { get; set; }
+    }
+}

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookHelper.cs
@@ -153,6 +153,11 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
                 activity.Type = ActivityTypes.Message;
                 activity.Text = message.PostBack.Payload;
             }
+            else if (message.Referral != null)
+            {
+                activity.Type = ActivityTypes.Event;
+                activity.Value = message.Referral.Ref;
+            }
 
             return activity;
         }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
@@ -149,5 +149,12 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
         /// See https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/message-reads. </value>.
         [JsonProperty(PropertyName = "read")]
         public FacebookRead Reads { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the referral property in an messaging_referrals event.
+        /// </summary>
+        /// <value>See https://developers.facebook.com/docs/messenger-platform/discovery/m-me-links/#reading_parameter. </value>
+        [JsonProperty(PropertyName = "referral")]
+        public FacebookReferral Referral { get; set; }
     }
 }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -120,6 +120,24 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
+        public async void ProcessAsyncShouldSucceedWithReferralMessages()
+        {
+            var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/PayloadWithReferral.json");
+            var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
+            var facebookAdapter = new FacebookAdapter(facebookClientWrapper.Object, _adapterOptions);
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+            var httpRequest = new Mock<HttpRequest>();
+            var httpResponse = new Mock<HttpResponse>();
+            var bot = new Mock<IBot>();
+
+            httpRequest.SetupGet(req => req.Query[It.IsAny<string>()]).Returns("test");
+            httpRequest.SetupGet(req => req.Body).Returns(stream);
+
+            await facebookAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, bot.Object, default(CancellationToken));
+            bot.Verify(b => b.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
         public async void ProcessAsyncShouldVerifyWebhookOnHubModeSubscribe()
         {
             var testOptionsVerifyEnabled = new FacebookAdapterOptions()

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookHelperTests.cs
@@ -163,6 +163,23 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
+        public void ProcessSingleMessageShouldReturnActivityWithReferral()
+        {
+            var facebookMessageJson = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/PayloadWithReferral.json");
+            var facebookResponse = JsonConvert.DeserializeObject<FacebookResponseEvent>(facebookMessageJson);
+
+            var payload = new List<FacebookMessage>();
+
+            payload = facebookResponse.Entry[0].Messaging;
+
+            var activity = FacebookHelper.ProcessSingleMessage(payload[0]);
+            Assert.Equal(facebookResponse.Entry[0].Messaging[0].Recipient.Id, activity.Recipient.Id);
+            Assert.Equal(facebookResponse.Entry[0].Messaging[0].Sender.Id, activity.Conversation.Id);
+            Assert.Equal(facebookResponse.Entry[0].Messaging[0].Sender.Id, activity.Conversation.Id);
+            Assert.Equal(facebookResponse.Entry[0].Messaging[0].Referral.Ref, activity.Value);
+        }
+
+        [Fact]
         public async Task WriteAsyncShouldFailWithNullResponse()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Files/PayloadWithReferral.json
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Files/PayloadWithReferral.json
@@ -1,0 +1,25 @@
+{
+  "object": "page",
+  "entry": [
+    {
+      "id": "0",
+      "time": 1111111,
+      "messaging": [
+        {
+          "sender": {
+            "id": "0"
+          },
+          "recipient": {
+            "id": "0"
+          },
+          "timestamp": 2222222,
+          "referral": {
+            "ref": "USER_DEFINED_REFERRAL_PARAM",
+            "source": "SHORTLINK",
+            "type": "OPEN_THREAD"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -39,6 +39,9 @@
     <None Update="Files\FacebookMessages.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\PayloadWithReferral.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Files\Payload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Fixes #5948  

## Description
Add support for Facebook Referral parameter
This handles the second scenario of Facebooks messaging_referrals event here: https://developers.facebook.com/docs/messenger-platform/discovery/m-me-links/#reading_parameter

## Specific Changes
-  added FacebookReferral.cs class for deserialisation of Facebook referral event messaging_referrals
 - added new property Referral on FacebookMessage
