### PR TITLE
Add OpenIdMetadata endpoint support to CloudAdapter.

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationBotFrameworkAuthentication.cs
@@ -54,6 +54,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 authConfiguration ?? new AuthenticationConfiguration(),
                 httpClientFactory,
                 logger);
+
+            // Update the OpenId metadata endpoint if configured in appsettings
+            var openIdEndpoint = configuration.GetSection(AuthenticationConstants.BotOpenIdMetadataKey)?.Value;
+            if (!string.IsNullOrEmpty(openIdEndpoint))
+            {
+                // Indicate which Cloud we are using, for example, Public or Sovereign.
+                ChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
+                GovernmentChannelValidation.OpenIdMetadataUrl = openIdEndpoint;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes #5964 

## Description
BotFrameworkHttpAdapter supports `BotOpenIdMetadata` in appsettings. This change incorporates this feature into CloudAdapter.

## Specific Changes
  - Read the `BotOpenIdMetadata` from appsettings in `ConfigurationBotFrameworkAuthentication`, and update the OpenId metadata endpoint if specified.

## Testing
Validated using echo bot sample.