### PR TITLE
Add v5 branch to js-parity workflow

### DIFF
--- a/.github/workflows/create-botbuilder-js-parity-issue.yml
+++ b/.github/workflows/create-botbuilder-js-parity-issue.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - main
+    - v5
     types: [closed]
 
 jobs:


### PR DESCRIPTION
Fixes #5978

Parity issues are created unless PR is tagged with `Automation: No parity`.

The workflow creates parity issues for JS, Java and Python.

## Specific Changes
Add v5 branch to create-botbuilder-js-parity-issue.yml