### PR TITLE
Adds missing obsolete attributes to member that depend on obsolete types 

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisApplication.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// Initializes a new instance of the <see cref="LuisApplication"/> class.
         /// </summary>
         /// <param name="service">LUIS configuration.</param>
+        [Obsolete("The LuisService class is obsolete and it will be removed in a future version of the framework, use LuisApplication(string applicationId, string endpointKey, string endpoint) instead.", false)]
         public LuisApplication(LuisService service)
             : this((service.AppId, service.SubscriptionKey, service.GetEndpoint()))
         {

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerEndpoint.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Configuration;
 using Newtonsoft.Json;
 
@@ -22,6 +23,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// Initializes a new instance of the <see cref="QnAMakerEndpoint"/> class.
         /// </summary>
         /// <param name="service">QnA service details from configuration.</param>
+        [Obsolete("This constructor is obsolete, the QnAMakerService class is obsolete and will be removed in a future version of the framework.")]
         public QnAMakerEndpoint(QnAMakerService service)
         {
             KnowledgeBaseId = service.KbId;

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
         /// <param name="botConfiguration">Bot configuration that contains the Application Insights configuration information.</param>
         /// <param name="appInsightsServiceInstanceName">(OPTIONAL) Specifies a Application Insights instance name in the Bot configuration.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
+        [Obsolete("This method is obsolete and will be removed in a future version of the framework, use AddBotApplicationInsights(this IServiceCollection services, IConfiguration config) instead.", false)]
         public static IServiceCollection AddBotApplicationInsights(this IServiceCollection services, BotConfiguration botConfiguration, string appInsightsServiceInstanceName = null)
         {
             if (botConfiguration == null)

--- a/tests/Microsoft.Bot.Configuration.Tests/ServiceTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ServiceTests.cs
@@ -1,37 +1,42 @@
-﻿using Newtonsoft.Json;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Bot.Configuration.Tests
 {
+#pragma warning disable CS0618 // Type or member is obsolete (Excluding so we can test obsolete classes)
     public class ServiceTests
     {
         [Fact]
         public void LuisReturnsCorrectUrl()
         {
-            var luis = new LuisService() { Region = "westus" };
+            var luis = new LuisService { Region = "westus" };
             Assert.Equal("https://westus.api.cognitive.microsoft.com", luis.GetEndpoint());
 
-            luis = new LuisService() { Region = "virginia" };
+            luis = new LuisService { Region = "virginia" };
             Assert.Equal("https://virginia.api.cognitive.microsoft.us", luis.GetEndpoint());
 
-            luis = new LuisService() { Region = "usgovvirginia" };
+            luis = new LuisService { Region = "usgovvirginia" };
             Assert.Equal("https://virginia.api.cognitive.microsoft.us", luis.GetEndpoint());
 
-            luis = new LuisService() { Region = "usgoviowa" };
+            luis = new LuisService { Region = "usgoviowa" };
             Assert.Equal("https://usgoviowa.api.cognitive.microsoft.us", luis.GetEndpoint());
         }
 
         [Fact]
         public void QnaMakerSuffixTest()
         {
-            var qnamaker = new QnAMakerService() { Hostname = "http://foo.azurewebsites.net" };
+            var qnamaker = new QnAMakerService { Hostname = "http://foo.azurewebsites.net" };
             Assert.Equal("http://foo.azurewebsites.net/qnamaker", qnamaker.Hostname);
 
-            qnamaker = new QnAMakerService() { Hostname = "http://foo.azurewebsites.net/asdf?x=15" };
+            qnamaker = new QnAMakerService { Hostname = "http://foo.azurewebsites.net/asdf?x=15" };
             Assert.Equal("http://foo.azurewebsites.net/qnamaker", qnamaker.Hostname);
 
             qnamaker = JsonConvert.DeserializeObject<QnAMakerService>("{\"hostname\":\"http://foo.azurewebsites.net/asdf?x=15\"}");
             Assert.Equal("http://foo.azurewebsites.net/qnamaker", qnamaker.Hostname);
         }
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }


### PR DESCRIPTION
Added obsolete attribute to classes that use obsolete objects from Configuration.
Added pragma to avoid warnings in test code.

Checked the dotnet samples and the deprecated members don't seem to be used there

Fixes #5996