### PR TITLE
Add default (C) in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,9 @@ charset = utf-8-bom
 # .NET Coding Conventions     #
 ###############################
 [*.{cs,vb}]
+# Copyright notice
+file_header_template = Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.
+
 # Organize usings
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false


### PR DESCRIPTION
#minor

Adds default (c) not to editorconfig so new files are created with the right copyright