### PR TITLE
Cherry-Pick to 4.15: LG Performance & Scalability: Speed up loading, fix concurrency and m…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Generators/TemplateEngineLanguageGenerator.cs
@@ -26,20 +26,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
 
         private const string DEFAULTLABEL = "Unknown";
 
-        private static readonly TaskFactory TaskFactory = new TaskFactory(
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            TaskContinuationOptions.None,
-            TaskScheduler.Default);
-
-        private readonly LanguageGeneration.Templates lg;
+        private readonly Lazy<Task<LanguageGeneration.Templates>> _lg;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TemplateEngineLanguageGenerator"/> class.
         /// </summary>
         public TemplateEngineLanguageGenerator()
         {
-            this.lg = new LanguageGeneration.Templates();
+            _lg = new Lazy<Task<LanguageGeneration.Templates>>(() => Task.FromResult(new LanguageGeneration.Templates()));
         }
 
         /// <summary>
@@ -48,7 +42,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// <param name="engine">template engine.</param>
         public TemplateEngineLanguageGenerator(LanguageGeneration.Templates engine = null)
         {
-            this.lg = engine ?? new LanguageGeneration.Templates();
+            _lg = new Lazy<Task<LanguageGeneration.Templates>>(() => Task.FromResult(engine ?? new LanguageGeneration.Templates()));
         }
 
         /// <summary>
@@ -60,11 +54,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         [Obsolete("This method will soon be deprecated. Use LGResource as the first parameter instead.")]
         public TemplateEngineLanguageGenerator(string lgText, string id, Dictionary<string, IList<Resource>> resourceMapping)
         {
-            this.Id = id ?? DEFAULTLABEL;
+            Id = id ?? DEFAULTLABEL;
             var (_, locale) = LGResourceLoader.ParseLGFileName(id);
             var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
             var lgResource = new LGResource(Id, Id, lgText ?? string.Empty);
-            this.lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
+            _lg = new Lazy<Task<LanguageGeneration.Templates>>(() => Task.FromResult(LanguageGeneration.Templates.ParseResource(lgResource, importResolver)));
         }
 
         /// <summary>
@@ -76,12 +70,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         public TemplateEngineLanguageGenerator(string filePath, Dictionary<string, IList<Resource>> resourceMapping)
         {
             filePath = PathUtils.NormalizePath(filePath);
-            this.Id = Path.GetFileName(filePath);
+            Id = Path.GetFileName(filePath);
 
             var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
             var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
             var resource = new LGResource(Id, filePath, File.ReadAllText(filePath));
-            this.lg = LanguageGeneration.Templates.ParseResource(resource, importResolver);
+            _lg = new Lazy<Task<LanguageGeneration.Templates>>(() => Task.FromResult(LanguageGeneration.Templates.ParseResource(resource, importResolver)));
         }
 
         /// <summary>
@@ -90,15 +84,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// <param name="resource">Resource.</param>
         /// <param name="resourceMapping">template resource loader delegate (locale) -> <see cref="ImportResolverDelegate"/>.</param>
         public TemplateEngineLanguageGenerator(Resource resource, Dictionary<string, IList<Resource>> resourceMapping)
+            : this(resource, resourceMapping, loadOnConstruction: true)
         {
-            this.Id = resource.Id;
+        }
 
-            var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
-            var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
-            var content = resource.ReadTextAsync().GetAwaiter().GetResult();
-            var lgResource = new LGResource(Id, resource.FullName, content);
-            this.lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
-            RegisterSourcemap(lg, resource);
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemplateEngineLanguageGenerator"/> class.
+        /// </summary>
+        /// <param name="resource">Resource.</param>
+        /// <param name="resourceMapping">template resource loader delegate (locale) -> <see cref="ImportResolverDelegate"/>.</param>
+        /// <param name="loadOnConstruction">Whether to load LG resources at build time. If false is specified, then LoadAsync needs to be called.</param>
+        internal TemplateEngineLanguageGenerator(Resource resource, Dictionary<string, IList<Resource>> resourceMapping, bool loadOnConstruction)
+        {
+            Id = resource.Id;
+            _lg = new Lazy<Task<LanguageGeneration.Templates>>(() => CreateTemplatesAsync(resource, resourceMapping));
+
+            // Legacy path: legacy constructor calls will load the content synchronously in the constructor as before to 
+            // maintain backward compatibility. New path through adaptive runtime will call LoadAsync separately in an asynchronous manner.
+            if (loadOnConstruction)
+            {
+                _ = _lg.Value.GetAwaiter().GetResult();
+            }
         }
 
         /// <summary>
@@ -118,15 +124,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
         /// <param name="data">data to bind to.</param>
         /// <param name="cancellationToken">the <see cref="CancellationToken"/> for the task.</param>
         /// <returns>generated text.</returns>
-        public override Task<object> GenerateAsync(DialogContext dialogContext, string template, object data, CancellationToken cancellationToken = default)
+        public override async Task<object> GenerateAsync(DialogContext dialogContext, string template, object data, CancellationToken cancellationToken = default)
         {
-            EventHandler onEvent = (s, e) => RunSync(() => HandlerLGEventAsync(dialogContext, s, e, cancellationToken));
-
-            var lgOpt = new EvaluationOptions() { Locale = dialogContext.GetLocale(), OnEvent = onEvent };
+            var lgOpt = new EvaluationOptions() { Locale = dialogContext.GetLocale() };
 
             try
             {
-                return Task.FromResult(lg.EvaluateText(template, data, lgOpt));
+                var lg = await _lg.Value.ConfigureAwait(false);
+                return lg.EvaluateText(template, data, lgOpt);
             }
             catch (Exception err)
             {
@@ -139,14 +144,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
             }
         }
 
-        private static void RunSync(Func<Task> func)
+        /// <summary>
+        /// Load templates.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        internal async Task LoadAsync()
         {
-#pragma warning disable CA2008 // Do not create tasks without passing a TaskScheduler
-            TaskFactory.StartNew(() =>
-            {
-                return func();
-            }).Unwrap().GetAwaiter().GetResult();
-#pragma warning restore CA2008 // Do not create tasks without passing a TaskScheduler
+            _ = await _lg.Value.ConfigureAwait(false);
         }
 
         private static void RegisterSourcemap(LanguageGeneration.Templates templates, Resource resource)
@@ -179,26 +183,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Generators
             }
         }
 
-        private async Task HandlerLGEventAsync(DialogContext dialogContext, object sender, EventArgs eventArgs, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Loads language generation templates asynchronously.
+        /// </summary>
+        /// <param name="resource">Resource.</param>
+        /// <param name="resourceMapping">template resource loader delegate (locale) -> <see cref="ImportResolverDelegate"/>.</param>
+        /// <returns>The loaded language generation templates.</returns>
+        private async Task<LanguageGeneration.Templates> CreateTemplatesAsync(Resource resource, Dictionary<string, IList<Resource>> resourceMapping)
         {
-            // skip the events that is not LG event or the event path is invalid.
-            if (!(eventArgs is LGEventArgs))
-            {
-                await Task.CompletedTask.ConfigureAwait(false);
-            }
-
-            if (eventArgs is BeginTemplateEvaluationArgs || eventArgs is BeginExpressionEvaluationArgs)
-            {
-                // Send debugger event
-                await dialogContext.GetDebugger().StepAsync(dialogContext, sender, DialogEvents.Custom, cancellationToken).ConfigureAwait(false);
-            }
-            else if (eventArgs is MessageArgs message && dialogContext.GetDebugger() is IDebugger dda)
-            {
-                // send debugger message
-                await dda.OutputAsync(message.Text, sender, message.Text, cancellationToken).ConfigureAwait(false);
-            }
-
-            await Task.CompletedTask.ConfigureAwait(false);
+            var (_, locale) = LGResourceLoader.ParseLGFileName(Id);
+            var importResolver = LanguageGeneratorManager.ResourceExplorerResolver(locale, resourceMapping);
+            var content = await resource.ReadTextAsync().ConfigureAwait(false);
+            var lgResource = new LGResource(Id, resource.FullName, content);
+            var lg = LanguageGeneration.Templates.ParseResource(lgResource, importResolver);
+            RegisterSourcemap(lg, resource);
+            return lg;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FileResource.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/FileResource.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under the MIT License.
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
@@ -12,14 +13,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
     /// </summary>
     public class FileResource : Resource
     {
+        private readonly Lazy<Task<string>> _contentCache;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FileResource"/> class.
         /// </summary>
         /// <param name="path">path to file.</param>
         public FileResource(string path)
         {
-            this.FullName = path;
-            this.Id = Path.GetFileName(path);
+            FullName = path;
+            Id = Path.GetFileName(path);
+            _contentCache = new Lazy<Task<string>>(GetOrLoadTextAsync);
+        }
+
+        /// <inheritdoc/>
+        public override async Task<string> ReadTextAsync()
+        {
+            return await _contentCache.Value.ConfigureAwait(false);
         }
 
         /// <summary>
@@ -28,7 +38,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <returns>Stream for accesssing the content of the resource.</returns>
         public override async Task<Stream> OpenStreamAsync()
         {
-            return await Task.FromResult(new FileStream(this.FullName, FileMode.Open)).ConfigureAwait(false);
+            return await Task.FromResult(new FileStream(FullName, FileMode.Open, FileAccess.Read)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -37,7 +47,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
         /// <returns>A string that represents the current object.</returns>
         public override string ToString()
         {
-            return this.Id;
+            return Id;
+        }
+
+        private async Task<string> GetOrLoadTextAsync()
+        {
+            return await base.ReadTextAsync().ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
…emory problems (#6061)

fixes: #6060

* Foreach: refactor from recursive to iterative implemeentation to keep stack depth constant

* Foreach: leave legacy foreach unchanged, deprecate it, and make ForEachElement the default

* Foreach: fix name in deprecation message

* LG Performance & Scalability: Speed up loading, fix concurrency problems, fix memory problems.

+ LG file content was loaded synchronously in a the TEmplateEngineLanguageGenerator constructor, not allowing for asynchronous execution and blocking the thread while we waited for each file to load. With this fix, we let LG load in the constructor for legacy paths, but the new paths have a LoadAsync method that loads asynchronously. The new path is internal only, meaning that the public surface is not affected. Each LGenerator is loaded only once by using LAzy with the default ExecutionAndPublication thread safety mode.
+ AdaptiveDialogBot: LanguageGeneratorManager can take minutes in a sizable bot. If there are multiple parallel requests, LanguageGeneratorManager will get constructed once per request, allowing for servers to do the same work and throw OutOfMemoryException, consuming upwards of 14GB. This fix uses Lazy initialization in AdaptiveDialogBot with ExecutionAndPublication thread safe mode to ensure that only one LanguageGeneratorManager is created at ones
+ Multiple reads of file contents: For our perf sample, each LG file was being read more than 30 times, despite its content never changing. Also there was no protection for parallel reads, which could lead to unexpected concurrency failures. This fix adds a caching element to FileResource and at the same time uses the Lazy ExecutionAndPublication thread safety mode to ensure that only one thread initializes the value. When there is a change Event, a new Fileresource is created so this does not affect functionality.

Some results for our test dataset:

Before
Single request total load time: 5 min 11 sec
Single request total memory: 4.1GB
Load test (100 users, 20 concurrent) total load time and memory: N/A OutOfMemoryException after 14GB

After
Single request total load time: 1 min 40 sec
Single request total memory: 4.1GB
Load test (100 users, 20 concurrent) total load time and memory: 1min 50 sec, 4.1 GB :)

* LG Performance: add legacy explanation comments

* FileResource: open files for read only.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->