### PR TITLE
Update connector client code to return and log the right assembly version.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <LocalPackageVersion>4.11.0-local</LocalPackageVersion>
+    <LocalPackageVersion>0.0.0.0</LocalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Bot.Connector
         /// <returns>The assembly version for this Bot Connector client.</returns>
         private static string GetClientVersion()
         {
-            var type = typeof(ConnectorClient).GetType();
+            var type = typeof(ConnectorClient);
             var assembly = type.GetTypeInfo().Assembly;
             return assembly.GetName().Version.ToString();
         }

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -337,7 +337,8 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             Assert.Contains("Microsoft.Azure.CognitiveServices.Language.LUIS.Runtime.LUISRuntimeClient", userAgent);
 
             // And that we added the bot.builder package details.
-            Assert.Contains("microsoft.bot.builder.ai.luis/4", userAgent.ToLower());
+            var majorVersion = typeof(ConnectorClient).GetTypeInfo().Assembly.GetName().Version.Major;
+            Assert.Contains($"microsoft.bot.builder.ai.luis/{majorVersion}", userAgent.ToLower());
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -311,7 +311,8 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var userAgent = clientHandler.UserAgent;
 
             // And that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/4", userAgent);
+            var majorVersion = typeof(ConnectorClient).GetTypeInfo().Assembly.GetName().Version.Major;
+            Assert.Contains($"Microsoft.Bot.Builder.AI.Luis/{majorVersion}", userAgent);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -19,6 +20,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
 using Microsoft.Bot.Configuration;
+using Microsoft.Bot.Connector;
 using Microsoft.Bot.Schema;
 using Moq;
 using Newtonsoft.Json;
@@ -810,7 +812,8 @@ namespace Microsoft.Bot.Builder.AI.Tests
             Assert.StartsWith("BaseCamp: You can use a damp rag to clean around the Power Pack", results[0].Answer);
 
             // Verify that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.QnA/4", interceptHttp.UserAgent);
+            var majorVersion = typeof(ConnectorClient).GetTypeInfo().Assembly.GetName().Version.Major;
+            Assert.Contains($"Microsoft.Bot.Builder.AI.QnA/{majorVersion}", interceptHttp.UserAgent);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
@@ -299,7 +299,8 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             var userAgent = clientHandler.UserAgent;
 
             // And that we added the bot.builder package details.
-            Assert.Contains("Microsoft.Bot.Builder.AI.Luis/4", userAgent);
+            var majorVersion = typeof(ConnectorClient).GetTypeInfo().Assembly.GetName().Version.Major;
+            Assert.Contains($"Microsoft.Bot.Builder.AI.Luis/{majorVersion}", userAgent);
         }
 
         [Fact]


### PR DESCRIPTION
Update connector client code to return and log the right assembly version.
Updated LocalPackageVersion in Directory.Build.props to use 0.0.0.0 so dev assembly versions can be easily identified in the logs.

Fixes #6072
