### PR TITLE
Default DialogSet to case insensitive comparison

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public class DialogSet
     {
-        private readonly IDictionary<string, Dialog> _dialogs = new Dictionary<string, Dialog>();
+        private readonly IDictionary<string, Dialog> _dialogs;
         private readonly IStatePropertyAccessor<DialogState> _dialogState;
         private IBotTelemetryClient _telemetryClient;
         private string _version;
@@ -25,12 +25,14 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <param name="dialogState">The state property accessor with which to manage the stack for
         /// this dialog set.</param>
+        /// <param name="stringComparer">The <see cref="StringComparer"/> to use for the Dictionary within the DialogSet.</param>
         /// <remarks>To start and control the dialogs in this dialog set, create a <see cref="DialogContext"/>
         /// and use its methods to start, continue, or end dialogs. To create a dialog context,
         /// call <see cref="CreateContextAsync(ITurnContext, CancellationToken)"/>.
         /// </remarks>
-        public DialogSet(IStatePropertyAccessor<DialogState> dialogState)
+        public DialogSet(IStatePropertyAccessor<DialogState> dialogState, StringComparer stringComparer = default(StringComparer))
         {
+            _dialogs = new Dictionary<string, Dialog>(stringComparer ?? StringComparer.OrdinalIgnoreCase);
             _dialogState = dialogState ?? throw new ArgumentNullException(nameof(dialogState));
             _telemetryClient = NullBotTelemetryClient.Instance;
         }
@@ -41,6 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         public DialogSet()
         {
             _dialogState = null;
+            _dialogs = new Dictionary<string, Dialog>(StringComparer.OrdinalIgnoreCase);
             _telemetryClient = NullBotTelemetryClient.Instance;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <remarks>The new instance is created with an empty dialog stack.</remarks>
         /// <seealso cref="DialogContext.Stack"/>
-        /// <seealso cref="DialogSet(IStatePropertyAccessor{DialogState})"/>
+        /// <seealso cref="DialogSet"/>
         public DialogState()
             : this(null)
         {

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/DialogSetTests.cs
@@ -109,6 +109,36 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
+        public async Task DialogSet_CaseInsensitive()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
+            var ds = new DialogSet(dialogStateProperty)
+                .Add(new WaterfallDialog("a"))
+                .Add(new WaterfallDialog("A"));
+
+            Assert.NotNull(ds.Find("a"));
+            Assert.NotNull(ds.Find("a2"));
+
+            await Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task DialogSet_CaseSensitive()
+        {
+            var convoState = new ConversationState(new MemoryStorage());
+            var dialogStateProperty = convoState.CreateProperty<DialogState>("dialogstate");
+            var ds = new DialogSet(dialogStateProperty, StringComparer.Ordinal)
+                .Add(new WaterfallDialog("a"))
+                .Add(new WaterfallDialog("A"));
+
+            Assert.NotNull(ds.Find("a"));
+            Assert.NotNull(ds.Find("A"));
+
+            await Task.CompletedTask;
+        }
+
+        [Fact]
         public async Task DialogSet_NullTelemetrySet()
         {
             var convoState = new ConversationState(new MemoryStorage());


### PR DESCRIPTION
Fixes #4870

Note: this is potentially a breaking change. Bots with dialog ids differing in only upper and lower case will no longer recognize them as different dialogs.