### PR TITLE
Add Component Governance to build

### DIFF
--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -22,6 +22,11 @@ steps:
     configuration: '$(BuildConfiguration)'
     maximumCpuCount: true
     logProjectEvents: false
+    
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    failOnAlert: true
 
 - script: |
    cd ..


### PR DESCRIPTION
The injected Component Governance task does not enable the option to fail the build when alerts are raised. This change adds the step to our build with the option to fail builds in case of alerts.

#minor