### PR TITLE
Add OnReactionsChanged to ActivityHandler

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -259,28 +259,63 @@ namespace Microsoft.Bot.Builder
         /// <see cref="OnReactionsAddedAsync(IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>.
         /// If the message reaction indicates that reactions were removed from a message, it calls
         /// <see cref="OnReactionsRemovedAsync(IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>.
-        ///
+        /// If the message reaction indicates that reactions were both added and removed from a message, it calls
+        /// <see cref="OnReactionsChangedAsync(IList{MessageReaction}, IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>.
+        /// 
         /// In a derived class, override this method to add logic that applies to all message reaction activities.
         /// Add logic to apply before the reactions added or removed logic before the call to the base class
-        /// <see cref="OnMessageReactionActivityAsync(ITurnContext{IMessageReactionActivity}, CancellationToken)"/> method.
-        /// Add logic to apply after the reactions added or removed logic after the call to the base class
         /// <see cref="OnMessageReactionActivityAsync(ITurnContext{IMessageReactionActivity}, CancellationToken)"/> method.
         ///
         /// </remarks>
         /// <seealso cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
         /// <seealso cref="OnReactionsAddedAsync(IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
         /// <seealso cref="OnReactionsRemovedAsync(IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
+        /// <seealso cref="OnReactionsChangedAsync(IList{MessageReaction}, IList{MessageReaction}, ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
         protected virtual async Task OnMessageReactionActivityAsync(ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
         {
-            if (turnContext.Activity.ReactionsAdded != null)
+            if (turnContext.Activity.ReactionsRemoved != null && turnContext.Activity.ReactionsAdded != null)
             {
-                await OnReactionsAddedAsync(turnContext.Activity.ReactionsAdded, turnContext, cancellationToken).ConfigureAwait(false);
+                await OnReactionsChangedAsync(turnContext.Activity.ReactionsAdded, turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
             }
+            else
+            {
+                if (turnContext.Activity.ReactionsAdded != null)
+                {
+                    await OnReactionsAddedAsync(turnContext.Activity.ReactionsAdded, turnContext, cancellationToken).ConfigureAwait(false);
+                }
 
-            if (turnContext.Activity.ReactionsRemoved != null)
-            {
-                await OnReactionsRemovedAsync(turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
+                if (turnContext.Activity.ReactionsRemoved != null)
+                {
+                    await OnReactionsRemovedAsync(turnContext.Activity.ReactionsRemoved, turnContext, cancellationToken).ConfigureAwait(false);
+                }
             }
+        }
+
+        /// <summary>
+        /// Override this in a derived class to provide logic for when reactions to a previous activity
+        /// are both added and removed.
+        /// </summary>
+        /// <param name="addedReactions">The list of reactions added.</param>
+        /// <param name="removedReactions">The list of reactions removed.</param>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>
+        /// Message reactions correspond to the user adding a 'like' or 'sad' etc. (often an emoji) to a
+        /// previously sent message on the conversation. Message reactions are supported by only a few channels.
+        /// The activity that the message is in reaction to is identified by the activity's
+        /// <see cref="Activity.ReplyToId"/> property. The value of this property is the activity ID
+        /// of a previously sent activity. When the bot sends an activity, the channel assigns an ID to it,
+        /// which is available in the <see cref="ResourceResponse.Id"/> of the result.
+        /// </remarks>
+        /// <seealso cref="OnMessageReactionActivityAsync(ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
+        /// <seealso cref="Activity.Id"/>
+        /// <seealso cref="ITurnContext.SendActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="ResourceResponse.Id"/>
+        protected virtual Task OnReactionsChangedAsync(IList<MessageReaction> addedReactions, IList<MessageReaction> removedReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -288,12 +288,12 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.Equal("OnConversationUpdateActivityAsync", bot.Record[0]);
         }
 
+
         [Fact]
-        public async Task TestMessageReaction()
+        public async Task TestMessageOnReactionsChanged()
         {
             // Note the code supports multiple adds and removes in the same activity though
-            // a channel may decide to send separate activities for each. For example, Teams
-            // sends separate activities each with a single add and a single remove.
+            // a channel may decide to send separate activities for each. 
 
             // Arrange
             var activity = new Activity
@@ -317,8 +317,61 @@ namespace Microsoft.Bot.Builder.Tests
             // Assert
             Assert.Equal(3, bot.Record.Count);
             Assert.Equal("OnMessageReactionActivityAsync", bot.Record[0]);
+            Assert.Equal("OnReactionsChangedAsync", bot.Record[1]);
+        }
+
+        [Fact]
+        public async Task TestMessageReactionAdded()
+        {
+            // Note the code supports multiple adds and removes in the same activity though
+            // a channel may decide to send separate activities for each. 
+
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageReaction,
+                ReactionsAdded = new List<MessageReaction>
+                {
+                    new MessageReaction("sad"),
+                },
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(3, bot.Record.Count);
+            Assert.Equal("OnMessageReactionActivityAsync", bot.Record[0]);
             Assert.Equal("OnReactionsAddedAsync", bot.Record[1]);
-            Assert.Equal("OnReactionsRemovedAsync", bot.Record[2]);
+        }
+
+        [Fact]
+        public async Task TestMessageReactionRemoved()
+        {
+            // Note the code supports multiple adds and removes in the same activity though
+            // a channel may decide to send separate activities for each. 
+
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageReaction,
+                ReactionsRemoved = new List<MessageReaction>
+                {
+                    new MessageReaction("angry"),
+                },
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(3, bot.Record.Count);
+            Assert.Equal("OnMessageReactionActivityAsync", bot.Record[0]);
+            Assert.Equal("OnReactionsRemovedAsync", bot.Record[1]);
         }
 
         [Fact]
@@ -718,6 +771,12 @@ namespace Microsoft.Bot.Builder.Tests
                 return base.OnMessageReactionActivityAsync(turnContext, cancellationToken);
             }
 
+            protected override Task OnReactionsChangedAsync(IList<MessageReaction> addedReactions, IList<MessageReaction> removedReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnReactionsChangedAsync(addedReactions, removedReactions, turnContext, cancellationToken);
+            }
+
             protected override Task OnReactionsAddedAsync(IList<MessageReaction> messageReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
@@ -836,42 +895,6 @@ namespace Microsoft.Bot.Builder.Tests
                 await turnContext.SendActivityAsync(new Activity());
                 await turnContext.SendActivitiesAsync(new IActivity[] { new Activity() });
                 await turnContext.UpdateActivityAsync(new Activity());
-            }
-        }
-
-        private class MockConnectorClient : IConnectorClient
-        {
-            private Uri _baseUri = new Uri("http://tempuri.org/whatever");
-
-            public Uri BaseUri
-            {
-                get { return _baseUri; }
-                set { _baseUri = value; }
-            }
-
-            public JsonSerializerSettings SerializationSettings => throw new NotImplementedException();
-
-            public JsonSerializerSettings DeserializationSettings => throw new NotImplementedException();
-
-            public ServiceClientCredentials Credentials { get => new MockCredentials(); }
-
-            public IAttachments Attachments => throw new NotImplementedException();
-
-            public IConversations Conversations => throw new NotImplementedException();
-
-            public void Dispose()
-            {
-                throw new NotImplementedException();
-            }
-
-            private class MockCredentials : ServiceClientCredentials
-            {
-                public override Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-                {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("awesome");
-                    request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Windows", "3.1"));
-                    return Task.CompletedTask;
-                }
             }
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerHidingTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerHidingTests.cs
@@ -271,11 +271,10 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         }
 
         [Fact]
-        public async Task TestMessageReaction()
+        public async Task TestMessageOnReactionsChanged()
         {
             // Note the code supports multiple adds and removes in the same activity though
-            // a channel may decide to send separate activities for each. For example, Teams
-            // sends separate activities each with a single add and a single remove.
+            // a channel may decide to send separate activities for each. 
 
             // Arrange
             var activity = new Activity
@@ -299,8 +298,61 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             // Assert
             Assert.Equal(3, bot.Record.Count);
             Assert.Equal("OnMessageReactionActivityAsync", bot.Record[0]);
+            Assert.Equal("OnReactionsChangedAsync", bot.Record[1]);
+        }
+
+        [Fact]
+        public async Task TestMessageReactionAdded()
+        {
+            // Note the code supports multiple adds and removes in the same activity though
+            // a channel may decide to send separate activities for each. 
+
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageReaction,
+                ReactionsAdded = new List<MessageReaction>
+                {
+                    new MessageReaction("sad"),
+                },
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(3, bot.Record.Count);
+            Assert.Equal("OnMessageReactionActivityAsync", bot.Record[0]);
             Assert.Equal("OnReactionsAddedAsync", bot.Record[1]);
-            Assert.Equal("OnReactionsRemovedAsync", bot.Record[2]);
+        }
+
+        [Fact]
+        public async Task TestMessageReactionRemoved()
+        {
+            // Note the code supports multiple adds and removes in the same activity though
+            // a channel may decide to send separate activities for each. 
+
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageReaction,
+                ReactionsRemoved = new List<MessageReaction>
+                {
+                    new MessageReaction("angry"),
+                },
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(3, bot.Record.Count);
+            Assert.Equal("OnMessageReactionActivityAsync", bot.Record[0]);
+            Assert.Equal("OnReactionsRemovedAsync", bot.Record[1]);
         }
 
         [Fact]
@@ -522,6 +574,12 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return base.OnMessageReactionActivityAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnReactionsChangedAsync(IList<MessageReaction> addedReactions, IList<MessageReaction> removedReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnReactionsChangedAsync(addedReactions, removedReactions, turnContext, cancellationToken);
             }
 
             protected override Task OnReactionsAddedAsync(IList<MessageReaction> messageReactions, ITurnContext<IMessageReactionActivity> turnContext, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #4388

The previous two events on ActivityHandler (OnReactionsAddedAsync and OnReactionsRemovedAsync) will no longer execute. This is a breaking change. 