### PR TITLE
Add 'Component Detection' task to DotNet signing build.

### DIFF
--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -53,4 +53,8 @@ jobs:
 
   - template: ci-build-steps.yml
   - template: sign-steps.yml
-#  - template: functional-test-setup-steps.yml
+
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    failOnAlert: false

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -55,6 +55,6 @@ jobs:
   - template: sign-steps.yml
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  inputs:
-    failOnAlert: false
+    displayName: 'Component Detection'
+    inputs:
+      failOnAlert: false


### PR DESCRIPTION
Fixes #minor

## Specific Changes
Add task ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection
