### PR TITLE
Add obsolete attribute to BotFrameworkHttpAdapter and related classes.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Bot.Builder
     /// <seealso cref="IActivity"/>
     /// <seealso cref="IBot"/>
     /// <seealso cref="IMiddleware"/>h
+    [Obsolete("Use `CloudAdapter` instead.", false)]
     public class BotFrameworkAdapter : BotAdapter, IAdapterIntegration, IExtendedUserTokenProvider, IConnectorClientBuilder
     {
         private static readonly HttpClient DefaultHttpClient = new HttpClient();

--- a/libraries/Microsoft.Bot.Builder/ChannelServiceHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ChannelServiceHandler.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Bot.Builder
     /// <summary>
     /// A class to help with the implementation of the Bot Framework protocol.
     /// </summary>
+    [Obsolete("Use `CloudChannelServiceHandler` instead.", false)]
     public class ChannelServiceHandler : ChannelServiceHandlerBase
     {
         private readonly AuthenticationConfiguration _authConfiguration;

--- a/libraries/Microsoft.Bot.Builder/Integration/BotFrameworkOptions.cs
+++ b/libraries/Microsoft.Bot.Builder/Integration/BotFrameworkOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Builder.Integration
     /// Contains settings used by the .NET integration APIs to initialize the <see cref="BotFrameworkAdapter"/>
     /// that processes the HTTP requests coming from the Bot Framework Service.
     /// </summary>
+    [Obsolete("Use `CloudAdapter` with `ConfigurationBotFrameworkAuthentication` instead to configure bot runtime.", false)]
     public class BotFrameworkOptions
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Integration/IAdapterIntegration.cs
+++ b/libraries/Microsoft.Bot.Builder/Integration/IAdapterIntegration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
@@ -10,6 +11,7 @@ namespace Microsoft.Bot.Builder.Integration
     /// <summary>
     /// An interface that defines the contract between web service integration pieces and the bot adapter.
     /// </summary>
+    [Obsolete("Use `CloudAdapter` instead to process incoming messages.", false)]
     public interface IAdapterIntegration
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandler.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Builder.Skills
     /// <summary>
     /// A Bot Framework Handler for skills.
     /// </summary>
+    [Obsolete("Use `CloudSkillHandler` instead.", false)]
     public class SkillHandler : ChannelServiceHandler
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Bot.Builder.Streaming
     /// <summary>
     /// An HTTP adapter base class.
     /// </summary>
+    [Obsolete("Use `CloudAdapter` instead.", false)]
     public class BotFrameworkHttpAdapterBase : BotFrameworkAdapter, IStreamingActivityProcessor, IDisposable
     {
         private bool _disposedValue;

--- a/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ChannelValidation.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Validates JWT tokens sent from Azure.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to perform channel validation.", false)]
     public static class ChannelValidation
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EmulatorValidation.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Validates and Examines JWT tokens from the Bot Framework Emulator.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to perform emulator validation.", false)]
     public static class EmulatorValidation
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EnterpriseChannelValidation.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Validates JWT tokens from an enterprise channel.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to perform enterprise channel validation.", false)]
     public sealed class EnterpriseChannelValidation
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/GovernmentChannelValidation.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Valies JWT tokens from a Government channel.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to perform government channel validation.", false)]
     public sealed class GovernmentChannelValidation
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/IChannelProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/IChannelProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Connector.Authentication
@@ -10,6 +11,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// implementation for the configuration parameters to connect to a Bot.
     /// Framework channel service.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure channel.", false)]
     public interface IChannelProvider
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ICredentialProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Connector.Authentication
@@ -15,6 +16,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// For Single Tenant bots (the vast majority) the simple static providers
     /// are sufficient.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure credentials.", false)]
     public interface ICredentialProvider
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/IServiceClientCredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/IServiceClientCredentialProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Rest;
 
 namespace Microsoft.Bot.Connector.Authentication
@@ -11,6 +12,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// channels. The implementor should return ServiceClientCredentails from GetCredentials 
     /// method.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure credentials.", false)]
     public interface IServiceClientCredentialProvider : ICredentialProvider
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/JwtTokenValidation.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Contains helper methods for authenticating incoming HTTP requests.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to perform JWT token validation.", false)]
     public static class JwtTokenValidation
     {
         private static readonly HttpClient _httpClient = new HttpClient();

--- a/libraries/Microsoft.Bot.Connector/Authentication/SimpleChannelProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SimpleChannelProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// A simple channel provider with basic configuration parameters to connect to a Bot Framework channel service.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure channel.", false)]
     public class SimpleChannelProvider : IChannelProvider
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/SimpleCredentialProvider.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SimpleCredentialProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Connector.Authentication
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// A simple implementation of the <see cref="ICredentialProvider"/> interface.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure credentials.", false)]
     public class SimpleCredentialProvider : ICredentialProvider
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/SkillValidation.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Validates JWT tokens sent to and from a Skill.
     /// </summary>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to perform skill validation.", false)]
 #pragma warning disable CA1052 // Static holder types should be Static or NotInheritable (we can't change this without breaking binary compat)
     public class SkillValidation
 #pragma warning restore CA1052 // Static holder types should be Static or NotInheritable

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// <summary>
     /// A Bot Builder Adapter implementation used to handled bot Framework HTTP requests.
     /// </summary>
+    [Obsolete("Use `CloudAdapter` instead.", false)]
     public class BotFrameworkHttpAdapter : BotFrameworkHttpAdapterBase, IBotFrameworkHttpAdapter
     {
         private const string AuthHeaderName = "authorization";

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpClient.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// * Posting an activity to yourself (External service => Bot) which is done via PostActivityAsync(botId, endpoint, activity)
     /// The latter is used by external services such as webjobs that need to post activities to the bot using the bots own credentials.
     /// </remarks>
+    [Obsolete("Use `BotFrameworkAuthentication.CreateBotFrameworkClient()` to obtain a client and perform the operations that were accomplished through `BotFrameworkHttpClient`.", false)]
     public class BotFrameworkHttpClient : BotFrameworkClient
     {
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -14,6 +15,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     /// <summary>
     /// A handler to process incoming http requests via using an adapter.
     /// </summary>
+    [Obsolete("Use `CloudAdapter` instead to process incoming messages.", false)]
     public class BotMessageHandler : BotMessageHandlerBase
     {
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     /// <summary>
     /// Abstract base class for a bot message handler.
     /// </summary>
+    [Obsolete("Use `CloudAdapter` instead to process incoming messages.", false)]
     public abstract class BotMessageHandlerBase
     {
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationChannelProvider.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationChannelProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 
@@ -14,6 +15,7 @@ namespace Microsoft.Bot.Builder.BotFramework
     ///
     /// NOTE: if the keys are not present, a <c>null</c> value will be used.
     /// </remarks>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure channel.", false)]
     public sealed class ConfigurationChannelProvider : SimpleChannelProvider
     {
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationCredentialProvider.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ConfigurationCredentialProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 
@@ -15,6 +16,7 @@ namespace Microsoft.Bot.Builder.BotFramework
     ///
     /// NOTE: if the keys are not present, a <c>null</c> value will be used.
     /// </remarks>
+    [Obsolete("Use `ConfigurationBotFrameworkAuthentication` instead to configure credentials.", false)]
     public sealed class ConfigurationCredentialProvider : SimpleCredentialProvider
     {
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// <seealso cref="ApplicationBuilderExtensions"/>
     /// <seealso cref="IAdapterIntegration"/>
     /// <seealso cref="IBot"/>
+    [Obsolete("Use `CloudAdapter` with `ConfigurationBotFrameworkAuthentication` instead to configure bot runtime.", false)]
     public static class ServiceCollectionExtensions
     {
         /// <summary>


### PR DESCRIPTION
Fixes #6022 

## Description
Added obsolete attribute to BotFrameworkHttpAdapter and related classes, in order to migrate to CloudAdapter.