### PR TITLE
Set up DotNet pipelines for SDK_Dotnet_V4_org feed.

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -37,7 +37,11 @@ steps:
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:
+    command: 'restore'
+    feedsToUse: 'config'
+    nugetConfigPath: 'nuget.config'
     restoreSolution: Microsoft.Bot.Builder-Standard.sln
+  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build'

--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -32,6 +32,8 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '
 
+- template: sdk_dotnet_v4_org-feed-setup-steps.yml
+
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:

--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -32,16 +32,10 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '
 
-- template: sdk_dotnet_v4_org-feed-setup-steps.yml
-
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:
-    command: 'restore'
-    feedsToUse: 'config'
-    nugetConfigPath: 'nuget.config'
     restoreSolution: Microsoft.Bot.Builder-Standard.sln
-  continueOnError: true
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet build'

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -25,10 +25,11 @@ variables:
   PreviewPackageVersion: 4.9.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
   ReleasePackageVersion: 4.9.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
   runCodesignValidationInjection: false # Disables unnecessary CodeSign Validation step
-#  DotNetCoverallsToken: define this in Azure
-#  GitHubCommentApiKey: define this in Azure
 #  ApiCompatExcludeClasses: (optional) define this in Azure
 #  DisableApiCompatibityValidation: (optional) define this in Azure
+#  DotNetCoverallsToken: define this in Azure
+#  GitHubCommentApiKey: define this in Azure
+#  SDK_Dotnet_V4_org_Url: define this in Azure
 
 # The following 2 stages run multi-configuration, multi-agent parallel jobs.
 # Debug-Windows/Release-Windows => Builds everything in Debug/Release + the ASP.NET Desktop.

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -43,6 +43,7 @@ stages:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
     steps:
+    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
   - job: Debug_Windows_Configuration_31
@@ -50,6 +51,7 @@ stages:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
+    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
   - job: Release_Windows_Configuration_21
@@ -58,6 +60,7 @@ stages:
       BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
       PublishCoverage: false
     steps:
+    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml
@@ -67,6 +70,7 @@ stages:
       BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
       PublishCoverage: true
     steps:
+    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -43,7 +43,6 @@ stages:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
     steps:
-    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
   - job: Debug_Windows_Configuration_31
@@ -51,7 +50,6 @@ stages:
       BuildConfiguration: Debug-Windows
       BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
-    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
   - job: Release_Windows_Configuration_21
@@ -60,7 +58,6 @@ stages:
       BuildTarget: 'netcoreapp21' # set the TargetFramework property for tests to use netcoreapp2.1
       PublishCoverage: false
     steps:
-    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml
@@ -70,7 +67,6 @@ stages:
       BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
       PublishCoverage: true
     steps:
-    - template: sdk_dotnet_v4_org-feed-setup-steps.yml
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -25,6 +25,7 @@ variables:
   PreviewPackageVersion: 4.9.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
   ReleasePackageVersion: 4.9.0-preview-$(Build.BuildNumber) # This is consumed by projects in Microsoft.Bot.Builder.sln.
   runCodesignValidationInjection: false # Disables unnecessary CodeSign Validation step
+  system_accesstoken: $(System.AccessToken)
 #  ApiCompatExcludeClasses: (optional) define this in Azure
 #  DisableApiCompatibityValidation: (optional) define this in Azure
 #  DotNetCoverallsToken: define this in Azure

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -51,7 +51,6 @@ jobs:
        Preview: $(PreviewPackageVersion)
     continueOnError: true
 
-  - template: sdk_dotnet_v4_org-feed-setup-steps.yml
   - template: ci-build-steps.yml
   - template: sign-steps.yml
 #  - template: functional-test-setup-steps.yml

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -51,6 +51,7 @@ jobs:
        Preview: $(PreviewPackageVersion)
     continueOnError: true
 
+  - template: sdk_dotnet_v4_org-feed-setup-steps.yml
   - template: ci-build-steps.yml
   - template: sign-steps.yml
 #  - template: functional-test-setup-steps.yml

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -23,6 +23,7 @@ variables:
   Parameters.solution: Microsoft.Bot.Builder.sln
 #  PreviewPackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
 #  ReleasePackageVersion: 4.8.0-preview-$(Build.BuildNumber) # Consumed by projects in Microsoft.Bot.Builder.sln. Define this in Azure to be settable at queue time.
+#  SDK_Dotnet_V4_org_Url: define this in Azure
 
 jobs:
 - job: Build_and_Sign

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -7,10 +7,16 @@ steps:
 - task: NuGetToolInstaller@1
   displayName: 'Use NuGet '
 
+- template: sdk_dotnet_v4_org-feed-setup-steps.yml
+
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:
+    command: 'restore'
+    feedsToUse: 'config'
+    nugetConfigPath: 'nuget.config'
     restoreSolution: '$(Parameters.solution)'
+  continueOnError: true
 
 - task: VSBuild@1
   displayName: 'Build solution Microsoft.Bot.Builder.sln'

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -16,7 +16,6 @@ steps:
     feedsToUse: 'config'
     nugetConfigPath: 'nuget.config'
     restoreSolution: '$(Parameters.solution)'
-  continueOnError: true
 
 - task: VSBuild@1
   displayName: 'Build solution Microsoft.Bot.Builder.sln'

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -13,6 +13,11 @@ steps:
       <activePackageSource>
         <add key="All" value="(Aggregate source)" />
       </activePackageSource>
+      <packageSourceCredentials>
+          <SDK_Dotnet_V4_org>
+              <add key="ClearTextPassword" value="%SDK_Dotnet_V4_org-PAT%" />
+          </SDK_Dotnet_V4_org>
+      </packageSourceCredentials>
     </configuration>
 
     "@;

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -15,7 +15,7 @@ steps:
       </activePackageSource>
       <packageSourceCredentials>
           <SDK_Dotnet_V4_org>
-              <add key="ClearTextPassword" value="%SDK_Dotnet_V4_org-PAT%" />
+              <add key="ClearTextPassword" value="%SDK_Dotnet_V4_org_PAT%" />
           </SDK_Dotnet_V4_org>
       </packageSourceCredentials>
     </configuration>

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -15,6 +15,7 @@ steps:
       </activePackageSource>
       <packageSourceCredentials>
           <SDK_Dotnet_V4_org>
+              <add key="Username" value="ado_pipeline" />
               <add key="ClearTextPassword" value="%SDK_Dotnet_V4_org_PAT%" />
           </SDK_Dotnet_V4_org>
       </packageSourceCredentials>

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -13,12 +13,6 @@ steps:
       <activePackageSource>
         <add key="All" value="(Aggregate source)" />
       </activePackageSource>
-      <packageSourceCredentials>
-          <SDK_Dotnet_V4_org>
-              <add key="Username" value="v-brucehaley@microsoft.com" />
-              <add key="ClearTextPassword" value="%SDK_Dotnet_V4_org_PAT%" />
-          </SDK_Dotnet_V4_org>
-      </packageSourceCredentials>
     </configuration>
 
     "@;

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -15,7 +15,7 @@ steps:
       </activePackageSource>
       <packageSourceCredentials>
           <SDK_Dotnet_V4_org>
-              <add key="Username" value="ado_pipeline" />
+              <add key="Username" value="v-brucehaley@microsoft.com" />
               <add key="ClearTextPassword" value="%SDK_Dotnet_V4_org_PAT%" />
           </SDK_Dotnet_V4_org>
       </packageSourceCredentials>

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -1,0 +1,22 @@
+# Create nuget.config for resolving dependencies exclusively from SDK_Dotnet_V4_org feed.
+steps:
+- powershell: |
+    $file = "$(Build.SourcesDirectory)\nuget.config";
+
+    $content = @"
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <packageSources>
+        <clear />
+        <add key="SDK_Dotnet_V4_org" value="https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json" />
+      </packageSources>
+      <activePackageSource>
+        <add key="All" value="(Aggregate source)" />
+      </activePackageSource>
+    </configuration>
+
+    "@;
+
+    New-Item -Path $file -ItemType "file" -Value $content -Force;
+    '-------------'; get-content "$file"; '===================';
+  displayName: Create nuget.config for SDK_Dotnet_V4_org feed

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -8,7 +8,7 @@ steps:
     <configuration>
       <packageSources>
         <clear />
-        <add key="SDK_Dotnet_V4_org" value="https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json" />
+        <add key="SDK_Dotnet_V4_org" value="$(SDK_Dotnet_V4_org_Url)" />
       </packageSources>
       <activePackageSource>
         <add key="All" value="(Aggregate source)" />


### PR DESCRIPTION
Fixes #minor

Getting sources from an ADO feed with pass-through to NuGet.org has been mandated by MS cyber security.

## Specific Changes
Set up daily and CI pipelines to get dependencies from the organization-scoped ADO feed "SDK_Dotnet_V4_org".

https://dev.azure.com/FuseLabs/SDK_v4/_packaging?_a=feed&feed=SDK_Dotnet_V4_org

Not completed: the macLinux CI pipeline.