### PR TITLE
Fix broken VSIX build

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/Directory.Build.props
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+    <!-- This suppresses usage of the Directory.Build.props at the root. -->
+</Project>


### PR DESCRIPTION
Fixes #minor

## Description
The Directory.Build.props at the repo root gets used in building the VSIX templates solution, causing it to error.

Example: https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=287122&view=results
## Specific Changes
Add an empty Directory.Build.props so the root copy is not used.