### PR TITLE
Add Obsolete attribute to custom adapters.

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapter.cs
@@ -24,9 +24,10 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook
 {
-     /// <summary>
-     /// BotAdapter to allow for handling Facebook App payloads and responses via the Facebook API.
-     /// </summary>
+    /// <summary>
+    /// BotAdapter to allow for handling Facebook App payloads and responses via the Facebook API.
+    /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
         private const string HubModeSubscribe = "subscribe";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterBotComponent.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
     /// <summary>
     /// <see cref="BotComponent"/> definition for <see cref="FacebookAdapter"/>.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookAdapterBotComponent : BotComponent
     {
         /// <inheritdoc/>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookAdapterOptions.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder.Adapters.Facebook
 {
     /// <summary>
     /// Options class for Facebook Adapter.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookAdapterOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
     /// <summary>
     /// Client for interacting with the Facebook API.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookClientWrapper
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapperOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapperOptions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
     /// <summary>
     /// Options class for Facebook Adapter.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookClientWrapperOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/AttachmentPayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/AttachmentPayload.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Inner Facebook Attachment payload that can be sent as part of a Facebook Attachment on a Facebook message.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class AttachmentPayload
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookAttachment.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookAttachment.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Facebook Attachment object that can be sent as part of a Facebook message.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookAttachment
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookBotUser.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookBotUser.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Represents a Facebook Bot User object.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookBotUser
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookEntry.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookEntry.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Represents a Facebook Message Entry.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookEntry
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookPostback.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookPostback.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Represents a Facebook Post Back.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookPostBack
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookQuickReply.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookQuickReply.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Facebook Quick Reply object that can be sent as part of a Facebook message.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookQuickReply
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookRead.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookRead.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
 {
     /// <summary>A Facebook read message, including watermark of messages that were read.</summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookRead
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookRecipient.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookRecipient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Facebook Recipient object used as part of a Facebook message.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookRecipient
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookReferral.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookReferral.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Represents the referral parameter in the messaging_referrals event.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookReferral
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookResponseEvent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookResponseEvent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -9,6 +10,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Represents the incoming object received from Facebook and processed by the adapter.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookResponseEvent
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookResponseOk.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/FacebookResponseOk.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents
     /// <summary>
     /// Represents the response object received from Facebook API when a message is sent.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookResponseOk
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookPassThreadControl.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookPassThreadControl.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
     /// <summary>
     /// Event object sent to Facebook when requesting to pass thread control to another app.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookPassThreadControl : FacebookThreadControl
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookRequestThreadControl.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookRequestThreadControl.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
 {
     /// <summary>A Facebook thread control message, including app ID of requested thread owner and an optional message
     /// to send with the request.</summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookRequestThreadControl : FacebookThreadControl
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookTakeThreadControl.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookTakeThreadControl.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
     /// <summary>
     /// Event object sent to Facebook when requesting to take thread control from another app.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookTakeThreadControl : FacebookThreadControl
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookThreadControl.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Handover/FacebookThreadControl.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
@@ -7,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover
     /// <summary>
     /// Base event object for thread control request payloads.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookThreadControl
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Templates/Button.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Templates/Button.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Templates
     /// <summary>
     /// Facebook button object.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class Button
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Templates/DefaultAction.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Templates/DefaultAction.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Templates
     /// <summary>
     /// Default action template.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class DefaultAction
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Templates/Element.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookEvents/Templates/Element.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Templates
     /// <summary>
     /// Represents an element of a template message.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class Element
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookMessage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents;
 using Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents.Handover;
 using Newtonsoft.Json;
@@ -11,6 +12,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
     /// Represents information associated with a Facebook webhook event. For more information, see the Facebook
     /// [Webhook Events Reference](https://developers.facebook.com/docs/messenger-platform/reference/webhook-events).
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class FacebookMessage
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Message.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/Message.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Adapters.Facebook.FacebookEvents;
 using Newtonsoft.Json;
@@ -10,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
     /// <summary>
     /// Facebook message object used when sending messages via the Facebook API.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class Message
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/README.md
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/README.md
@@ -1,3 +1,9 @@
+> ## Important Notice!
+>
+> The Bot Framework Custom Adapters are being moved to the [BotBuilder Community](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) repository.
+> We recommend moving bot dependencies and submit new feature requests and contributions to the new location.
+>
+
 # Microsoft Bot Framework Facebook Adapter for .NET
 
 This package contains an adapter that communicates directly with the Facebook API, and translates messages to and from a standard format used by your bot. 
@@ -45,17 +51,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project is no longer accepting community contributions. Please refer to the project's [new location](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) for future development.
 
 ## License
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ActivityResourceResponse.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/ActivityResourceResponse.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Schema;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
     /// <summary>
     /// Extends ResourceResponse with ActivityId and Conversation properties.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class ActivityResourceResponse : ResourceResponse
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/CommandPayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/CommandPayload.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     /// <summary>
     /// Represents a Slack Command request https://api.slack.com/interactivity/slash-commands.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class CommandPayload
     {
         [JsonProperty(PropertyName = "token")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventRequest.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -10,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     /// <summary>
     /// Represents an incoming request from the Event API https://api.slack.com/events-api#receiving_events.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class EventRequest
     {
         [JsonProperty(PropertyName = "token")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/EventType.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
@@ -11,6 +12,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     /// <summary>
     /// Represents a Slack Event Type object https://api.slack.com/events-api#receiving_events.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class EventType
     {
         public string Type { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/Events/MessageEvent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/Events/MessageEvent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -10,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model.Events
     /// <summary>
     /// Represents a Slack Message event https://api.slack.com/events/message.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class MessageEvent : EventType
     {
         public string Text { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/Events/UrlVerificationEvent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/Events/UrlVerificationEvent.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model.Events
 {
     /// <summary>
     /// Represents a Slack Url Verification event https://api.slack.com/events/url_verification.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class UrlVerificationEvent
     {
         public string Type { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/InteractionPayload.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/InteractionPayload.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     /// <summary>
     /// Union class to represent various user interaction payloads https://api.slack.com/interactivity/handling#payloads.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class InteractionPayload
     {
         [JsonProperty(PropertyName = "type")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/ModalBlock.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/ModalBlock.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class ModalBlock
     {
         [JsonProperty(PropertyName = "type")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/ModalView.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/ModalView.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class ModalView
     {
         [JsonProperty(PropertyName = "id")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/ModelViewState.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/ModelViewState.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class ModelViewState
     {
         [JsonProperty(PropertyName = "values")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/NewSlackMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/NewSlackMessage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     /// <summary>
     /// Message to send to Slack.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class NewSlackMessage
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SelectOption.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SelectOption.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SelectOption
     {
         [JsonProperty(PropertyName = "text")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackAction.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackAction.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackAction
     {
         [JsonProperty(PropertyName = "action_id")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackAttachment.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackAttachment.cs
@@ -8,6 +8,7 @@ using SlackAPI;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackAttachment
     {
         [JsonProperty(PropertyName = "callback_id")]

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackResponse.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackResponse.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Bot.Builder.Adapters.Slack.Model.Events;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
@@ -8,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Model
     /// <summary>
     /// SlackResponse class.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackResponse
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackTeam.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackTeam.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackTeam
     {
         public string Id { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackUser.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/Model/SlackUser.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack.Model
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackUser
     {
         public string Id { get; set; }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/README.md
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/README.md
@@ -1,3 +1,8 @@
+> ## Important Notice!
+>
+> The Bot Framework Custom Adapters are being moved to the [BotBuilder Community](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) repository.
+> We recommend moving bot dependencies and submit new feature requests and contributions to the new location.
+>
 # Microsoft Bot Framework SlackAdapter for .NET
 
 This package contains an adapter that communicates directly with the Slack API, and translates messages to and from a standard format used by your bot.
@@ -44,17 +49,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project is no longer accepting community contributions. Please refer to the project's [new location](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) for future development.
 
 ## License
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapter.cs
@@ -24,6 +24,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
         private const string SlackVerificationTokenKey = "SlackVerificationToken";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterBotComponent.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
     /// <summary>
     /// <see cref="BotComponent"/> definition for <see cref="SlackAdapter"/>.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackAdapterBotComponent : BotComponent
     {
         /// <inheritdoc/>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackAdapterOptions.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder.Adapters.Slack
 {
     /// <summary>
     /// Class for defining implementation of the SlackAdapter Options.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackAdapterOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapper.cs
@@ -18,6 +18,7 @@ using Attachment = SlackAPI.Attachment;
 
 namespace Microsoft.Bot.Builder.Adapters.Slack
 {
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackClientWrapper
     {
         private const string PostMessageUrl = "https://slack.com/api/chat.postMessage";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapperOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Slack/SlackClientWrapperOptions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack
     /// <summary>
     /// Class for defining implementation of the SlackClientWrapperOptions Options.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class SlackClientWrapperOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/README.md
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/README.md
@@ -1,4 +1,10 @@
-﻿# Microsoft Bot Framework TwilioAdapter for .NET
+﻿> ## Important Notice!
+>
+> The Bot Framework Custom Adapters are being moved to the [BotBuilder Community](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) repository.
+> We recommend moving bot dependencies and submit new feature requests and contributions to the new location.
+>
+
+# Microsoft Bot Framework TwilioAdapter for .NET
 
 This package contains an adapter that communicates directly with the Twilio API, and translates messages to and from a standard format used by your bot.
 
@@ -45,17 +51,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project is no longer accepting community contributions. Please refer to the project's [new location](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) for future development.
 
 ## License
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapter.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     /// <summary>
     /// A <see cref="BotAdapter"/> that can connect to Twilio's SMS service.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
         private const string TwilioNumberKey = "TwilioNumber";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterBotComponent.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     /// <summary>
     /// <see cref="BotComponent"/> definition for <see cref="TwilioAdapter"/>.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioAdapterBotComponent : BotComponent
     {
         /// <inheritdoc/>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioAdapterOptions.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+
 namespace Microsoft.Bot.Builder.Adapters.Twilio
 {
     /// <summary>
     /// Options for the <see cref="TwilioAdapter"/>.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioAdapterOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapper.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     /// <summary>
     /// Wrapper class for the Twilio API.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioClientWrapper
     {
         private const string TwilioSignature = "x-twilio-signature";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapperOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioClientWrapperOptions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     /// <summary>
     /// Defines options for a <see cref="TwilioClientWrapper"/>.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioClientWrapperOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessage.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     /// A class wrapping Twilio request parameters.
     /// </summary>
     /// <remarks>These parameters can be included in an HTTP request that contains a Twilio message.</remarks>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioMessage
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessageOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioMessageOptions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
     /// <summary>
     /// Represents an outgoing message content and options for Twilio.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class TwilioMessageOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/AttachmentActionData.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/AttachmentActionData.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Bot.Builder.Adapters.Webex
@@ -10,6 +11,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// message attachments such as clicking on a submit button in a card.
     /// https://developer.webex.com/docs/api/v1/attachment-actions.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class AttachmentActionData
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/README.md
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/README.md
@@ -1,4 +1,10 @@
-﻿# Microsoft Bot Framework WebexAdapter for .NET
+﻿> ## Important Notice!
+>
+> The Bot Framework Custom Adapters are being moved to the [BotBuilder Community](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) repository.
+> We recommend moving bot dependencies and submit new feature requests and contributions to the new location.
+>
+
+# Microsoft Bot Framework WebexAdapter for .NET
 
 This package contains an adapter that communicates directly with the Webex Teams API, and translates messages to and from a standard format used by your bot.
 
@@ -46,17 +52,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project is no longer accepting community contributions. Please refer to the project's [new location](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet) for future development.
 
 ## License
 

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapter.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// <summary>
     /// BotAdapter to allow for handling Webex Teams app payloads and responses via the Webex Teams API.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class WebexAdapter : BotAdapter, IBotFrameworkHttpAdapter
     {
         private const string WebexAccessTokenKey = "WebexAccessToken";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterBotComponent.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// <summary>
     /// <see cref="BotComponent"/> definition for <see cref="WebexAdapter"/>.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class WebexAdapterBotComponent : BotComponent
     {
         /// <inheritdoc/>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexAdapterOptions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// <summary>
     /// Options class for the <see cref="WebexAdapter" />.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class WebexAdapterOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// <summary>
     /// A client for interacting with the Webex Teams API.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class WebexClientWrapper
     {
         private const string MessageUrl = "https://api.ciscospark.com/v1/messages";

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapperOptions.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapperOptions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// <summary>
     /// Defines implementation of the WebexAdapter Options.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class WebexClientWrapperOptions
     {
         /// <summary>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexMessageRequest.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexMessageRequest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
     /// <summary>
     /// Represents the payload received when a Webex Message is sent to the bot.
     /// </summary>
+    [Obsolete("The Bot Framework Adapters will be deprecated in the next version of the Bot Framework SDK and moved to https://github.com/BotBuilderCommunity/botbuilder-community-dotnet. Please refer to their new location for all future work.")]
     public class WebexMessageRequest
     {
         /// <summary>


### PR DESCRIPTION
Fixes #5976 

## Description
This change adds the Obsolete attribute to the custom adapters.
The change that adds the adapters to the Community repo can be found here: [botbuilder-community-dotnet PR 461](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/pull/461)