### PR TITLE
Cherry-pick to 4.15: Fix for when Actions are updated in ForEachElement (#6143)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             set
             {
-                this._actions = value ?? new List<Dialog>();
+                _actions = value ?? new List<Dialog>();
+                _scope.Actions = _actions;
             }
         }
 #pragma warning restore CA2227 // Collection properties should be read only
@@ -166,10 +167,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var list = GetItemsProperty(dc.State, beginDialog);
 
             var indexProperty = Index.GetValue(dc.State);
-            var index = dc.State.GetIntValue(indexProperty, 0);
+            var index = beginDialog ? 0 : dc.State.GetIntValue(indexProperty, 0);
 
             // Next item
-            while (list != null && index < list.Count)
+            while (dc.ActiveDialog != null && list != null && index < list.Count)
             {
                 var childDialogState = GetActionScopeState(dc);
                 var childDc = new DialogContext(new DialogSet().Add(_scope), dc.Parent ?? dc, childDialogState);
@@ -210,7 +211,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 }
 
                 index++;
-                dc.State.SetValue(indexProperty, index);
+                if (dc.ActiveDialog != null)
+                {
+                    dc.State.SetValue(indexProperty, index);
+                }
 
                 if (turnResult.Status == DialogTurnStatus.CompleteAndWait)
                 {
@@ -253,7 +257,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 state = new DialogState();
             }
 
-            activeDialogState[ActionScopeState] = state;
+            if (activeDialogState != null)
+            {
+                activeDialogState[ActionScopeState] = state;
+            }
 
             return state;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.Foreach.schema
@@ -29,14 +29,16 @@
         "index": {
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Index property",
-            "description": "Property that holds the index of the item.",
-            "default": "dialog.foreach.index"
+            "description": "Property that holds the index of the item (must be unique within the dialog scope).",
+            "default": "dialog.foreach.index",
+            "examples": [ "dialog.myForEach.myIndex" ]
         },
         "value": {
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Value property",
-            "description": "Property that holds the value of the item.",
-            "default": "dialog.foreach.value"
+            "description": "Property that holds the value of the item (must be unique within the dialog scope).",
+            "default": "dialog.foreach.value",
+            "examples": [ "dialog.myForEach.myValue" ]
         },
         "actions": {
             "type": "array",

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ActionTests.cs
@@ -36,6 +36,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task Action_Foreach_WithEvent()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task Action_AttachmentInput()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Bot.Builder.Dialogs.Adaptive.Input;
 using Microsoft.Bot.Schema;
 using AdaptiveExpressions.Properties;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
@@ -254,7 +255,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
-        
+
         [Fact]
         public async Task TestForeachWithPromptCachedItems()
         {
@@ -285,17 +286,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
         }
 
-        [Fact(Skip = "Ignore")]
-        public async Task TestForeachWithLargeItems()
+        [Theory]
+
+        //[InlineData(1000)]
+        [InlineData(500)]
+        [InlineData(1)]
+        public async Task TestForeachWithLargeItems(int itemCount)
         {
             var testFlow = new TestScript()
             {
-                Dialog = new ForeachItemsDialog()
+                Dialog = new ForeachItemsDialog(itemCount)
             }
             .SendConversationUpdate();
 
-            for (var i = 0; i < 1000; i++)
+            for (var i = 0; i < itemCount; i++)
             {
+                testFlow = testFlow.AssertReply("Send me some text.");
+                testFlow.Script.Add(new UserSays() { Text = "1" });
                 testFlow = testFlow.AssertReply(i.ToString());
             }
 
@@ -304,8 +311,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 
         private class ForeachItemsDialog : ComponentDialog
         {
-            internal ForeachItemsDialog()
+            private readonly int _itemCount;
+
+            internal ForeachItemsDialog(int itemCount)
             {
+                _itemCount = itemCount;
                 AddDialog(new AdaptiveDialog
                 {
                     Id = "doItems",
@@ -315,10 +325,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                         {
                             Actions = new List<Dialog>
                             {
-                                new Foreach
+                                new ForEachElement
                                 {
                                     ItemsProperty = "$items",
-                                    Actions = new List<Dialog> { new SendActivity { Activity = new ActivityTemplate("${$foreach.value}") } }
+                                    Actions = new List<Dialog>
+                                    {
+                                        new TextInput { Prompt = new ActivityTemplate("Send me some text.") },
+                                        new SendActivity { Activity = new ActivityTemplate("${$foreach.value}") }
+                                    }
                                 }
                             }
                         }
@@ -329,7 +343,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             protected override async Task<DialogTurnResult> OnBeginDialogAsync(DialogContext innerDc, object options, CancellationToken cancellationToken = default)
             {
                 var items = new List<string>();
-                for (var i = 0; i < 1000; i++)
+                for (var i = 0; i < _itemCount; i++)
                 {
                     items.Add(i.ToString());
                 }
@@ -337,7 +351,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 return await innerDc.BeginDialogAsync("doItems", new { Items = items }, cancellationToken);
             }
         }
-
+            
         [Fact]
         public void AdaptiveDialog_GetInternalVersion()
         {
@@ -754,7 +768,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         {
             public AttachmentOrNullInput([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
                 : base(callerPath, callerLine)
-            { 
+            {
             }
 
             protected override Task<InputState> OnRecognizeInputAsync(DialogContext dc, CancellationToken cancellationToken = default)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Foreach_WithEvent.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_Foreach_WithEvent.test.dialog
@@ -1,0 +1,95 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "root",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.todo",
+                        "value": "=[]"
+                    },
+                    {
+                        "$kind": "Microsoft.EditArray",
+                        "itemsProperty": "dialog.todo",
+                        "value": "=1"
+                    },
+                    {
+                        "$kind": "Microsoft.EditArray",
+                        "itemsProperty": "dialog.todo",
+                        "value": "=2"
+                    },
+                    {
+                        "$kind": "Microsoft.Foreach",
+                        "itemsProperty": "dialog.todo",
+                        "actions": [
+                          {
+                              "$kind": "Microsoft.EmitEvent",
+                              "eventName": "CustomEvent",
+                              "bubbleEvent": true
+                          },
+                            {
+                                "$kind": "Microsoft.SendActivity",
+                                "activity": "index is: ${dialog.foreach.index} and value is: ${dialog.foreach.value}"
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Done"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnDialogEvent",
+                "event": "CustomEvent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "CustomEventFired"
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "CustomEventFired"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "index is: 0 and value is: 1"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "CustomEventFired"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "index is: 1 and value is: 2"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Done"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "hi (this should not break)",
+    },
+    {
+        "$kind": "Microsoft.Test.AssertReply",
+        "text": "CustomEventFired"
+    }
+  ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/TestNestedForeachWithPromptCachedItems.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/TestNestedForeachWithPromptCachedItems.test.dialog
@@ -29,14 +29,14 @@
               {
                 "$kind": "Microsoft.Foreach",
                 "itemsProperty": "turn.Activity.Value",
-                "value": "dialog.foreach2.value",
-                "index": "dialog.foreach2.index",
+                "value": "dialog.foreach2.valuex",
+                "index": "dialog.foreach2.indexx",
                 "actions": [
                   {
                     "$kind": "Microsoft.TextInput",
                     "alwaysPrompt": true,
                     "property": "$answer2",
-                    "prompt": "Hi ${dialog.foreach2.value}. Do you have any feedback?"
+                    "prompt": "Hi ${dialog.foreach2.valuex}. Do you have any feedback?"
                   },
                   {
                     "$kind": "Microsoft.SendActivity",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -3432,14 +3432,20 @@
         "index": {
           "$ref": "#/definitions/stringExpression",
           "title": "Index property",
-          "description": "Property that holds the index of the item.",
-          "default": "dialog.foreach.index"
+          "description": "Property that holds the index of the item (must be unique within the dialog scope).",
+          "default": "dialog.foreach.index",
+          "examples": [
+            "dialog.myForEach.myIndex"
+          ]
         },
         "value": {
           "$ref": "#/definitions/stringExpression",
           "title": "Value property",
-          "description": "Property that holds the value of the item.",
-          "default": "dialog.foreach.value"
+          "description": "Property that holds the value of the item (must be unique within the dialog scope).",
+          "default": "dialog.foreach.value",
+          "examples": [
+            "dialog.myForEach.myValue"
+          ]
         },
         "actions": {
           "type": "array",


### PR DESCRIPTION
Fixes #6149

* Fix for when Actions are updated in ForEachElement

* use ForEachElement not Foreach in test

* Add Action_Foreach_WithEvent test

* Add example of foreach index and value to .schema

* Update tests.schema results

* Add TestForeachWithLargeItems back to active tests
