### PR TITLE
Implement AddBotRuntime

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CoreBotAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CoreBotAdapter.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// CoreBotAdapter is a base BotAdapter that derives from CloudAdapter and implements OnTurnError handling. This class
     /// also registers any middleware services that are contained in the middlewares collection.
     /// </summary>
-    public class CoreBotAdapter : CloudAdapter
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes. This class is only instantiated via dependency injection so no direct reference is made.
+    internal class CoreBotAdapter : CloudAdapter
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CoreBotAdapter"/> class.

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CoreBotAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CoreBotAdapter.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+{
+    /// <summary>
+    /// CoreBotAdapter is a base BotAdapter that derives from CloudAdapter and implements OnTurnError handling. This class
+    /// also registers any middleware services that are contained in the middlewares collection.
+    /// </summary>
+    public class CoreBotAdapter : CloudAdapter
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CoreBotAdapter"/> class.
+        /// </summary>
+        /// <param name="botFrameworkAuthentication">An instance of a BotFrameworkAuthentication.</param>
+        /// <param name="middlewares">The collection of middleware instances.</param>
+        /// <param name="logger">The logger instance.</param>
+        public CoreBotAdapter(
+            BotFrameworkAuthentication botFrameworkAuthentication,
+            IEnumerable<IMiddleware> middlewares,
+            ILogger<CoreBotAdapter> logger = null)
+            : base(botFrameworkAuthentication, logger)
+        {
+            // Pick up feature based middlewares such as telemetry or transcripts
+            foreach (IMiddleware middleware in middlewares)
+            {
+                Use(middleware);
+            }
+
+            OnTurnError = async (turnContext, exception) =>
+            {
+                // Log any leaked exception from the application.
+                Logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
+
+                // Send the exception message to the user. Since the default behavior does not
+                // send logs or trace activities, the bot appears hanging without any activity
+                // to the user.
+                await turnContext.SendActivityAsync(exception.Message).ConfigureAwait(false);
+
+                var conversationState = turnContext.TurnState.Get<ConversationState>();
+
+                if (conversationState != null)
+                {
+                    // Delete the conversationState for the current conversation to prevent the
+                    // bot from getting stuck in a error-loop caused by being in a bad state.
+                    await conversationState.DeleteAsync(turnContext).ConfigureAwait(false);
+                }
+            };
+        }
+    }
+}

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Bot.Builder.Dialogs\Microsoft.Bot.Builder.Dialogs.csproj" />
     <ProjectReference Include="..\..\Microsoft.Bot.Builder\Microsoft.Bot.Builder.csproj" />
     <ProjectReference Include="..\..\Microsoft.Bot.Connector.Streaming\Microsoft.Bot.Connector.Streaming.csproj" />
     <ProjectReference Include="..\..\Microsoft.Bot.Streaming\Microsoft.Bot.Streaming.csproj" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -4,12 +4,13 @@
 using System;
 using System.Linq;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+namespace Microsoft.Bot.Builder.Extensions.DependencyInjection
 {
     /// <summary>
     /// Defines extension methods for to add common services to the application's service collection<see cref="IServiceCollection"/>.
@@ -58,7 +59,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// <param name="services">The application's collection of registered services.</param>
         /// <param name="configuration">The application configuration.</param>
         /// <typeparam name="TBot">Type of Bot.</typeparam>
-        public static void AddBotRuntime<TBot>(this IServiceCollection services, IConfiguration configuration) 
+        public static void AddBotRuntime<TBot>(this IServiceCollection services, IConfiguration configuration)
             where TBot : class, IBot
         {
             RegisterCommonServices(services, configuration);
@@ -91,8 +92,178 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             where TDialog : Dialog
         {
             RegisterCommonServices(services, configuration);
+
+            // Register the User state. (Used in Dialog implementation.)
+            services.TryAddSingleton<UserState>();
+
+            // Register the Conversation state. (Used in Dialog system itself.)
+            services.TryAddSingleton<ConversationState>();
+
+            // Register the root Dialog type.
             services.AddSingleton<TDialog>();
             services.AddSingleton<IBot, TBot>();
+        }
+
+        // The methods below create a Fluent style API for adding required services to the bot startup.
+
+        /// <summary>
+        /// Configures service collection to contain an IConfiguration instance.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <param name="configuration">The IConfiguration instance to register.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotConfiguration(this IServiceCollection services, IConfiguration configuration)
+        {
+            // Ensure the IConfiguration is available. (Azure Functions don't do this.)
+            services.TryAddSingleton(configuration);
+            return services;
+        }
+
+        /// <summary>
+        /// Configures service collection to use the default ConfigurationBotFrameworkAuthentication implementation.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotAuthentication(this IServiceCollection services)
+        {
+            // Register the default ConfigurationBotFrameworkAuthentication type.
+            services.TryAddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures service collection to use a user specified BotFrameworkAuthentication implementation.
+        /// </summary>
+        /// <typeparam name="T">The type of the user specified BotFrameworkAuthentication class.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotAuthentication<T>(this IServiceCollection services)
+            where T : BotFrameworkAuthentication
+        {
+            // Register the user specified authentication type.
+            services.TryAddSingleton<BotFrameworkAuthentication, T>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a default IBotFrameworkHttpAdapter based on the CoreBotAdapter implementation.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotHttpAdapter(this IServiceCollection services)
+        {
+            // Add a CoreBotAdapter as the IBotFrameworkHttpAdapter unless one was already registered.
+            services.TryAddSingleton<IBotFrameworkHttpAdapter, CoreBotAdapter>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a user specified IBotFrameworkHttpAdapter implementation.
+        /// </summary>
+        /// <typeparam name="T">Type of the IBotFramworkHttpAdapter to register.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotHttpAdapter<T>(this IServiceCollection services)
+            where T : class, IBotFrameworkHttpAdapter
+        {
+            // Add the user specified adapter as the IBotFrameworkHttpAdapter unless one was already registered.
+            services.TryAddSingleton<IBotFrameworkHttpAdapter, T>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a user specified implementation of IStorage.
+        /// </summary>
+        /// <typeparam name="T">Type of the IStorage to register.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotStorage<T>(this IServiceCollection services)
+            where T : class, IStorage
+        {
+            // Registers an IStorage implementation Type.
+            services.TryAddSingleton<IStorage, T>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a UserState instance. This is required if you use Dialogs.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotUserState(this IServiceCollection services)
+        {
+            // Register the UserState. (Used in Dialog implementation.)
+            services.TryAddSingleton<UserState>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a ConversationState instance. This is required if you use Dialogs.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <typeparam name="T">Type of the IStorage to register.</typeparam>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotState<T>(this IServiceCollection services)
+            where T : BotState
+        {
+            // Register the State Type.
+            services.TryAddSingleton<T>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a ConversationState instance. This is required if you use Dialogs.
+        /// </summary>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotConversationState(this IServiceCollection services)
+        {
+            // Register the ConversationState. (Used in Dialog implementation.)
+            services.TryAddSingleton<ConversationState>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a Dialog.
+        /// </summary>
+        /// <typeparam name="T">Type of the Dialog to register.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <param name="instance">The Dialog instance to register.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotDialog<T>(this IServiceCollection services, Dialog instance)
+            where T : Dialog
+        {
+            // Register the Dialog.
+            services.AddSingleton<T>((T)instance);
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a Dialog.
+        /// </summary>
+        /// <typeparam name="T">Type of the Dialog to register.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBotDialog<T>(this IServiceCollection services) 
+            where T : Dialog
+        {
+            // Register the Dialog.
+            services.AddSingleton<T>();
+            return services;
+        }
+
+        /// <summary>
+        /// Configures the service collection with a Bot.
+        /// </summary>
+        /// <typeparam name="T">Type of the Bot to register.</typeparam>
+        /// <param name="services">The services collection.</param>
+        /// <returns>The updated services collection.</returns>
+        public static IServiceCollection UseBot<T>(this IServiceCollection services)
+            where T : class, IBot
+        {
+            // Register the Bot.
+            services.AddSingleton<T>();
+            return services;
         }
 
         private static void RegisterCommonServices(IServiceCollection services, IConfiguration configuration)
@@ -118,12 +289,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
             services.TryAddSingleton<IStorage>(new MemoryStorage());
-
-            // Create the User state. (Used in this bot's Dialog implementation.)
-            services.TryAddSingleton<UserState>();
-
-            // Create the Conversation state. (Used by the Dialog system itself.)
-            services.TryAddSingleton<ConversationState>();
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -84,18 +84,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
             // Ensure the IConfiguration is available. (Azure Functions don't do this.)
             services.TryAddSingleton(configuration);
 
-            // All things auth
+            // Add basic authentication.
             services.TryAddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
 
-            // Check to see if a different IBotFrameworkHttpAdapter was already registered, if it was, skip registering.
-            // We do this not because of the IBotFrameworkHttpAdapter, but to keep from adding the CoreBotAdapter if 
-            // the bot won't be using it and a different implementation was registered.
-            if (!services.Any(x => x.ServiceType == typeof(IBotFrameworkHttpAdapter)))
-            {
-                // CoreBotAdapter registration
-                services.TryAddSingleton<CoreBotAdapter>();
-                services.TryAddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
-            }
+            // Add a CoreBotAdapter as the IBotFrameworkHttpAdapter unless one was already registered.
+            services.TryAddSingleton<IBotFrameworkHttpAdapter, CoreBotAdapter>();
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
             services.TryAddSingleton<IStorage>(new MemoryStorage());

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         {
             RegisterCommonServices(services, configuration);
 
-            services.AddTransient<IBot, TBot>();
+            services.AddSingleton<IBot, TBot>();
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         {
             RegisterCommonServices(services, configuration);
             services.AddSingleton<TDialog>();
-            services.AddTransient<IBot, TBot>();
+            services.AddSingleton<IBot, TBot>();
         }
 
         private static void RegisterCommonServices(IServiceCollection services, IConfiguration configuration)

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         /// <see cref="ConversationState"/>
         /// 
         /// This set of dependencies is designed to be sufficient to run a typical bot. Since each of these
-        /// are registered using TrySingleton to provide a different implementation of any of the dependencies
+        /// are registered using TrySingleton if you want to provide a different implementation of any of the dependencies
         /// just register them with the service collection before calling AddBotRuntime.
         /// 
         /// </remark>
@@ -40,11 +40,24 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <summary>
-        /// Overload that allows for creating the Bot (IBot) type as well as other startup types.
+        /// Adds bot related services to the application's service collection.
         /// </summary>
-        /// <typeparam name="TBot">Type of Bot.</typeparam>
+        /// <remark>
+        /// The following dependencies are added with TrySingleton so advanced scenarios can override them to customize the runtime behavior:
+        /// <see cref="BotFrameworkAuthentication"/>,
+        /// <see cref="IBotFrameworkHttpAdapter"/>,
+        /// <see cref="IStorage"/>,
+        /// <see cref="UserState"/>,
+        /// <see cref="ConversationState"/>
+        /// 
+        /// This set of dependencies is designed to be sufficient to run a typical bot. Since each of these
+        /// are registered using TrySingleton if you want to provide a different implementation of any of the dependencies
+        /// just register them with the service collection before calling AddBotRuntime.
+        /// 
+        /// </remark>
         /// <param name="services">The application's collection of registered services.</param>
         /// <param name="configuration">The application configuration.</param>
+        /// <typeparam name="TBot">Type of Bot.</typeparam>
         public static void AddBotRuntime<TBot>(this IServiceCollection services, IConfiguration configuration) 
             where TBot : class, IBot
         {
@@ -54,12 +67,25 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
         }
 
         /// <summary>
-        /// Overload that allows for providing the Bot (IBot) type, and the main Dialog type as well as other startup types.
+        /// Adds bot related services to the application's service collection.
         /// </summary>
-        /// <typeparam name="TBot">Type of Bot.</typeparam>
-        /// <typeparam name="TDialog">Type of Dialog.</typeparam>
+        /// <remark>
+        /// The following dependencies are added with TrySingleton so advanced scenarios can override them to customize the runtime behavior:
+        /// <see cref="BotFrameworkAuthentication"/>,
+        /// <see cref="IBotFrameworkHttpAdapter"/>,
+        /// <see cref="IStorage"/>,
+        /// <see cref="UserState"/>,
+        /// <see cref="ConversationState"/>
+        /// 
+        /// This set of dependencies is designed to be sufficient to run a typical bot. Since each of these
+        /// are registered using TrySingleton if you want to provide a different implementation of any of the dependencies
+        /// just register them with the service collection before calling AddBotRuntime.
+        /// 
+        /// </remark>
         /// <param name="services">The application's collection of registered services.</param>
         /// <param name="configuration">The application configuration.</param>
+        /// <typeparam name="TBot">Type of Bot.</typeparam>
+        /// <typeparam name="TDialog">Type of Dialog.</typeparam>
         public static void AddBotRuntime<TBot, TDialog>(this IServiceCollection services, IConfiguration configuration)
             where TBot : class, IBot
             where TDialog : Dialog

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+{
+    /// <summary>
+    /// Defines extension methods for to add common services to the application's service collection<see cref="IServiceCollection"/>.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds bot related services to the application's service collection.
+        /// </summary>
+        /// <remark>
+        /// The following dependencies are added with TrySingleton so advanced scenarios can override them to customize the runtime behavior:
+        /// <see cref="BotFrameworkAuthentication"/>,
+        /// <see cref="IBotFrameworkHttpAdapter"/>,
+        /// <see cref="IStorage"/>,
+        /// <see cref="UserState"/>,
+        /// <see cref="ConversationState"/>
+        /// 
+        /// This set of dependencies is designed to be sufficient to run a typical bot. Since each of these
+        /// are registered using TrySingleton to provide a different implementation of any of the dependencies
+        /// just register them with the service collection before calling AddBotRuntime.
+        /// 
+        /// </remark>
+        /// <param name="services">The application's collection of registered services.</param>
+        /// <param name="configuration">The application configuration.</param>
+        public static void AddBotRuntime(this IServiceCollection services, IConfiguration configuration)
+        {
+            RegisterCommonServices(services, configuration);
+        }
+
+        /// <summary>
+        /// Overload that allows for creating the Bot (IBot) type as well as other startup types.
+        /// </summary>
+        /// <typeparam name="TBot">Type of Bot.</typeparam>
+        /// <param name="services">The application's collection of registered services.</param>
+        /// <param name="configuration">The application configuration.</param>
+        public static void AddBotRuntime<TBot>(this IServiceCollection services, IConfiguration configuration) 
+            where TBot : class, IBot
+        {
+            RegisterCommonServices(services, configuration);
+
+            services.AddTransient<IBot, TBot>();
+        }
+
+        /// <summary>
+        /// Overload that allows for providing the Bot (IBot) type, and the main Dialog type as well as other startup types.
+        /// </summary>
+        /// <typeparam name="TBot">Type of Bot.</typeparam>
+        /// <typeparam name="TDialog">Type of Dialog.</typeparam>
+        /// <param name="services">The application's collection of registered services.</param>
+        /// <param name="configuration">The application configuration.</param>
+        public static void AddBotRuntime<TBot, TDialog>(this IServiceCollection services, IConfiguration configuration)
+            where TBot : class, IBot
+            where TDialog : Dialog
+        {
+            RegisterCommonServices(services, configuration);
+            services.AddSingleton<TDialog>();
+            services.AddTransient<IBot, TBot>();
+        }
+
+        private static void RegisterCommonServices(IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            // Ensure the IConfiguration is available. (Azure Functions don't do this.)
+            services.TryAddSingleton(configuration);
+
+            // All things auth
+            services.TryAddSingleton<BotFrameworkAuthentication, ConfigurationBotFrameworkAuthentication>();
+
+            // Check to see if a different IBotFrameworkHttpAdapter was already registered, if it was, skip registering.
+            // We do this not because of the IBotFrameworkHttpAdapter, but to keep from adding the CoreBotAdapter if 
+            // the bot won't be using it and a different implementation was registered.
+            if (!services.Any(x => x.ServiceType == typeof(IBotFrameworkHttpAdapter)))
+            {
+                // CoreBotAdapter registration
+                services.TryAddSingleton<CoreBotAdapter>();
+                services.TryAddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetRequiredService<CoreBotAdapter>());
+            }
+
+            // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
+            services.TryAddSingleton<IStorage>(new MemoryStorage());
+
+            // Create the User state. (Used in this bot's Dialog implementation.)
+            services.TryAddSingleton<UserState>();
+
+            // Create the Conversation state. (Used by the Dialog system itself.)
+            services.TryAddSingleton<ConversationState>();
+        }
+    }
+}

--- a/testbots/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/testbots/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -42,20 +42,7 @@ namespace Microsoft.BotBuilderSamples
             // Create the debug middleware
             services.AddSingleton(sp => new MicrosoftAppCredentials(sp.GetRequiredService<IConfiguration>()["MicrosoftAppId"], sp.GetRequiredService<IConfiguration>()["MicrosoftAppPassword"]));
 
-            // Create the Bot Framework Adapter with error handling enabled.
-            //services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
-
-            // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
-            //services.AddSingleton<IStorage, MemoryStorage>();
-
-            // Create the User state. (Used in this bot's Dialog implementation.)
-            //services.AddSingleton<UserState>();
-
-            // Create the Conversation state. (Used by the Dialog system itself.)
-            //services.AddSingleton<ConversationState>();
-
-            // The extension method AddBotRuntime will register common services (those commented out above) to the
-            // service connection.
+            // The extension method AddBotRuntime will register common services to the service collection.
             services.AddBotRuntime(Configuration);
 
             // Register LUIS recognizer

--- a/testbots/Microsoft.Bot.Builder.TestBot/Startup.cs
+++ b/testbots/Microsoft.Bot.Builder.TestBot/Startup.cs
@@ -41,18 +41,22 @@ namespace Microsoft.BotBuilderSamples
 
             // Create the debug middleware
             services.AddSingleton(sp => new MicrosoftAppCredentials(sp.GetRequiredService<IConfiguration>()["MicrosoftAppId"], sp.GetRequiredService<IConfiguration>()["MicrosoftAppPassword"]));
-            
+
             // Create the Bot Framework Adapter with error handling enabled.
-            services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
+            //services.AddSingleton<IBotFrameworkHttpAdapter, AdapterWithErrorHandler>();
 
             // Create the storage we'll be using for User and Conversation state. (Memory is great for testing purposes.)
-            services.AddSingleton<IStorage, MemoryStorage>();
+            //services.AddSingleton<IStorage, MemoryStorage>();
 
             // Create the User state. (Used in this bot's Dialog implementation.)
-            services.AddSingleton<UserState>();
+            //services.AddSingleton<UserState>();
 
             // Create the Conversation state. (Used by the Dialog system itself.)
-            services.AddSingleton<ConversationState>();
+            //services.AddSingleton<ConversationState>();
+
+            // The extension method AddBotRuntime will register common services (those commented out above) to the
+            // service connection.
+            services.AddBotRuntime(Configuration);
 
             // Register LUIS recognizer
             RegisterLuisRecognizers(services);

--- a/testbots/Microsoft.Bot.Builder.TestBot/appsettings.json
+++ b/testbots/Microsoft.Bot.Builder.TestBot/appsettings.json
@@ -4,7 +4,7 @@
   "LuisAppId": "",
   "LuisAPIKey": "",
   "LuisAPIHostName": "",
-  "ChannelService": "http://tempuri.org",
+  "ChannelService": "",
   "ValidateAuthority": true,
   "ToChannelFromBotLoginUrl": "https://login.microsoftonline.com/botframework.com",
   "ToChannelFromBotOAuthScope": "https://api.botframework.com",


### PR DESCRIPTION
Fixes #6024 

## Description
Implemented the AddBotRuntime from Adaptive for V5.

## Specific Changes
Implemented AddBotRuntime via an extension method for IServiceCollection. There are three separate extension methods, one adds just the minimal runtime components which include:

- IConfiguration (for Azure functions that doesn't already include IConfiguration in the service collection).
- BotFrameworkAuthentication as an instance of ConfigurationBotFrameworkAuthentication
- IBotFrameworkHttpAdapter as an instance of CoreBotAdapter which derives from CloudAdapter and so implements IBotFrameworkAdapter
- IStorage as an instance of MemoryStorage
- UserState
- ConversationState

The second extension method allows the type of the IBot to be provided, which will then add it as a Transient

The third extension method allows the type of the IBot to be provided, as well as the type of Dialog and both will be registered, the Dialog as a Singleton and the Bot as a Transient.

Included CoreBotAdapter which derives from CloudAdapter and provides a minimal implementation of an IBotFrameworkAdapter that adds any middlewares 

## Testing
Tested against TestBot (which is modified in this PR to use AddBotRuntim) and multiple samples that were temporarily modified to use AddBotRuntime and validated that they all worked the same as they did originally when adding their own services directly.