### PR TITLE
Add continueOnError: true for publish

### DIFF
--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -95,6 +95,7 @@ steps:
   inputs:
     artifactName: 'BotBuilderDLLs-$(BuildConfiguration)-$(BuildTarget)'
     targetPath: outputLibraries
+  continueOnError: true
 
 - script: |
    cd ..


### PR DESCRIPTION
Fixes #minor

## Description
This fixes CI build failures that happen when someone picks "Rerun failed jobs".

The step 'Publish Microsoft.Bot.Builder DLLs artifact' fails when it runs the second time with the error ##[error]Artifact BotBuilderDLLs-Release-Windows-netcoreapp31 already exists for build nnnnn. (A pipeline should be idempotent. ;-) )

Example: https://dev.azure.com/FuseLabs/SDK_Public/_build/results?buildId=289085&view=logs&j=3caee121-a023-5855-b1e2-fa52c30e4794&t=77840afb-f9eb-5759-8afb-e28266d81ed6

## Specific Changes
Added continueOnError: true to task.