### PR TITLE
In CI pipeline, make API compatibility run only when warranted.

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -74,8 +74,8 @@ stages:
     - template: ci-component-detection-steps.yml
 
 - stage: API_Compatibility_Validation
-  condition: ne(variables['DisableApiCompatibityValidation'], 'true')
   dependsOn: Build
+  condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build jobs, so unnecessary here.
   jobs:


### PR DESCRIPTION
Fixes #minor

## Description
When the dotnet CI-PR pipeline's Build stage fails, the API_Compatibility_Validation stage should be skipped. But it runs anyway, wasting pipeline time and resources.

This fixes that.
