### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA1822

### DIFF
--- a/BotBuilder-DotNet.ruleset
+++ b/BotBuilder-DotNet.ruleset
@@ -4,7 +4,6 @@
     <Rule Id="CA1054" Action="None" /> <!-- UriParametersShouldNotBeStrings -->
     <Rule Id="CA1062" Action="None" /> <!-- ValidateArgumentsOfPublicMethods -->
     <Rule Id="CA1308" Action="None" /> <!-- Normalize strings to uppercase (most of our operations are normalized on lowercase -->
-    <Rule Id="CA1822" Action="None" /> <!-- Ignore Mark members as static -->
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
     <Rule Id="CA1303" Action="None" /> <!-- DoNotPassLiteralsAsLocalizedParameters -->

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -570,6 +570,38 @@ namespace Microsoft.Bot.Builder.AI.Luis
             return Task.FromResult(properties);
         }
 
+        private static DelegatingHandler CreateHttpHandlerPipeline(HttpClientHandler httpClientHandler, params DelegatingHandler[] handlers)
+        {
+            // Now, the RetryAfterDelegatingHandler should be the absolute outermost handler
+            // because it's extremely lightweight and non-interfering
+            DelegatingHandler currentHandler =
+#pragma warning disable CA2000 // Dispose objects before losing scope (suppressing this warning, for now! we will address this once we implement HttpClientFactory in a future release)
+                new RetryDelegatingHandler(new RetryAfterDelegatingHandler { InnerHandler = httpClientHandler });
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            if (handlers != null)
+            {
+                for (var i = handlers.Length - 1; i >= 0; --i)
+                {
+                    var handler = handlers[i];
+
+                    // Non-delegating handlers are ignored since we always
+                    // have RetryDelegatingHandler as the outer-most handler
+                    while (handler.InnerHandler is DelegatingHandler)
+                    {
+                        handler = handler.InnerHandler as DelegatingHandler;
+                    }
+
+                    handler.InnerHandler = currentHandler;
+                    currentHandler = handlers[i];
+                }
+            }
+
+            return currentHandler;
+        }
+
+        private static HttpClientHandler CreateRootHandler() => new HttpClientHandler();
+
         /// <summary>
         /// Returns a LuisRecognizerOptions object with the correspondig version.
         /// If no V2 LuisPredictionoption passed it sets the recognizer to use Luis V3 endpoint.
@@ -694,37 +726,5 @@ namespace Microsoft.Bot.Builder.AI.Luis
             };
             return BuildLuisRecognizerOptionsV2(_luisRecognizerOptions.Application, overrideV2, _luisRecognizerOptions.IncludeAPIResults);
         }
-
-        private DelegatingHandler CreateHttpHandlerPipeline(HttpClientHandler httpClientHandler, params DelegatingHandler[] handlers)
-        {
-            // Now, the RetryAfterDelegatingHandler should be the absolute outermost handler
-            // because it's extremely lightweight and non-interfering
-            DelegatingHandler currentHandler =
-#pragma warning disable CA2000 // Dispose objects before losing scope (suppressing this warning, for now! we will address this once we implement HttpClientFactory in a future release)
-                new RetryDelegatingHandler(new RetryAfterDelegatingHandler { InnerHandler = httpClientHandler });
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-            if (handlers != null)
-            {
-                for (var i = handlers.Length - 1; i >= 0; --i)
-                {
-                    var handler = handlers[i];
-
-                    // Non-delegating handlers are ignored since we always
-                    // have RetryDelegatingHandler as the outer-most handler
-                    while (handler.InnerHandler is DelegatingHandler)
-                    {
-                        handler = handler.InnerHandler as DelegatingHandler;
-                    }
-
-                    handler.InnerHandler = currentHandler;
-                    currentHandler = handlers[i];
-                }
-            }
-
-            return currentHandler;
-        }
-
-        private HttpClientHandler CreateRootHandler() => new HttpClientHandler();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisRecognizer.cs
@@ -570,38 +570,6 @@ namespace Microsoft.Bot.Builder.AI.Luis
             return Task.FromResult(properties);
         }
 
-        private static DelegatingHandler CreateHttpHandlerPipeline(HttpClientHandler httpClientHandler, params DelegatingHandler[] handlers)
-        {
-            // Now, the RetryAfterDelegatingHandler should be the absolute outermost handler
-            // because it's extremely lightweight and non-interfering
-            DelegatingHandler currentHandler =
-#pragma warning disable CA2000 // Dispose objects before losing scope (suppressing this warning, for now! we will address this once we implement HttpClientFactory in a future release)
-                new RetryDelegatingHandler(new RetryAfterDelegatingHandler { InnerHandler = httpClientHandler });
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-            if (handlers != null)
-            {
-                for (var i = handlers.Length - 1; i >= 0; --i)
-                {
-                    var handler = handlers[i];
-
-                    // Non-delegating handlers are ignored since we always
-                    // have RetryDelegatingHandler as the outer-most handler
-                    while (handler.InnerHandler is DelegatingHandler)
-                    {
-                        handler = handler.InnerHandler as DelegatingHandler;
-                    }
-
-                    handler.InnerHandler = currentHandler;
-                    currentHandler = handlers[i];
-                }
-            }
-
-            return currentHandler;
-        }
-
-        private static HttpClientHandler CreateRootHandler() => new HttpClientHandler();
-
         /// <summary>
         /// Returns a LuisRecognizerOptions object with the correspondig version.
         /// If no V2 LuisPredictionoption passed it sets the recognizer to use Luis V3 endpoint.
@@ -634,6 +602,38 @@ namespace Microsoft.Bot.Builder.AI.Luis
 
             return luisVersionOptions;
         }
+
+        private static DelegatingHandler CreateHttpHandlerPipeline(HttpClientHandler httpClientHandler, params DelegatingHandler[] handlers)
+        {
+            // Now, the RetryAfterDelegatingHandler should be the absolute outermost handler
+            // because it's extremely lightweight and non-interfering
+            DelegatingHandler currentHandler =
+#pragma warning disable CA2000 // Dispose objects before losing scope (suppressing this warning, for now! we will address this once we implement HttpClientFactory in a future release)
+                new RetryDelegatingHandler(new RetryAfterDelegatingHandler { InnerHandler = httpClientHandler });
+#pragma warning restore CA2000 // Dispose objects before losing scope
+
+            if (handlers != null)
+            {
+                for (var i = handlers.Length - 1; i >= 0; --i)
+                {
+                    var handler = handlers[i];
+
+                    // Non-delegating handlers are ignored since we always
+                    // have RetryDelegatingHandler as the outer-most handler
+                    while (handler.InnerHandler is DelegatingHandler)
+                    {
+                        handler = handler.InnerHandler as DelegatingHandler;
+                    }
+
+                    handler.InnerHandler = currentHandler;
+                    currentHandler = handlers[i];
+                }
+            }
+
+            return currentHandler;
+        }
+
+        private static HttpClientHandler CreateRootHandler() => new HttpClientHandler();
 
         /// <summary>
         /// Returns a RecognizerResult object.

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -741,7 +741,21 @@ namespace Microsoft.Bot.Builder
             return Task.CompletedTask;
         }
 
-        private AdaptiveCardInvokeValue GetAdaptiveCardInvokeValue(IInvokeActivity activity)
+        private static AdaptiveCardInvokeResponse CreateAdaptiveCardInvokeErrorResponse(HttpStatusCode statusCode, string code, string message)
+        {
+            return new AdaptiveCardInvokeResponse()
+            {
+                StatusCode = (int)statusCode,
+                Type = "application/vnd.microsoft.error",
+                Value = new Error()
+                {
+                    Code = code,
+                    Message = message
+                }
+            };
+        }
+
+        private static AdaptiveCardInvokeValue GetAdaptiveCardInvokeValue(IInvokeActivity activity)
         {
             if (activity.Value == null)
             {
@@ -783,20 +797,6 @@ namespace Microsoft.Bot.Builder
             }
 
             return invokeValue;
-        }
-
-        private AdaptiveCardInvokeResponse CreateAdaptiveCardInvokeErrorResponse(HttpStatusCode statusCode, string code, string message)
-        {
-            return new AdaptiveCardInvokeResponse()
-            {
-                StatusCode = (int)statusCode,
-                Type = "application/vnd.microsoft.error",
-                Value = new Error()
-                {
-                    Code = code,
-                    Message = message
-                }
-            };
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -741,20 +741,6 @@ namespace Microsoft.Bot.Builder
             return Task.CompletedTask;
         }
 
-        private static AdaptiveCardInvokeResponse CreateAdaptiveCardInvokeErrorResponse(HttpStatusCode statusCode, string code, string message)
-        {
-            return new AdaptiveCardInvokeResponse()
-            {
-                StatusCode = (int)statusCode,
-                Type = "application/vnd.microsoft.error",
-                Value = new Error()
-                {
-                    Code = code,
-                    Message = message
-                }
-            };
-        }
-
         private static AdaptiveCardInvokeValue GetAdaptiveCardInvokeValue(IInvokeActivity activity)
         {
             if (activity.Value == null)
@@ -797,6 +783,20 @@ namespace Microsoft.Bot.Builder
             }
 
             return invokeValue;
+        }
+
+        private static AdaptiveCardInvokeResponse CreateAdaptiveCardInvokeErrorResponse(HttpStatusCode statusCode, string code, string message)
+        {
+            return new AdaptiveCardInvokeResponse()
+            {
+                StatusCode = (int)statusCode,
+                Type = "application/vnd.microsoft.error",
+                Value = new Error()
+                {
+                    Code = code,
+                    Message = message
+                }
+            };
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
@@ -51,46 +51,7 @@ namespace Microsoft.Bot.Builder
             await next(cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Normalize the activity.
-        /// </summary>
-        /// <param name="activity">activity.</param>
-        private void NormalizeActivity(Activity activity)
-        {
-            if (activity.Type == ActivityTypes.Message)
-            {
-                if (this.RemoveRecipientMention)
-                {
-                    // strip recipient mention tags and text.
-                    activity.RemoveRecipientMention();
-
-                    if (activity.Entities != null)
-                    {
-                        // strip entity.mention records for recipient id.
-                        activity.Entities = activity.Entities.Where(entity => entity.Type == "mention" &&
-                           ((dynamic)entity.Properties["mentioned"]).id != activity.Recipient.Id).ToList();
-                    }
-                }
-
-                // remove <at> </at> tags keeping the inner text.
-                activity.Text = RemoveAt(activity.Text);
-
-                if (activity.Entities != null)
-                {
-                    // remove <at> </at> tags from mention records keeping the inner text.
-                    foreach (var entity in activity.Entities)
-                    {
-                        if (entity.Type == "mention")
-                        {
-                            string entityText = (string)entity.Properties["text"];
-                            entity.Properties["text"] = RemoveAt(entityText)?.Trim();
-                        }
-                    }
-                }
-            }
-        }
-
-        private string RemoveAt(string text)
+        private static string RemoveAt(string text)
         {
             if (string.IsNullOrEmpty(text))
             {
@@ -134,6 +95,45 @@ namespace Microsoft.Bot.Builder
             while (foundTag);
 
             return text;
+        }
+
+        /// <summary>
+        /// Normalize the activity.
+        /// </summary>
+        /// <param name="activity">activity.</param>
+        private void NormalizeActivity(Activity activity)
+        {
+            if (activity.Type == ActivityTypes.Message)
+            {
+                if (this.RemoveRecipientMention)
+                {
+                    // strip recipient mention tags and text.
+                    activity.RemoveRecipientMention();
+
+                    if (activity.Entities != null)
+                    {
+                        // strip entity.mention records for recipient id.
+                        activity.Entities = activity.Entities.Where(entity => entity.Type == "mention" &&
+                           ((dynamic)entity.Properties["mentioned"]).id != activity.Recipient.Id).ToList();
+                    }
+                }
+
+                // remove <at> </at> tags keeping the inner text.
+                activity.Text = RemoveAt(activity.Text);
+
+                if (activity.Entities != null)
+                {
+                    // remove <at> </at> tags from mention records keeping the inner text.
+                    foreach (var entity in activity.Entities)
+                    {
+                        if (entity.Type == "mention")
+                        {
+                            string entityText = (string)entity.Properties["text"];
+                            entity.Properties["text"] = RemoveAt(entityText)?.Trim();
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder
             await next(cancellationToken).ConfigureAwait(false);
         }
 
-        private bool HasTag(string tagName, string speakText)
+        private static bool HasTag(string tagName, string speakText)
         {
             try
             {

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsSSOTokenExchangeMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsSSOTokenExchangeMiddleware.cs
@@ -82,6 +82,20 @@ namespace Microsoft.Bot.Builder.Teams
             await next(cancellationToken).ConfigureAwait(false);
         }
 
+        private static async Task SendInvokeResponseAsync(ITurnContext turnContext, object body = null, HttpStatusCode httpStatusCode = HttpStatusCode.OK, CancellationToken cancellationToken = default)
+        {
+            await turnContext.SendActivityAsync(
+                new Activity
+                {
+                    Type = ActivityTypesEx.InvokeResponse,
+                    Value = new InvokeResponse
+                    {
+                        Status = (int)httpStatusCode,
+                        Body = body,
+                    },
+                }, cancellationToken).ConfigureAwait(false);
+        }
+
         private async Task<bool> DeduplicatedTokenExchangeIdAsync(ITurnContext turnContext, CancellationToken cancellationToken)
         {
             // Create a StoreItem with Etag of the unique 'signin/tokenExchange' request
@@ -110,20 +124,6 @@ namespace Microsoft.Bot.Builder.Teams
             }
 
             return true;
-        }
-
-        private async Task SendInvokeResponseAsync(ITurnContext turnContext, object body = null, HttpStatusCode httpStatusCode = HttpStatusCode.OK, CancellationToken cancellationToken = default)
-        {
-            await turnContext.SendActivityAsync(
-                new Activity
-                {
-                    Type = ActivityTypesEx.InvokeResponse,
-                    Value = new InvokeResponse
-                    {
-                        Status = (int)httpStatusCode,
-                        Body = body,
-                    },
-                }, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<bool> ExchangedTokenAsync(ITurnContext turnContext, CancellationToken cancellationToken)

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -120,6 +120,38 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <summary>
+        /// Fills event properties for the <see cref="TelemetryLoggerConstants.BotMsgDeleteEvent"/> event.
+        /// </summary>
+        /// <param name="activity">The Activity object deleted by bot.</param>
+        /// <param name="additionalProperties">Additional properties to add to the event.</param>
+        /// <returns>The properties and their values to log when the bot deletes a message it sent previously.</returns>
+        protected static Task<Dictionary<string, string>> FillDeleteEventPropertiesAsync(IMessageDeleteActivity activity, Dictionary<string, string> additionalProperties = null)
+        {
+            if (activity == null)
+            {
+                return Task.FromResult(new Dictionary<string, string>());
+            }
+
+            var properties = new Dictionary<string, string>()
+                {
+                    { TelemetryConstants.RecipientIdProperty, activity.Recipient?.Id },
+                    { TelemetryConstants.ConversationIdProperty, activity.Conversation?.Id },
+                    { TelemetryConstants.ConversationNameProperty, activity.Conversation?.Name },
+                    { TelemetryConstants.ActivityTypeProperty, activity.Type },
+                };
+
+            // Additional Properties can override "stock" properties.
+            if (additionalProperties != null)
+            {
+                return Task.FromResult(additionalProperties.Concat(properties)
+                           .GroupBy(kv => kv.Key)
+                           .ToDictionary(g => g.Key, g => g.First().Value));
+            }
+
+            return Task.FromResult(properties);
+        }
+
+        /// <summary>
         /// Uses the telemetry client's
         /// <see cref="IBotTelemetryClient.TrackEvent(string, IDictionary{string, string}, IDictionary{string, double})"/> method to
         /// log telemetry data when a message is received from the user.
@@ -327,38 +359,6 @@ namespace Microsoft.Bot.Builder
             {
                 properties.Add(TelemetryConstants.TextProperty, activity.Text);
             }
-
-            // Additional Properties can override "stock" properties.
-            if (additionalProperties != null)
-            {
-                return Task.FromResult(additionalProperties.Concat(properties)
-                           .GroupBy(kv => kv.Key)
-                           .ToDictionary(g => g.Key, g => g.First().Value));
-            }
-
-            return Task.FromResult(properties);
-        }
-
-        /// <summary>
-        /// Fills event properties for the <see cref="TelemetryLoggerConstants.BotMsgDeleteEvent"/> event.
-        /// </summary>
-        /// <param name="activity">The Activity object deleted by bot.</param>
-        /// <param name="additionalProperties">Additional properties to add to the event.</param>
-        /// <returns>The properties and their values to log when the bot deletes a message it sent previously.</returns>
-        protected Task<Dictionary<string, string>> FillDeleteEventPropertiesAsync(IMessageDeleteActivity activity, Dictionary<string, string> additionalProperties = null)
-        {
-            if (activity == null)
-            {
-                return Task.FromResult(new Dictionary<string, string>());
-            }
-
-            var properties = new Dictionary<string, string>()
-                {
-                    { TelemetryConstants.RecipientIdProperty, activity.Recipient?.Id },
-                    { TelemetryConstants.ConversationIdProperty, activity.Conversation?.Id },
-                    { TelemetryConstants.ConversationNameProperty, activity.Conversation?.Name },
-                    { TelemetryConstants.ActivityTypeProperty, activity.Type },
-                };
 
             // Additional Properties can override "stock" properties.
             if (additionalProperties != null)

--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkAuthentication.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="callerId">The default callerId to use if this is not a skill.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The callerId, this might be null.</returns>
-        protected internal async Task<string> GenerateCallerIdAsync(ServiceClientCredentialsFactory credentialFactory, ClaimsIdentity claimsIdentity, string callerId, CancellationToken cancellationToken)
+        protected internal static async Task<string> GenerateCallerIdAsync(ServiceClientCredentialsFactory credentialFactory, ClaimsIdentity claimsIdentity, string callerId, CancellationToken cancellationToken)
         {
             // Is the bot accepting all incoming messages?
             if (await credentialFactory.IsAuthenticationDisabledAsync(cancellationToken).ConfigureAwait(false))

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -177,6 +177,80 @@ namespace Microsoft.Bot.Connector.Authentication
             return true;
         }
 
+        private static bool IsTokenFromSkill(string authHeader)
+        {
+            if (!IsValidTokenFormat(authHeader))
+            {
+                return false;
+            }
+
+            // We know is a valid token, split it and work with it:
+            // [0] = "Bearer"
+            // [1] = "[Big Long String]"
+            var bearerToken = authHeader.Split(' ')[1];
+
+            // Parse the Big Long String into an actual token.
+            var token = new JwtSecurityToken(bearerToken);
+
+            return token.Claims.IsSkillClaim();
+        }
+
+        private static TokenValidationParameters GetEmulatorTokenValidationParameters()
+        {
+            return new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidIssuers = new[]
+                {
+                    // TODO: presumably this table should also come from configuration
+                    "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/", // Auth v3.1, 1.0 token
+                    "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0", // Auth v3.1, 2.0 token
+                    "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/", // Auth v3.2, 1.0 token
+                    "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0", // Auth v3.2, 2.0 token
+                    "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/", // Auth for US Gov, 1.0 token
+                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0", // Auth for US Gov, 2.0 token
+                },
+                ValidateAudience = false, // Audience validation takes place manually in code.
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5),
+                RequireSignedTokens = true,
+            };
+        }
+
+        private static bool IsTokenFromEmulator(string authHeader)
+        {
+            if (!IsValidTokenFormat(authHeader))
+            {
+                return false;
+            }
+
+            // We know is a valid token, split it and work with it:
+            // [0] = "Bearer"
+            // [1] = "[Big Long String]"
+            var bearerToken = authHeader.Split(' ')[1];
+
+            // Parse the Big Long String into an actual token.
+            var token = new JwtSecurityToken(bearerToken);
+
+            // Is there an Issuer?
+            if (string.IsNullOrWhiteSpace(token.Issuer))
+            {
+                // No Issuer, means it's not from the Emulator.
+                return false;
+            }
+
+            // Is the token issued by a source we consider to be the emulator?
+            var emulatorTokenValidationParameters = GetEmulatorTokenValidationParameters();
+            if (!emulatorTokenValidationParameters.ValidIssuers.Contains(token.Issuer))
+            {
+                // Not a Valid Issuer. This is NOT a Bot Framework Emulator Token.
+                return false;
+            }
+
+            // The Token is from the Bot Framework Emulator. Success!
+            return true;
+        }
+
         // The following code is based on JwtTokenValidation.AuthenticateRequest
         private async Task<ClaimsIdentity> JwtTokenValidation_AuthenticateRequestAsync(Activity activity, string authHeader, CancellationToken cancellationToken)
         {
@@ -332,24 +406,6 @@ namespace Microsoft.Bot.Connector.Authentication
             }
         }
 
-        private bool IsTokenFromSkill(string authHeader)
-        {
-            if (!IsValidTokenFormat(authHeader))
-            {
-                return false;
-            }
-
-            // We know is a valid token, split it and work with it:
-            // [0] = "Bearer"
-            // [1] = "[Big Long String]"
-            var bearerToken = authHeader.Split(' ')[1];
-
-            // Parse the Big Long String into an actual token.
-            var token = new JwtSecurityToken(bearerToken);
-
-            return token.Claims.IsSkillClaim();
-        }
-
         // The following code is based on EmulatorValidation.AuthenticateEmulatorToken
         private async Task<ClaimsIdentity> AuthenticateEmulatorTokenAsync(string authHeader, string channelId, CancellationToken cancellationToken)
         {
@@ -434,62 +490,6 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             return identity;
-        }
-
-        private bool IsTokenFromEmulator(string authHeader)
-        {
-            if (!IsValidTokenFormat(authHeader))
-            {
-                return false;
-            }
-
-            // We know is a valid token, split it and work with it:
-            // [0] = "Bearer"
-            // [1] = "[Big Long String]"
-            var bearerToken = authHeader.Split(' ')[1];
-
-            // Parse the Big Long String into an actual token.
-            var token = new JwtSecurityToken(bearerToken);
-
-            // Is there an Issuer?
-            if (string.IsNullOrWhiteSpace(token.Issuer))
-            {
-                // No Issuer, means it's not from the Emulator.
-                return false;
-            }
-
-            // Is the token issued by a source we consider to be the emulator?
-            var emulatorTokenValidationParameters = GetEmulatorTokenValidationParameters();
-            if (!emulatorTokenValidationParameters.ValidIssuers.Contains(token.Issuer))
-            {
-                // Not a Valid Issuer. This is NOT a Bot Framework Emulator Token.
-                return false;
-            }
-
-            // The Token is from the Bot Framework Emulator. Success!
-            return true;
-        }
-
-        private TokenValidationParameters GetEmulatorTokenValidationParameters()
-        {
-            return new TokenValidationParameters
-            {
-                ValidateIssuer = true,
-                ValidIssuers = new[]
-                {
-                    // TODO: presumably this table should also come from configuration
-                    "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/", // Auth v3.1, 1.0 token
-                    "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0", // Auth v3.1, 2.0 token
-                    "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/", // Auth v3.2, 1.0 token
-                    "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0", // Auth v3.2, 2.0 token
-                    "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/", // Auth for US Gov, 1.0 token
-                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0", // Auth for US Gov, 2.0 token
-                },
-                ValidateAudience = false, // Audience validation takes place manually in code.
-                ValidateLifetime = true,
-                ClockSkew = TimeSpan.FromMinutes(5),
-                RequireSignedTokens = true,
-            };
         }
 
         // The following code is based on GovernmentChannelValidation.AuthenticateChannelToken

--- a/libraries/Storage/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Storage/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -346,6 +346,18 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             while (!string.IsNullOrEmpty(token));
         }
 
+        private static string GetBlobName(IActivity activity)
+        {
+            var blobName = $"{SanitizeKey(activity.ChannelId)}/{SanitizeKey(activity.Conversation.Id)}/{activity.Timestamp.Value.Ticks.ToString("x", CultureInfo.InvariantCulture)}-{SanitizeKey(activity.Id)}.json";
+            return blobName;
+        }
+
+        private static string SanitizeKey(string key)
+        {
+            // Blob Name rules: case-sensitive any url char
+            return Uri.EscapeDataString(key);
+        }
+
         private async Task<(Activity, BlobClient)> InnerReadBlobAsync(IActivity activity)
         {
             var i = 0;
@@ -438,18 +450,6 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             memoryStream.Seek(0, SeekOrigin.Begin);
 
             await blobClient.UploadAsync(memoryStream, options).ConfigureAwait(false);
-        }
-
-        private string GetBlobName(IActivity activity)
-        {
-            var blobName = $"{SanitizeKey(activity.ChannelId)}/{SanitizeKey(activity.Conversation.Id)}/{activity.Timestamp.Value.Ticks.ToString("x", CultureInfo.InvariantCulture)}-{SanitizeKey(activity.Id)}.json";
-            return blobName;
-        }
-
-        private string SanitizeKey(string key)
-        {
-            // Blob Name rules: case-sensitive any url char
-            return Uri.EscapeDataString(key);
         }
     }
 }

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -314,7 +314,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                         return httpResponseMessage;
                     }
 
-                    private async Task<StreamingRequest> CreateSteamingRequestAsync(HttpRequestMessage httpRequestMessage)
+                    private static async Task<StreamingRequest> CreateSteamingRequestAsync(HttpRequestMessage httpRequestMessage)
                     {
                         var streamingRequest = new StreamingRequest
                         {
@@ -325,7 +325,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                         return streamingRequest;
                     }
 
-                    private async Task<HttpResponseMessage> CreateHttpResponseAsync(ReceiveResponse receiveResponse)
+                    private static async Task<HttpResponseMessage> CreateHttpResponseAsync(ReceiveResponse receiveResponse)
                     {
                         var httpResponseMessage = new HttpResponseMessage((HttpStatusCode)receiveResponse.StatusCode);
                         httpResponseMessage.Content = new StringContent(await receiveResponse.ReadBodyAsStringAsync().ConfigureAwait(false));


### PR DESCRIPTION
Addresses #6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA1822](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822) (Mark members as static).

### Detailed Changes
- Updated the `.ruleset` file removing the exclusion of the CA1822 rule.
- Added the `static` modifier to the following methods:
   - _CreateHttpHandlerPipeline_ of the _LuisRecognizer_ class.
   -  CreateAdaptiveCardInvokeErrorResponse of the ActivityHandler class.
   -  _CreateClaimsIdentity_, _CreateCreateActivity_, _ValidateContinuationActivity_, and _ProcessTurnResults_ of the _CloudAdapterBase_ class.
   -  _RemoveAt_ of the _NormalizeMentionsMiddleware_ class.
   -  _HasTag_ of the _SetSpeakMiddleware_ class.
   -  _SendInvokeResponseAsync_ of the _TeamsSSOTokenExchangeMiddleware_ class.
   -  _FillDeleteEventPropertiesAsync_ of the _TelemetryLoggerMiddleware_ class.
   -  _GenerateCallerIdAsync_ of the _BotFrameworkAuthentication_ class.
   -  _IsTokenFromSkill_, _GetEmulatorTokenValidationParameters_, and _IsTokenFromEmulator_ of the _ParameterizedBotFrameworkAuthentication_ class.
   - _GetBlobName_ of the _BlobsTranscriptStore_ class.
   - _IsNestingError_ and _IsInDialogState_ of the _CosmosDbPartitionedStorage_ class.
   - _CreateSteamingRequestAsync_ and _CreateHttpResponseAsync_ of the _CloudAdapter_ class.
- Reordered the methods to appear before non-static members.

## Testing
These images show the number of issues fixed after removing the exclusion and the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/153278590-229f0b95-3b6c-40d3-a333-b9eaf6df90fa.png)

![image](https://user-images.githubusercontent.com/44245136/153278604-f99c56ba-0e75-43ec-bc42-b95d1c588391.png)