### PR TITLE
v5: Fix BinSkim alert EnableSecureSourceCodeHashing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,6 +76,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GeneratePackageOnBuild)' == 'True'">


### PR DESCRIPTION
Fixes #minor

[BinSkim pipeline](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=291183&view=results) is failing with Warning	BA2004	EnableSecureSourceCodeHashing.

Legacy hashing algorithm SHA1 (default)) used to encode source files in the PDB is not secure. Use SHA256.

The fix: Add ChecksumAlgorithm SHA256 to Directory.Build.props.
