### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 2/8)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
@@ -43,14 +43,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         public CardAction Action { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of synonyms to recognize in addition to the value. This is optional.
+        /// Gets the list of synonyms to recognize in addition to the value. This is optional.
         /// </summary>
         /// <value>
         /// The list of synonyms to recognize in addition to the value.
         /// </value>
         [JsonProperty("synonyms")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public List<string> Synonyms { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<string> Synonyms { get; private set; } = new List<string>();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Find.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Find.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                     synonyms.Add(new SortedValue { Value = choice.Action.Title, Index = index });
                 }
 
-                if (choice.Synonyms != null)
+                if (choice.Synonyms.Any())
                 {
                     foreach (var synonym in choice.Synonyms)
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ComponentDialog.cs
@@ -393,11 +393,6 @@ namespace Microsoft.Bot.Builder.Dialogs
                 instance.State[PersistedDialogState] = state;
             }
 
-            if (state.DialogStack == null)
-            {
-                state.DialogStack = new List<DialogInstance>();
-            }
-
             return state;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -172,10 +172,9 @@ namespace Microsoft.Bot.Builder.Dialogs
                 }
 
                 // Push new instance onto stack
-                var instance = new DialogInstance
+                var instance = new DialogInstance()
                 {
                     Id = dialogId,
-                    State = new Dictionary<string, object>(),
                 };
 
                 Stack.Insert(0, instance);

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogInstance.cs
@@ -23,15 +23,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         public string Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the instance's persisted state.
+        /// Gets the instance's persisted state.
         /// </summary>
         /// <value>
         /// The instance's persisted state.
         /// </value>
         [JsonProperty("state")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IDictionary<string, object> State { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IDictionary<string, object> State { get; private set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Gets or sets a stack index. Positive values are indexes within the current DC and negative values are 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
@@ -35,12 +35,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
-        /// Gets or sets the state information for a dialog stack.
+        /// Gets the state information for a dialog stack.
         /// </summary>
         /// <value>State information for a dialog stack.</value>
         [JsonProperty("dialogStack")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public List<DialogInstance> DialogStack { get; set; } = new List<DialogInstance>();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<DialogInstance> DialogStack { get; private set; } = new List<DialogInstance>();
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/PersistedState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/PersistedState.cs
@@ -32,19 +32,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
-        /// Gets or sets the user profile data.
+        /// Gets the user profile data.
         /// </summary>
         /// <value>The user profile data.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IDictionary<string, object> UserState { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IDictionary<string, object> UserState { get; private set; }
 
         /// <summary>
-        /// Gets or sets the dialog state data.
+        /// Gets the dialog state data.
         /// </summary>
         /// <value>The dialog state data.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IDictionary<string, object> ConversationState { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IDictionary<string, object> ConversationState { get; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <summary>
         /// Initializes a new instance of the <see cref="PromptOptions"/> class.
         /// </summary>
-        /// <param name="prompt">The initial prompt to send the user as and <see cref="Activity"/>.</param>
+        /// <param name="prompt">The initial prompt to send the user as an <see cref="Activity"/>.</param>
         /// <param name="choices">The list of available choices.</param>
-        public PromptOptions(Activity prompt = null, IList<Choice> choices = null)
+        public PromptOptions(Activity prompt = default, IList<Choice> choices = default)
         {
             Prompt = prompt;
             Choices = choices;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -13,6 +13,17 @@ namespace Microsoft.Bot.Builder.Dialogs
     public class PromptOptions
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="PromptOptions"/> class.
+        /// </summary>
+        /// <param name="prompt">The initial prompt to send the user as and <see cref="Activity"/>.</param>
+        /// <param name="choices">The list of available choices.</param>
+        public PromptOptions(Activity prompt = null, IList<Choice> choices = null)
+        {
+            Prompt = prompt;
+            Choices = choices;
+        }
+
+        /// <summary>
         /// Gets or sets the initial prompt to send the user as an <see cref="Activity"/>.
         /// </summary>
         /// <value>
@@ -29,12 +40,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         public Activity RetryPrompt { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of choices for the user to choose from, for use with a <see cref="ChoicePrompt"/>.
+        /// Gets a list of choices for the user to choose from, for use with a <see cref="ChoicePrompt"/>.
         /// </summary>
         /// <value>The list of available choices.</value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public IList<Choice> Choices { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Choice> Choices { get; } = new List<Choice>();
 
         /// <summary>
         /// Gets or sets the <see cref="ListStyle"/> for a <see cref="ChoicePrompt"/>.

--- a/testbots/Microsoft.Bot.Builder.TestBot.Shared/Dialogs/UserProfileDialog.cs
+++ b/testbots/Microsoft.Bot.Builder.TestBot.Shared/Dialogs/UserProfileDialog.cs
@@ -46,11 +46,10 @@ namespace Microsoft.Bot.Builder.TestBot.Shared.Dialogs
             // Running a prompt here means the next WaterfallStep will be run when the users response is received.
             return await stepContext.PromptAsync(
                 nameof(ChoicePrompt),
-                new PromptOptions
-                {
-                    Prompt = MessageFactory.Text("Please enter your mode of transport."),
-                    Choices = ChoiceFactory.ToChoices(new List<string> { "Car", "Bus", "Bicycle" }),
-                }, cancellationToken);
+                new PromptOptions(
+                    prompt: MessageFactory.Text("Please enter your mode of transport."),
+                    choices: ChoiceFactory.ToChoices(new List<string> { "Car", "Bus", "Bicycle" })),
+                cancellationToken);
         }
 
         private static async Task<DialogTurnResult> NameActionAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -101,10 +101,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                             },
                         };
 
-                        var options = new PromptOptions()
-                        {
-                            Choices = new List<Choice> { choice },
-                        };
+                        var options = new PromptOptions(choices: new List<Choice> { choice });
                         await dc.PromptAsync(
                         "ChoicePrompt",
                         options,
@@ -138,11 +135,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -172,11 +167,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -212,11 +205,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -250,11 +241,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -298,11 +287,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -347,14 +334,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         // Create mock attachment for testing.
                         var attachment = new Attachment { Content = "some content", ContentType = "text/plain" };
+                        var prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Attachments = new List<Attachment> { attachment } };
 
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Attachments = new List<Attachment> { attachment } },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: prompt,
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -400,11 +386,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -439,16 +423,14 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity
+                            new PromptOptions(
+                                prompt: new Activity
                                 {
                                     Type = ActivityTypes.Message,
                                     Text = "favorite color?",
                                     Speak = "spoken prompt",
                                 },
-                                Choices = _colorChoices,
-                            },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -483,11 +465,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                     else if (results.Status == DialogTurnStatus.Complete)
@@ -528,11 +508,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices)
                             {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
                                 RetryPrompt = new Activity { Type = ActivityTypes.Message, Text = "your favorite color, please?" },
-                                Choices = _colorChoices,
                             },
                             cancellationToken);
                     }
@@ -575,11 +555,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
-                            {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
-                            },
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices),
                             cancellationToken);
                     }
                 })
@@ -611,10 +589,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     {
                         await dc.PromptAsync(
                             "ChoicePrompt",
-                            new PromptOptions
+                            new PromptOptions(
+                                prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
+                                choices: _colorChoices)
                             {
-                                Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?" },
-                                Choices = _colorChoices,
                                 Style = ListStyle.SuggestedAction,
                             },
                             cancellationToken);
@@ -661,11 +639,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     await dc.PromptAsync(
                         "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Locale = testCulture },
-                            Choices = _colorChoices,
-                        },
+                        new PromptOptions(
+                            prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Locale = testCulture },
+                            choices: _colorChoices),
                         cancellationToken);
                 }
             })
@@ -712,11 +688,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     await dc.PromptAsync(
                         "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Locale = activityLocale },
-                            Choices = _colorChoices,
-                        },
+                        new PromptOptions(
+                            prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Locale = activityLocale },
+                            choices: _colorChoices),
                         cancellationToken);
                 }
             })
@@ -776,11 +750,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     await dc.PromptAsync(
                         "ChoicePrompt",
-                        new PromptOptions
-                        {
-                            Prompt = new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Locale = culture.Locale },
-                            Choices = _colorChoices,
-                        },
+                        new PromptOptions(
+                            prompt: new Activity { Type = ActivityTypes.Message, Text = "favorite color?", Locale = culture.Locale },
+                            choices: _colorChoices),
                         cancellationToken);
                 }
             })

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/CloudOAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/CloudOAuthPromptTests.cs
@@ -329,7 +329,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             BotCallbackHandler callback = async (turnContext, cancellationToken) =>
             {
                 var dialogContext = await dialogs.CreateContextAsync(turnContext);
-                dialogContext.Stack.Insert(0, new DialogInstance { Id = "OAuthPrompt", State = new Dictionary<string, object> { { "expires", DateTime.UtcNow.AddMinutes(-5) } } });
+                var dialogInstance = new DialogInstance()
+                {
+                    Id = "OAuthPrompt",
+                };
+                dialogInstance.State.Add("expires", DateTime.UtcNow.AddMinutes(-5));
+
+                dialogContext.Stack.Insert(0, dialogInstance);
 
                 dialogTurnResult = await dialogContext.ContinueDialogAsync();
             };
@@ -408,19 +414,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             BotCallbackHandler callback = async (turnContext, cancellationToken) =>
             {
                 var dialogContext = await dialogs.CreateContextAsync(turnContext);
-                dialogContext.Stack.Insert(
-                    0,
-                    new DialogInstance
-                    {
-                        Id = "OAuthPrompt",
-                        State = new Dictionary<string, object>
-                        {
-                            { "expires", DateTime.UtcNow.AddHours(8) },
-                            { "caller", null },
-                            { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
-                            { "options", new PromptOptions() }
-                        }
-                    });
+                var dialogInstance = new DialogInstance()
+                {
+                    Id = "OAuthPrompt",
+                };
+                var states = new Dictionary<string, object>
+                {
+                    { "expires", DateTime.UtcNow.AddHours(8) },
+                    { "caller", null },
+                    { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
+                    { "options", new PromptOptions() }
+                };
+                states.ToList().ForEach(dialogInstance.State.Add);
+
+                dialogContext.Stack.Insert(0, dialogInstance);
 
                 dialogTurnResult = await dialogContext.ContinueDialogAsync();
             };
@@ -496,19 +503,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             BotCallbackHandler callback = async (turnContext, cancellationToken) =>
             {
                 var dialogContext = await dialogs.CreateContextAsync(turnContext);
-                dialogContext.Stack.Insert(
-                    0,
-                    new DialogInstance
-                    {
-                        Id = "OAuthPrompt",
-                        State = new Dictionary<string, object>
-                        {
-                            { "expires", DateTime.UtcNow.AddHours(8) },
-                            { "caller", null },
-                            { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
-                            { "options", new PromptOptions() }
-                        }
-                    });
+                var dialogInstance = new DialogInstance()
+                {
+                    Id = "OAuthPrompt",
+                };
+                var states = new Dictionary<string, object>
+                {
+                    { "expires", DateTime.UtcNow.AddHours(8) },
+                    { "caller", null },
+                    { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
+                    { "options", new PromptOptions() }
+                };
+                states.ToList().ForEach(dialogInstance.State.Add);
+
+                dialogContext.Stack.Insert(0, dialogInstance);
 
                 dialogTurnResult = await dialogContext.ContinueDialogAsync();
             };
@@ -598,19 +606,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             BotCallbackHandler callback = async (turnContext, cancellationToken) =>
             {
                 var dialogContext = await dialogs.CreateContextAsync(turnContext);
-                dialogContext.Stack.Insert(
-                    0,
-                    new DialogInstance
-                    {
-                        Id = "OAuthPrompt",
-                        State = new Dictionary<string, object>
-                        {
-                            { "expires", DateTime.UtcNow.AddHours(8) },
-                            { "caller", null },
-                            { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
-                            { "options", new PromptOptions() }
-                        }
-                    });
+                var dialogInstance = new DialogInstance()
+                {
+                    Id = "OAuthPrompt",
+                };
+                var states = new Dictionary<string, object>
+                {
+                    { "expires", DateTime.UtcNow.AddHours(8) },
+                    { "caller", null },
+                    { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
+                    { "options", new PromptOptions() }
+                };
+                states.ToList().ForEach(dialogInstance.State.Add);
+
+                dialogContext.Stack.Insert(0, dialogInstance);
 
                 dialogTurnResult = await dialogContext.ContinueDialogAsync();
             };
@@ -692,19 +701,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             BotCallbackHandler callback = async (turnContext, cancellationToken) =>
             {
                 var dialogContext = await dialogs.CreateContextAsync(turnContext);
-                dialogContext.Stack.Insert(
-                    0,
-                    new DialogInstance
-                    {
-                        Id = "OAuthPrompt",
-                        State = new Dictionary<string, object>
-                        {
-                            { "expires", DateTime.UtcNow.AddHours(8) },
-                            { "caller", null },
-                            { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
-                            { "options", new PromptOptions() }
-                        }
-                    });
+                var dialogInstance = new DialogInstance()
+                {
+                    Id = "OAuthPrompt",
+                };
+                var states = new Dictionary<string, object>
+                {
+                    { "expires", DateTime.UtcNow.AddHours(8) },
+                    { "caller", null },
+                    { "state", new Dictionary<string, object> { { "AttemptCount", 0 } } },
+                    { "options", new PromptOptions() }
+                };
+                states.ToList().ForEach(dialogInstance.State.Add);
+
+                dialogContext.Stack.Insert(0, dialogInstance);
 
                 dialogTurnResult = await dialogContext.ContinueDialogAsync();
             };

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/WaterfallTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
@@ -377,17 +378,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 trackEventCalled = true;
             });
 
+            var dialogInstance = new DialogInstance()
+            {
+                Id = id,
+            };
+            var states = new Dictionary<string, object>
+            {
+                { "stepIndex", index },
+                { "instanceId", "(guid)" },
+            };
+            states.ToList().ForEach(dialogInstance.State.Add);
+
             await dialog.EndDialogAsync(
                 new TurnContext(new TestAdapter(), new Activity()),
-                new DialogInstance
-                {
-                    Id = id,
-                    State = new Dictionary<string, object>
-                    {
-                        { "stepIndex", index },
-                        { "instanceId", "(guid)" },
-                    }
-                },
+                dialogInstance,
                 DialogReason.CancelCalled);
 
             Assert.True(trackEventCalled, "TrackEvent was never called.");


### PR DESCRIPTION
Addresses #6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties should be read-only).

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- Updated `null` validations with `Count()` or `Any()` validations.
- Added a constructor to `PromptOptions` class to set the prompt activity and the choices as almost every instance of this class had these two properties set.
- The following properties were updated:
   - Microsoft.Bot.Builder.Dialogs/Choices/Choice: Synonyms
   - Microsoft.Bot.Builder.Dialogs/DialogInstance: State
   - Microsoft.Bot.Builder.Dialogs/DialogInstance: DialogStack
   - Microsoft.Bot.Builder.Dialogs/PersistedState: UserState, ConversationState
   - Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions: Choices

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
