### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 4/8)

### DIFF
--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveRequest.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveRequest.cs
@@ -27,13 +27,11 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         public string Path { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of stream attachments included in this request.
+        /// Gets the collection of stream attachments included in this request.
         /// </summary>
         /// <value>
         /// A <see cref="List{T}"/> of <see cref="IContentStream"/> items associated with this request.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public List<IContentStream> Streams { get; set; } = new List<IContentStream>();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<IContentStream> Streams { get; private set; } = new List<IContentStream>();
     }
 }

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveResponse.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveResponse.cs
@@ -20,13 +20,11 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         public int StatusCode { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of <see cref="IContentStream"/>s contained within this response.
+        /// Gets the collection of <see cref="IContentStream"/>s contained within this response.
         /// </summary>
         /// <value>
         /// A <see cref="List{T}"/> of type <see cref="IContentStream"/> containing information on streams attached to this response.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public List<IContentStream> Streams { get; set; } = new List<IContentStream>();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<IContentStream> Streams { get; private set; } = new List<IContentStream>();
     }
 }

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingRequest.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingRequest.cs
@@ -51,14 +51,12 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         public string Path { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of stream attachments included in this request.
+        /// Gets the collection of stream attachments included in this request.
         /// </summary>
         /// <value>
         /// A <see cref="List{T}"/> of <see cref="ResponseMessageStream"/> items associated with this request.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public List<ResponseMessageStream> Streams { get; set; } = new List<ResponseMessageStream>();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<ResponseMessageStream> Streams { get; private set; } = new List<ResponseMessageStream>();
 
         /// <summary>
         /// Creates a <see cref="StreamingRequest"/> to get resources hosted on a remote server.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingResponse.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingResponse.cs
@@ -24,14 +24,12 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         public int StatusCode { get; set; }
 
         /// <summary>
-        /// Gets or sets the collection of streams attached to this response.
+        /// Gets the collection of streams attached to this response.
         /// </summary>
         /// <value>
         /// A <see cref="List{T}"/> of type <see cref="ResponseMessageStream"/>.
         /// </value>
-#pragma warning disable CA2227 // Collection properties should be read only
-        public List<ResponseMessageStream> Streams { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public List<ResponseMessageStream> Streams { get; private set; } = new List<ResponseMessageStream>();
 
         /// <summary>
         /// Creates a response indicating the requested resource was not found.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Bot.Connector.Streaming.Session
                 StatusCode = response.StatusCode,
             };
 
-            if (response.Streams != null)
+            if (response.Streams.Any())
             {
                 payload.Streams = new List<StreamDescription>();
                 foreach (var contentStream in response.Streams)
@@ -128,7 +128,7 @@ namespace Microsoft.Bot.Connector.Streaming.Session
 
             await _sender.SendResponseAsync(header.Id, payload, cancellationToken).ConfigureAwait(false);
 
-            if (response.Streams != null)
+            if (response.Streams.Any())
             {
                 foreach (var stream in response.Streams)
                 {
@@ -401,7 +401,6 @@ namespace Microsoft.Bot.Connector.Streaming.Session
                         {
                             Verb = requestPayload.Verb,
                             Path = requestPayload.Path,
-                            Streams = new List<IContentStream>(),
                         };
 
                         CreatePlaceholderStreams(header, request.Streams, requestPayload.Streams);
@@ -415,7 +414,6 @@ namespace Microsoft.Bot.Connector.Streaming.Session
                         var response = new ReceiveResponse()
                         {
                             StatusCode = responsePayload.StatusCode,
-                            Streams = new List<IContentStream>(),
                         };
 
                         CreatePlaceholderStreams(header, response.Streams, responsePayload.Streams);

--- a/libraries/Microsoft.Bot.Schema/TokenExchangeInvokeRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenExchangeInvokeRequest.cs
@@ -39,14 +39,12 @@ namespace Microsoft.Bot.Schema
         public string Token { get; set; }
 
         /// <summary>
-        /// Gets or sets extension data for overflow of properties.
+        /// Gets extension data for overflow of properties.
         /// </summary>
         /// <value>
         /// Extension data for overflow of properties.
         /// </value>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenExchangeInvokeResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenExchangeInvokeResponse.cs
@@ -39,14 +39,12 @@ namespace Microsoft.Bot.Schema
         public string FailureDetail { get; set; }
 
         /// <summary>
-        /// Gets or sets extension data for overflow of properties.
+        /// Gets extension data for overflow of properties.
         /// </summary>
         /// <value>
         /// Extension data for overflow of properties.
         /// </value>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenRequest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Schema
         public TokenRequest(string provider = default, IDictionary<string, object> settings = default)
         {
             Provider = provider;
-            Settings = settings;
+            Settings = settings ?? new Dictionary<string, object>();
             CustomInit();
         }
 
@@ -41,14 +41,12 @@ namespace Microsoft.Bot.Schema
         public string Provider { get; set; }
 
         /// <summary>
-        /// Gets or sets a collection of settings for the specific provider for
+        /// Gets a collection of settings for the specific provider for
         /// this request.
         /// </summary>
         /// <value>The collection of settings for the specific provider for this request.</value>
         [JsonProperty(PropertyName = "settings")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IDictionary<string, object> Settings { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IDictionary<string, object> Settings { get; private set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/TokenResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenResponse.cs
@@ -26,12 +26,14 @@ namespace Microsoft.Bot.Schema
         /// <param name="connectionName">The connection name.</param>
         /// <param name="token">The token.</param>
         /// <param name="expiration">The expiration.</param>
-        public TokenResponse(string channelId = default, string connectionName = default, string token = default, string expiration = default)
+        /// <param name="properties">The properties.</param>
+        public TokenResponse(string channelId = default, string connectionName = default, string token = default, string expiration = default, JObject properties = default)
         {
             ChannelId = channelId;
             ConnectionName = connectionName;
             Token = token;
             Expiration = expiration;
+            Properties = properties;
             CustomInit();
         }
 
@@ -62,15 +64,13 @@ namespace Microsoft.Bot.Schema
         /// <value>The expiration.</value>
         [JsonProperty(PropertyName = "expiration")]
         public string Expiration { get; set; }
-        
+
         /// <summary>
-        /// Gets or sets extra propreties.
+        /// Gets extra properties.
         /// </summary>
         /// <value>The extra properties.</value>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Transcript.cs
+++ b/libraries/Microsoft.Bot.Schema/Transcript.cs
@@ -26,19 +26,17 @@ namespace Microsoft.Bot.Schema
         /// to the Transcript schema.</param>
         public Transcript(IList<Activity> activities = default)
         {
-            Activities = activities;
+            Activities = activities ?? new List<Activity>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets a collection of Activities that conforms to the
+        /// Gets a collection of Activities that conforms to the
         /// Transcript schema.
         /// </summary>
         /// <value>A collection of activities that conforms to the Transcript schema.</value>
         [JsonProperty(PropertyName = "activities")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<Activity> Activities { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Activity> Activities { get; private set; } = new List<Activity>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Payloads/RequestTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Payloads/RequestTests.cs
@@ -43,10 +43,9 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var mockContentStream = new Mock<IContentStream>();
             mockContentStream.Setup(e => e.Stream).Returns(stream);
 
-            var request = new ReceiveRequest
-            {
-                Streams = new List<IContentStream> { mockContentStream.Object }
-            };
+            var request = new ReceiveRequest();
+            request.Streams.AddRange(new List<IContentStream> { mockContentStream.Object });
+            
             var result = request.ReadBodyAsJson<Activity>();
 
             Assert.NotNull(result);
@@ -112,7 +111,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var s = new StringContent("hi");
             var s2 = new StringContent("hello");
 
-            r.Streams = new List<ResponseMessageStream> { new ResponseMessageStream { Content = s2 } };
+            r.Streams.AddRange(new List<ResponseMessageStream> { new ResponseMessageStream { Content = s2 } });
 
             r.AddStream(s);
 

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Payloads/ResponseTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Payloads/ResponseTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
         {
             var r = new StreamingResponse();
             Assert.Equal(0, r.StatusCode);
-            Assert.Null(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var s = new StringContent("hi");
             var s2 = new StringContent("hello");
 
-            r.Streams = new List<ResponseMessageStream> { new ResponseMessageStream { Content = s2 } };
+            r.Streams.AddRange(new List<ResponseMessageStream> { new ResponseMessageStream { Content = s2 } });
 
             r.AddStream(s);
 
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var r = StreamingResponse.NotFound();
 
             Assert.Equal((int)HttpStatusCode.NotFound, r.StatusCode);
-            Assert.Null(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var r = StreamingResponse.Forbidden();
 
             Assert.Equal((int)HttpStatusCode.Forbidden, r.StatusCode);
-            Assert.Null(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var r = StreamingResponse.OK();
 
             Assert.Equal((int)HttpStatusCode.OK, r.StatusCode);
-            Assert.Null(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var r = StreamingResponse.InternalServerError();
 
             Assert.Equal((int)HttpStatusCode.InternalServerError, r.StatusCode);
-            Assert.Null(r.Streams);
+            Assert.Empty(r.Streams);
         }
 
         [Fact]
@@ -224,7 +224,6 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
         public void ReceiveBase_ReadBodyAsString_NoContent_EmptyString()
         {
             var r = new ReceiveResponse();
-            r.Streams = new List<IContentStream>();
 
             var result = r.ReadBodyAsString();
 
@@ -241,10 +240,9 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var mockContentStream = new Mock<IContentStream>();
             mockContentStream.Setup(e => e.Stream).Returns(stream);
 
-            var response = new ReceiveResponse
-            {
-                Streams = new List<IContentStream> { mockContentStream.Object }
-            };
+            var response = new ReceiveResponse();
+            response.Streams.AddRange(new List<IContentStream> { mockContentStream.Object });
+
             var result = response.ReadBodyAsJson<Activity>();
 
             Assert.NotNull(result);
@@ -274,10 +272,9 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Payloads
             var mockContentStream = new Mock<IContentStream>();
             mockContentStream.Setup(e => e.Stream).Returns(stream);
 
-            var response = new ReceiveResponse
-            {
-                Streams = new List<IContentStream> { mockContentStream.Object }
-            };
+            var response = new ReceiveResponse();
+            response.Streams.AddRange(new List<IContentStream> { mockContentStream.Object });
+
             var result = response.ReadBodyAsString();
 
             Assert.NotNull(result);

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Session/StreamingSessionTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Session/StreamingSessionTests.cs
@@ -165,10 +165,9 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
             {
                 Verb = "GET",
                 Path = "api/version",
-                Streams = new List<IContentStream>()
             };
 
-            request.Streams = StreamingDataGenerator.CreateStreams(requestId, streamLength, streamCount, chunkCount);
+            request.Streams.AddRange(StreamingDataGenerator.CreateStreams(requestId, streamLength, streamCount, chunkCount));
 
             var requestHandler = new Mock<RequestHandler>();
 
@@ -230,7 +229,6 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
             {
                 Verb = "GET",
                 Path = "api/version",
-                Streams = new List<ResponseMessageStream>()
             };
 
             request.AddStream(new StringContent("Hello human, I'm Bender!"));
@@ -259,7 +257,8 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 (Guid requestId, RequestModel requestPayload, CancellationToken cancellationToken) =>
                 {
                     responseHeader = new Header() { Id = requestId, Type = PayloadTypes.Response };
-                    response = new ReceiveResponse() { StatusCode = 200, Streams = StreamingDataGenerator.CreateStreams(requestId, streamLength, streamCount, chunkCount, PayloadTypes.Response) };
+                    response = new ReceiveResponse() { StatusCode = 200, };
+                    response.Streams.AddRange(StreamingDataGenerator.CreateStreams(requestId, streamLength, streamCount, chunkCount, PayloadTypes.Response));
 
                     session.ReceiveResponse(responseHeader, response);
 

--- a/tests/Microsoft.Bot.Schema.Tests/TokenTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/TokenTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Bot.Schema.Tests
                 Id = id,
                 ConnectionName = connectionName,
                 Token = token,
-                Properties = properties
             };
+            tokenExchangeInvokeRequest.Properties.Merge(properties);
 
             Assert.NotNull(tokenExchangeInvokeRequest);
             Assert.IsType<TokenExchangeInvokeRequest>(tokenExchangeInvokeRequest);
@@ -46,8 +46,8 @@ namespace Microsoft.Bot.Schema.Tests
                 Id = id,
                 ConnectionName = connectionName,
                 FailureDetail = failureDetail,
-                Properties = properties,
             };
+            tokenExchangeInvokeResponse.Properties.Merge(properties);
 
             Assert.NotNull(tokenExchangeInvokeResponse);
             Assert.IsType<TokenExchangeInvokeResponse>(tokenExchangeInvokeResponse);
@@ -206,10 +206,7 @@ namespace Microsoft.Bot.Schema.Tests
             var expiration = "expiration";
             var properties = new JObject();
 
-            var tokenResponse = new TokenResponse(channelId, connectionName, token, expiration)
-            {
-                Properties = properties
-            };
+            var tokenResponse = new TokenResponse(channelId, connectionName, token, expiration, properties);
 
             Assert.NotNull(tokenResponse);
             Assert.IsType<TokenResponse>(tokenResponse);

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -246,24 +246,27 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             };
 
             var streamingConnection = new Mock<StreamingConnection>(null);
+            var request = new ReceiveRequest
+            {
+                Verb = "POST",
+                Path = "/api/messages",
+            };
+
+            request.Streams.AddRange(new List<IContentStream>
+            {
+                new TestContentStream
+                {
+                    Id = Guid.NewGuid(),
+                    ContentType = "application/json",
+                    Length = (int?)validContent.Headers.ContentLength,
+                    Stream = validContent.ReadAsStreamAsync().GetAwaiter().GetResult()
+                }
+            });
+
             streamingConnection
                 .Setup(c => c.ListenAsync(It.IsAny<RequestHandler>(), It.IsAny<CancellationToken>()))
                 .Returns<RequestHandler, CancellationToken>((handler, cancellationToken) => handler.ProcessRequestAsync(
-                    new ReceiveRequest
-                    {
-                        Verb = "POST",
-                        Path = "/api/messages",
-                        Streams = new List<IContentStream>
-                        {
-                            new TestContentStream
-                            {
-                                Id = Guid.NewGuid(),
-                                ContentType = "application/json",
-                                Length = (int?)validContent.Headers.ContentLength,
-                                Stream = validContent.ReadAsStreamAsync().GetAwaiter().GetResult()
-                            }
-                        }
-                    },
+                    request,
                     null,
                     cancellationToken: cancellationToken));
 


### PR DESCRIPTION
Addresses #6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties should be read-only) in **Bot.Connector.Streaming** classes.

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- Updated `null` validations with `Count()` or `Any()` validations.
- The following properties were updated:
   - **_Streams_** property: 
      - Microsoft.Bot.Connector.Streaming/Payloads/ReceiveRequest
      - Microsoft.Bot.Connector.Streaming/Payloads/ReceiveResponse
      - Microsoft.Bot.Connector.Streaming/Payloads/StreamingRequest
      - Microsoft.Bot.Connector.Streaming/Payloads/StreamingResponse
   - **_Properties_** property:   
      - Microsoft.Bot.Schema/TokenExchangeInvokeRequest: Properties.
      - Microsoft.Bot.Schema/TokenExchangeInvokeResponse
      - Microsoft.Bot.Schema/TokenResponse.cs
   - Microsoft.Bot.Schema/TokenRequest: **_Settings_** property.
   - Microsoft.Bot.Schema/Transcript: **_Activities_** property.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
