### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 5/8)

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -53,23 +53,25 @@ namespace Microsoft.Bot.Connector.Authentication
             var activityClone = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
 
             // Apply the appropriate addressing to the newly created Activity.
+            var conversation = new ConversationAccount
+            {
+                Id = activityClone.Conversation.Id,
+                Name = activityClone.Conversation.Name,
+                ConversationType = activityClone.Conversation.ConversationType,
+                AadObjectId = activityClone.Conversation.AadObjectId,
+                IsGroup = activityClone.Conversation.IsGroup,
+                Role = activityClone.Conversation.Role,
+                TenantId = activityClone.Conversation.TenantId,
+            };
+            conversation.Properties.Merge(activityClone.Conversation.Properties);
+
             activityClone.RelatesTo = new ConversationReference
             {
                 ServiceUrl = activityClone.ServiceUrl,
                 ActivityId = activityClone.Id,
                 ChannelId = activityClone.ChannelId,
                 Locale = activityClone.Locale,
-                Conversation = new ConversationAccount
-                {
-                    Id = activityClone.Conversation.Id,
-                    Name = activityClone.Conversation.Name,
-                    ConversationType = activityClone.Conversation.ConversationType,
-                    AadObjectId = activityClone.Conversation.AadObjectId,
-                    IsGroup = activityClone.Conversation.IsGroup,
-                    Properties = activityClone.Conversation.Properties,
-                    Role = activityClone.Conversation.Role,
-                    TenantId = activityClone.Conversation.TenantId,
-                }
+                Conversation = conversation,
             };
             activityClone.Conversation.Id = conversationId;
             activityClone.ServiceUrl = serviceUrl.ToString();

--- a/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/UserTokenClientImpl.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _ = connectionName ?? throw new ArgumentNullException(nameof(connectionName));
 
             _logger.LogInformation($"GetAadTokensAsync ConnectionName: {connectionName}");
-            return (Dictionary<string, TokenResponse>)await _client.UserToken.GetAadTokensAsync(userId, connectionName, new AadResourceUrls() { ResourceUrls = resourceUrls?.ToList() }, channelId, cancellationToken).ConfigureAwait(false);
+            return (Dictionary<string, TokenResponse>)await _client.UserToken.GetAadTokensAsync(userId, connectionName, new AadResourceUrls(resourceUrls?.ToList()), channelId, cancellationToken).ConfigureAwait(false);
         }
 
         public override async Task<TokenResponse> ExchangeTokenAsync(string userId, string connectionName, string channelId, TokenExchangeRequest exchangeRequest, CancellationToken cancellationToken)

--- a/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationsEx.cs
@@ -175,22 +175,26 @@ namespace Microsoft.Bot.Connector
 
         private static ConversationParameters GetDirectParameters(string botId, string userId, Activity activity)
         {
-            return new ConversationParameters()
+            var convParameters = new ConversationParameters()
             {
                 Bot = new ChannelAccount(botId),
-                Members = new ChannelAccount[] { new ChannelAccount(userId) },
                 Activity = activity,
             };
+            convParameters.Members.Add(new ChannelAccount(userId));
+
+            return convParameters;
         }
 
         private static ConversationParameters GetDirectParameters(ChannelAccount bot, ChannelAccount user, Activity activity)
         {
-            return new ConversationParameters()
+            var convParameters = new ConversationParameters()
             {
                 Bot = bot,
-                Members = new ChannelAccount[] { user },
                 Activity = activity,
             };
+            convParameters.Members.Add(user);
+
+            return convParameters;
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
+++ b/libraries/Microsoft.Bot.Connector/OAuthClientOld.cs
@@ -475,7 +475,7 @@ namespace Microsoft.Bot.Connector
             httpRequest.RequestUri = new Uri(tokenUrl);
 
             // Serialize Request
-            string requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(new AadResourceUrls() { ResourceUrls = resourceUrls }, _client.SerializationSettings);
+            string requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(new AadResourceUrls(resourceUrls), _client.SerializationSettings);
             httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
             httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
 

--- a/libraries/Microsoft.Bot.Schema/AadResourceUrls.cs
+++ b/libraries/Microsoft.Bot.Schema/AadResourceUrls.cs
@@ -27,18 +27,16 @@ namespace Microsoft.Bot.Schema
         /// <param name="resourceUrls">The URLs to the resource you want to connect to.</param>
         public AadResourceUrls(IList<string> resourceUrls = default)
         {
-            ResourceUrls = resourceUrls;
+            ResourceUrls = resourceUrls ?? new List<string>();
             CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets the URLs to the resource you want to connect to.
+        /// Gets the URLs to the resource you want to connect to.
         /// </summary>
         /// <value>The URLs to the resources you want to connect to.</value>
         [JsonProperty(PropertyName = "resourceUrls")]
-#pragma warning disable CA2227 // Collection properties should be read only
-        public IList<string> ResourceUrls { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> ResourceUrls { get; private set; } = new List<string>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/ChannelAccount.cs
+++ b/libraries/Microsoft.Bot.Schema/ChannelAccount.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Schema
         public string AadObjectId { get; set; }
         
         /// <summary>
-        /// Gets or sets properties that are not otherwise defined by the <see cref="ChannelAccount"/> type but that
+        /// Gets properties that are not otherwise defined by the <see cref="ChannelAccount"/> type but that
         /// might appear in the REST JSON object.
         /// </summary>
         /// <value>The extended properties for the object.</value>
@@ -51,9 +51,7 @@ namespace Microsoft.Bot.Schema
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>Gets or sets role of the entity behind the account (Example: User, Bot, etc.). Possible values include: 'user', 'bot'.</summary>
         /// <value>The role of the entity behind the account.</value>

--- a/libraries/Microsoft.Bot.Schema/ConversationAccount.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationAccount.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Schema
         public string AadObjectId { get; set; }
         
         /// <summary>
-        /// Gets or sets properties that are not otherwise defined by the <see cref="ConversationAccount"/> type but that
+        /// Gets properties that are not otherwise defined by the <see cref="ConversationAccount"/> type but that
         /// might appear in the REST JSON object.
         /// </summary>
         /// <value>The extended properties for the object.</value>
@@ -67,9 +67,7 @@ namespace Microsoft.Bot.Schema
         /// the JSON object is deserialized, but are instead stored in this property. Such properties
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
-        public JObject Properties { get; set; } = new JObject();
-#pragma warning restore CA2227 // Collection properties should be read only
+        public JObject Properties { get; private set; } = new JObject();
 
         /// <summary>Gets or sets role of the entity behind the account (Example: User, Bot, etc.). Possible values include: 'user', 'bot'.</summary>
         /// <value>The role of the entity behind the account.</value>

--- a/libraries/Microsoft.Bot.Schema/ConversationMembers.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationMembers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema
         public ConversationMembers(string id = default, IList<ChannelAccount> members = default)
         {
             Id = id;
-            Members = members;
+            Members = members ?? new List<ChannelAccount>();
             CustomInit();
         }
 
@@ -34,12 +34,10 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
-        /// <summary>Gets or sets list of members in this conversation.</summary>
+        /// <summary>Gets list of members in this conversation.</summary>
         /// <value>The members in the conversation.</value>
         [JsonProperty(PropertyName = "members")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<ChannelAccount> Members { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ChannelAccount> Members { get; private set; } = new List<ChannelAccount>();
 
         /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
         partial void CustomInit();

--- a/libraries/Microsoft.Bot.Schema/ConversationParameters.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationParameters.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Bot.Schema
         {
             IsGroup = isGroup;
             Bot = bot;
-            Members = members;
+            Members = members ?? new List<ChannelAccount>();
             TopicName = topicName;
             Activity = activity;
             ChannelData = channelData;
@@ -45,12 +45,10 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "bot")]
         public ChannelAccount Bot { get; set; }
 
-        /// <summary>Gets or sets members to add to the conversation.</summary>
+        /// <summary>Gets members to add to the conversation.</summary>
         /// <value>The members added to the conversation.</value>
         [JsonProperty(PropertyName = "members")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<ChannelAccount> Members { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ChannelAccount> Members { get; private set; } = new List<ChannelAccount>();
 
         /// <summary>Gets or sets (Optional) Topic of the conversation (if supported by the channel).</summary>
         /// <value>The topic of the conversation.</value>

--- a/libraries/Microsoft.Bot.Schema/ConversationsResult.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationsResult.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema
         public ConversationsResult(string continuationToken = default, IList<ConversationMembers> conversations = default)
         {
             ContinuationToken = continuationToken;
-            Conversations = conversations;
+            Conversations = conversations ?? new List<ConversationMembers>();
             CustomInit();
         }
 
@@ -34,12 +34,10 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "continuationToken")]
         public string ContinuationToken { get; set; }
 
-        /// <summary>Gets or sets list of conversations.</summary>
+        /// <summary>Gets list of conversations.</summary>
         /// <value>A list of conversations.</value>
         [JsonProperty(PropertyName = "conversations")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<ConversationMembers> Conversations { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ConversationMembers> Conversations { get; private set; } = new List<ConversationMembers>();
 
         /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
         partial void CustomInit();

--- a/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var param = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            param.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -102,10 +102,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var param = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = new ChannelAccount() { Id = "invalid-id" },
                 Activity = activity,
             };
+            param.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -132,7 +132,6 @@ namespace Microsoft.Bot.Connector.Tests
 
             var param = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { },
                 Bot = Bot,
                 Activity = activity,
             };
@@ -162,10 +161,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var param = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { Bot },
                 Bot = Bot,
                 Activity = activity,
             };
+            param.Members.Add(Bot);
 
             await UseClientFor(async client =>
             {
@@ -201,10 +200,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var param = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            param.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -226,9 +225,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -259,9 +258,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -291,9 +290,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -327,9 +326,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -360,9 +359,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -381,9 +380,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -414,9 +413,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -460,10 +459,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -491,10 +490,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -514,9 +513,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -552,10 +551,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -569,9 +568,9 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -618,9 +617,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -648,10 +647,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -681,10 +680,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -723,10 +722,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -754,10 +753,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -780,10 +779,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -806,10 +805,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -860,9 +859,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -899,9 +898,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -938,9 +937,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -972,9 +971,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -998,9 +997,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1032,9 +1031,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -1078,10 +1077,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1108,10 +1107,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1139,10 +1138,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1165,10 +1164,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1191,10 +1190,10 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
                 Activity = activity,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 
@@ -1225,9 +1224,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1263,9 +1262,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1302,9 +1301,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1336,9 +1335,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1370,9 +1369,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             await UseClientFor(async client =>
             {
@@ -1396,9 +1395,9 @@ namespace Microsoft.Bot.Connector.Tests
 
             var createMessage = new ConversationParameters()
             {
-                Members = new ChannelAccount[] { User },
                 Bot = Bot,
             };
+            createMessage.Members.Add(User);
 
             var customHeaders = new Dictionary<string, List<string>>() { { "customHeader", new List<string>() { "customValue" } } };
 

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Bot.Connector.Tests
         public async Task GetAadTokensWithHttpMessagesAsync_ShouldThrowOnNullUserId()
         {
             var client = new OAuthClient(new Uri("http://localhost"), new BotAccessTokenStub("token"));
-            await Assert.ThrowsAsync<ValidationException>(() => client.UserToken.GetAadTokensAsync(null, "connection", new AadResourceUrls() { ResourceUrls = new string[] { "hello" } }));
+            await Assert.ThrowsAsync<ValidationException>(() => client.UserToken.GetAadTokensAsync(null, "connection", new AadResourceUrls(new string[] { "hello" })));
         }
 
         [Fact]
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Connector.Tests
         {
             var client = new OAuthClient(new Uri("http://localhost"), new BotAccessTokenStub("token"));
             await Assert.ThrowsAsync<ValidationException>(() => client.UserToken.GetAadTokensAsync(
-                "dummyUserId", null, new AadResourceUrls() { ResourceUrls = new string[] { "dummyUrl" } }));
+                "dummyUserId", null, new AadResourceUrls(new string[] { "dummyUrl" })));
         }
 
         [Fact]
@@ -202,13 +202,13 @@ namespace Microsoft.Bot.Connector.Tests
             {
                 // Automated Windows build exception:
                 await Assert.ThrowsAsync<Microsoft.Bot.Schema.ErrorResponseException>(() => client.UserToken.GetAadTokensAsync(
-                    "dummyUserId", "dummyConnectionName", new AadResourceUrls() { ResourceUrls = new string[] { "dummyUrl" } }, "dummyChannelId"));
+                    "dummyUserId", "dummyConnectionName", new AadResourceUrls(new string[] { "dummyUrl" }), "dummyChannelId"));
             }
             else
             {
                 // MacLinux build and local build exception:
                 await Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(() => client.UserToken.GetAadTokensAsync(
-                    "dummyUserId", "dummyConnectionName", new AadResourceUrls() { ResourceUrls = new string[] { "dummyUrl" } }, "dummyChannelId"));
+                    "dummyUserId", "dummyConnectionName", new AadResourceUrls(new string[] { "dummyUrl" }), "dummyChannelId"));
             }
         }
 

--- a/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ActivityTest.cs
@@ -483,19 +483,21 @@ namespace Microsoft.Bot.Schema.Tests
             {
                 Id = "ChannelAccount_Id_1",
                 Name = "ChannelAccount_Name_1",
-                Properties = new JObject { { "Name", "Value" } },
                 Role = "ChannelAccount_Role_1",
             }
             : null;
+
+            account1?.Properties.Add("Name", "Value");
 
             var account2 = createRecipient ? new ChannelAccount
             {
                 Id = "ChannelAccount_Id_2",
                 Name = "ChannelAccount_Name_2",
-                Properties = new JObject { { "Name", "Value" } },
                 Role = "ChannelAccount_Role_2",
             }
             : null;
+
+            account2?.Properties.Add("Name", "Value");
 
             var conversationAccount = new ConversationAccount
             {
@@ -503,9 +505,9 @@ namespace Microsoft.Bot.Schema.Tests
                 Id = "123",
                 IsGroup = true,
                 Name = "Name",
-                Properties = new JObject { { "Name", "Value" } },
                 Role = "ConversationAccount_Role",
             };
+            conversationAccount.Properties.Add("Name", "Value");
 
             var activity = new Activity
             {

--- a/tests/Microsoft.Bot.Schema.Tests/ConversationTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/ConversationTests.cs
@@ -22,10 +22,7 @@ namespace Microsoft.Bot.Schema.Tests
             var tenantId = "tenantId";
             var props = new JObject();
 
-            var convoAccount = new ConversationAccount(isGroup, conversationType, id, name, aadObjectId, role, tenantId)
-            {
-                Properties = props
-            };
+            var convoAccount = new ConversationAccount(isGroup, conversationType, id, name, aadObjectId, role, tenantId);
 
             Assert.NotNull(convoAccount);
             Assert.IsType<ConversationAccount>(convoAccount);

--- a/tests/Microsoft.Bot.Schema.Tests/IActivityExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/IActivityExtensionsTests.cs
@@ -38,17 +38,19 @@ namespace Microsoft.Bot.Schema.Tests
         [ClassData(typeof(MentionsData))]
         public void DetectsMentionedRecipient(List<Entity> entities, bool expectsMention)
         {
+            var recipient = new ChannelAccount
+            {
+                Id = "ChannelAccountId",
+                Name = "ChannelAccountName",
+                Role = "ChannelAccountRole",
+            };
+            recipient.Properties.Add("Name", "Value");
+
             var message = new Activity()
             {
                 Type = ActivityTypes.Message,
                 Entities = entities,
-                Recipient = new ChannelAccount
-                {
-                    Id = "ChannelAccountId",
-                    Name = "ChannelAccountName",
-                    Properties = new JObject { { "Name", "Value" } },
-                    Role = "ChannelAccountRole",
-                }
+                Recipient = recipient,
             };
 
             var mentionsRecipient = ActivityExtensions.MentionsRecipient(message);

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -735,7 +735,6 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             {
                 IsGroup = false,
                 Bot = new ChannelAccount { },
-                Members = new ChannelAccount[] { },
                 TenantId = "tenantId",
             };
 


### PR DESCRIPTION
Addresses #6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties must be read-only).

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- Updated `null` validations with `Count()` or `Any()` validations.
- The following properties were updated:
   - Microsoft.Bot.Schema/AadResourceUrls: ResourceUrls.
   - Microsoft.Bot.Schema/ChannelAccount: Properties.
   - Microsoft.Bot.Schema/ConversationAccount: Properties.
   - Microsoft.Bot.Schema/ConversationMembers: Members.
   - Microsoft.Bot.Schema/ConversationParameters: Members.
   - Microsoft.Bot.Schema/ConversationsResult: Conversations.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
