### PR TITLE
[#6099] Remove low impact FxCop exclusions - Rule CA2227 (Part 6/8)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
@@ -63,10 +63,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     Title = cardNoMatchText
                 });
 
-            var plCard = new HeroCard()
-            {
-                Buttons = buttonList
-            };
+            var plCard = new HeroCard(buttons: buttonList);
 
             // Create the attachment.
             var attachment = plCard.ToAttachment();
@@ -110,10 +107,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     });
             }
 
-            var plCard = new HeroCard()
-            {
-                Buttons = buttonList
-            };
+            var plCard = new HeroCard(buttons: buttonList);
 
             // Create the attachment.
             var attachment = plCard.ToAttachment();

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -116,21 +116,22 @@ namespace Microsoft.Bot.Builder.Dialogs
                 if (!prompt.Attachments.Any(a => a.Content is SigninCard))
                 {
                     var signInResource = await UserTokenAccess.GetSignInResourceAsync(turnContext, settings, cancellationToken).ConfigureAwait(false);
+                    var buttons = new[]
+                    {
+                        new CardAction
+                        {
+                            Title = settings.Title,
+                            Value = signInResource.SignInLink,
+                            Type = ActionTypes.Signin,
+                        },
+                    };
+
                     prompt.Attachments.Add(new Attachment
                     {
                         ContentType = SigninCard.ContentType,
-                        Content = new SigninCard
+                        Content = new SigninCard(buttons: buttons)
                         {
                             Text = settings.Text,
-                            Buttons = new[]
-                            {
-                                new CardAction
-                                {
-                                    Title = settings.Title,
-                                    Value = signInResource.SignInLink,
-                                    Type = ActionTypes.Signin,
-                                },
-                            },
                         },
                     });
                 }
@@ -160,23 +161,24 @@ namespace Microsoft.Bot.Builder.Dialogs
                     value = null;
                 }
 
+                var buttons = new[]
+                {
+                    new CardAction
+                    {
+                        Title = settings.Title,
+                        Text = settings.Text,
+                        Type = cardActionType,
+                        Value = value
+                    },
+                };
+
                 prompt.Attachments.Add(new Attachment
                 {
                     ContentType = OAuthCard.ContentType,
-                    Content = new OAuthCard
+                    Content = new OAuthCard(buttons: buttons)
                     {
                         Text = settings.Text,
                         ConnectionName = settings.ConnectionName,
-                        Buttons = new[]
-                        {
-                            new CardAction
-                            {
-                                Title = settings.Title,
-                                Text = settings.Text,
-                                Type = cardActionType,
-                                Value = value
-                            },
-                        },
                         TokenExchangeResource = signInResource.TokenExchangeResource,
                     },
                 });

--- a/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityFactory.cs
@@ -141,10 +141,7 @@ namespace Microsoft.Bot.Builder
         {
             var actions = NormalizedToList(value);
 
-            var suggestedActions = new SuggestedActions()
-            {
-                Actions = GetCardActions(actions)
-            };
+            var suggestedActions = new SuggestedActions(actions: GetCardActions(actions));
 
             return suggestedActions;
         }

--- a/libraries/Microsoft.Bot.Builder/MessageFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/MessageFactory.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Bot.Builder
             var ma = Activity.CreateMessageActivity();
             SetTextAndSpeak(ma, text, ssml, inputHint);
 
-            ma.SuggestedActions = new SuggestedActions { Actions = cardActions.ToList() };
+            ma.SuggestedActions = new SuggestedActions(actions: cardActions.ToList());
 
             return ma;
         }

--- a/libraries/Microsoft.Bot.Schema/AnimationCard.cs
+++ b/libraries/Microsoft.Bot.Schema/AnimationCard.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Bot.Schema
             Subtitle = subtitle;
             Text = text;
             Image = image;
-            Media = media;
-            Buttons = buttons;
+            Media = media ?? new List<MediaUrl>();
+            Buttons = buttons ?? new List<CardAction>();
             Shareable = shareable;
             Autoloop = autoloop;
             Autostart = autostart;
@@ -88,24 +88,20 @@ namespace Microsoft.Bot.Schema
         public ThumbnailUrl Image { get; set; }
 
         /// <summary>
-        /// Gets or sets media URLs for this card. When this field contains
+        /// Gets media URLs for this card. When this field contains
         /// more than one URL, each URL is an alternative format of the same
         /// content.
         /// </summary>
         /// <value>The media URLs for this card.</value>
         [JsonProperty(PropertyName = "media")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<MediaUrl> Media { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MediaUrl> Media { get; private set; } = new List<MediaUrl>();
 
         /// <summary>
-        /// Gets or sets actions on this card.
+        /// Gets actions on this card.
         /// </summary>
         /// <value>The actions on this card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// Gets or sets this content may be shared with others (default:true).

--- a/libraries/Microsoft.Bot.Schema/AudioCard.cs
+++ b/libraries/Microsoft.Bot.Schema/AudioCard.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Bot.Schema
             Subtitle = subtitle;
             Text = text;
             Image = image;
-            Media = media;
-            Buttons = buttons;
+            Media = media ?? new List<MediaUrl>();
+            Buttons = buttons ?? new List<CardAction>();
             Shareable = shareable;
             Autoloop = autoloop;
             Autostart = autostart;
@@ -78,24 +78,20 @@ namespace Microsoft.Bot.Schema
         public ThumbnailUrl Image { get; set; }
 
         /// <summary>
-        /// Gets or sets media URLs for this card. When this field contains
+        /// Gets media URLs for this card. When this field contains
         /// more than one URL, each URL is an alternative format of the same
         /// content.
         /// </summary>
         /// <value>The media URLs of this card.</value>
         [JsonProperty(PropertyName = "media")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<MediaUrl> Media { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MediaUrl> Media { get; private set; } = new List<MediaUrl>(); 
 
         /// <summary>
-        /// Gets or sets actions on this card.
+        /// Gets actions on this card.
         /// </summary>
         /// <value>The actions on this card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>(); 
 
         /// <summary>
         /// Gets or sets this content may be shared with others (default:true).

--- a/libraries/Microsoft.Bot.Schema/BasicCard.cs
+++ b/libraries/Microsoft.Bot.Schema/BasicCard.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Bot.Schema
             Title = title;
             Subtitle = subtitle;
             Text = text;
-            Images = images;
-            Buttons = buttons;
+            Images = images ?? new List<CardImage>();
+            Buttons = buttons ?? new List<CardAction>();
             Tap = tap;
             CustomInit();
         }
@@ -50,19 +50,15 @@ namespace Microsoft.Bot.Schema
         [JsonProperty(PropertyName = "text")]
         public string Text { get; set; }
 
-        /// <summary>Gets or sets list of images for the card.</summary>
+        /// <summary>Gets list of images for the card.</summary>
         /// <value>A list of images for the card.</value>
         [JsonProperty(PropertyName = "images")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardImage> Images { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardImage> Images { get; private set; } = new List<CardImage>();
 
-        /// <summary>Gets or sets set of actions applicable to the current card.</summary>
+        /// <summary>Gets set of actions applicable to the current card.</summary>
         /// <value>The actions applicable to the current card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>Gets or sets this action will be activated when user taps on the card itself.</summary>
         /// <value>The action that will activate when user taps card.</value>

--- a/libraries/Microsoft.Bot.Schema/HeroCard.cs
+++ b/libraries/Microsoft.Bot.Schema/HeroCard.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Bot.Schema
             Title = title;
             Subtitle = subtitle;
             Text = text;
-            Images = images;
-            Buttons = buttons;
+            Images = images ?? new List<CardImage>();
+            Buttons = buttons ?? new List<CardAction>();
             Tap = tap;
             CustomInit();
         }
@@ -63,22 +63,18 @@ namespace Microsoft.Bot.Schema
         public string Text { get; set; }
 
         /// <summary>
-        /// Gets or sets array of images for the card.
+        /// Gets array of images for the card.
         /// </summary>
         /// <value>The collection of images for the card.</value>
         [JsonProperty(PropertyName = "images")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardImage> Images { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardImage> Images { get; private set; } = new List<CardImage>();
 
         /// <summary>
-        /// Gets or sets set of actions applicable to the current card.
+        /// Gets set of actions applicable to the current card.
         /// </summary>
         /// <value>The actions applicable to the current card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// Gets or sets this action will be activated when user taps on the

--- a/libraries/Microsoft.Bot.Schema/MediaCard.cs
+++ b/libraries/Microsoft.Bot.Schema/MediaCard.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Bot.Schema
             Subtitle = subtitle;
             Text = text;
             Image = image;
-            Media = media;
-            Buttons = buttons;
+            Media = media ?? new List<MediaUrl>();
+            Buttons = buttons ?? new List<CardAction>();
             Shareable = shareable;
             Autoloop = autoloop;
             Autostart = autostart;
@@ -88,24 +88,20 @@ namespace Microsoft.Bot.Schema
         public ThumbnailUrl Image { get; set; }
 
         /// <summary>
-        /// Gets or sets media URLs for this card. When this field contains
+        /// Gets media URLs for this card. When this field contains
         /// more than one URL, each URL is an alternative format of the same
         /// content.
         /// </summary>
         /// <value>The media URLs for this card.</value>
         [JsonProperty(PropertyName = "media")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<MediaUrl> Media { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MediaUrl> Media { get; private set; } = new List<MediaUrl>();
 
         /// <summary>
-        /// Gets or sets actions on this card.
+        /// Gets actions on this card.
         /// </summary>
         /// <value>The actions on this card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat)
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// Gets or sets this content may be shared with others (default:true).

--- a/libraries/Microsoft.Bot.Schema/OAuthCard.cs
+++ b/libraries/Microsoft.Bot.Schema/OAuthCard.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Schema
         {
             Text = text;
             ConnectionName = connectionName;
-            Buttons = buttons;
+            Buttons = buttons ?? new List<CardAction>();
             CustomInit();
         }
 
@@ -58,13 +58,11 @@ namespace Microsoft.Bot.Schema
         public TokenExchangeResource TokenExchangeResource { get; set; }
 
         /// <summary>
-        /// Gets or sets action to use to perform signin.
+        /// Gets action to use to perform signin.
         /// </summary>
         /// <value>The actions used to perform sign-in.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/ReceiptCard.cs
+++ b/libraries/Microsoft.Bot.Schema/ReceiptCard.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Bot.Schema
         public ReceiptCard(string title = default, IList<Fact> facts = default, IList<ReceiptItem> items = default, CardAction tap = default, string total = default, string tax = default, string vat = default, IList<CardAction> buttons = default)
         {
             Title = title;
-            Facts = facts;
-            Items = items;
+            Facts = facts ?? new List<Fact>();
+            Items = items ?? new List<ReceiptItem>();
             Tap = tap;
             Total = total;
             Tax = tax;
             Vat = vat;
-            Buttons = buttons;
+            Buttons = buttons ?? new List<CardAction>();
             CustomInit();
         }
 
@@ -54,22 +54,18 @@ namespace Microsoft.Bot.Schema
         public string Title { get; set; }
 
         /// <summary>
-        /// Gets or sets array of Fact objects.
+        /// Gets array of Fact objects.
         /// </summary>
         /// <value>The collection of <see cref="Fact"/>'s.</value>
         [JsonProperty(PropertyName = "facts")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<Fact> Facts { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<Fact> Facts { get; private set; } = new List<Fact>();
 
         /// <summary>
-        /// Gets or sets array of Receipt Items.
+        /// Gets array of Receipt Items.
         /// </summary>
         /// <value>The receipt items.</value>
         [JsonProperty(PropertyName = "items")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<ReceiptItem> Items { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<ReceiptItem> Items { get; private set; } = new List<ReceiptItem>();
 
         /// <summary>
         /// Gets or sets this action will be activated when user taps on the
@@ -101,13 +97,11 @@ namespace Microsoft.Bot.Schema
         public string Vat { get; set; }
 
         /// <summary>
-        /// Gets or sets set of actions applicable to the current card.
+        /// Gets set of actions applicable to the current card.
         /// </summary>
         /// <value>The actions applicable to the current card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/SigninCard.cs
+++ b/libraries/Microsoft.Bot.Schema/SigninCard.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Schema
         public SigninCard(string text = default, IList<CardAction> buttons = default)
         {
             Text = text;
-            Buttons = buttons;
+            Buttons = buttons ?? new List<CardAction>();
         }
 
         /// <summary>
@@ -37,13 +37,11 @@ namespace Microsoft.Bot.Schema
         public string Text { get; set; }
 
         /// <summary>
-        /// Gets or sets action to use to perform signin.
+        /// Gets action to use to perform signin.
         /// </summary>
         /// <value>The action(s) to use to perform sign-in.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// Creates a <see cref="SigninCard"/>.

--- a/libraries/Microsoft.Bot.Schema/SuggestedActions.cs
+++ b/libraries/Microsoft.Bot.Schema/SuggestedActions.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Bot.Schema
         /// <param name="actions">Actions that can be shown to the user.</param>
         public SuggestedActions(IList<string> to = default, IList<CardAction> actions = default)
         {
-            To = to;
-            Actions = actions;
+            To = to ?? new List<string>();
+            Actions = actions ?? new List<CardAction>();
         }
 
         /// <summary>
@@ -47,23 +47,19 @@ namespace Microsoft.Bot.Schema
         }
 
         /// <summary>
-        /// Gets or sets ids of the recipients that the actions should be shown
+        /// Gets ids of the recipients that the actions should be shown
         /// to.  These Ids are relative to the channelId and a subset of all
         /// recipients of the activity.
         /// </summary>
         /// <value>The ID's of the recipients that the actions should be shown to.</value>
         [JsonProperty(PropertyName = "to")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<string> To { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<string> To { get; private set; } = new List<string>();
 
         /// <summary>
-        /// Gets or sets actions that can be shown to the user.
+        /// Gets actions that can be shown to the user.
         /// </summary>
         /// <value>The actions that can be shown to the user.</value>
         [JsonProperty(PropertyName = "actions")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Actions { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Actions { get; private set; } = new List<CardAction>();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ThumbnailCard.cs
+++ b/libraries/Microsoft.Bot.Schema/ThumbnailCard.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Bot.Schema
             Title = title;
             Subtitle = subtitle;
             Text = text;
-            Images = images;
-            Buttons = buttons;
+            Images = images ?? new List<CardImage>();
+            Buttons = buttons ?? new List<CardAction>();
             Tap = tap;
             CustomInit();
         }
@@ -65,22 +65,18 @@ namespace Microsoft.Bot.Schema
         public string Text { get; set; }
 
         /// <summary>
-        /// Gets or sets array of images for the card.
+        /// Gets array of images for the card.
         /// </summary>
         /// <value>The images for the card.</value>
         [JsonProperty(PropertyName = "images")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardImage> Images { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardImage> Images { get; private set; } = new List<CardImage>();
 
         /// <summary>
-        /// Gets or sets set of actions applicable to the current card.
+        /// Gets set of actions applicable to the current card.
         /// </summary>
         /// <value>The actions applicable to the current card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// Gets or sets this action will be activated when user taps on the

--- a/libraries/Microsoft.Bot.Schema/VideoCard.cs
+++ b/libraries/Microsoft.Bot.Schema/VideoCard.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Bot.Schema
             Subtitle = subtitle;
             Text = text;
             Image = image;
-            Media = media;
-            Buttons = buttons;
+            Media = media ?? new List<MediaUrl>();
+            Buttons = buttons ?? new List<CardAction>();
             Shareable = shareable;
             Autoloop = autoloop;
             Autostart = autostart;
@@ -88,24 +88,20 @@ namespace Microsoft.Bot.Schema
         public ThumbnailUrl Image { get; set; }
 
         /// <summary>
-        /// Gets or sets media URLs for this card. When this field contains
+        /// Gets media URLs for this card. When this field contains
         /// more than one URL, each URL is an alternative format of the same
         /// content.
         /// </summary>
         /// <value>The media URLs for this card.</value>
         [JsonProperty(PropertyName = "media")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<MediaUrl> Media { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<MediaUrl> Media { get; private set; } = new List<MediaUrl>();
 
         /// <summary>
-        /// Gets or sets actions on this card.
+        /// Gets actions on this card.
         /// </summary>
         /// <value>The actions of this card.</value>
         [JsonProperty(PropertyName = "buttons")]
-#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking compat).
-        public IList<CardAction> Buttons { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public IList<CardAction> Buttons { get; private set; } = new List<CardAction>();
 
         /// <summary>
         /// Gets or sets this content may be shared with others (default:true).

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicePromptTests.cs
@@ -241,6 +241,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             };
             dialogs.Add(listPrompt);
 
+            var actions = new List<CardAction>
+            {
+                new CardAction { Type = "imBack", Value = "red", Title = "red" },
+                new CardAction { Type = "imBack", Value = "green", Title = "green" },
+                new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
+            };
+
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
                 {
                     var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
@@ -259,17 +266,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     }
                 })
                 .Send("hello")
-                .AssertReply(SuggestedActionsValidator(
-                    "favorite color?",
-                    new SuggestedActions
-                    {
-                        Actions = new List<CardAction>
-                        {
-                            new CardAction { Type = "imBack", Value = "red", Title = "red" },
-                            new CardAction { Type = "imBack", Value = "green", Title = "green" },
-                            new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
-                        },
-                    }))
+                .AssertReply(SuggestedActionsValidator("favorite color?", new SuggestedActions(actions: actions)))
                 .StartTestAsync();
         }
 
@@ -288,6 +285,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 Style = ListStyle.HeroCard,
             };
             dialogs.Add(listPrompt);
+
+            var heroCard = new HeroCard
+            {
+                Text = "favorite color?",
+            };
+            ((List<CardAction>)heroCard.Buttons).AddRange(
+                new List<CardAction>
+                {
+                    new CardAction { Type = "imBack", Value = "red", Title = "red" },
+                    new CardAction { Type = "imBack", Value = "green", Title = "green" },
+                    new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
+                });
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
                 {
@@ -308,16 +317,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 })
                 .Send("hello")
                 .AssertReply(HeroCardValidator(
-                    new HeroCard
-                    {
-                        Text = "favorite color?",
-                        Buttons = new List<CardAction>
-                        {
-                            new CardAction { Type = "imBack", Value = "red", Title = "red" },
-                            new CardAction { Type = "imBack", Value = "green", Title = "green" },
-                            new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
-                        },
-                    },
+                    heroCard,
                     0))
                 .StartTestAsync();
         }
@@ -337,6 +337,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 Style = ListStyle.HeroCard,
             };
             dialogs.Add(listPrompt);
+
+            var heroCard = new HeroCard
+            {
+                Text = "favorite color?",
+            };
+            ((List<CardAction>)heroCard.Buttons).AddRange(new List<CardAction>
+            {
+                new CardAction { Type = "imBack", Value = "red", Title = "red" },
+                new CardAction { Type = "imBack", Value = "green", Title = "green" },
+                new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
+            });
 
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
                 {
@@ -360,16 +371,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 })
                 .Send("hello")
                 .AssertReply(HeroCardValidator(
-                    new HeroCard
-                    {
-                        Text = "favorite color?",
-                        Buttons = new List<CardAction>
-                        {
-                            new CardAction { Type = "imBack", Value = "red", Title = "red" },
-                            new CardAction { Type = "imBack", Value = "green", Title = "green" },
-                            new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
-                        },
-                    },
+                    heroCard,
                     1))
                 .StartTestAsync();
         }
@@ -602,6 +604,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             var dialogs = new DialogSet(dialogState);
             dialogs.Add(new ChoicePrompt("ChoicePrompt", defaultLocale: Culture.English) { Style = ListStyle.HeroCard });
 
+            var actions = new List<CardAction>
+            {
+                new CardAction { Type = "imBack", Value = "red", Title = "red" },
+                new CardAction { Type = "imBack", Value = "green", Title = "green" },
+                new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
+            };
+
             await new TestFlow(adapter, async (turnContext, cancellationToken) =>
                 {
                     var dc = await dialogs.CreateContextAsync(turnContext, cancellationToken);
@@ -621,17 +630,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     }
                 })
                 .Send("hello")
-                .AssertReply(SuggestedActionsValidator(
-                    "favorite color?",
-                    new SuggestedActions
-                    {
-                        Actions = new List<CardAction>
-                        {
-                            new CardAction { Type = "imBack", Value = "red", Title = "red" },
-                            new CardAction { Type = "imBack", Value = "green", Title = "green" },
-                            new CardAction { Type = "imBack", Value = "blue", Title = "blue" },
-                        },
-                    }))
+                .AssertReply(SuggestedActionsValidator("favorite color?", new SuggestedActions(actions: actions)))
                 .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
@@ -101,6 +101,13 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
         {
             var logger = XUnitLogger.CreateLogger(_testOutput);
 
+            var actions = new List<CardAction>
+            {
+                new CardAction() { Title = "Red", Type = ActionTypes.ImBack, Value = "Red", Image = "https://via.placeholder.com/20/FF0000?text=R", ImageAltText = "R" },
+                new CardAction() { Title = "Yellow", Type = ActionTypes.ImBack, Value = "Yellow", Image = "https://via.placeholder.com/20/FFFF00?text=Y", ImageAltText = "Y" },
+                new CardAction() { Title = "Blue", Type = ActionTypes.ImBack, Value = "Blue", Image = "https://via.placeholder.com/20/0000FF?text=B", ImageAltText = "B" }
+            };
+
             // Arrange
             var activities = new[]
             {
@@ -114,15 +121,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
                     ServiceUrl = "wss://InvalidServiceUrl/api/messages",
                     ChannelId = "test",
                     Text = "hi",
-                    SuggestedActions = new SuggestedActions
-                    {
-                        Actions = new List<CardAction>
-                        {
-                            new CardAction() { Title = "Red", Type = ActionTypes.ImBack, Value = "Red", Image = "https://via.placeholder.com/20/FF0000?text=R", ImageAltText = "R" },
-                            new CardAction() { Title = "Yellow", Type = ActionTypes.ImBack, Value = "Yellow", Image = "https://via.placeholder.com/20/FFFF00?text=Y", ImageAltText = "Y" },
-                            new CardAction() { Title = "Blue", Type = ActionTypes.ImBack, Value = "Blue", Image = "https://via.placeholder.com/20/0000FF?text=B", ImageAltText = "B" }
-                        }
-                    }
+                    SuggestedActions = new SuggestedActions(actions: actions)
                 }
             };
 

--- a/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/ConversationsTests.cs
@@ -584,6 +584,20 @@ namespace Microsoft.Bot.Connector.Tests
         [Fact]
         public async Task SendCardToConversation()
         {
+            var heroCardStatic = new HeroCard()
+            {
+                Title = "A static image",
+                Subtitle = "JPEG image",
+            };
+            heroCardStatic.Images.Add(new CardImage() { Url = "https://docs.microsoft.com/bot-framework/media/designing-bots/core/dialogs-screens.png" });
+
+            var heroCardAnimation = new HeroCard()
+            {
+                Title = "An animation",
+                Subtitle = "GIF image",
+            };
+            heroCardAnimation.Images.Add(new CardImage() { Url = "http://i.giphy.com/Ki55RUbOV5njy.gif" });
+
             var activity = new Activity()
             {
                 Type = ActivityTypes.Message,
@@ -596,24 +610,14 @@ namespace Microsoft.Bot.Connector.Tests
                     new Attachment()
                     {
                         ContentType = HeroCard.ContentType,
-                        Content = new HeroCard()
-                        {
-                            Title = "A static image",
-                            Subtitle = "JPEG image",
-                            Images = new CardImage[] { new CardImage() { Url = "https://docs.microsoft.com/bot-framework/media/designing-bots/core/dialogs-screens.png" } },
-                        },
+                        Content = heroCardStatic,
                     },
                     new Attachment()
                     {
                         ContentType = HeroCard.ContentType,
-                        Content = new HeroCard()
-                        {
-                            Title = "An animation",
-                            Subtitle = "GIF image",
-                            Images = new CardImage[] { new CardImage() { Url = "http://i.giphy.com/Ki55RUbOV5njy.gif" } },
-                        },
-                    },
-                },
+                        Content = heroCardAnimation,
+                    }
+                }
             };
 
             var createMessage = new ConversationParameters()

--- a/tests/Microsoft.Bot.Schema.Tests/CardExTest.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/CardExTest.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Bot.Schema.Tests
                 Title = "Hero Card Title",
                 Subtitle = "Hero Card Subtitle",
                 Text = "Testing Text.",
-                Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
             };
+            heroCard.Buttons.Add(new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework"));
 
             attachments.Add(heroCard.ToAttachment());
 
@@ -40,13 +40,13 @@ namespace Microsoft.Bot.Schema.Tests
         public void ThumbnailCardToAttachmentTest()
         {
             var attachments = new List<Attachment>();
+            var buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") };
 
-            var thumbnailCard = new ThumbnailCard
+            var thumbnailCard = new ThumbnailCard(buttons: buttons)
             {
                 Title = "Thumbnail Card Title",
                 Subtitle = "Thumbnail Card Subtitle",
                 Text = "Testing Text.",
-                Buttons = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") },
             };
 
             attachments.Add(thumbnailCard.ToAttachment());
@@ -62,11 +62,11 @@ namespace Microsoft.Bot.Schema.Tests
         public void SigninCardToAttachmentTest()
         {
             var attachments = new List<Attachment>();
+            var buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Sign-in", value: "https://login.microsoftonline.com/") };
 
-            var signinCard = new SigninCard
+            var signinCard = new SigninCard(buttons: buttons)
             {
                 Text = "Testing Text.",
-                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Sign-in", value: "https://login.microsoftonline.com/") },
             };
 
             attachments.Add(signinCard.ToAttachment());
@@ -82,34 +82,34 @@ namespace Microsoft.Bot.Schema.Tests
         public void ReceiptCardToAttachmentTest()
         {
             var attachments = new List<Attachment>();
+            var facts = new List<Fact> { new Fact("Order Number", "1234"), new Fact("Payment Method", "VISA 5555-****") };
+            var items = new List<ReceiptItem>
+            {
+                new ReceiptItem(
+                    "Data Transfer",
+                    price: "$ 38.45",
+                    quantity: "368",
+                    image: new CardImage(url: "https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png")),
+                new ReceiptItem(
+                    "App Service",
+                    price: "$ 45.00",
+                    quantity: "720",
+                    image: new CardImage(url: "https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png")),
+            };
+            var buttons = new List<CardAction>
+            {
+                new CardAction(
+                    ActionTypes.OpenUrl,
+                    "More information",
+                    "https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png",
+                    value: "https://azure.microsoft.com/en-us/pricing/"),
+            };
 
-            var receiptCard = new ReceiptCard
+            var receiptCard = new ReceiptCard(facts: facts, items: items, buttons: buttons)
             {
                 Title = "John Doe",
-                Facts = new List<Fact> { new Fact("Order Number", "1234"), new Fact("Payment Method", "VISA 5555-****") },
-                Items = new List<ReceiptItem>
-                {
-                    new ReceiptItem(
-                        "Data Transfer",
-                        price: "$ 38.45",
-                        quantity: "368",
-                        image: new CardImage(url: "https://github.com/amido/azure-vector-icons/raw/master/renders/traffic-manager.png")),
-                    new ReceiptItem(
-                        "App Service",
-                        price: "$ 45.00",
-                        quantity: "720",
-                        image: new CardImage(url: "https://github.com/amido/azure-vector-icons/raw/master/renders/cloud-service.png")),
-                },
                 Tax = "$ 7.50",
                 Total = "$ 90.95",
-                Buttons = new List<CardAction>
-                {
-                    new CardAction(
-                        ActionTypes.OpenUrl,
-                        "More information",
-                        "https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png",
-                        value: "https://azure.microsoft.com/en-us/pricing/"),
-                },
             };
 
             attachments.Add(receiptCard.ToAttachment());
@@ -134,24 +134,18 @@ namespace Microsoft.Bot.Schema.Tests
                 Image = new ThumbnailUrl
                 {
                     Url = "https://upload.wikimedia.org/wikipedia/en/3/3c/SW_-_Empire_Strikes_Back.jpg",
-                },
-                Media = new List<MediaUrl>
-                {
-                    new MediaUrl()
-                    {
-                        Url = "http://www.wavlist.com/movies/004/father.wav",
-                    },
-                },
-                Buttons = new List<CardAction>
-                {
-                    new CardAction()
-                    {
-                        Title = "Read More",
-                        Type = ActionTypes.OpenUrl,
-                        Value = "https://en.wikipedia.org/wiki/The_Empire_Strikes_Back",
-                    },
-                },
+                }
             };
+            audioCard.Media.Add(new MediaUrl()
+            {
+                Url = "http://www.wavlist.com/movies/004/father.wav",
+            });
+            audioCard.Buttons.Add(new CardAction()
+            {
+                Title = "Read More",
+                Type = ActionTypes.OpenUrl,
+                Value = "https://en.wikipedia.org/wiki/The_Empire_Strikes_Back",
+            });
 
             attachments.Add(audioCard.ToAttachment());
 
@@ -166,8 +160,24 @@ namespace Microsoft.Bot.Schema.Tests
         public void VideoCardToAttachmentTest()
         {
             var attachments = new List<Attachment>();
+            var media = new List<MediaUrl>
+            {
+                new MediaUrl()
+                {
+                    Url = "http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4",
+                },
+            };
+            var buttons = new List<CardAction>
+            {
+                new CardAction()
+                {
+                    Title = "Learn More",
+                    Type = ActionTypes.OpenUrl,
+                    Value = "https://peach.blender.org/",
+                },
+            };
 
-            var videoCard = new VideoCard
+            var videoCard = new VideoCard(media: media, buttons: buttons)
             {
                 Title = "Audio Card Title",
                 Subtitle = "Audio Card Subtitle",
@@ -175,23 +185,7 @@ namespace Microsoft.Bot.Schema.Tests
                 Image = new ThumbnailUrl
                 {
                     Url = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Big_buck_bunny_poster_big.jpg/220px-Big_buck_bunny_poster_big.jpg",
-                },
-                Media = new List<MediaUrl>
-                {
-                    new MediaUrl()
-                    {
-                        Url = "http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4",
-                    },
-                },
-                Buttons = new List<CardAction>
-                {
-                    new CardAction()
-                    {
-                        Title = "Learn More",
-                        Type = ActionTypes.OpenUrl,
-                        Value = "https://peach.blender.org/",
-                    },
-                },
+                }
             };
 
             attachments.Add(videoCard.ToAttachment());
@@ -215,15 +209,12 @@ namespace Microsoft.Bot.Schema.Tests
                 Image = new ThumbnailUrl
                 {
                     Url = "https://docs.microsoft.com/en-us/bot-framework/media/how-it-works/architecture-resize.png",
-                },
-                Media = new List<MediaUrl>
-                {
-                    new MediaUrl()
-                    {
-                        Url = "http://i.giphy.com/Ki55RUbOV5njy.gif",
-                    },
-                },
+                }
             };
+            animationCard.Media.Add(new MediaUrl()
+            {
+                Url = "http://i.giphy.com/Ki55RUbOV5njy.gif",
+            });
 
             attachments.Add(animationCard.ToAttachment());
 
@@ -238,12 +229,12 @@ namespace Microsoft.Bot.Schema.Tests
         public void OAuthCardToAttachmentTest()
         {
             var attachments = new List<Attachment>();
+            var buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Login", value: "https://login.microsoftonline.com/") };
 
-            var oauthCard = new OAuthCard
+            var oauthCard = new OAuthCard(buttons: buttons)
             {
                 Text = "Please, sign in",
-                ConnectionName = "testConnection",
-                Buttons = new List<CardAction> { new CardAction(ActionTypes.Signin, "Login", value: "https://login.microsoftonline.com/") },
+                ConnectionName = "testConnection"
             };
 
             attachments.Add(oauthCard.ToAttachment());


### PR DESCRIPTION
Addresses #6099
#minor

## Description
This PR removes the exclusions of the FxCop rule [CA2227](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2227) (Collection properties should be read-only) in **Cards** classes.

### Detailed Changes
- Updated Collection properties (Dictionary, List, JObject)' accessor from `set` to `private set`.
- Initialized collection properties with empty collections.
- Replaced direct set of the properties with calls to the Collections' methods _Add(), AddRange(), Merge()_, and _Clear()_ depending on the case.
- Updated `null` validations with `Count()` or `Any()` validations.
- The following properties were updated:
   - **_Media_** and **_Buttons_** properties:
      - Microsoft.Bot.Schema/AnimationCard
      - Microsoft.Bot.Schema/AudioCard
      - Microsoft.Bot.Schema/BasicCard
      - Microsoft.Bot.Schema/HeroCard
      - Microsoft.Bot.Schema/MediaCard
      - Microsoft.Bot.Schema/VideoCard
   - **_Buttons_** property:
      - Microsoft.Bot.Schema/OAuthCard
      - Microsoft.Bot.Schema/SigninCard.cs
   - Microsoft.Bot.Schema/ReceiptCard: **_Facts_**, **_Items_**, **_Buttons_** properties.
   - Microsoft.Bot.Schema/SuggestedActions: **_To_**, **_Actions_** properties.
   - Microsoft.Bot.Schema/ThumbnailCard: **_Images_**, **_Buttons_** properties.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/154278898-76dbcfed-be0e-4e1b-b7d2-7f01a2fc1dcc.png)
