### PR TITLE
Fix incorrect date in v5 package versioning 

### DIFF
--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -21,24 +21,23 @@ variables:
   MSBuildArguments: -p:PublishRepositoryUrl=true -p:GeneratePackages=true -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
   Packaging.EnableSBOMSigning: true
   Parameters.solution: Microsoft.Bot.Builder.sln
-#  Variable 'PreviewPackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-preview-$(Build.BuildNumber) Consumed by projects in Microsoft.Bot.Builder.sln.
-#  Variable 'ReleasePackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-$(Build.BuildNumber) Consumed by projects in Microsoft.Bot.Builder.sln.
+#  Variable 'PreviewPackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-daily.preview.${Build.BuildNumber}.{CommitHash} Consumed by projects in Microsoft.Bot.Builder.sln.
+#  Variable 'ReleasePackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-daily.${Build.BuildNumber}.{CommitHash} Consumed by projects in Microsoft.Bot.Builder.sln.
 
 jobs:
 - job: Build_and_Sign
   steps:
   - powershell: |
-     # Replace {DateStamp} and {CommitHash} tokens with the actual values in vars ReleasePackageVersion and PreviewPackageVersion
-     $dateStamp = (Get-Date -format "yyyyMMdd");
+     # Replace {CommitHash} token with the actual value in vars ReleasePackageVersion and PreviewPackageVersion
      $commitHash = "$(Build.SourceVersion)".SubString(0,7);
 
      "Raw ReleasePackageVersion = $(ReleasePackageVersion)";
-     $v = "$(ReleasePackageVersion)".Replace("{DateStamp}",$dateStamp).Replace("{CommitHash}",$commitHash);
+     $v = "$(ReleasePackageVersion)".Replace("{CommitHash}",$commitHash);
      Write-Host "##vso[task.setvariable variable=ReleasePackageVersion;]$v";
      "Resolved ReleasePackageVersion = $v";
 
      "Raw PreviewPackageVersion = $(PreviewPackageVersion)";
-     $ppv = "$(PreviewPackageVersion)".Replace("{DateStamp}",$dateStamp).Replace("{CommitHash}",$commitHash);
+     $ppv = "$(PreviewPackageVersion)".Replace("{CommitHash}",$commitHash);
      Write-Host "##vso[task.setvariable variable=PreviewPackageVersion;]$ppv";
      "Resolved PreviewPackageVersion = $ppv";
     displayName: 'Resolve package version variables'

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -21,8 +21,8 @@ variables:
   MSBuildArguments: -p:PublishRepositoryUrl=true -p:GeneratePackages=true -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
   Packaging.EnableSBOMSigning: true
   Parameters.solution: Microsoft.Bot.Builder.sln
-#  Variable 'PreviewPackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-daily.preview.${Build.BuildNumber}.{CommitHash} Consumed by projects in Microsoft.Bot.Builder.sln.
-#  Variable 'ReleasePackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-daily.${Build.BuildNumber}.{CommitHash} Consumed by projects in Microsoft.Bot.Builder.sln.
+#  Variable 'PreviewPackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-daily.preview.{BuildNumber}.{CommitHash} Consumed by projects in Microsoft.Bot.Builder.sln.
+#  Variable 'ReleasePackageVersion' is defined in Azure, settable at queue time. Value: 5.0.0-daily.{BuildNumber}.{CommitHash} Consumed by projects in Microsoft.Bot.Builder.sln.
 
 jobs:
 - job: Build_and_Sign

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -28,16 +28,17 @@ jobs:
 - job: Build_and_Sign
   steps:
   - powershell: |
-     # Replace {CommitHash} token with the actual value in vars ReleasePackageVersion and PreviewPackageVersion
+     # Replace {BuildNumber} and {CommitHash} tokens with the actual values in vars ReleasePackageVersion and PreviewPackageVersion
+     $buildNumber = "$(Build.BuildNumber)";
      $commitHash = "$(Build.SourceVersion)".SubString(0,7);
 
      "Raw ReleasePackageVersion = $(ReleasePackageVersion)";
-     $v = "$(ReleasePackageVersion)".Replace("{CommitHash}",$commitHash);
+     $v = "$(ReleasePackageVersion)".Replace("{BuildNumber}",$buildNumber).Replace("{CommitHash}",$commitHash);
      Write-Host "##vso[task.setvariable variable=ReleasePackageVersion;]$v";
      "Resolved ReleasePackageVersion = $v";
 
      "Raw PreviewPackageVersion = $(PreviewPackageVersion)";
-     $ppv = "$(PreviewPackageVersion)".Replace("{CommitHash}",$commitHash);
+     $ppv = "$(PreviewPackageVersion)".Replace("{BuildNumber}",$buildNumber).Replace("{CommitHash}",$commitHash);
      Write-Host "##vso[task.setvariable variable=PreviewPackageVersion;]$ppv";
      "Resolved PreviewPackageVersion = $ppv";
     displayName: 'Resolve package version variables'


### PR DESCRIPTION
Fixes #minor

## Description
This fixes incorrect PreviewPackageVersion and ReleasePackageVersion resolution in pipeline BotBuilder-DotNet-Signed-daily-v5.

Versions currently use UTC date. They should use the local date, the date that is embedded in the build number and that is shown in the build datetime listings.
