### PR TITLE
update readme file

### DIFF
--- a/generators/dotnet-templates/README.md
+++ b/generators/dotnet-templates/README.md
@@ -121,7 +121,8 @@ dotnet new -i Microsoft.Bot.Framework.CSharp.EmptyBot
 dotnet new echobot -n MyEchoBot
 ```
 
-#### Create CoreBot
+#### Create CoreBot 
+> Note: For a core bot project, only the parent folder receives the bot name
 ```bash
 # Generate a Core Bot
 dotnet new corebot -n MyCoreBot


### PR DESCRIPTION
Updated readme file to clarify when running the command `dotnet new corebot -n TestBot` expects to create project at 'TestBot/CoreBot' directory.

Fixes #6216 <!-- If this addresses a specific issue, please provide the issue number here -->
