### PR TITLE
Update v5 dependencies to latest versions - Part 2

### DIFF
--- a/libraries/Directory.Build.props
+++ b/libraries/Directory.Build.props
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.117" />
-    <PackageReference Include="ReportGenerator" Version="5.0.3" />
+    <PackageReference Include="ReportGenerator" Version="5.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes #6174

## Description
Update additional 3rd party dependencies beyond those of PR #6191

This completes the updates for Issue #6174

## Changes
ReportGenerator 5.0.3 -> 5.0.4

Microsoft.CodeAnalysis.FxCopAnalyzers 3.0.0 (deprecated) -> Microsoft.CodeAnalysis.NetAnalyzers 5.0.3

