### PR TITLE
Fix Publish To Coveralls in the CI build

### DIFF
--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -11,7 +11,7 @@ Param(
 Write-Host Install tools
 $basePath = (get-item $pathToCoverageFiles ).parent.FullName
 $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
-dotnet tool install coveralls.net --version 1.0.0 --tool-path tools --add-source "https://api.nuget.org/v3/index.json"
+dotnet tool install coveralls.net --version 1.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
 # Download temporary version of Archive module that fixes issue on macOS/Linux with path separator

--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -11,7 +11,7 @@ Param(
 Write-Host Install tools
 $basePath = (get-item $pathToCoverageFiles ).parent.FullName
 $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
-dotnet tool install coveralls.net --version 1.0.0 --tool-path tools
+dotnet tool install coveralls.net --version 1.0.0 --tool-path tools --add-source "https://api.nuget.org/v3/index.json"
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
 # Download temporary version of Archive module that fixes issue on macOS/Linux with path separator

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -9,19 +9,6 @@ steps:
 
 - template: sdk_dotnet_v4_org-feed-setup-steps.yml
 
-- powershell: |
-    dotnet nuget remove source SDK_Dotnet_V4_org
-  displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
-
-- task: PowerShell@2
-  displayName: 'DEBUG: Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
-  inputs:
-    targetType: filePath
-    filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
-    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
-  continueOnError: true
-  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
-
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -9,10 +9,6 @@ steps:
 
 - template: sdk_dotnet_v4_org-feed-setup-steps.yml
 
-- powershell: |
-    dotnet nuget remove source SDK_Dotnet_V4_org
-  displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
-
 - task: PowerShell@2
   displayName: 'DEBUG: Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
   inputs:

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -18,7 +18,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
-    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)" -serviceName "CI-PR build"'
+    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
   continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -14,7 +14,7 @@ steps:
   inputs:
     targetType: filePath
     filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
-    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
+    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)" -serviceName "CI-PR build"'
   continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -9,6 +9,15 @@ steps:
 
 - template: sdk_dotnet_v4_org-feed-setup-steps.yml
 
+- task: PowerShell@2
+  displayName: 'DEBUG: Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
+  inputs:
+    targetType: filePath
+    filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
+    arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -9,6 +9,10 @@ steps:
 
 - template: sdk_dotnet_v4_org-feed-setup-steps.yml
 
+- powershell: |
+    dotnet nuget remove source SDK_Dotnet_V4_org
+  displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
+
 - task: PowerShell@2
   displayName: 'DEBUG: Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
   inputs:

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -59,6 +59,12 @@ steps:
     version: 2.1.x
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 
+- powershell: |
+   dotnet nuget remove source SDK_Dotnet_V4_org
+  displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+
 - task: PowerShell@2
   displayName: 'Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
   inputs:

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -52,6 +52,13 @@ steps:
   continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 2.1, required for Upload Coverage Files task'
+  inputs:
+    packageType: sdk
+    version: 2.1.x
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+
 - task: PowerShell@2
   displayName: 'Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
   inputs:

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -45,7 +45,7 @@ steps:
    
    Get-ChildItem -Path "D:\a\_temp" -Include "*.coverage" -Recurse | Copy-Item -Destination CodeCoverage
   displayName: 'Copy .coverage Files to CodeCoverage folder'
-  condition: eq(variables['BuildConfiguration'],'Release-Windows')
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
 
 - powershell: 'echo ''##vso[task.setvariable variable=CoverallsToken]$(DotNetCoverallsToken)'''
   displayName: 'Set CoverallsToken for PublishToCoveralls.ps1 if token exists'

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -52,17 +52,17 @@ steps:
   continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 
+- powershell: |
+   dotnet nuget remove source SDK_Dotnet_V4_org
+  displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 2.1, required for Upload Coverage Files task'
   inputs:
     packageType: sdk
     version: 2.1.x
-  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
-
-- powershell: |
-   dotnet nuget remove source SDK_Dotnet_V4_org
-  displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
-  continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 
 - task: PowerShell@2

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -45,7 +45,7 @@ steps:
    
    Get-ChildItem -Path "D:\a\_temp" -Include "*.coverage" -Recurse | Copy-Item -Destination CodeCoverage
   displayName: 'Copy .coverage Files to CodeCoverage folder'
-  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
 
 - powershell: 'echo ''##vso[task.setvariable variable=CoverallsToken]$(DotNetCoverallsToken)'''
   displayName: 'Set CoverallsToken for PublishToCoveralls.ps1 if token exists'
@@ -73,13 +73,6 @@ steps:
     arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
   continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish build artifact CodeCoverage'
-  inputs:
-    PathtoPublish: CodeCoverage
-    ArtifactName: CodeCoverage
-  enabled: false
 
 - powershell: |
    New-Item -ItemType directory -Path "outputLibraries\" -Force


### PR DESCRIPTION
Fixes #minor

## Description
In pipeline BotBuilder-DotNet-CI-PR-yaml, the task that uploads test results to coveralls.io has been failing. This fixes it.