### PR TITLE
[#5276] Update code analysis to latest VS recommendations - Disable rules

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptivePredictionOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptivePredictionOptions.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// External entities recognized in query.
         /// </value>
         [JsonProperty("externalEntities")]
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<ExternalEntity> ExternalEntities { get; } = new List<ExternalEntity>();
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets or sets a value indicating whether external entities should override other means of recognizing entities.

--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptiveRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptiveRecognizer.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// </summary>
         /// <value>Dynamic lists.</value>
         [JsonProperty("dynamicLists")]
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<Luis.DynamicList> DynamicLists { get; } = new List<Luis.DynamicList>();
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets or sets LUIS prediction options.

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -104,7 +104,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             string cardNoMatchText = DefaultCardNoMatchText,
             int top = DefaultTopN,
             Activity cardNoMatchResponse = null,
+#pragma warning disable CA1002 // Do not expose generic lists
             List<Metadata> strictFilters = null,
+#pragma warning restore CA1002 // Do not expose generic lists
             HttpClient httpClient = null)
             : base(dialogId)
         {
@@ -157,7 +159,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             string cardNoMatchText = DefaultCardNoMatchText,
             int top = DefaultTopN,
             Activity cardNoMatchResponse = null,
+#pragma warning disable CA1002 // Do not expose generic lists
             List<Metadata> strictFilters = null,
+#pragma warning restore CA1002 // Do not expose generic lists
             HttpClient httpClient = null)
             : this(
                 nameof(QnAMakerDialog),
@@ -281,7 +285,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// The QnA Maker metadata with which to filter or boost queries to the knowledge base
         /// or an expression which evaluates to the QnA Maker metadata.
         /// </value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<Metadata> StrictFilters { get; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets or sets a value indicating whether gets or sets the flag to determine if personal information should be logged in telemetry.

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerRecognizer.cs
@@ -130,7 +130,9 @@ namespace Microsoft.Bot.Builder.AI.QnA.Recognizers
         /// </summary>
         /// <value>An expression to evaluate for pairs of metadata.</value>
         [JsonProperty("metadata")]
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<Metadata> Metadata { get; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets or sets an expression to evaluate to set the context.

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/ActiveLearningUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/ActiveLearningUtils.cs
@@ -42,7 +42,9 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// </summary>
         /// <param name="qnaSearchResults">List of QnaSearch results.</param>
         /// <returns>List of filtered qnaSearch results.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<QueryResult> GetLowScoreVariation(List<QueryResult> qnaSearchResults)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             var filteredQnaSearchResult = new List<QueryResult>();
 

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <param name="cardTitle">Title of the cards.</param>
         /// <param name="cardNoMatchText">No match text.</param>
         /// <returns>IMessageActivity.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static IMessageActivity GetSuggestionsCard(List<string> suggestionsList, string cardTitle, string cardNoMatchText)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             if (suggestionsList == null)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Choice.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// The list of synonyms to recognize in addition to the value.
         /// </value>
         [JsonProperty("synonyms")]
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<string> Synonyms { get; private set; } = new List<string>();
+#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceRecognizers.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="choices">The list of choices.</param>
         /// <param name="options">Optional, options to control the recognition strategy.</param>
         /// <returns>A list of found choices, sorted by most relevant first.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<ModelResult<FoundChoice>> RecognizeChoices(string utterance, IList<string> choices, FindChoicesOptions options = null)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             return RecognizeChoices(utterance, choices.Select(s => new Choice { Value = s }).ToList(), options);
         }
@@ -35,7 +37,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="list">The list of choices.</param>
         /// <param name="options">Optional, options to control the recognition strategy.</param>
         /// <returns>A list of found choices, sorted by most relevant first.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<ModelResult<FoundChoice>> RecognizeChoices(string utterance, IList<Choice> list, FindChoicesOptions options = null)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             utterance ??= string.Empty;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Find.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Find.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="choices">The list of choices.</param>
         /// <param name="options">Optional, options to control the recognition strategy.</param>
         /// <returns>A list of found choices, sorted by most relevant first.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<ModelResult<FoundChoice>> FindChoices(string utterance, IList<string> choices, FindChoicesOptions options = null)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             if (choices == null)
             {
@@ -36,7 +38,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="choices">The list of choices.</param>
         /// <param name="options">Optional, options to control the recognition strategy.</param>
         /// <returns>A list of found choices, sorted by most relevant first.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<ModelResult<FoundChoice>> FindChoices(string utterance, IList<Choice> choices, FindChoicesOptions options = null)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             if (choices == null)
             {
@@ -101,7 +105,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="values">The values.</param>
         /// <param name="options">The options for the search.</param>
         /// <returns>A list of found values.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<ModelResult<FoundValue>> FindValues(string utterance, List<SortedValue> values, FindValuesOptions options = null)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             if (FindExactMatch(utterance, values) is ModelResult<FoundValue> exactMatch)
             {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Tokenizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Tokenizer.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <returns>A list of tokens.</returns>
         /// <remarks>This is an exact port of the JavaScript implementation of the algorithm except that here
         /// the .NET library functions are used in place of the JavaScript string code point functions.</remarks>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static List<Token> DefaultTokenizerImpl(string text, string locale = null)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             var tokens = new List<Token>();
             Token token = null;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Tokenizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Tokenizer.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <remarks>This is an exact port of the JavaScript implementation of the algorithm except that here
         /// the .NET library functions are used in place of the JavaScript string code point functions.</remarks>
 #pragma warning disable CA1002 // Do not expose generic lists
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
         public static List<Token> DefaultTokenizerImpl(string text, string locale = null)
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 #pragma warning restore CA1002 // Do not expose generic lists
         {
             var tokens = new List<Token>();

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -78,7 +78,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <value>
         /// The current dialog stack.
         /// </value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<DialogInstance> Stack { get; private set; }
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Gets or sets the parent <see cref="DialogContext"/>, if any. Used when searching for the ID of a dialog to start.

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogSet.cs
@@ -201,7 +201,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Gets the Dialogs of the set.
         /// </summary>
         /// <returns>A collection of <see cref="Dialog"/>.</returns>
+#pragma warning disable CA1024 // Use properties where appropriate
         public IEnumerable<Dialog> GetDialogs()
+#pragma warning restore CA1024 // Use properties where appropriate
         {
             return _dialogs.Values;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogState.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="stack">The state information to initialize the stack with.</param>
         /// <remarks>The new instance has a dialog stack that is populated using the information
         /// in <paramref name="stack"/>.</remarks>
+#pragma warning disable CA1002 // Do not expose generic lists
         public DialogState(List<DialogInstance> stack)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             DialogStack = stack ?? new List<DialogInstance>();
         }
@@ -39,6 +41,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <value>State information for a dialog stack.</value>
         [JsonProperty("dialogStack")]
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<DialogInstance> DialogStack { get; private set; } = new List<DialogInstance>();
+#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -475,7 +475,9 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="segments">Path segments.</param>
         /// <param name="eval">True to evaluate resulting segments.</param>
         /// <returns>True if it was able to resolve all nested references.</returns>
+#pragma warning disable CA1002 // Do not expose generic lists
         public static bool TryResolvePath(object obj, string propertyPath, out List<object> segments, bool eval = false)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             var soFar = new List<object>();
             segments = soFar;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -17,7 +17,11 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public static class ObjectPath
     {
+#pragma warning disable CA2326 // Do not use TypeNameHandling values other than None
+#pragma warning disable CA2327 // Do not use insecure JsonSerializerSettings
         private static readonly JsonSerializerSettings _cloneSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+#pragma warning restore CA2327 // Do not use insecure JsonSerializerSettings
+#pragma warning restore CA2326 // Do not use TypeNameHandling values other than None
 
         private static readonly JsonSerializerSettings _expressionCaseSettings = new JsonSerializerSettings
         {

--- a/libraries/Microsoft.Bot.Builder/BotStateSet.cs
+++ b/libraries/Microsoft.Bot.Builder/BotStateSet.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Bot.Builder
         /// Gets the BotStates list for the BotStateSet.
         /// </summary>
         /// <value>The BotState objects managed by this class.</value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<BotState> BotStates { get; } = new List<BotState>();
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Adds a bot state object to the set.

--- a/libraries/Microsoft.Bot.Builder/IMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/IMiddleware.cs
@@ -14,7 +14,9 @@ namespace Microsoft.Bot.Builder
     /// <param name="cancellationToken">A cancellation token that can be used by other objects
     /// or threads to receive notice of cancellation.</param>
     /// <returns>A task that represents the work queued to execute.</returns>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
     public delegate Task NextDelegate(CancellationToken cancellationToken);
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 
     /// <summary>
     /// Represents middleware that can operate on incoming activities.

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -16,11 +16,15 @@ namespace Microsoft.Bot.Builder
     /// </summary>
     public class MemoryStorage : IStorage
     {
+#pragma warning disable CA2329 // Do not deserialize with JsonSerializer using an insecure configuration
         private static readonly JsonSerializer StateJsonSerializer = new JsonSerializer()
         {
+#pragma warning disable CA2326 // Do not use TypeNameHandling values other than None
             TypeNameHandling = TypeNameHandling.All,
+#pragma warning restore CA2326 // Do not use TypeNameHandling values other than None
             ReferenceLoopHandling = ReferenceLoopHandling.Error,
         };
+#pragma warning restore CA2329 // Do not deserialize with JsonSerializer using an insecure configuration
 
         // If a JsonSerializer is not provided during construction, this will be the default static JsonSerializer.
         private readonly JsonSerializer _stateJsonSerializer;

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -372,7 +372,9 @@ namespace Microsoft.Bot.Builder.Streaming
         /// </summary>
         /// <param name="sender">The source of the disconnection event.</param>
         /// <param name="e">The arguments specified by the disconnection event.</param>
+#pragma warning disable CA2109 // Review visible event handlers
         protected virtual void ServerDisconnected(object sender, DisconnectedEventArgs e)
+#pragma warning restore CA2109 // Review visible event handlers
         {
             // Subtypes can override this method to add logging when an underlying transport server is disconnected
         }

--- a/libraries/Microsoft.Bot.Builder/TurnContext.cs
+++ b/libraries/Microsoft.Bot.Builder/TurnContext.cs
@@ -146,7 +146,9 @@ namespace Microsoft.Bot.Builder
         /// Gets a list of activities to send when `context.Activity.DeliveryMode == 'expectReplies'.
         /// </summary>
         /// <value>A list of activities.</value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<Activity> BufferedReplyActivities { get; } = new List<Activity>();
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Adds a response handler for send activity operations.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/IContentStream.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/IContentStream.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
     /// <summary>
     /// Implemented by stream attachments compatible with the Bot Framework Protocol 3 with Streaming Extensions.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
     public interface IContentStream
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     {
         /// <summary>
         /// Gets a guid to use as the unique identifier of this ContentStream.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveRequest.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveRequest.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         /// <value>
         /// A <see cref="List{T}"/> of <see cref="IContentStream"/> items associated with this request.
         /// </value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<IContentStream> Streams { get; private set; } = new List<IContentStream>();
+#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveResponse.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ReceiveResponse.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         /// <value>
         /// A <see cref="List{T}"/> of type <see cref="IContentStream"/> containing information on streams attached to this response.
         /// </value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<IContentStream> Streams { get; private set; } = new List<IContentStream>();
+#pragma warning restore CA1002 // Do not expose generic lists
     }
 }

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ResponseMessageStream.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/ResponseMessageStream.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
     /// An attachment contained within a <see cref="StreamingRequest"/>'s stream collection,
     /// which itself contains any form of media item.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
     public class ResponseMessageStream
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ResponseMessageStream"/> class.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingRequest.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingRequest.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         /// <value>
         /// A <see cref="List{T}"/> of <see cref="ResponseMessageStream"/> items associated with this request.
         /// </value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<ResponseMessageStream> Streams { get; private set; } = new List<ResponseMessageStream>();
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Creates a <see cref="StreamingRequest"/> to get resources hosted on a remote server.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingResponse.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Payloads/StreamingResponse.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Bot.Connector.Streaming.Payloads
         /// <value>
         /// A <see cref="List{T}"/> of type <see cref="ResponseMessageStream"/>.
         /// </value>
+#pragma warning disable CA1002 // Do not expose generic lists
         public List<ResponseMessageStream> Streams { get; private set; } = new List<ResponseMessageStream>();
+#pragma warning restore CA1002 // Do not expose generic lists
 
         /// <summary>
         /// Creates a response indicating the requested resource was not found.

--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -197,6 +197,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
         private static TokenValidationParameters GetEmulatorTokenValidationParameters()
         {
+#pragma warning disable CA5404 // Do not disable token validation checks
             return new TokenValidationParameters
             {
                 ValidateIssuer = true,
@@ -215,6 +216,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true,
             };
+#pragma warning restore CA5404 // Do not disable token validation checks
         }
 
         private static bool IsTokenFromEmulator(string authHeader)
@@ -323,6 +325,7 @@ namespace Microsoft.Bot.Connector.Authentication
         // The following code is based on SkillValidation.AuthenticateChannelToken
         private async Task<ClaimsIdentity> AuthenticateSkillTokenAsync(string authHeader, string channelId, CancellationToken cancellationToken)
         {
+#pragma warning disable CA5404 // Do not disable token validation checks
             var skillTokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,
@@ -341,6 +344,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 ClockSkew = TimeSpan.FromMinutes(5),
                 RequireSignedTokens = true
             };
+#pragma warning restore CA5404 // Do not disable token validation checks
 
             // Add allowed token issuers from configuration (if present)
             if (_authConfiguration.ValidTokenIssuers != null && _authConfiguration.ValidTokenIssuers.Any())
@@ -495,6 +499,7 @@ namespace Microsoft.Bot.Connector.Authentication
         // The following code is based on GovernmentChannelValidation.AuthenticateChannelToken
         private async Task<ClaimsIdentity> AuthenticateChannelTokenAsync(string authHeader, string serviceUrl, string channelId, CancellationToken cancellationToken)
         {
+#pragma warning disable CA5404 // Do not disable token validation checks
             var channelTokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,
@@ -505,6 +510,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 RequireSignedTokens = true,
                 ValidateIssuerSigningKey = true,
             };
+#pragma warning restore CA5404 // Do not disable token validation checks
 
             // Add allowed token issuers from configuration (if present)
             if (_authConfiguration.ValidTokenIssuers != null && _authConfiguration.ValidTokenIssuers.Any())

--- a/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/TimeSpanExtensions.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Bot.Connector.Authentication
             // The reason for this is that if there are multiple threads about to retry
             // at the same time, it can overload the server again and trigger throttling again.
             // By adding a bit of random noise, we distribute requests a across time.
+#pragma warning disable CA5394 // Do not use insecure randomness
             return delay + TimeSpan.FromMilliseconds(_random.NextDouble() * delay.TotalMilliseconds * multiplier);
+#pragma warning restore CA5394 // Do not use insecure randomness
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
+++ b/libraries/Microsoft.Bot.Connector/ConnectorClientEx.cs
@@ -131,7 +131,9 @@ namespace Microsoft.Bot.Connector
 
         /// <summary>Gets a description of the operating system of the Azure Bot Service.</summary>
         /// <returns>A description of the operating system of the Azure Bot Service.</returns>
+#pragma warning disable CA1024 // Use properties where appropriate
         public static string GetOsVersion()
+#pragma warning restore CA1024 // Use properties where appropriate
         {
             return System.Runtime.InteropServices.RuntimeInformation.OSDescription;
         }

--- a/libraries/Microsoft.Bot.Schema/ActivityTypesEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityTypesEx.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Additional values for ActivityTypes beyond the auto-generated ActivityTypes class.
     /// </summary>
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
     public static class ActivityTypesEx
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     {
         /// <summary>
         /// The type value for delay activities.

--- a/libraries/Storage/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Storage/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -75,10 +75,14 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
             _storageTransferOptions = storageTransferOptions;
 
+#pragma warning disable CA2326 // Do not use TypeNameHandling values other than None
+#pragma warning disable CA2327 // Do not use insecure JsonSerializerSettings
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
                                                 {
                                                     TypeNameHandling = TypeNameHandling.All,
                                                 });
+#pragma warning restore CA2327 // Do not use insecure JsonSerializerSettings
+#pragma warning restore CA2326 // Do not use TypeNameHandling values other than None
 
             // Triggers a check for the existence of the container
             _checkForContainerExistence = 1;

--- a/libraries/Storage/Microsoft.Bot.Builder.Azure.Cosmos/CosmosDbPartitionedStorage.cs
+++ b/libraries/Storage/Microsoft.Bot.Builder.Azure.Cosmos/CosmosDbPartitionedStorage.cs
@@ -19,7 +19,11 @@ namespace Microsoft.Bot.Builder.Azure.Cosmos
     public class CosmosDbPartitionedStorage : IStorage, IDisposable
     {
         private const int MaxDepthAllowed = 127;
+#pragma warning disable CA2327 // Do not use insecure JsonSerializerSettings
+#pragma warning disable CA2326 // Do not use TypeNameHandling values other than None
         private readonly JsonSerializer _jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+#pragma warning restore CA2326 // Do not use TypeNameHandling values other than None
+#pragma warning restore CA2327 // Do not use insecure JsonSerializerSettings
 
         private Container _container;
         private readonly CosmosDbPartitionedStorageOptions _cosmosDbStorageOptions;


### PR DESCRIPTION
Addresses #5276
#minor

> ### **IMPORTANT!**
> **Note:** These changes are being address as part of enabling the [.NET Analyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) library in the PR #6251.

## Description
This PR disables new rules detected by the new .NET Analyzers that are considered high impact.

List:
- CA1002
- CA1024
- CA1711
- CA2109
- CA2326
- CA2327
- CA2329
- CA5394
- CA5404

## Testing
This image shows the CI pipeline successfully running after the changes.
![imagen](https://user-images.githubusercontent.com/62260472/156584317-04b6aee1-6f9a-4d51-acce-874955716025.png)