### PR TITLE
[#5276] Update code analysis to latest VS recommendations - Fix error rules - Part 1

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Bot.Connector.Authentication
             var token = await _authenticator.Value.GetTokenAsync(forceRefresh).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(token.AccessToken))
             {
-                Logger.LogWarning($"{GetType().FullName}.ProcessHttpRequestAsync(): got empty token from call to the configured IAuthenticator.");
+                Log.EmptyToken(Logger, $"{GetType().FullName}.ProcessHttpRequestAsync()");
             }
 
             return token.AccessToken;
@@ -196,6 +196,21 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Log messages for <see cref="AppCredentials"/>.
+        /// </summary>
+        /// <remarks>
+        /// Messages implemented using <see cref="LoggerMessage.Define(LogLevel, EventId, string)"/> to maximize performance.
+        /// For more information, see https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-5.0.
+        /// </remarks>
+        private static class Log
+        {
+            private static readonly Action<ILogger, string, Exception> _emptyToken =
+                LoggerMessage.Define<string>(LogLevel.Warning, new EventId(1, nameof(EmptyToken)), "{String}: got empty token from call to the configured IAuthenticator.");
+
+            public static void EmptyToken(ILogger logger, string name) => _emptyToken(logger, name, null);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
+using LoggerLogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Microsoft.Bot.Connector.Authentication
 {
@@ -107,7 +108,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 retryExceptionHandler: (ex, ct) => HandleMsalException(ex, ct)).ConfigureAwait(false);
 
             watch.Stop();
-            _logger?.LogInformation($"GetTokenAsync: Acquired token using MSAL in {watch.ElapsedMilliseconds}.");
+            Log.AcquiredToken(_logger, nameof(GetTokenAsync), watch.ElapsedMilliseconds);
 
             return result;
         }
@@ -198,7 +199,7 @@ namespace Microsoft.Bot.Connector.Authentication
             catch (SemaphoreFullException)
             {
                 // This should never happen but we want to know if it does.
-                _logger?.LogWarning("Attempted to release a full semaphore.");
+                Log.AttemptedSemaphoreRelease(_logger);
             }
 
             // Any exception other than SemaphoreFullException should be thrown right away
@@ -206,11 +207,11 @@ namespace Microsoft.Bot.Connector.Authentication
 
         private RetryParams HandleMsalException(Exception ex, int ct)
         {
-            _logger?.LogError(ex, "Exception acquiring token through MSAL.");
+            Log.AcquiringTokenFailed(_logger, ex);
 
             if (ex is MsalServiceException msalException)
             {
-                _logger?.LogWarning(msalException, $"MSAL service error code: {msalException.ErrorCode}.");
+                Log.ServiceErrorCode(_logger, msalException.ErrorCode);
 
                 // Service error with status code "temporarily_unavailable" is retryable.
                 // Spec and reference: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-aadsts-error-codes.
@@ -221,6 +222,36 @@ namespace Microsoft.Bot.Connector.Authentication
             }
 
             return RetryParams.StopRetrying;
+        }
+
+        /// <summary>
+        /// Log messages for <see cref="MsalAppCredentials"/>.
+        /// </summary>
+        /// <remarks>
+        /// Messages implemented using <see cref="LoggerMessage.Define(LoggerLogLevel, EventId, string)"/> to maximize performance.
+        /// For more information, see https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/loggermessage?view=aspnetcore-5.0.
+        /// </remarks>
+        private static class Log
+        {
+            private static readonly Action<ILogger, string, long, Exception> _acquiredToken =
+                LoggerMessage.Define<string, long>(LoggerLogLevel.Information, new EventId(1, nameof(AcquiredToken)), "{String}: Acquired token using MSAL in {Int64}.");
+
+            private static readonly Action<ILogger, Exception> _attemptedSemaphoreRelease =
+                LoggerMessage.Define(LoggerLogLevel.Warning, new EventId(2, nameof(AttemptedSemaphoreRelease)), "Attempted to release a full semaphore.");
+
+            private static readonly Action<ILogger, Exception> _acquiringTokenFailed =
+                LoggerMessage.Define(LoggerLogLevel.Error, new EventId(3, nameof(AcquiringTokenFailed)), "Exception acquiring token through MSAL.");
+
+            private static readonly Action<ILogger, string, Exception> _serviceErrorCode =
+                LoggerMessage.Define<string>(LoggerLogLevel.Warning, new EventId(4, nameof(ServiceErrorCode)), "MSAL service error code: {String}.");
+
+            public static void AcquiredToken(ILogger logger, string name, long elapsedMilliseconds) => _acquiredToken(logger, name, elapsedMilliseconds, null);
+
+            public static void AttemptedSemaphoreRelease(ILogger logger) => _attemptedSemaphoreRelease(logger, null);
+
+            public static void AcquiringTokenFailed(ILogger logger, Exception ex) => _acquiringTokenFailed(logger, ex);
+
+            public static void ServiceErrorCode(ILogger logger, string errorCode) => _serviceErrorCode(logger, errorCode, null);
         }
     }
 }


### PR DESCRIPTION
Addresses #5276
#minor

> ### **IMPORTANT!**
> **Note:** These changes are being address as part of enabling the [.NET Analyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) library in the PR #6251.

## Description
This PR replaces all the `Logger` methods' calls (`LogInformation`, `LogError`, etc) with defining the output using the `LoggerMessage.Define` method.

List:
- CA1848
- CA2254

## Specific changes
- Add `Log` private class for each class that is using the Logger, which contains all the methods and defined messages.
- Update all `Logger` methods' calls to use the `Log` methods for each impacted class.

## Testing
This image shows the CI pipeline successfully running after the changes.
![imagen](https://user-images.githubusercontent.com/62260472/156584317-04b6aee1-6f9a-4d51-acce-874955716025.png)