### PR TITLE
[#5276] Update code analysis to latest VS recommendations - Fix error rules - Part 2

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptiveRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.LUIS/LuisAdaptiveRecognizer.cs
@@ -174,9 +174,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
         /// </summary>
         /// <param name="recognizerResult">An instance of <see cref="RecognizerResult"/> to extract the telemetry properties from.</param>
         /// <param name="telemetryProperties">A collection of additional properties to be added to the returned dictionary of properties.</param>
-        /// <param name="dc">An instance of <see cref="DialogContext"/>.</param>
+        /// <param name="dialogContext">An instance of <see cref="DialogContext"/>.</param>
         /// <returns>The dictionary of properties to be logged with telemetry for the recongizer result.</returns>
-        protected override Dictionary<string, string> FillRecognizerResultTelemetryProperties(RecognizerResult recognizerResult, Dictionary<string, string> telemetryProperties, DialogContext dc)
+        protected override Dictionary<string, string> FillRecognizerResultTelemetryProperties(RecognizerResult recognizerResult, Dictionary<string, string> telemetryProperties, DialogContext dialogContext)
         {
             var logPersonalInfo = LogPersonalInformation;
             var applicationId = ApplicationId;
@@ -191,7 +191,7 @@ namespace Microsoft.Bot.Builder.AI.Luis
                 { LuisTelemetryConstants.IntentScoreProperty, topTwoIntents?[0].Value.Score?.ToString("N2", CultureInfo.InvariantCulture) ?? "0.00" },
                 { LuisTelemetryConstants.Intent2Property, (topTwoIntents?.Length > 1) ? topTwoIntents?[1].Key ?? string.Empty : string.Empty },
                 { LuisTelemetryConstants.IntentScore2Property, (topTwoIntents?.Length > 1) ? topTwoIntents?[1].Value.Score?.ToString("N2", CultureInfo.InvariantCulture) ?? "0.00" : "0.00" },
-                { LuisTelemetryConstants.FromIdProperty, dc.Context.Activity.From.Id },
+                { LuisTelemetryConstants.FromIdProperty, dialogContext.Context.Activity.From.Id },
             };
 
             if (recognizerResult.Properties.TryGetValue("sentiment", out var sentiment) && sentiment is JObject)
@@ -211,9 +211,9 @@ namespace Microsoft.Bot.Builder.AI.Luis
             properties.Add(LuisTelemetryConstants.EntitiesProperty, entities);
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example
-            if (logPersonalInfo && !string.IsNullOrEmpty(dc.Context.Activity.Text))
+            if (logPersonalInfo && !string.IsNullOrEmpty(dialogContext.Context.Activity.Text))
             {
-                properties.Add(LuisTelemetryConstants.QuestionProperty, dc.Context.Activity.Text);
+                properties.Add(LuisTelemetryConstants.QuestionProperty, dialogContext.Context.Activity.Text);
             }
 
             // Additional Properties can override "stock" properties.

--- a/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.Orchestrator/OrchestratorRecognizer.cs
@@ -121,13 +121,13 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
         /// <summary>
         /// Return recognition results.
         /// </summary>
-        /// <param name="dc">Context object containing information for a single turn of conversation with a user.</param>
+        /// <param name="dialogContext">Context object containing information for a single turn of conversation with a user.</param>
         /// <param name="activity">The incoming activity received from the user. The Text property value is used as the query text for QnA Maker.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the LuisResult event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the LuisResult event.</param>
         /// <returns>A <see cref="RecognizerResult"/> containing the QnA Maker result.</returns>
-        public override async Task<RecognizerResult> RecognizeAsync(DialogContext dc, Schema.Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
+        public override async Task<RecognizerResult> RecognizeAsync(DialogContext dialogContext, Schema.Activity activity, CancellationToken cancellationToken, Dictionary<string, string> telemetryProperties = null, Dictionary<string, double> telemetryMetrics = null)
         {
             if (_resolver == null)
             {
@@ -230,15 +230,15 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator
             if (ExternalEntityRecognizer != null)
             {
                 // Run external recognition
-                var externalResults = await ExternalEntityRecognizer.RecognizeAsync(dc, activity, cancellationToken, telemetryProperties, telemetryMetrics).ConfigureAwait(false);
+                var externalResults = await ExternalEntityRecognizer.RecognizeAsync(dialogContext, activity, cancellationToken, telemetryProperties, telemetryMetrics).ConfigureAwait(false);
                 recognizerResult.Entities.Merge(externalResults.Entities);
             }
 
             TryScoreEntities(text, recognizerResult);
 
             // Add full recognition result as a 'result' property
-            await dc.Context.TraceActivityAsync($"{nameof(OrchestratorRecognizer)}Result", JObject.FromObject(recognizerResult), nameof(OrchestratorRecognizer), "Orchestrator Recognition", cancellationToken).ConfigureAwait(false);
-            TrackRecognizerResult(dc, $"{nameof(OrchestratorRecognizer)}Result", FillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dc), telemetryMetrics);
+            await dialogContext.Context.TraceActivityAsync($"{nameof(OrchestratorRecognizer)}Result", JObject.FromObject(recognizerResult), nameof(OrchestratorRecognizer), "Orchestrator Recognition", cancellationToken).ConfigureAwait(false);
+            TrackRecognizerResult(dialogContext, $"{nameof(OrchestratorRecognizer)}Result", FillRecognizerResultTelemetryProperties(recognizerResult, telemetryProperties, dialogContext), telemetryMetrics);
 
             return recognizerResult;
         }

--- a/libraries/Microsoft.Bot.Builder.Testing/XUnit/TestDataObject.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/XUnit/TestDataObject.cs
@@ -45,19 +45,19 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
         /// <summary>
         /// Used by XUnit.net for deserialization.
         /// </summary>
-        /// <param name="serializationInfo">A parameter used by XUnit.net.</param>
-        public void Deserialize(IXunitSerializationInfo serializationInfo)
+        /// <param name="info">A parameter used by XUnit.net.</param>
+        public void Deserialize(IXunitSerializationInfo info)
         {
-            TestObject = serializationInfo.GetValue<string>(TestObjectKey);
+            TestObject = info.GetValue<string>(TestObjectKey);
         }
 
         /// <summary>
         /// Used by XUnit.net for serialization.
         /// </summary>
-        /// <param name="serializationInfo">A parameter used by XUnit.net.</param>
-        public void Serialize(IXunitSerializationInfo serializationInfo)
+        /// <param name="info">A parameter used by XUnit.net.</param>
+        public void Serialize(IXunitSerializationInfo info)
         {
-            serializationInfo.AddValue(TestObjectKey, TestObject);
+            info.AddValue(TestObjectKey, TestObject);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Testing/XUnit/XUnitDialogTestLogger.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/XUnit/XUnitDialogTestLogger.cs
@@ -48,20 +48,20 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
         /// <summary>
         /// Processes the incoming activity and logs it using the <see cref="ITestOutputHelper"/>.
         /// </summary>
-        /// <param name="context">The context object for this turn.</param>
-        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task OnTurnAsync(ITurnContext context, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken = default(CancellationToken))
         {
             var stopwatch = new Stopwatch();
             stopwatch.Start();
-            context.TurnState[_stopWatchStateKey] = stopwatch;
-            await LogIncomingActivityAsync(context, context.Activity, cancellationToken).ConfigureAwait(false);
-            context.OnSendActivities(OnSendActivitiesAsync);
+            turnContext.TurnState[_stopWatchStateKey] = stopwatch;
+            await LogIncomingActivityAsync(turnContext, turnContext.Activity, cancellationToken).ConfigureAwait(false);
+            turnContext.OnSendActivities(OnSendActivitiesAsync);
 
-            await next(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/AutoSaveStateMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/AutoSaveStateMiddleware.cs
@@ -62,14 +62,14 @@ namespace Microsoft.Bot.Builder
         /// on each state object.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>This middleware persists state after the bot logic completes and before the turn ends.</remarks>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await next(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
             await this.BotStateSet.SaveAllChangesAsync(turnContext, false, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs
@@ -138,11 +138,11 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <inheritdoc/>
-        public override Task ContinueConversationAsync(string botAppId, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
+        public override Task ContinueConversationAsync(string botId, ConversationReference reference, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             _ = reference ?? throw new ArgumentNullException(nameof(reference));
 
-            return ProcessProactiveAsync(CreateClaimsIdentity(botAppId), reference.GetContinuationActivity(), null, callback, cancellationToken);
+            return ProcessProactiveAsync(CreateClaimsIdentity(botId), reference.GetContinuationActivity(), null, callback, cancellationToken);
         }
 
         /// <inheritdoc/>
@@ -164,12 +164,12 @@ namespace Microsoft.Bot.Builder
         }
 
         /// <inheritdoc/>
-        public override Task ContinueConversationAsync(string botAppId, Activity continuationActivity, BotCallbackHandler callback, CancellationToken cancellationToken)
+        public override Task ContinueConversationAsync(string botId, Activity continuationActivity, BotCallbackHandler callback, CancellationToken cancellationToken)
         {
             _ = callback ?? throw new ArgumentNullException(nameof(callback));
             ValidateContinuationActivity(continuationActivity);
 
-            return ProcessProactiveAsync(CreateClaimsIdentity(botAppId), continuationActivity, null, callback, cancellationToken);
+            return ProcessProactiveAsync(CreateClaimsIdentity(botId), continuationActivity, null, callback, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/libraries/Microsoft.Bot.Builder/MiddlewareSet.cs
+++ b/libraries/Microsoft.Bot.Builder/MiddlewareSet.cs
@@ -32,14 +32,14 @@ namespace Microsoft.Bot.Builder
         /// Processes an incoming activity.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken)
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken)
         {
             await ReceiveActivityInternalAsync(turnContext, null, 0, cancellationToken).ConfigureAwait(false);
-            await next(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/NormalizeMentionsMiddleware.cs
@@ -43,13 +43,13 @@ namespace Microsoft.Bot.Builder
         /// Middleware implementation which corrects Enity.Mention.Text to a value RemoveMentionText can work with.
         /// </summary>
         /// <param name="turnContext">turn context.</param>
-        /// <param name="next">next middleware.</param>
+        /// <param name="nextDelegate">next middleware.</param>
         /// <param name="cancellationToken">cancellationToken.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken = default(CancellationToken))
         {
             NormalizeActivity(turnContext.Activity);
-            await next(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
         }
 
         private static string RemoveAt(string text)

--- a/libraries/Microsoft.Bot.Builder/RegisterClassMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/RegisterClassMiddleware.cs
@@ -47,13 +47,13 @@ namespace Microsoft.Bot.Builder
         /// Adds the associated object or service to the current turn context.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken)
         {
             // Register service
             if (this._key != null)
@@ -65,7 +65,7 @@ namespace Microsoft.Bot.Builder
                 turnContext.TurnState.Add(this.Service);
             }
 
-            await nextTurn(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SetSpeakMiddleware.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Bot.Builder
         /// Processes an incoming activity.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="IActivity"/>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken = default)
         {
             turnContext.OnSendActivities(async (ctx, activities, nextSend) =>
             {
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder
                 return await nextSend().ConfigureAwait(false);
             });
 
-            await next(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
         }
 
         private static bool HasTag(string tagName, string speakText)

--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Bot.Builder
         /// Processes an incoming activity.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// <param name="next">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken)
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken)
         {
             using (var cts = new CancellationTokenSource())
             {
@@ -70,7 +70,7 @@ namespace Microsoft.Bot.Builder
                         typingTask = SendTypingAsync(turnContext, _delay, _period, cts.Token);
                     }
 
-                    await next(cancellationToken).ConfigureAwait(false);
+                    await nextDelegate(cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsSSOTokenExchangeMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsSSOTokenExchangeMiddleware.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Bot.Builder.Teams
         }
 
         /// <inheritdoc/>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken = default)
         {
             if (string.Equals(Channels.Msteams, turnContext.Activity.ChannelId, StringComparison.OrdinalIgnoreCase) 
                 && string.Equals(SignInConstants.TokenExchangeOperationName, turnContext.Activity.Name, StringComparison.OrdinalIgnoreCase))
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Teams
                 }
             }
 
-            await next(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task SendInvokeResponseAsync(ITurnContext turnContext, object body = null, HttpStatusCode httpStatusCode = HttpStatusCode.OK, CancellationToken cancellationToken = default)

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -51,28 +51,28 @@ namespace Microsoft.Bot.Builder
         /// <summary>
         /// Logs events for incoming, outgoing, updated, or deleted message activities, using the <see cref="TelemetryClient"/>.
         /// </summary>
-        /// <param name="context">The context object for this turn.</param>
-        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public virtual async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken)
         {
-            BotAssert.ContextNotNull(context);
+            BotAssert.ContextNotNull(turnContext);
 
             // log incoming activity at beginning of turn
-            if (context.Activity != null)
+            if (turnContext.Activity != null)
             {
-                var activity = context.Activity;
+                var activity = turnContext.Activity;
 
                 // Log Bot Message Received
                 await OnReceiveActivityAsync(activity, cancellationToken).ConfigureAwait(false);
             }
 
             // hook up onSend pipeline
-            context.OnSendActivities(async (ctx, activities, nextSend) =>
+            turnContext.OnSendActivities(async (ctx, activities, nextSend) =>
             {
                 // run full pipeline
                 var responses = await nextSend().ConfigureAwait(false);
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder
             });
 
             // hook up update activity pipeline
-            context.OnUpdateActivity(async (ctx, activity, nextUpdate) =>
+            turnContext.OnUpdateActivity(async (ctx, activity, nextUpdate) =>
             {
                 // run full pipeline
                 var response = await nextUpdate().ConfigureAwait(false);
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder
             });
 
             // hook up delete activity pipeline
-            context.OnDeleteActivity(async (ctx, reference, nextDelete) =>
+            turnContext.OnDeleteActivity(async (ctx, reference, nextDelete) =>
             {
                 // run full pipeline
                 await nextDelete().ConfigureAwait(false);
@@ -113,9 +113,9 @@ namespace Microsoft.Bot.Builder
                 await OnDeleteActivityAsync((Activity)deleteActivity, cancellationToken).ConfigureAwait(false);
             });
 
-            if (nextTurn != null)
+            if (nextDelegate != null)
             {
-                await nextTurn(cancellationToken).ConfigureAwait(false);
+                await nextDelegate(cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Bot.Builder
         /// Records incoming and outgoing activities to the conversation store.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken)
         {
             var transcript = new Queue<IActivity>();
 
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Builder
             });
 
             // process bot logic
-            await nextTurn(cancellationToken).ConfigureAwait(false);
+            await nextDelegate(cancellationToken).ConfigureAwait(false);
 
             // flush transcript at end of turn
             // NOTE: We are not awaiting this task by design, TryLogTranscriptAsync() observes all exceptions and we don't need to or want to block execution on the completion.

--- a/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/EndorsementsRetriever.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Bot.Connector.Authentication
         /// </summary>
         /// <param name="address">Address of the discovery document.</param>
         /// <param name="retriever">The document retriever to use to read the discovery document.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// <param name="cancel">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the activities are successfully sent, the task result contains
         /// a populated configuration.</remarks>
-        public async Task<IDictionary<string, HashSet<string>>> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancellationToken)
+        public async Task<IDictionary<string, HashSet<string>>> GetConfigurationAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
         {
             if (address == null)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(retriever));
             }
 
-            var jsonDocument = await retriever.GetDocumentAsync(address, cancellationToken).ConfigureAwait(false);
+            var jsonDocument = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
             var configurationRoot = JObject.Parse(jsonDocument);
 
             var keys = configurationRoot["keys"]?.Value<JArray>();
@@ -109,19 +109,19 @@ namespace Microsoft.Bot.Connector.Authentication
         /// Obtains a document from an address.
         /// </summary>
         /// <param name="address">location of document.</param>
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// <param name="cancel">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <remarks>If the activities are successfully sent, the task result contains
         /// the document as a string.</remarks>
-        public async Task<string> GetDocumentAsync(string address, CancellationToken cancellationToken)
+        public async Task<string> GetDocumentAsync(string address, CancellationToken cancel)
         {
             if (address == null)
             {
                 throw new ArgumentNullException(nameof(address));
             }
 
-            using (var documentResponse = await _httpClient.GetAsync(address, cancellationToken).ConfigureAwait(false))
+            using (var documentResponse = await _httpClient.GetAsync(address, cancel).ConfigureAwait(false))
             {
                 if (!documentResponse.IsSuccessStatusCode)
                 {
@@ -143,7 +143,7 @@ namespace Microsoft.Bot.Connector.Authentication
                     return string.Empty;
                 }
 
-                using (var keysResponse = await _httpClient.GetAsync(keysUrl, cancellationToken).ConfigureAwait(false))
+                using (var keysResponse = await _httpClient.GetAsync(keysUrl, cancel).ConfigureAwait(false))
                 {
                     if (!keysResponse.IsSuccessStatusCode)
                     {

--- a/libraries/Microsoft.Bot.Connector/Authentication/PasswordServiceClientCredentialFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/PasswordServiceClientCredentialFactory.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Connector.Authentication
         }
 
         /// <inheritdoc/>
-        public override Task<ServiceClientCredentials> CreateCredentialsAsync(string appId, string oauthScope, string loginEndpoint, bool validateAuthority, CancellationToken cancellationToken)
+        public override Task<ServiceClientCredentials> CreateCredentialsAsync(string appId, string audience, string loginEndpoint, bool validateAuthority, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(AppId))
             {
@@ -96,17 +96,17 @@ namespace Microsoft.Bot.Connector.Authentication
             if (loginEndpoint.StartsWith(AuthenticationConstants.ToChannelFromBotLoginUrlTemplate, StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult<ServiceClientCredentials>(new MicrosoftAppCredentials(
-                    appId, Password, TenantId, _httpClient, _logger, oauthScope));
+                    appId, Password, TenantId, _httpClient, _logger, audience));
             }
             else if (loginEndpoint.Equals(GovernmentAuthenticationConstants.ToChannelFromBotLoginUrl, StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult<ServiceClientCredentials>(new MicrosoftGovernmentAppCredentials(
-                    appId, Password, TenantId, _httpClient, _logger, oauthScope));
+                    appId, Password, TenantId, _httpClient, _logger, audience));
             }
             else
             {
                 return Task.FromResult<ServiceClientCredentials>(new PrivateCloudAppCredentials(
-                    AppId, Password, TenantId, _httpClient, _logger, oauthScope, loginEndpoint, validateAuthority));
+                    AppId, Password, TenantId, _httpClient, _logger, audience, loginEndpoint, validateAuthority));
             }
         }
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetryInitializerMiddleware.cs
@@ -34,20 +34,20 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
         /// <summary>
         /// Stores the incoming activity as JSON in the items collection on the HttpContext.
         /// </summary>
-        /// <param name="context">The context object for this turn.</param>
-        /// <param name="nextTurn">The delegate to call to continue the bot middleware pipeline.</param>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="nextDelegate">The delegate to call to continue the bot middleware pipeline.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
         /// <seealso cref="ITurnContext"/>
         /// <seealso cref="Bot.Schema.IActivity"/>
-        public virtual async Task OnTurnAsync(ITurnContext context, NextDelegate nextTurn, CancellationToken cancellationToken)
+        public virtual async Task OnTurnAsync(ITurnContext turnContext, NextDelegate nextDelegate, CancellationToken cancellationToken)
         {
-            BotAssert.ContextNotNull(context);
+            BotAssert.ContextNotNull(turnContext);
 
-            if (context.Activity != null)
+            if (turnContext.Activity != null)
             {
-                var activity = context.Activity;
+                var activity = turnContext.Activity;
 
                 var httpContext = _httpContextAccessor.HttpContext;
                 var items = httpContext?.Items;
@@ -65,12 +65,12 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
             if (_logActivityTelemetry)
             {
                 await _telemetryLoggerMiddleware
-                    .OnTurnAsync(context, nextTurn, cancellationToken)
+                    .OnTurnAsync(turnContext, nextDelegate, cancellationToken)
                     .ConfigureAwait(false);
             }
             else
             {
-                await nextTurn(cancellationToken).ConfigureAwait(false);
+                await nextDelegate(cancellationToken).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Addresses #5276
#minor

> ### **IMPORTANT!**
> **Note:** These changes are being address as part of enabling the [.NET Analyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) library in the PR #6251.

## Description
This PR updates all the overridden and inherited methods parameters to match the base declaration.

List:
- CA1725

## Specific changes
- Updates all the overridden and inherited methods parameters that doesn't match the base declaration.

## Testing
This image shows the CI pipeline successfully running after the changes.
![imagen](https://user-images.githubusercontent.com/62260472/156584317-04b6aee1-6f9a-4d51-acce-874955716025.png)