### PR TITLE
[#5276] Update code analysis to latest VS recommendations - Fix error rules - Part 5

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 if (dc.ActiveDialog.State.TryGetValue(SuggestedQuestionsData, out object value))
                 {
                     var suggestedQuestions = value as List<string>; 
-                    if (suggestedQuestions != null && suggestedQuestions.Any(question => string.Compare(question, reply.Trim(), StringComparison.OrdinalIgnoreCase) == 0))
+                    if (suggestedQuestions != null && suggestedQuestions.Any(question => string.Equals(question, reply.Trim(), StringComparison.OrdinalIgnoreCase)))
                     {
                         // it matches one of the suggested actions, we like that.
                         return true;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Dialog.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// Called from constructors in derived classes to initialize the <see cref="Dialog"/> class.
         /// </summary>
         /// <param name="dialogId">The ID to assign to this dialog.</param>
-        public Dialog(string dialogId = null)
+        protected Dialog(string dialogId = null)
         {
             Id = dialogId;
             _telemetryClient = NullBotTelemetryClient.Instance;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// custom validation for this prompt.</param>
         /// <remarks>The value of <paramref name="dialogId"/> must be unique within the
         /// <see cref="DialogSet"/> or <see cref="ComponentDialog"/> to which the prompt is added.</remarks>
-        public Prompt(string dialogId, PromptValidator<T> validator = null)
+        protected Prompt(string dialogId, PromptValidator<T> validator = null)
             : base(dialogId)
         {
             if (string.IsNullOrWhiteSpace(dialogId))

--- a/libraries/Microsoft.Bot.Builder/BotAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotAdapter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Builder
         /// <summary>
         /// Initializes a new instance of the <see cref="BotAdapter"/> class.
         /// </summary>
-        public BotAdapter()
+        protected BotAdapter()
             : base()
         {
         }

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Builder
         /// <exception cref="ArgumentNullException"><paramref name="storage"/> or <paramref name="contextServiceKey"/>
         /// is <c>null</c>.</exception>
         /// <seealso cref="ITurnContext"/>
-        public BotState(IStorage storage, string contextServiceKey)
+        protected BotState(IStorage storage, string contextServiceKey)
         {
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _contextServiceKey = contextServiceKey ?? throw new ArgumentNullException(nameof(contextServiceKey));

--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Bot.Builder.Streaming
             }
             else
             {
-                throw new Exception($"Failed to send request through streaming transport. Status code: {serverResponse.StatusCode}.");
+                throw new InvalidOperationException($"Failed to send request through streaming transport. Status code: {serverResponse.StatusCode}.");
             }
         }
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/IStreamingTransportClient.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/IStreamingTransportClient.cs
@@ -10,13 +10,6 @@ using Microsoft.Bot.Connector.Streaming.Payloads;
 namespace Microsoft.Bot.Connector.Streaming.Application
 {
     /// <summary>
-    /// Delegate used to setup actions to be taken when disconnection events are triggered.
-    /// </summary>
-    /// <param name="sender">The source of the disconnection event.</param>
-    /// <param name="e">The arguments specified by the disconnection event.</param>
-    public delegate void DisconnectedEventHandler(object sender, DisconnectedEventArgs e);
-
-    /// <summary>
     /// Implemented by clients compatible with the Bot Framework Protocol 3 with Streaming Extensions.
     /// </summary>
     public interface IStreamingTransportClient : IDisposable
@@ -24,7 +17,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         /// <summary>
         /// An event used to signal when the underlying connection has disconnected.
         /// </summary>
-        event DisconnectedEventHandler Disconnected;
+        event EventHandler<DisconnectedEventArgs> Disconnected;
 
         /// <summary>
         /// Gets a value indicating whether this client is currently connected.

--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         }
 
         /// <inheritdoc />
-        public event DisconnectedEventHandler Disconnected;
+        public event EventHandler<DisconnectedEventArgs> Disconnected;
 
         /// <inheritdoc />
         public bool IsConnected { get; private set; } = false;

--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
@@ -300,19 +300,19 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         private static class Log
         {
             private static readonly Action<ILogger, string, Exception> _clientStarted = LoggerMessage.Define<string>(
-                LogLevel.Information, new EventId(1, nameof(ClientStarted)), "Streaming transport client connected to {string}.");
+                LogLevel.Information, new EventId(1, nameof(ClientStarted)), "Streaming transport client connected to {String}.");
 
             private static readonly Action<ILogger, string, Exception> _clientCompleted = LoggerMessage.Define<string>(
-                LogLevel.Information, new EventId(2, nameof(ClientKeepAliveSucceed)), "Streaming transport client connection to {string} closed.");
+                LogLevel.Information, new EventId(2, nameof(ClientKeepAliveSucceed)), "Streaming transport client connection to {String} closed.");
 
             private static readonly Action<ILogger, string, Exception> _clientKeepAliveSucceed = LoggerMessage.Define<string>(
-                LogLevel.Debug, new EventId(3, nameof(ClientStarted)), "Streaming transport client heartbeat to {string} succeeded.");
+                LogLevel.Debug, new EventId(3, nameof(ClientStarted)), "Streaming transport client heartbeat to {String} succeeded.");
 
             private static readonly Action<ILogger, string, int, Exception> _clientKeepAliveFail = LoggerMessage.Define<string, int>(
-                LogLevel.Error, new EventId(4, nameof(ClientKeepAliveFail)), "Streaming transport client heartbeat to {string} failed with status code {int}.");
+                LogLevel.Error, new EventId(4, nameof(ClientKeepAliveFail)), "Streaming transport client heartbeat to {String} failed with status code {Int32}.");
 
             private static readonly Action<ILogger, string, Exception> _clientTransportApplicationCompleted = LoggerMessage.Define<string>(
-                LogLevel.Debug, new EventId(5, nameof(ClientTransportApplicationCompleted)), "Streaming transport client heartbeat to {string} completed transport and application tasks.");
+                LogLevel.Debug, new EventId(5, nameof(ClientTransportApplicationCompleted)), "Streaming transport client heartbeat to {String} completed transport and application tasks.");
 
             public static void ClientStarted(ILogger logger, string url) => _clientStarted(logger, url ?? string.Empty, null);
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
@@ -501,10 +501,10 @@ namespace Microsoft.Bot.Connector.Streaming.Session
         private class Log
         {
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _orphanedStream =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(1, nameof(OrphanedStream)), "Stream has no associated payload. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(1, nameof(OrphanedStream)), "Stream has no associated payload. Header: ID {Guid} Type {Char} Payload length:{Int32}. End :{Boolean}.");
 
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _payloadReceived =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(2, nameof(PayloadReceived)), "Payload received in session. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}..");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(2, nameof(PayloadReceived)), "Payload received in session. Header: ID {Guid} Type {Char} Payload length:{Int32}. End :{Boolean}..");
 
             public static void OrphanedStream(ILogger logger, Header header) => _orphanedStream(logger, header.Id, header.Type, header.PayloadLength, header.End, null);
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
@@ -338,16 +338,16 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
         private static class Log
         {
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _payloadReceived =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(1, nameof(PayloadReceived)), "Payload received. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(1, nameof(PayloadReceived)), "Payload received. Header: ID {Guid} Type {Char} Payload length:{Int32}. End :{Boolean}.");
 
             private static readonly Action<ILogger, Exception> _readFrameFailed =
                 LoggerMessage.Define(LogLevel.Error, new EventId(2, nameof(ReadFrameFailed)), "Failed to read frame from transport.");
 
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _payloadSending =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(3, nameof(SendingPayload)), "Sending Payload. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(3, nameof(SendingPayload)), "Sending Payload. Header: ID {Guid} Type {Char} Payload length:{Int32}. End :{Boolean}.");
 
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _semaphoreTimeOut =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(4, nameof(SemaphoreTimeOut)), "Timed out trying to acquire write semaphore. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(4, nameof(SemaphoreTimeOut)), "Timed out trying to acquire write semaphore. Header: ID {Guid} Type {Char} Payload length:{Int32}. End :{Boolean}.");
 
             private static readonly Action<ILogger, Exception> _listenError =
                 LoggerMessage.Define(LogLevel.Error, new EventId(5, nameof(ListenError)), "TransportHandler encountered an error and will stop listening.");

--- a/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AdalAuthenticator.cs
@@ -269,9 +269,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 // with and without the semaphore (and different configs for the semaphore), not limiting concurrency actually
                 // results in higher response times overall. Without the use of this semaphore calls to AcquireTokenAsync can take up
                 // to 5 seconds under high concurrency scenarios.
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                acquired = tokenRefreshSemaphore.Wait(SemaphoreTimeout);
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+                acquired = await tokenRefreshSemaphore.WaitAsync(SemaphoreTimeout).ConfigureAwait(false);
 
                 // If we are allowed to enter the semaphore, acquire the token.
                 if (acquired)

--- a/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/AppCredentials.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="channelAuthTenant">Optional. The oauth token tenant.</param>
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
-        public AppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
+        protected AppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
             : this(channelAuthTenant, customHttpClient, logger, null)
         {
         }
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Connector.Authentication
         /// <param name="customHttpClient">Optional <see cref="HttpClient"/> to be used when acquiring tokens.</param>
         /// <param name="logger">Optional <see cref="ILogger"/> to gather telemetry data while acquiring and managing credentials.</param>
         /// <param name="oAuthScope">The scope for the token.</param>
-        public AppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null, string oAuthScope = null)
+        protected AppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null, string oAuthScope = null)
         {
             OAuthScope = string.IsNullOrWhiteSpace(oAuthScope) ? AuthenticationConstants.ToChannelFromBotOAuthScope : oAuthScope;
             ChannelAuthTenant = channelAuthTenant;

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -140,9 +140,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 // with and without the semaphore (and different configs for the semaphore), not limiting concurrency actually
                 // results in higher response times, more throttling and more contention. 
                 // Without the use of this semaphore calls to AcquireTokenAsync can take tens of seconds under high concurrency scenarios.
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-                acquired = tokenRefreshSemaphore.Wait(SemaphoreTimeout);
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
+                acquired = await tokenRefreshSemaphore.WaitAsync(SemaphoreTimeout).ConfigureAwait(false);
 
                 // If we are allowed to enter the semaphore, acquire the token.
                 if (acquired)

--- a/libraries/Microsoft.Bot.Schema/ActivityEx.cs
+++ b/libraries/Microsoft.Bot.Schema/ActivityEx.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Bot.Schema
         /// <seealso cref="Mention"/>
         public Mention[] GetMentions()
         {
-            return Entities?.Where(entity => string.Compare(entity.Type, "mention", StringComparison.OrdinalIgnoreCase) == 0)
+            return Entities?.Where(entity => string.Equals(entity.Type, "mention", StringComparison.OrdinalIgnoreCase))
                 .Select(e => e.Properties.ToObject<Mention>()).ToArray() ?? Array.Empty<Mention>();
         }
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/TelemetrySaveBodyASPMiddleware.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Bot.Builder.Integration.ApplicationInsights.Core
 
             if (request.Method == "POST"
                 && !string.IsNullOrEmpty(request.ContentType)
-                && request.ContentType.StartsWith("application/json"))
+                && request.ContentType.StartsWith("application/json", StringComparison.Ordinal))
             {
                 var items = httpContext.Items;
                 request.EnableBuffering();

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ChannelServiceExceptionFilterAttribute.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/ChannelServiceExceptionFilterAttribute.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 {
     [AttributeUsage(AttributeTargets.Class)]
-    internal class ChannelServiceExceptionFilterAttribute : Attribute, IExceptionFilter
+    internal sealed class ChannelServiceExceptionFilterAttribute : Attribute, IExceptionFilter
     {
         public void OnException(ExceptionContext context)
         {

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 }
             }
 
-            throw new ApplicationException($"No streaming connection found for activity: {activity}");
+            throw new InvalidOperationException($"No streaming connection found for activity: {activity}");
         }
 
         /// <summary>

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             Assert.Null(validContinuation.Exception);
             Assert.True(invalidContinuation.IsFaulted);
             Assert.NotEmpty(invalidContinuation.Exception.InnerExceptions);
-            Assert.True(invalidContinuation.Exception.InnerExceptions[0] is ApplicationException);
+            Assert.True(invalidContinuation.Exception.InnerExceptions[0] is InvalidOperationException);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses #5276
#minor

> ### **IMPORTANT!**
> **Note:** These changes are being address as part of enabling the [.NET Analyzers](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) library in the PR #6251.

## Description
This PR updates and fixes multiple rule errors.

List:
- CA1003
- CA1012
- CA1310
- CA1727
- CA1813
- CA1849
- CA2201
- CA2251

## Specific changes
- Replaces event handlers to use the generic `EventHandler` type, instead of creating a custom one.
- Replaces constructor `public` to `private` access for abstract classes.
- Adds the `StringComparison.Ordinal` when doing a string comparison.
- Updates `LoggerMessage.Define` template string to use `PascalCase` placeholders.
- Added `sealed` modifier to `Attribute` classes.
- Updated methods to be called as `async`, when called from an `async` method.
- Updated exceptions to be specific, instead of a generic `Exception`, `ApplicationException`, etc.
- Updated the use of `String.Compare` to `String.Equals` instead.

## Testing
This image shows the CI pipeline successfully running after the changes.
![imagen](https://user-images.githubusercontent.com/62260472/156584317-04b6aee1-6f9a-4d51-acce-874955716025.png)