### PR TITLE
[#6100] Remove unnecessary partial classes - Schema classes (1/2)

### DIFF
--- a/libraries/Microsoft.Bot.Schema/AadResourceUrls.cs
+++ b/libraries/Microsoft.Bot.Schema/AadResourceUrls.cs
@@ -3,24 +3,14 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Schema of the target resource for which the Bot Framework Token Service would exchange a cached token for a user. This class applies only to AAD V1 connections.
     /// </summary>
-    public partial class AadResourceUrls
+    public class AadResourceUrls
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AadResourceUrls"/> class.
-        /// </summary>
-        public AadResourceUrls()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AadResourceUrls"/> class.
         /// </summary>
@@ -28,7 +18,6 @@ namespace Microsoft.Bot.Schema
         public AadResourceUrls(IList<string> resourceUrls = default)
         {
             ResourceUrls = resourceUrls ?? new List<string>();
-            CustomInit();
         }
 
         /// <summary>
@@ -37,10 +26,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The URLs to the resources you want to connect to.</value>
         [JsonProperty(PropertyName = "resourceUrls")]
         public IList<string> ResourceUrls { get; private set; } = new List<string>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/AttachmentData.cs
+++ b/libraries/Microsoft.Bot.Schema/AttachmentData.cs
@@ -7,14 +7,8 @@ namespace Microsoft.Bot.Schema
     using Newtonsoft.Json;
 
     /// <summary> Attachment data. </summary>
-    public partial class AttachmentData
+    public class AttachmentData
     {
-        /// <summary>Initializes a new instance of the <see cref="AttachmentData"/> class.</summary>
-        public AttachmentData()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="AttachmentData"/> class.</summary>
         /// <param name="type">Content-Type of the attachment.</param>
         /// <param name="name">Name of the attachment.</param>
@@ -24,9 +18,16 @@ namespace Microsoft.Bot.Schema
         {
             Type = type;
             Name = name;
-            OriginalBase64 = new Collection<byte>(originalBase64);
-            ThumbnailBase64 = new Collection<byte>(thumbnailBase64);
-            CustomInit();
+
+            if (originalBase64 != null)
+            {
+                OriginalBase64 = new Collection<byte>(originalBase64);
+            }
+
+            if (thumbnailBase64 != null)
+            {
+                ThumbnailBase64 = new Collection<byte>(thumbnailBase64);
+            }
         }
 
         /// <summary>Gets or sets content-type of the attachment.</summary>
@@ -42,14 +43,11 @@ namespace Microsoft.Bot.Schema
         /// <summary>Gets attachment content.</summary>
         /// <value>The attachment content.</value>
         [JsonProperty(PropertyName = "originalBase64")]
-        public Collection<byte> OriginalBase64 { get; private set; }
+        public Collection<byte> OriginalBase64 { get; private set; } = new Collection<byte>();
 
         /// <summary>Gets attachment thumbnail.</summary>
         /// <value>The attachment thumbnail.</value>
         [JsonProperty(PropertyName = "thumbnailBase64")]
-        public Collection<byte> ThumbnailBase64 { get; private set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
+        public Collection<byte> ThumbnailBase64 { get; private set; } = new Collection<byte>();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/AttachmentInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/AttachmentInfo.cs
@@ -7,14 +7,8 @@ namespace Microsoft.Bot.Schema
     using Newtonsoft.Json;
 
     /// <summary>Metadata for an attachment.</summary>
-    public partial class AttachmentInfo
+    public class AttachmentInfo
     {
-        /// <summary>Initializes a new instance of the <see cref="AttachmentInfo"/> class.</summary>
-        public AttachmentInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="AttachmentInfo"/> class.</summary>
         /// <param name="name">Name of the attachment.</param>
         /// <param name="type">ContentType of the attachment.</param>
@@ -24,7 +18,6 @@ namespace Microsoft.Bot.Schema
             Name = name;
             Type = type;
             Views = views ?? new List<AttachmentView>();
-            CustomInit();
         }
 
         /// <summary>Gets or sets name of the attachment.</summary>
@@ -41,8 +34,5 @@ namespace Microsoft.Bot.Schema
         /// <value> The attachment views.</value>
         [JsonProperty(PropertyName = "views")]
         public IList<AttachmentView> Views { get; private set; } = new List<AttachmentView>();
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/AttachmentView.cs
+++ b/libraries/Microsoft.Bot.Schema/AttachmentView.cs
@@ -8,14 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Attachment View name and size.
     /// </summary>
-    public partial class AttachmentView
+    public class AttachmentView
     {
-        /// <summary>Initializes a new instance of the <see cref="AttachmentView"/> class.</summary>
-        public AttachmentView()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="AttachmentView"/> class.</summary>
         /// <param name="viewId">Id of the attachment.</param>
         /// <param name="size">Size of the attachment.</param>
@@ -23,7 +17,6 @@ namespace Microsoft.Bot.Schema
         {
             ViewId = viewId;
             Size = size;
-            CustomInit();
         }
 
         /// <summary>
@@ -39,8 +32,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The size of the attachment.</value>
         [JsonProperty(PropertyName = "size")]
         public int? Size { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Error.cs
+++ b/libraries/Microsoft.Bot.Schema/Error.cs
@@ -3,22 +3,15 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Object representing error information.
     /// </summary>
 #pragma warning disable CA1716 // Identifiers should not match keywords (Cannot change without breaking backwards compatibility.)
-    public partial class Error
+    public class Error
 #pragma warning restore CA1716 // Identifiers should not match keywords
     {
-        /// <summary>Initializes a new instance of the <see cref="Error"/> class.</summary>
-        public Error()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="Error"/> class.</summary>
         /// <param name="code">Error code.</param>
         /// <param name="message">Error message.</param>
@@ -28,7 +21,6 @@ namespace Microsoft.Bot.Schema
             Code = code;
             Message = message;
             InnerHttpError = innerHttpError;
-            CustomInit();
         }
 
         /// <summary>Gets or sets error code.</summary>
@@ -45,8 +37,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The error from the inner HTTP call.</value>
         [JsonProperty(PropertyName = "innerHttpError")]
         public InnerHttpError InnerHttpError { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ErrorResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/ErrorResponse.cs
@@ -8,20 +8,13 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// An HTTP API response.
     /// </summary>
-    public partial class ErrorResponse
+    public class ErrorResponse
     {
-        /// <summary>Initializes a new instance of the <see cref="ErrorResponse"/> class.</summary>
-        public ErrorResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="ErrorResponse"/> class.</summary>
         /// <param name="error">Error message.</param>
         public ErrorResponse(Error error = default)
         {
             Error = error;
-            CustomInit();
         }
 
         /// <summary>
@@ -30,8 +23,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The error.</value>
         [JsonProperty(PropertyName = "error")]
         public Error Error { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ExpectedReplies.cs
+++ b/libraries/Microsoft.Bot.Schema/ExpectedReplies.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Replies in response to <see cref="DeliveryModes.ExpectReplies"/>.
     /// </summary>
-    public partial class ExpectedReplies
+    public class ExpectedReplies
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExpectedReplies"/> class.
-        /// </summary>
-        public ExpectedReplies()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ExpectedReplies"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema
         public ExpectedReplies(IList<Activity> activities = default)
         {
             Activities = activities ?? new List<Activity>();
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +27,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The collection of activities that conforms to the ExpectedREplies schema.</value>
         [JsonProperty(PropertyName = "activities")]
         public IList<Activity> Activities { get; private set; } = new List<Activity>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Fact.cs
+++ b/libraries/Microsoft.Bot.Schema/Fact.cs
@@ -11,16 +11,8 @@ namespace Microsoft.Bot.Schema
     /// rendered with default style information with some delimiter between
     /// them. So there is no need for developer to specify style information.
     /// </summary>
-    public partial class Fact
+    public class Fact
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Fact"/> class.
-        /// </summary>
-        public Fact()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Fact"/> class.
         /// </summary>
@@ -30,7 +22,6 @@ namespace Microsoft.Bot.Schema
         {
             Key = key;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -46,10 +37,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The value for this Fact.</value>
         [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/InnerHttpError.cs
+++ b/libraries/Microsoft.Bot.Schema/InnerHttpError.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Object representing inner http error.
     /// </summary>
-    public partial class InnerHttpError
+    public class InnerHttpError
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InnerHttpError"/> class.
-        /// </summary>
-        public InnerHttpError()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InnerHttpError"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema
         {
             StatusCode = statusCode;
             Body = body;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The body from failed request.</value>
         [JsonProperty(PropertyName = "body")]
         public object Body { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/MediaEventValue.cs
+++ b/libraries/Microsoft.Bot.Schema/MediaEventValue.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Supplementary parameter for media events.
     /// </summary>
-    public partial class MediaEventValue
+    public class MediaEventValue
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MediaEventValue"/> class.
-        /// </summary>
-        public MediaEventValue()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaEventValue"/> class.
         /// </summary>
@@ -26,7 +18,6 @@ namespace Microsoft.Bot.Schema
         public MediaEventValue(object cardValue = default)
         {
             CardValue = cardValue;
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +27,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The callback parameter specifid in the Value field of the MediaCard that originated this event.</value>
         [JsonProperty(PropertyName = "cardValue")]
         public object CardValue { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/MediaUrl.cs
+++ b/libraries/Microsoft.Bot.Schema/MediaUrl.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Media URL.
     /// </summary>
-    public partial class MediaUrl
+    public class MediaUrl
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MediaUrl"/> class.
-        /// </summary>
-        public MediaUrl()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MediaUrl"/> class.
         /// </summary>
@@ -28,7 +20,6 @@ namespace Microsoft.Bot.Schema
         {
             Url = url;
             Profile = profile;
-            CustomInit();
         }
 
         /// <summary>
@@ -47,10 +38,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The profile hint.</value>
         [JsonProperty(PropertyName = "profile")]
         public string Profile { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/MessageReaction.cs
+++ b/libraries/Microsoft.Bot.Schema/MessageReaction.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Message reaction object.
     /// </summary>
-    public partial class MessageReaction
+    public class MessageReaction
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageReaction"/> class.
-        /// </summary>
-        public MessageReaction()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageReaction"/> class.
         /// </summary>
@@ -26,7 +18,6 @@ namespace Microsoft.Bot.Schema
         public MessageReaction(string type = default)
         {
             Type = type;
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +27,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The message reaction type.</value>
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PagedMembersResult.cs
+++ b/libraries/Microsoft.Bot.Schema/PagedMembersResult.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Page of members.
     /// </summary>
-    public partial class PagedMembersResult
+    public class PagedMembersResult
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PagedMembersResult"/> class.
-        /// </summary>
-        public PagedMembersResult()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PagedMembersResult"/> class.
         /// </summary>
@@ -28,7 +20,6 @@ namespace Microsoft.Bot.Schema
         {
             ContinuationToken = continuationToken;
             Members = members ?? new List<ChannelAccount>();
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +35,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The Channel Accounts.</value>
         [JsonProperty(PropertyName = "members")]
         public IList<ChannelAccount> Members { get; private set; } = new List<ChannelAccount>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentAddress.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentAddress.cs
@@ -11,16 +11,8 @@ namespace Microsoft.Bot.Schema
     /// Address within a Payment Request.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentAddress
+    public class PaymentAddress
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentAddress"/> class.
-        /// </summary>
-        public PaymentAddress()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentAddress"/> class.
         /// </summary>
@@ -64,7 +56,6 @@ namespace Microsoft.Bot.Schema
             Organization = organization;
             Recipient = recipient;
             Phone = phone;
-            CustomInit();
         }
 
         /// <summary>
@@ -157,10 +148,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The phone number of the recipient or contact person.</value>
         [JsonProperty(PropertyName = "phone")]
         public string Phone { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentCurrencyAmount.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentCurrencyAmount.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// Supplies monetary amounts.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentCurrencyAmount
+    public class PaymentCurrencyAmount
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentCurrencyAmount"/> class.
-        /// </summary>
-        public PaymentCurrencyAmount()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentCurrencyAmount"/> class.
         /// </summary>
@@ -31,7 +23,6 @@ namespace Microsoft.Bot.Schema
             Currency = currency;
             Value = value;
             CurrencySystem = currencySystem;
-            CustomInit();
         }
 
         /// <summary>
@@ -54,10 +45,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The currency system.</value>
         [JsonProperty(PropertyName = "currencySystem")]
         public string CurrencySystem { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentDetails.cs
@@ -11,16 +11,8 @@ namespace Microsoft.Bot.Schema
     /// Provides information about the requested transaction.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentDetails
+    public class PaymentDetails
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentDetails"/> class.
-        /// </summary>
-        public PaymentDetails()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentDetails"/> class.
         /// </summary>
@@ -40,7 +32,6 @@ namespace Microsoft.Bot.Schema
             ShippingOptions = shippingOptions ?? new List<PaymentShippingOption>();
             Modifiers = modifiers ?? new List<PaymentDetailsModifier>();
             Error = error;
-            CustomInit();
         }
 
         /// <summary>
@@ -80,10 +71,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The error description.</value>
         [JsonProperty(PropertyName = "error")]
         public string Error { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentDetailsModifier.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentDetailsModifier.cs
@@ -12,16 +12,8 @@ namespace Microsoft.Bot.Schema
     /// identifier.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentDetailsModifier
+    public class PaymentDetailsModifier
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentDetailsModifier"/> class.
-        /// </summary>
-        public PaymentDetailsModifier()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentDetailsModifier"/> class.
         /// </summary>
@@ -43,7 +35,6 @@ namespace Microsoft.Bot.Schema
             Total = total;
             AdditionalDisplayItems = additionalDisplayItems ?? new List<PaymentItem>();
             Data = data;
-            CustomInit();
         }
 
         /// <summary>
@@ -78,10 +69,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The JSON-serializable object that provides optional information.</value>
         [JsonProperty(PropertyName = "data")]
         public object Data { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentItem.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentItem.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// Indicates what the payment request is for and the value asked for.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentItem
+    public class PaymentItem
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentItem"/> class.
-        /// </summary>
-        public PaymentItem()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentItem"/> class.
         /// </summary>
@@ -32,7 +24,6 @@ namespace Microsoft.Bot.Schema
             Label = label;
             Amount = amount;
             Pending = pending;
-            CustomInit();
         }
 
         /// <summary>
@@ -56,10 +47,5 @@ namespace Microsoft.Bot.Schema
         /// <value>A boolean indicating that amount in field is pending (i.e. not final).</value>
         [JsonProperty(PropertyName = "pending")]
         public bool? Pending { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentMethodData.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentMethodData.cs
@@ -12,16 +12,8 @@ namespace Microsoft.Bot.Schema
     /// method specific data for those methods.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentMethodData
+    public class PaymentMethodData
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentMethodData"/> class.
-        /// </summary>
-        public PaymentMethodData()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentMethodData"/> class.
         /// </summary>
@@ -35,7 +27,6 @@ namespace Microsoft.Bot.Schema
         {
             SupportedMethods = supportedMethods ?? new List<string>();
             Data = data;
-            CustomInit();
         }
 
         /// <summary>
@@ -53,10 +44,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The JSON-serializable data object that provides optional information.</value>
         [JsonProperty(PropertyName = "data")]
         public object Data { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentOptions.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentOptions.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// Provides information about the options desired for the payment request.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentOptions
+    public class PaymentOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentOptions"/> class.
-        /// </summary>
-        public PaymentOptions()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentOptions"/> class.
         /// </summary>
@@ -46,7 +38,6 @@ namespace Microsoft.Bot.Schema
             RequestPayerPhone = requestPayerPhone;
             RequestShipping = requestShipping;
             ShippingType = shippingType;
-            CustomInit();
         }
 
         /// <summary>
@@ -89,10 +80,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The shipping type.</value>
         [JsonProperty(PropertyName = "shippingType")]
         public string ShippingType { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentRequestComplete.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentRequestComplete.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// Payload delivered when completing a payment request.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentRequestComplete
+    public class PaymentRequestComplete
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentRequestComplete"/> class.
-        /// </summary>
-        public PaymentRequestComplete()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentRequestComplete"/> class.
         /// </summary>
@@ -32,7 +24,6 @@ namespace Microsoft.Bot.Schema
             Id = id;
             PaymentRequest = paymentRequest;
             PaymentResponse = paymentResponse;
-            CustomInit();
         }
 
         /// <summary>
@@ -55,10 +46,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The payment reesponse.</value>
         [JsonProperty(PropertyName = "paymentResponse")]
         public PaymentResponse PaymentResponse { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentRequestCompleteResult.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentRequestCompleteResult.cs
@@ -10,17 +10,8 @@ namespace Microsoft.Bot.Schema
     /// Result from a completed payment request.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentRequestCompleteResult
+    public class PaymentRequestCompleteResult
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentRequestCompleteResult"/> class.
-        /// class.
-        /// </summary>
-        public PaymentRequestCompleteResult()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentRequestCompleteResult"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema
         public PaymentRequestCompleteResult(string result = default)
         {
             Result = result;
-            CustomInit();
         }
 
         /// <summary>
@@ -37,10 +27,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The result of the payment request completion.</value>
         [JsonProperty(PropertyName = "result")]
         public string Result { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentRequestUpdate.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentRequestUpdate.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// An update to a payment request.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentRequestUpdate
+    public class PaymentRequestUpdate
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentRequestUpdate"/> class.
-        /// </summary>
-        public PaymentRequestUpdate()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentRequestUpdate"/> class.
         /// </summary>
@@ -33,7 +25,6 @@ namespace Microsoft.Bot.Schema
             Details = details;
             ShippingAddress = shippingAddress;
             ShippingOption = shippingOption;
-            CustomInit();
         }
 
         /// <summary>
@@ -63,10 +54,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The updated shipping options.</value>
         [JsonProperty(PropertyName = "shippingOption")]
         public string ShippingOption { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentRequestUpdateResult.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentRequestUpdateResult.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// A result object from a Payment Request Update invoke operation.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentRequestUpdateResult
+    public class PaymentRequestUpdateResult
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentRequestUpdateResult"/> class.
-        /// </summary>
-        public PaymentRequestUpdateResult()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentRequestUpdateResult"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema
         public PaymentRequestUpdateResult(PaymentDetails details = default)
         {
             Details = details;
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +27,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The update payment details.</value>
         [JsonProperty(PropertyName = "details")]
         public PaymentDetails Details { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentResponse.cs
@@ -11,16 +11,8 @@ namespace Microsoft.Bot.Schema
     /// and approved a payment request.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentResponse
+    public class PaymentResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentResponse"/> class.
-        /// </summary>
-        public PaymentResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentResponse"/> class.
         /// </summary>
@@ -54,7 +46,6 @@ namespace Microsoft.Bot.Schema
             ShippingOption = shippingOption;
             PayerEmail = payerEmail;
             PayerPhone = payerPhone;
-            CustomInit();
         }
 
         /// <summary>
@@ -111,10 +102,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The payer phone number chosen by the user.</value>
         [JsonProperty(PropertyName = "payerPhone")]
         public string PayerPhone { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/PaymentShippingOption.cs
+++ b/libraries/Microsoft.Bot.Schema/PaymentShippingOption.cs
@@ -10,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// Describes a shipping option.
     /// </summary>
     [Obsolete("Bot Framework no longer supports payments.")]
-    public partial class PaymentShippingOption
+    public class PaymentShippingOption
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PaymentShippingOption"/> class.
-        /// </summary>
-        public PaymentShippingOption()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentShippingOption"/> class.
         /// </summary>
@@ -36,7 +28,6 @@ namespace Microsoft.Bot.Schema
             Label = label;
             Amount = amount;
             Selected = selected;
-            CustomInit();
         }
 
         /// <summary>
@@ -67,10 +58,5 @@ namespace Microsoft.Bot.Schema
         /// <value>Boolean indivating if this is the default selected <see cref="PaymentShippingOption"/>.</value>
         [JsonProperty(PropertyName = "selected")]
         public bool? Selected { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }


### PR DESCRIPTION
Addresses #6100
#minor

## Description
This PR removes the `partial` modifier from classes with only one definition in **_Microsoft.Bot.Schema_**.

## Specific Changes
  - Removed the `partial` modifier from classes with only one definition.
  - Removed partial method `CustomInit` and the constructor that was using it.
  - Removed unnecessary using statements.
  - Added null validation for constructor's parameters in **_AttachmentData_** class.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/156618795-ba85f68b-70d8-4e82-8f7a-cab3057db9bb.png)