### PR TITLE
[#6100] Remove unnecessary partial classes - Schema classes (2/2)

### DIFF
--- a/libraries/Microsoft.Bot.Schema/ConversationMembers.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationMembers.cs
@@ -3,22 +3,14 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Conversation and its members.
     /// </summary>
-    public partial class ConversationMembers
+    public class ConversationMembers
     {
-        /// <summary>Initializes a new instance of the <see cref="ConversationMembers"/> class.</summary>
-        public ConversationMembers()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="ConversationMembers"/> class.</summary>
         /// <param name="id">Conversation ID.</param>
         /// <param name="members">List of members in this conversation.</param>
@@ -26,7 +18,6 @@ namespace Microsoft.Bot.Schema
         {
             Id = id;
             Members = members ?? new List<ChannelAccount>();
-            CustomInit();
         }
 
         /// <summary>Gets or sets conversation ID.</summary>
@@ -38,8 +29,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The members in the conversation.</value>
         [JsonProperty(PropertyName = "members")]
         public IList<ChannelAccount> Members { get; private set; } = new List<ChannelAccount>();
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ConversationParameters.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationParameters.cs
@@ -7,14 +7,8 @@ namespace Microsoft.Bot.Schema
     using Newtonsoft.Json;
 
     /// <summary>Parameters for creating a new conversation.</summary>
-    public partial class ConversationParameters
+    public class ConversationParameters
     {
-        /// <summary>Initializes a new instance of the <see cref="ConversationParameters"/> class.</summary>
-        public ConversationParameters()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="ConversationParameters"/> class.</summary>
         /// <param name="isGroup">IsGroup.</param>
         /// <param name="bot">The bot address for this conversation.</param>
@@ -32,7 +26,6 @@ namespace Microsoft.Bot.Schema
             Activity = activity;
             ChannelData = channelData;
             TenantId = tenantId;
-            CustomInit();
         }
 
         /// <summary>Gets or sets isGroup.</summary>
@@ -69,8 +62,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The tenant ID.</value>
         [JsonProperty(PropertyName = "tenantId")]
         public string TenantId { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ConversationResourceResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationResourceResponse.cs
@@ -3,18 +3,11 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>A response containing a resource.</summary>
-    public partial class ConversationResourceResponse
+    public class ConversationResourceResponse
     {
-        /// <summary>Initializes a new instance of the <see cref="ConversationResourceResponse"/> class.</summary>
-        public ConversationResourceResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="ConversationResourceResponse"/> class.</summary>
         /// <param name="activityId">ID of the Activity (if sent).</param>
         /// <param name="serviceUrl">Service endpoint where operations concerning the conversation may be performed.</param>
@@ -24,7 +17,6 @@ namespace Microsoft.Bot.Schema
             ActivityId = activityId;
             ServiceUrl = serviceUrl;
             Id = id;
-            CustomInit();
         }
 
         /// <summary>Gets or sets ID of the Activity (if sent).</summary>
@@ -43,8 +35,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The resource ID.</value>
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ConversationsResult.cs
+++ b/libraries/Microsoft.Bot.Schema/ConversationsResult.cs
@@ -11,14 +11,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Conversations result.
     /// </summary>
-    public partial class ConversationsResult
+    public class ConversationsResult
     {
-        /// <summary>Initializes a new instance of the <see cref="ConversationsResult"/> class.</summary>
-        public ConversationsResult()
-        {
-            CustomInit();
-        }
-
         /// <summary>Initializes a new instance of the <see cref="ConversationsResult"/> class.</summary>
         /// <param name="continuationToken">Paging token.</param>
         /// <param name="conversations">List of conversations.</param>
@@ -26,7 +20,6 @@ namespace Microsoft.Bot.Schema
         {
             ContinuationToken = continuationToken;
             Conversations = conversations ?? new List<ConversationMembers>();
-            CustomInit();
         }
 
         /// <summary>Gets or sets paging token.</summary>
@@ -38,8 +31,5 @@ namespace Microsoft.Bot.Schema
         /// <value>A list of conversations.</value>
         [JsonProperty(PropertyName = "conversations")]
         public IList<ConversationMembers> Conversations { get; private set; } = new List<ConversationMembers>();
-
-        /// <summary>An initialization method that performs custom operations like setting defaults.</summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ReceiptItem.cs
+++ b/libraries/Microsoft.Bot.Schema/ReceiptItem.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// An item on a receipt card.
     /// </summary>
-    public partial class ReceiptItem
+    public class ReceiptItem
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReceiptItem"/> class.
-        /// </summary>
-        public ReceiptItem()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ReceiptItem"/> class.
         /// </summary>
@@ -41,7 +32,6 @@ namespace Microsoft.Bot.Schema
             Price = price;
             Quantity = quantity;
             Tap = tap;
-            CustomInit();
         }
 
         /// <summary>
@@ -95,10 +85,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The action that will activate when the user taps on the Item bubble.</value>
         [JsonProperty(PropertyName = "tap")]
         public CardAction Tap { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ResourceResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/ResourceResponse.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// A response containing a resource ID.
     /// </summary>
-    public partial class ResourceResponse
+    public class ResourceResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ResourceResponse"/> class.
-        /// </summary>
-        public ResourceResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceResponse"/> class.
         /// </summary>
@@ -26,7 +17,6 @@ namespace Microsoft.Bot.Schema
         public ResourceResponse(string id = default)
         {
             Id = id;
-            CustomInit();
         }
 
         /// <summary>
@@ -35,10 +25,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The ID of the resource.</value>
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/SemanticAction.cs
+++ b/libraries/Microsoft.Bot.Schema/SemanticAction.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Represents a reference to a programmatic action.
     /// </summary>
-    public partial class SemanticAction
+    public class SemanticAction
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SemanticAction"/> class.
-        /// </summary>
-        public SemanticAction()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SemanticAction"/> class.
         /// </summary>
@@ -28,7 +20,6 @@ namespace Microsoft.Bot.Schema
         {
             Id = id;
             Entities = entities ?? new Dictionary<string, Entity>();
-            CustomInit();
         }
 
         /// <summary>
@@ -52,10 +43,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The state of this action.</value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/SignInResource.cs
+++ b/libraries/Microsoft.Bot.Schema/SignInResource.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// A type containing information for single sign-on.
     /// </summary>
-    public partial class SignInResource
+    public class SignInResource
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SignInResource"/> class.
-        /// </summary>
-        public SignInResource()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SignInResource"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema
         {
             SignInLink = signInLink;
             TokenExchangeResource = tokenExchangeResource;
-            CustomInit();
         }
 
         /// <summary>
@@ -43,10 +34,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The additional properties can be used for token exchange operations.</value>
         [JsonProperty(PropertyName = "tokenExchangeResource")]
         public TokenExchangeResource TokenExchangeResource { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TextHighlight.cs
+++ b/libraries/Microsoft.Bot.Schema/TextHighlight.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Refers to a substring of content within another field.
     /// </summary>
-    public partial class TextHighlight
+    public class TextHighlight
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TextHighlight"/> class.
-        /// </summary>
-        public TextHighlight()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TextHighlight"/> class.
         /// </summary>
@@ -29,7 +20,6 @@ namespace Microsoft.Bot.Schema
         {
             Text = text;
             Occurrence = occurrence;
-            CustomInit();
         }
 
         /// <summary>
@@ -46,10 +36,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The number of occurrences of the text field within the referenced text.</value>
         [JsonProperty(PropertyName = "occurrence")]
         public int? Occurrence { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Thing.cs
+++ b/libraries/Microsoft.Bot.Schema/Thing.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Thing (entity type: "https://schema.org/Thing").
     /// </summary>
-    public partial class Thing
+    public class Thing
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Thing"/> class.
-        /// </summary>
-        public Thing()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Thing"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema
         {
             Type = type;
             Name = name;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The name of the thing.</value>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/ThumbnailUrl.cs
+++ b/libraries/Microsoft.Bot.Schema/ThumbnailUrl.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Thumbnail URL.
     /// </summary>
-    public partial class ThumbnailUrl
+    public class ThumbnailUrl
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThumbnailUrl"/> class.
-        /// </summary>
-        public ThumbnailUrl()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ThumbnailUrl"/> class.
         /// </summary>
@@ -30,7 +21,6 @@ namespace Microsoft.Bot.Schema
         {
             Url = url;
             Alt = alt;
-            CustomInit();
         }
 
         /// <summary>
@@ -48,10 +38,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The HTML alt text to include on this thumbnail image.</value>
         [JsonProperty(PropertyName = "alt")]
         public string Alt { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenExchangeRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenExchangeRequest.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Bot.Schema
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -11,16 +10,8 @@ namespace Microsoft.Bot.Schema
     /// If the URI is set to a custom scope, then Token Service will exchange the token in its cache for a token targeting the custom scope and return it in the response.
     /// If a Token is sent in the payload, then Token Service will exchange the token for a token targetting the scopes specified in the corresponding OAauth connection.
     /// </summary>
-    public partial class TokenExchangeRequest
+    public class TokenExchangeRequest
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TokenExchangeRequest"/> class.
-        /// </summary>
-        public TokenExchangeRequest()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenExchangeRequest"/> class.
         /// </summary>
@@ -30,7 +21,6 @@ namespace Microsoft.Bot.Schema
         {
             Uri = uri;
             Token = token;
-            CustomInit();
         }
 
         /// <summary>
@@ -48,10 +38,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The token.</value>
         [JsonProperty(PropertyName = "token")]
         public string Token { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenExchangeResource.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenExchangeResource.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Response schema sent back from Bot Framework Token Service required to initiate a user single sign on.
     /// </summary>
-    public partial class TokenExchangeResource
+    public class TokenExchangeResource
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TokenExchangeResource"/> class.
-        /// </summary>
-        public TokenExchangeResource()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenExchangeResource"/> class.
         /// </summary>
@@ -29,7 +21,6 @@ namespace Microsoft.Bot.Schema
             Id = id;
             Uri = uri;
             ProviderId = providerId;
-            CustomInit();
         }
 
         /// <summary>
@@ -55,10 +46,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The ID of the provider with which to attempt a tocken exchange.</value>
         [JsonProperty(PropertyName = "providerId")]
         public string ProviderId { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenRequest.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// A request to receive a user token.
     /// </summary>
-    public partial class TokenRequest
+    public class TokenRequest
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TokenRequest"/> class.
-        /// </summary>
-        public TokenRequest()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenRequest"/> class.
         /// </summary>
@@ -30,7 +22,6 @@ namespace Microsoft.Bot.Schema
         {
             Provider = provider;
             Settings = settings ?? new Dictionary<string, object>();
-            CustomInit();
         }
 
         /// <summary>
@@ -47,10 +38,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The collection of settings for the specific provider for this request.</value>
         [JsonProperty(PropertyName = "settings")]
         public IDictionary<string, object> Settings { get; private set; } = new Dictionary<string, object>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenResponse.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Response schema sent back from Bot Framework Token Service, in response to a request to get or exchange a token for a user.
     /// </summary>
-    public partial class TokenResponse
+    public class TokenResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TokenResponse"/> class.
-        /// </summary>
-        public TokenResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenResponse"/> class.
         /// </summary>
@@ -34,7 +26,6 @@ namespace Microsoft.Bot.Schema
             Token = token;
             Expiration = expiration;
             Properties = properties;
-            CustomInit();
         }
 
         /// <summary>
@@ -71,10 +62,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The extra properties.</value>
         [JsonExtensionData(ReadData = true, WriteData = true)]
         public JObject Properties { get; private set; } = new JObject();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/TokenStatus.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenStatus.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// The status of a particular token.
     /// </summary>
-    public partial class TokenStatus
+    public class TokenStatus
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TokenStatus"/> class.
-        /// </summary>
-        public TokenStatus()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TokenStatus"/> class.
         /// </summary>
@@ -35,7 +27,6 @@ namespace Microsoft.Bot.Schema
             ConnectionName = connectionName;
             HasToken = hasToken;
             ServiceProviderDisplayName = serviceProviderDisplayName;
-            CustomInit();
         }
 
         /// <summary>
@@ -67,10 +58,5 @@ namespace Microsoft.Bot.Schema
         /// <value>The display name of the service provider for which this Token belongs to.</value>
         [JsonProperty(PropertyName = "serviceProviderDisplayName")]
         public string ServiceProviderDisplayName { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Transcript.cs
+++ b/libraries/Microsoft.Bot.Schema/Transcript.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema
     /// <summary>
     /// Transcript.
     /// </summary>
-    public partial class Transcript
+    public class Transcript
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Transcript"/> class.
-        /// </summary>
-        public Transcript()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Transcript"/> class.
         /// </summary>
@@ -27,7 +19,6 @@ namespace Microsoft.Bot.Schema
         public Transcript(IList<Activity> activities = default)
         {
             Activities = activities ?? new List<Activity>();
-            CustomInit();
         }
 
         /// <summary>
@@ -37,10 +28,5 @@ namespace Microsoft.Bot.Schema
         /// <value>A collection of activities that conforms to the Transcript schema.</value>
         [JsonProperty(PropertyName = "activities")]
         public IList<Activity> Activities { get; private set; } = new List<Activity>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }


### PR DESCRIPTION
Addresses #6100
#minor

## Description
This PR removes the `partial` modifier from classes with only one definition in **_Microsoft.Bot.Schema_**.

## Specific Changes
  - Removed the `partial` modifier from classes with only one definition.
  - Removed partial method `CustomInit` and the constructor that was using it.
  - Removed unnecessary using statements.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/156618795-ba85f68b-70d8-4e82-8f7a-cab3057db9bb.png)