### PR TITLE
[#6100] Remove unnecessary partial classes - Schema/Teams classes (2/2)

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Teams/NotificationInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/NotificationInfo.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Specifies if a notification is to be sent for the mentions.
     /// </summary>
-    public partial class NotificationInfo
+    public class NotificationInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NotificationInfo"/> class.
-        /// </summary>
-        public NotificationInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationInfo"/> class.
         /// </summary>
@@ -27,7 +18,6 @@ namespace Microsoft.Bot.Schema.Teams
         public NotificationInfo(bool? alert = default)
         {
             Alert = alert;
-            CustomInit();
         }
 
         /// <summary>
@@ -54,10 +44,5 @@ namespace Microsoft.Bot.Schema.Teams
 #pragma warning disable CA1056 // Uri properties should not be strings
         public string ExternalResourceUrl { get; set; }
 #pragma warning restore CA1056 // Uri properties should not be strings
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionBase.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// O365 connector card action base.
     /// </summary>
-    public partial class O365ConnectorCardActionBase
+    public class O365ConnectorCardActionBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardActionBase"/> class.
-        /// </summary>
-        public O365ConnectorCardActionBase()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardActionBase"/> class.
         /// </summary>
@@ -31,7 +23,6 @@ namespace Microsoft.Bot.Schema.Teams
             Type = type;
             Name = name;
             Id = id;
-            CustomInit();
         }
 
         /// <summary>
@@ -55,10 +46,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The action ID.</value>
         [JsonProperty(PropertyName = "@id")]
         public string Id { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardActionQuery.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// O365 connector card HttpPOST invoke query.
     /// </summary>
-    public partial class O365ConnectorCardActionQuery
+    public class O365ConnectorCardActionQuery
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardActionQuery"/> class.
-        /// </summary>
-        public O365ConnectorCardActionQuery()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardActionQuery"/> class.
         /// </summary>
@@ -30,7 +22,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Body = body;
             ActionId = actionId;
-            CustomInit();
         }
 
         /// <summary>
@@ -48,10 +39,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The action ID associated with the HttpPOST action button triggered.</value>
         [JsonProperty(PropertyName = "actionId")]
         public string ActionId { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardFact.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardFact.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// O365 connector card fact.
     /// </summary>
-    public partial class O365ConnectorCardFact
+    public class O365ConnectorCardFact
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardFact"/> class.
-        /// </summary>
-        public O365ConnectorCardFact()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardFact"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Name = name;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The display value for the fact.</value>
         [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardImage.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardImage.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// O365 connector card image.
     /// </summary>
-    public partial class O365ConnectorCardImage
+    public class O365ConnectorCardImage
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardImage"/> class.
-        /// </summary>
-        public O365ConnectorCardImage()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardImage"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Image = image;
             Title = title;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The alternative text for the image.</value>
         [JsonProperty(PropertyName = "title")]
         public string Title { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInputChoice.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardMultichoiceInputChoice.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// O365O365 connector card multiple choice input item.
     /// </summary>
-    public partial class O365ConnectorCardMultichoiceInputChoice
+    public class O365ConnectorCardMultichoiceInputChoice
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardMultichoiceInputChoice"/> class.
-        /// </summary>
-        public O365ConnectorCardMultichoiceInputChoice()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardMultichoiceInputChoice"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Display = display;
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -44,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The value received as results.</value>
         [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUriTarget.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardOpenUriTarget.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// O365 connector card OpenUri target.
     /// </summary>
-    public partial class O365ConnectorCardOpenUriTarget
+    public class O365ConnectorCardOpenUriTarget
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardOpenUriTarget"/> class.
-        /// </summary>
-        public O365ConnectorCardOpenUriTarget()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardOpenUriTarget"/> class.
         /// </summary>
@@ -29,7 +20,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Os = os;
             Uri = uri;
-            CustomInit();
         }
 
         /// <summary>
@@ -48,10 +38,5 @@ namespace Microsoft.Bot.Schema.Teams
 #pragma warning disable CA1056 // Uri properties should not be strings
         public string Uri { get; set; }
 #pragma warning restore CA1056 // Uri properties should not be strings
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardSection.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/O365ConnectorCardSection.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// O365 connector card section.
     /// </summary>
-    public partial class O365ConnectorCardSection
+    public class O365ConnectorCardSection
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="O365ConnectorCardSection"/> class.
-        /// </summary>
-        public O365ConnectorCardSection()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="O365ConnectorCardSection"/> class.
         /// </summary>
@@ -46,7 +38,6 @@ namespace Microsoft.Bot.Schema.Teams
             Facts = facts ?? new List<O365ConnectorCardFact>();
             Images = images ?? new List<O365ConnectorCardImage>();
             PotentialAction = potentialAction ?? new List<O365ConnectorCardActionBase>();
-            CustomInit();
         }
 
         /// <summary>
@@ -127,10 +118,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The actions for the current section.</value>
         [JsonProperty(PropertyName = "potentialAction")]
         public IList<O365ConnectorCardActionBase> PotentialAction { get; private set; } = new List<O365ConnectorCardActionBase>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/SigninStateVerificationQuery.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/SigninStateVerificationQuery.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Signin state (part of signin action auth flow) verification invoke query.
     /// </summary>
-    public partial class SigninStateVerificationQuery
+    public class SigninStateVerificationQuery
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SigninStateVerificationQuery"/> class.
-        /// </summary>
-        public SigninStateVerificationQuery()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SigninStateVerificationQuery"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         public SigninStateVerificationQuery(string state = default)
         {
             State = state;
-            CustomInit();
         }
 
         /// <summary>
@@ -39,10 +29,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The state.</value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabContext.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabContext.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Current tab request context, i.e., the current theme.
     /// </summary>
-    public partial class TabContext
+    public class TabContext
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabContext"/> class.
-        /// </summary>
-        public TabContext()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets the current user's theme.
         /// </summary>
@@ -26,10 +18,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "theme")]
         public string Theme { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabEntityContext.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabEntityContext.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Current TabRequest entity context, or 'tabEntityId'.
     /// </summary>
-    public partial class TabEntityContext
+    public class TabEntityContext
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabEntityContext"/> class.
-        /// </summary>
-        public TabEntityContext()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets the entity id of the tab.
         /// </summary>
@@ -26,10 +18,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "tabEntityId")]
         public string TabEntityId { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabRequest.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Invoke ('tab/fetch') request value payload.
     /// </summary>
-    public partial class TabRequest
+    public class TabRequest
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabRequest"/> class.
-        /// </summary>
-        public TabRequest()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets current tab entity request context.
         /// </summary>
@@ -44,10 +36,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "state")]
         public string State { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabResponse.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Envelope for Card Tab Response Payload.
     /// </summary>
-    public partial class TabResponse
+    public class TabResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabResponse"/> class.
-        /// </summary>
-        public TabResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets the response to the tab/fetch message.
         /// Possible values for the tab type include: 'continue', 'auth' or 'silentAuth'.
@@ -27,10 +19,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "tab")]
         public TabResponsePayload Tab { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabResponseCard.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabResponseCard.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Envelope for cards for a Tab request.
     /// </summary>
-    public partial class TabResponseCard
+    public class TabResponseCard
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabResponseCard"/> class.
-        /// </summary>
-        public TabResponseCard()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets adaptive card for this card tab response.
         /// </summary>
@@ -26,10 +18,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "card")]
         public object Card { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabResponseCards.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabResponseCards.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Envelope for cards for a <see cref="TabResponse"/>.
     /// </summary>
-    public partial class TabResponseCards
+    public class TabResponseCards
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabResponseCards"/> class.
-        /// </summary>
-        public TabResponseCards()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets adaptive cards for this card tab response.
         /// </summary>
@@ -27,10 +19,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "cards")]
         public IList<TabResponseCard> Cards { get; private set; } = new List<TabResponseCard>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabResponsePayload.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabResponsePayload.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Payload for Tab Response.
     /// </summary>
-    public partial class TabResponsePayload
+    public class TabResponsePayload
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabResponsePayload"/> class.
-        /// </summary>
-        public TabResponsePayload()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets choice of action options when responding to the
         /// tab/fetch message. Possible values include: 'continue', 'auth' or 'silentAuth'.
@@ -46,10 +38,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "suggestedActions")]
         public TabSuggestedActions SuggestedActions { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabSubmit.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabSubmit.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Invoke ('tab/submit') request value payload.
     /// </summary>
-    public partial class TabSubmit
+    public class TabSubmit
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabSubmit"/> class.
-        /// </summary>
-        public TabSubmit()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets current tab entity request context.
         /// </summary>
@@ -44,10 +36,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "data")]
         public TabSubmitData Data { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabSubmitData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabSubmitData.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Invoke ('tab/submit') request value payload data.
     /// </summary>
-    public partial class TabSubmitData
+    public class TabSubmitData
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabSubmitData"/> class.
-        /// </summary>
-        public TabSubmitData()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets or sets the type for this TabSubmitData.
         /// </summary>
@@ -38,10 +30,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// will be written to a JSON object when the instance is serialized.</remarks>
         [JsonExtensionData(ReadData = true, WriteData = true)]
         public JObject Properties { get; private set; } = new JObject();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TabSuggestedActions.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TabSuggestedActions.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Tab SuggestedActions (Only when type is 'auth' or 'silentAuth').
     /// </summary>
-    public partial class TabSuggestedActions
+    public class TabSuggestedActions
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TabSuggestedActions"/> class.
-        /// </summary>
-        public TabSuggestedActions()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Gets actions for a card tab response.
         /// </summary>
@@ -27,10 +19,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "actions")]
         public IList<CardAction> Actions { get; private set; } = new List<CardAction>();
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleCardResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleCardResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Tab Response to 'task/submit' from a tab.
     /// </summary>
-    public partial class TaskModuleCardResponse : TaskModuleResponseBase
+    public class TaskModuleCardResponse : TaskModuleResponseBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleCardResponse"/> class.
@@ -16,7 +16,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleCardResponse()
             : base("continue")
         {
-            CustomInit();
         }
 
         /// <summary>
@@ -27,7 +26,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base("continue")
         {
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -38,10 +36,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "value")]
         public TabResponse Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleContinueResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleContinueResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Task Module Response with continue action.
     /// </summary>
-    public partial class TaskModuleContinueResponse : TaskModuleResponseBase
+    public class TaskModuleContinueResponse : TaskModuleResponseBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleContinueResponse"/> class.
@@ -16,7 +16,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleContinueResponse()
             : base("continue")
         {
-            CustomInit();
         }
 
         /// <summary>
@@ -27,7 +26,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base("continue")
         {
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +34,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The JSON for the adaptive card to appear in the task module.</value>
         [JsonProperty(PropertyName = "value")]
         public TaskModuleTaskInfo Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleMessageResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleMessageResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Task Module response with message action.
     /// </summary>
-    public partial class TaskModuleMessageResponse : TaskModuleResponseBase
+    public class TaskModuleMessageResponse : TaskModuleResponseBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleMessageResponse"/> class.
@@ -16,7 +16,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleMessageResponse()
             : base("message")
         {
-            CustomInit();
         }
 
         /// <summary>
@@ -27,7 +26,6 @@ namespace Microsoft.Bot.Schema.Teams
             : base("message")
         {
             Value = value;
-            CustomInit();
         }
 
         /// <summary>
@@ -37,10 +35,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The value Teams will display in a pop-up message box.</value>
         [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequest.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequest.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Task module invoke request value payload.
     /// </summary>
-    public partial class TaskModuleRequest
+    public class TaskModuleRequest
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TaskModuleRequest"/> class.
-        /// </summary>
-        public TaskModuleRequest()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleRequest"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Data = data;
             Context = context;
-            CustomInit();
         }
 
         /// <summary>
@@ -53,10 +43,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "tabContext")]
         public TabEntityContext TabEntityContext { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequestContext.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleRequestContext.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Current user context, i.e., the current theme.
     /// </summary>
-    public partial class TaskModuleRequestContext
+    public class TaskModuleRequestContext
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TaskModuleRequestContext"/> class.
-        /// </summary>
-        public TaskModuleRequestContext()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleRequestContext"/> class.
         /// </summary>
@@ -26,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleRequestContext(string theme = default)
         {
             Theme = theme;
-            CustomInit();
         }
 
         /// <summary>
@@ -35,10 +25,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The theme.</value>
         [JsonProperty(PropertyName = "theme")]
         public string Theme { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponse.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Envelope for Task Module Response.
     /// </summary>
-    public partial class TaskModuleResponse
+    public class TaskModuleResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TaskModuleResponse"/> class.
-        /// </summary>
-        public TaskModuleResponse()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleResponse"/> class.
         /// </summary>
@@ -26,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleResponse(TaskModuleResponseBase task = default)
         {
             Task = task;
-            CustomInit();
         }
 
         /// <summary>
@@ -43,10 +33,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The CacheInfo for this <see cref="TaskModuleResponse"/>.</value>
         [JsonProperty(PropertyName = "cacheInfo")]
         public CacheInfo CacheInfo { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponseBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleResponseBase.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Base class for Task Module responses.
     /// </summary>
-    public partial class TaskModuleResponseBase
+    public class TaskModuleResponseBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TaskModuleResponseBase"/> class.
-        /// </summary>
-        public TaskModuleResponseBase()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleResponseBase"/> class.
         /// </summary>
@@ -26,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TaskModuleResponseBase(string type = default)
         {
             Type = type;
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +26,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The choice of action options when responding to the task/submit message.</value>
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TaskModuleTaskInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TaskModuleTaskInfo.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Metadata for a Task Module.
     /// </summary>
-    public partial class TaskModuleTaskInfo
+    public class TaskModuleTaskInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TaskModuleTaskInfo"/> class.
-        /// </summary>
-        public TaskModuleTaskInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TaskModuleTaskInfo"/> class.
         /// </summary>
@@ -39,7 +30,6 @@ namespace Microsoft.Bot.Schema.Teams
             Card = card;
             FallbackUrl = fallbackUrl;
             CompletionBotId = completionBotId;
-            CustomInit();
         }
 
         /// <summary>
@@ -102,10 +92,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The completion bot ID.</value>
         [JsonProperty(PropertyName = "completionBotId")]
         public string CompletionBotId { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamDetails.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamDetails.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Details related to a team.
     /// </summary>
-    public partial class TeamDetails
+    public class TeamDetails
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamDetails"/> class.
-        /// </summary>
-        public TeamDetails()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamDetails"/> class.
         /// </summary>
@@ -31,7 +23,6 @@ namespace Microsoft.Bot.Schema.Teams
             Id = id;
             Name = name;
             AadGroupId = aadGroupId;
-            CustomInit();
         }
 
         /// <summary>
@@ -78,10 +69,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "memberCount")]
         public int MemberCount { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamInfo.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Describes a team.
     /// </summary>
-    public partial class TeamInfo
+    public class TeamInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamInfo"/> class.
-        /// </summary>
-        public TeamInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamInfo"/> class.
         /// </summary>
@@ -28,7 +19,6 @@ namespace Microsoft.Bot.Schema.Teams
         {
             Id = id;
             Name = name;
-            CustomInit();
         }
 
         /// <summary>
@@ -51,10 +41,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The Azure Active Directory Teams group ID.</value>
         [JsonProperty(PropertyName = "aadGroupId")]
         public string AadGroupId { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsChannelData.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Channel data specific to messages received in Microsoft Teams.
     /// </summary>
-    public partial class TeamsChannelData
+    public class TeamsChannelData
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamsChannelData"/> class.
-        /// </summary>
-        public TeamsChannelData()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsChannelData"/> class.
         /// </summary>
@@ -34,7 +26,6 @@ namespace Microsoft.Bot.Schema.Teams
             Team = team;
             Notification = notification;
             Tenant = tenant;
-            CustomInit();
         }
 
         /// <summary>
@@ -82,10 +73,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The information about the meeting.</value>
         [JsonProperty(PropertyName = "meeting")]
         public TeamsMeetingInfo Meeting { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingInfo.cs
@@ -8,16 +8,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Describes a Teams Meeting.
     /// </summary>
-    public partial class TeamsMeetingInfo
+    public class TeamsMeetingInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamsMeetingInfo"/> class.
-        /// </summary>
-        public TeamsMeetingInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsMeetingInfo"/> class.
         /// </summary>
@@ -25,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TeamsMeetingInfo(string id = default)
         {
             Id = id;
-            CustomInit();
         }
 
         /// <summary>
@@ -36,10 +27,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingParticipant.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingParticipant.cs
@@ -8,14 +8,13 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Teams meeting participant information, detailing user Azure Active Directory and meeting participant details.
     /// </summary>
-    public partial class TeamsMeetingParticipant
+    public class TeamsMeetingParticipant
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsMeetingParticipant"/> class.
         /// </summary>
         public TeamsMeetingParticipant()
         {
-            CustomInit();
         }
 
         /// <summary>
@@ -29,7 +28,6 @@ namespace Microsoft.Bot.Schema.Teams
             User = user;
             Meeting = meeting;
             Conversation = conversation;
-            CustomInit();
         }
 
         /// <summary>
@@ -58,10 +56,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "conversation")]
         public ConversationAccount Conversation { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsParticipantChannelAccount.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsParticipantChannelAccount.cs
@@ -9,16 +9,8 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Teams participant channel account detailing user Azure Active Directory and meeting participant details.
     /// </summary>
-    public partial class TeamsParticipantChannelAccount : TeamsChannelAccount
+    public class TeamsParticipantChannelAccount : TeamsChannelAccount
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TeamsParticipantChannelAccount"/> class.
-        /// </summary>
-        public TeamsParticipantChannelAccount()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamsParticipantChannelAccount"/> class.
         /// </summary>
@@ -40,7 +32,6 @@ namespace Microsoft.Bot.Schema.Teams
             MeetingRole = meetingRole;
             InMeeting = inMeeting;
             Conversation = conversation;
-            CustomInit();
         }
         
         /// <summary>
@@ -69,10 +60,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "conversation")]
         public ConversationAccount Conversation { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/TenantInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TenantInfo.cs
@@ -3,22 +3,13 @@
 
 namespace Microsoft.Bot.Schema.Teams
 {
-    using System.Linq;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Describes a tenant.
     /// </summary>
-    public partial class TenantInfo
+    public class TenantInfo
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TenantInfo"/> class.
-        /// </summary>
-        public TenantInfo()
-        {
-            CustomInit();
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TenantInfo"/> class.
         /// </summary>
@@ -26,7 +17,6 @@ namespace Microsoft.Bot.Schema.Teams
         public TenantInfo(string id = default)
         {
             Id = id;
-            CustomInit();
         }
 
         /// <summary>
@@ -35,10 +25,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The ID representing a tenant.</value>
         [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
-
-        /// <summary>
-        /// An initialization method that performs custom operations like setting defaults.
-        /// </summary>
-        partial void CustomInit();
     }
 }


### PR DESCRIPTION
Addresses #6100
#minor

## Description
This PR removes the `partial` modifier from classes with only one definition in **_Microsoft.Bot.Schema/Teams_**.

## Specific Changes
  - Removed the `partial` modifier from classes with only one definition.
  - Removed partial method `CustomInit` and the constructor that was using it.
  - Removed unnecessary using statements.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/156618795-ba85f68b-70d8-4e82-8f7a-cab3057db9bb.png)