### PR TITLE
Fix PR validation builds against forks no. 2

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -39,6 +39,14 @@ steps:
   inputs:
     projects: Microsoft.Bot.Builder.sln
     arguments: ' --source $(SDK_Dotnet_V4_org_Url)'
+  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build for forks'
+  inputs:
+    projects: Microsoft.Bot.Builder.sln
+    arguments: ' --source https://api.nuget.org/v3/index.json'
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -2,7 +2,7 @@
 # Resolve from nuget.org when PR is from a fork, as forks do not have access to our private feed.
 steps:
 - powershell: |
-    if ($(System.PullRequest.IsFork) -eq 'True') {
+    if ("$(System.PullRequest.IsFork)" -eq 'True') {
       $key = "nuget.org";
       $value = "https://api.nuget.org/v3/index.json";
     }

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -1,7 +1,16 @@
 # Create nuget.config for resolving dependencies exclusively from SDK_Dotnet_V4_org feed.
-# Skip this if PR is from a fork, as forks do not have access to our private feed.
+# Resolve from nuget.org when PR is from a fork, as forks do not have access to our private feed.
 steps:
 - powershell: |
+    if ($(System.PullRequest.IsFork) -eq 'True') {
+      $key = "nuget.org";
+      $value = "https://api.nuget.org/v3/index.json";
+    }
+    else {
+      $key = "SDK_Dotnet_V4_org";
+      $value = "$(SDK_Dotnet_V4_org_Url)";
+    }
+
     $file = "$(Build.SourcesDirectory)\nuget.config";
 
     $content = @"
@@ -9,7 +18,7 @@ steps:
     <configuration>
       <packageSources>
         <clear />
-        <add key="SDK_Dotnet_V4_org" value="$(SDK_Dotnet_V4_org_Url)" />
+        <add key="$key" value="$value" />
       </packageSources>
       <activePackageSource>
         <add key="All" value="(Aggregate source)" />
@@ -21,4 +30,3 @@ steps:
     New-Item -Path $file -ItemType "file" -Value $content -Force;
     '-------------'; get-content "$file"; '===================';
   displayName: Create nuget.config for SDK_Dotnet_V4_org feed
-  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))


### PR DESCRIPTION
Fixes #minor

This fixes a regression from PR #6227.

The nuget restore task fails when a nuget.config file is not created. So instead of skipping nuget.config creation for forks, this now points sources to nuget.org for forks.

Also fixes mac PR builds against forks.