### PR TITLE
Bug fix: multi-choice options can now be logged in App Insights

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -218,6 +218,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             return AppendChoices(prompt.AsMessageActivity(), channelId, options.Choices, Style.GetValue(dc.State), choiceOptions);
         }
 
+        /// <inheritdoc/>
+        protected override void TrackGeneratorResultEvent(DialogContext dc, ITemplate<Activity> activityTemplate, IMessageActivity msg)
+        {
+            var options = dc.State.GetValue<ChoiceInputOptions>(ThisPath.Options);
+            var serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
+            var properties = new Dictionary<string, string>()
+            {
+                { "template", JsonConvert.SerializeObject(activityTemplate) },
+                { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, serializationSettings) },
+                { "choices", options.Choices == null ? string.Empty : JsonConvert.SerializeObject(options.Choices, serializationSettings) },
+                { "context", TelemetryLoggerConstants.InputDialogResultEvent }
+            };
+            TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);
+        }
+
         private async Task<ChoiceSet> GetChoiceSetAsync(DialogContext dc)
         {
             if (Choices.ExpressionText != null && Choices.ExpressionText.TrimStart().StartsWith("${", StringComparison.InvariantCultureIgnoreCase))

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -487,15 +487,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 msg.InputHint = InputHints.ExpectingInput;
             }
 
+            TrackGeneratorResultEvent(dc, template, msg);
+
+            return msg;
+        }
+
+        /// <summary>
+        /// Track GeneratorResultEvent telemetry event with InputDialogResultEvent context.
+        /// </summary>
+        /// <param name="dc">Current <see cref="DialogContext"/>.</param>
+        /// <param name="activityTemplate"><see cref="ITemplate{T}"/> used to create the Activity.</param>
+        /// <param name="msg">The <see cref="IMessageActivity"/> which will be sent.</param>
+        protected virtual void TrackGeneratorResultEvent(DialogContext dc, ITemplate<Activity> activityTemplate, IMessageActivity msg)
+        {
             var properties = new Dictionary<string, string>()
             {
-                { "template", JsonConvert.SerializeObject(template) },
+                { "template", JsonConvert.SerializeObject(activityTemplate) },
                 { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
                 { "context", TelemetryLoggerConstants.InputDialogResultEvent }
             };
             TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);
-
-            return msg;
         }
 
         private async Task<InputState> RecognizeInputAsync(DialogContext dc, int turnCount, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Fixed multi-choice prompt options bug not being logged by Application Insights. 

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Created a virtual method in [/InputDialog.cs](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs) base class and override in [/ChoiceInput.cs](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs) to return the missing data.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->

Before
<img src="https://i.gyazo.com/16f98d089b4c578d95a12fd30b37ef6a.png" width="500"/>

After (choices are logged)
<img src="https://i.gyazo.com/a8ad90a6f7d4f982bc31d2c8aaf4ba85.png" width="500"/>