### PR TITLE
Improved fork handling in CI pipeline

### DIFF
--- a/build/yaml/ci-post-to-github-steps.yml
+++ b/build/yaml/ci-post-to-github-steps.yml
@@ -13,7 +13,8 @@ steps:
     userToken: '$(GitHubCommentApiKey)'
     bodyFilePath: '$(System.ArtifactsDirectory)\ApiCompat'
     getSubFolders: true
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+  # Skip forks, as they can't get credentials.
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - powershell: |
    # Check for string in the logs in the current DevOps pipeline run.

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -56,7 +56,7 @@ steps:
    dotnet nuget remove source SDK_Dotnet_V4_org
   displayName: Remove SDK_Dotnet_V4_org feed source reference from nuget.config
   continueOnError: true
-  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 2.1, required for Upload Coverage Files task'

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -63,7 +63,7 @@ steps:
   inputs:
     packageType: sdk
     version: 2.1.x
-  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: PowerShell@2
   displayName: 'Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
@@ -72,7 +72,8 @@ steps:
     filePath: '$(Build.SourcesDirectory)\build\PublishToCoveralls.ps1'
     arguments: '-pathToCoverageFiles "$(Build.SourcesDirectory)\CodeCoverage" -serviceName "CI-PR build"'
   continueOnError: true
-  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'))
+  # Skip for forks because it errors: "Couldn't find a repository matching this job."
+  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - powershell: |
    New-Item -ItemType directory -Path "outputLibraries\" -Force

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -5,6 +5,7 @@ steps:
     if ("$(System.PullRequest.IsFork)" -eq 'True') {
       $key = "nuget.org";
       $value = "https://api.nuget.org/v3/index.json";
+      Write-Host 'System.PullRequest.IsFork = True';
     }
     else {
       $key = "SDK_Dotnet_V4_org";

--- a/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
+++ b/build/yaml/sdk_dotnet_v4_org-feed-setup-steps.yml
@@ -1,7 +1,16 @@
 # Create nuget.config for resolving dependencies exclusively from SDK_Dotnet_V4_org feed.
-# Skip this if PR is from a fork, as forks do not have access to our private feed.
+# Resolve from nuget.org when PR is from a fork, as forks do not have access to our private feed.
 steps:
 - powershell: |
+    if ($(System.PullRequest.IsFork) -eq 'True') {
+      $key = "nuget.org";
+      $value = "https://api.nuget.org/v3/index.json";
+    }
+    else {
+      $key = "SDK_Dotnet_V4_org";
+      $value = "$(SDK_Dotnet_V4_org_Url)";
+    }
+
     $file = "$(Build.SourcesDirectory)\nuget.config";
 
     $content = @"
@@ -9,7 +18,7 @@ steps:
     <configuration>
       <packageSources>
         <clear />
-        <add key="SDK_Dotnet_V4_org" value="$(SDK_Dotnet_V4_org_Url)" />
+        <add key="$key" value="$value" />
       </packageSources>
       <activePackageSource>
         <add key="All" value="(Aggregate source)" />
@@ -21,4 +30,3 @@ steps:
     New-Item -Path $file -ItemType "file" -Value $content -Force;
     '-------------'; get-content "$file"; '===================';
   displayName: Create nuget.config for SDK_Dotnet_V4_org feed
-  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))


### PR DESCRIPTION
Fixes #minor

## Description
Smooth out fork handling in CI builds.

## Specific Changes
Skip the failing task "Remove SDK_Dotnet_V4_org feed..."
Add clarifying log message 'System.PullRequest.IsFork = True'
