### PR TITLE
Remove customer data from error logging

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateErrors.cs
@@ -89,7 +89,9 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
         public static string TemplateNotExist(string templateName) => $"No such template '{templateName}'.";
 
-        public static string ErrorExpression(string refFullText, string templateName, string prefixText) => $"[{templateName}] {prefixText} Error occurred when evaluating '{refFullText}'.";
+#pragma warning disable CA1801 // Review unused parameters
+        public static string ErrorExpression(string refFullText, string templateName, string prefixText) => $"[{templateName}] {prefixText} Error occurred when evaluating expression.";
+#pragma warning restore CA1801 // Review unused parameters
 
         public static string NullExpression(string expression) => $"'{expression}' evaluated to null.";
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -329,34 +329,36 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var lgFile = GetTemplates("RunTimeErrors.lg");
 
             var exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("template1"));
-            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("prebuilt1"));
-            Assert.Equal("'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want ${foreach(dialog.abc, item, template1())}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("template2"));
-            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition ${template1()}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating expression. [template2]  Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("conditionalTemplate1", new { dialog = true }));
-            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating '-I want ${template1()}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating expression. [conditionalTemplate1] Condition '${dialog}':  Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("conditionalTemplate2"));
-            Assert.Equal("'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating '-IF :${dialog.abc}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '${dialog.abc}': Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("structured1"));
-            Assert.Equal("'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want ${dialog.abc}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("structured2"));
-            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating expression. [structured2] Property 'Text': Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("structured3"));
-            Assert.Equal("'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want ${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want ${template1()}'. [structured3]  Error occurred when evaluating '${structured2()}'.", exception.Message);
+            Assert.Equal(
+                "'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating expression. [structured2] Property 'Text': Error occurred when evaluating expression. [structured3]  Error occurred when evaluating expression.",
+                exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("switchcase1", new { turn = new { testValue = 1 } }));
-            Assert.Equal("'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [switchcase1] Case '${1}': Error occurred when evaluating expression.", exception.Message);
 
             exception = Assert.Throws<InvalidOperationException>(() => lgFile.Evaluate("switchcase2", new { turn = new { testValue = 0 } }));
-            Assert.Equal("'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want ${dialog.abc}'.", exception.Message);
+            Assert.Equal("'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating expression.", exception.Message);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -854,7 +854,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             templates = Templates.ParseFile(GetExampleFilePath("EvaluationOptions/StrictModeTrue.lg"));
 
             var exception = Assert.Throws<InvalidOperationException>(() => templates.ExpandTemplate("StrictTrue"));
-            Assert.Contains("'variable_not_defined' evaluated to null. [StrictTrue]  Error occurred when evaluating '-${variable_not_defined}'", exception.Message);
+            Assert.Contains("'variable_not_defined' evaluated to null. [StrictTrue]  Error occurred when evaluating expression", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6269 

### Changes

- Remove customer data from error messages
- Update unit tests

### Notes
To avoid making changes to the public surface area, method parameters are not being changed. This introduces a rule violation that is being bypassed.