### PR TITLE
Fix for null exception on null handoff context in CreateHandoffEvent

### DIFF
--- a/libraries/Microsoft.Bot.Builder/EventFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/EventFactory.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder
             var handoffEvent = Activity.CreateEventActivity() as Activity;
 
             handoffEvent.Name = name;
-            handoffEvent.Value = JObject.FromObject(value ?? new { Skill = "any" });
+            handoffEvent.Value = value == null ? null : JObject.FromObject(value);
             handoffEvent.Id = Guid.NewGuid().ToString();
             handoffEvent.Timestamp = DateTime.UtcNow;
             handoffEvent.Conversation = conversation;

--- a/libraries/Microsoft.Bot.Builder/EventFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/EventFactory.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder
             var handoffEvent = Activity.CreateEventActivity() as Activity;
 
             handoffEvent.Name = name;
-            handoffEvent.Value = JObject.FromObject(value);
+            handoffEvent.Value = JObject.FromObject(value ?? new { Skill = "any" });
             handoffEvent.Id = Guid.NewGuid().ToString();
             handoffEvent.Timestamp = DateTime.UtcNow;
             handoffEvent.Conversation = conversation;

--- a/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
@@ -58,9 +58,6 @@ namespace Microsoft.Bot.Builder.Tests
             var skill = (handoffEvent.Value as JObject)?.Value<string>("Skill");
             Assert.Equal("any", skill);
             Assert.Equal(handoffEvent.From.Id, fromID);
-
-            var nullHandoffEvent = EventFactory.CreateHandoffInitiation(context, null, transcript);
-            Assert.NotNull(nullHandoffEvent.Value);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
@@ -58,6 +58,9 @@ namespace Microsoft.Bot.Builder.Tests
             var skill = (handoffEvent.Value as JObject)?.Value<string>("Skill");
             Assert.Equal("any", skill);
             Assert.Equal(handoffEvent.From.Id, fromID);
+
+            var nullHandoffEvent = EventFactory.CreateHandoffInitiation(context, null, transcript);
+            Assert.NotNull(nullHandoffEvent.Value);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6240 

## Description
This PR fixes an issue in `CreateHandoffEvent` in `EventFactory.cs` where the function expects that the handoff context will be non-null, but no error checking is performed. Thus, the function breaks and throws a null exception if no context is supplied. For example, if a handoff event is created in Composer and no context is specified in the action, this error will occur.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

- Adds a null check in `CreateHandoffEvent` in `EventFactory.cs` to only try to convert the handoff context to a `JObject` if it is not null.

## Testing
Ran the unit tests and attempted the scenario in a fresh Composer bot. Both ran without failing.

![image](https://user-images.githubusercontent.com/33945547/159072722-38ec1b1a-16cf-47dd-9356-29eb2cc7f512.png)
