### PR TITLE
Add support for search invoke

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -505,7 +505,7 @@ namespace Microsoft.Bot.Builder
         /// Invoked when the bot is sent an Adaptive Card Action Execute.
         /// </summary>
         /// <param name="turnContext">A strongly-typed context object for this turn.</param>
-        /// <param name="invokeValue">A stringly-typed object from the incoming activity's Value.</param>
+        /// <param name="invokeValue">A strongly-typed object from the incoming activity's Value.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
@@ -524,7 +524,7 @@ namespace Microsoft.Bot.Builder
         /// Invoked when the bot is sent an 'invoke' activity having name of 'application/search'.
         /// </summary>
         /// <param name="turnContext">A strongly-typed context object for this turn.</param>
-        /// <param name="invokeValue">A stringly-typed object from the incoming activity's Value.</param>
+        /// <param name="invokeValue">A strongly-typed object from the incoming activity's Value.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>

--- a/libraries/Microsoft.Bot.Schema/SearchInvokeOptions.cs
+++ b/libraries/Microsoft.Bot.Schema/SearchInvokeOptions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Defines the query options in the <see cref="SearchInvokeValue"/> for Invoke activity with Name of 'application/search'.
+    /// </summary>
+    public class SearchInvokeOptions
+    {
+        /// <summary>
+        /// Gets or sets the the starting reference number from which ordered search results should be returned.
+        /// </summary>
+        /// <value>
+        /// The the starting reference number from which ordered search results should be returned.
+        /// </value>
+        [JsonProperty("skip")]
+        public int Skip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of search results that should be returned.
+        /// </summary>
+        /// <value>
+        /// The number of search results that should be returned.
+        /// </value>
+        [JsonProperty("top")]
+        public int Top { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/SearchInvokeResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/SearchInvokeResponse.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Defines the structure that is returned as the result of an Invoke activity with Name of 'application/search'.
+    /// </summary>
+    public class SearchInvokeResponse : AdaptiveCardInvokeResponse
+    {
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/SearchInvokeTypes.cs
+++ b/libraries/Microsoft.Bot.Schema/SearchInvokeTypes.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Defines values for SearchInvokeTypes. See <see cref="SearchInvokeValue"/>.
+    /// </summary>
+    public static class SearchInvokeTypes
+    {
+        /// <summary>
+        /// The type for Search.
+        /// Implies a standard, paginated search operation that expects
+        /// one or more templated results to be returned.
+        /// </summary>
+        public const string Search = "search";
+
+        /// <summary>
+        /// The type for bot SearchAnswer.
+        /// Implies a simpler search that does not include pagination,
+        /// and most typically only returns a single search result.
+        /// </summary>
+        public const string SearchAnswer = "searchAnswer";
+
+        /// <summary>
+        /// The type for Typeahead.
+        /// Implies a search for a small set of values, most often used
+        /// for dynamic auto-complete or type-ahead UI controls.
+        /// This search supports pagination.
+        /// </summary>
+        public const string Typeahead = "typeahead";
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/SearchInvokeValue.cs
+++ b/libraries/Microsoft.Bot.Schema/SearchInvokeValue.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Defines the structure that arrives in the Activity.Value for Invoke activity
+    /// with Name of 'application/search'.
+    /// </summary>
+    public class SearchInvokeValue
+    {
+        /// <summary>
+        /// Gets or sets the kind for the search invoke value.
+        /// Must be either search, searchAnswer, or typeahead.
+        /// <see cref="SearchInvokeTypes"/>.
+        /// </summary>
+        /// <value>
+        /// The kind for this search invoke action value.
+        /// </value>
+        [JsonProperty("kind")]
+        public string Kind { get; set; }
+
+        /// <summary>
+        /// Gets or sets the query text for the search invoke value.
+        /// </summary>
+        /// <value>
+        /// The query text of this search invoke action value.
+        /// </value>
+        [JsonProperty("queryText")]
+        public string QueryText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="SearchInvokeOptions"/> for this search invoke.
+        /// </summary>
+        /// <value>
+        /// The <see cref="SearchInvokeOptions"/> for this search invoke.
+        /// </value>
+        [JsonProperty("queryOptions")]
+        public SearchInvokeOptions QueryOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the context information about the query. Such as the UI
+        /// control that issued the query. The type of the context field is object
+        /// and is dependent on the kind field. For search and searchAnswers,
+        /// there is no defined context value.
+        /// </summary>
+        /// <value>
+        /// The context information about the query.
+        /// </value>
+        [JsonProperty("context")]
+        public object Context { get; set; }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -559,6 +559,31 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [Fact]
+        public async Task TestOnSearchInvokeAsync()
+        {
+            var value = JObject.FromObject(new SearchInvokeValue { Kind = SearchInvokeTypes.Search, QueryText = "bot" });
+
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "application/search",
+                Value = value
+            };
+
+            var turnContext = new TurnContext(new TestInvokeAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(2, bot.Record.Count);
+            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+            Assert.Equal("OnSearchQueryInvokeAsync", bot.Record[1]);
+        }
+
+        [Fact]
         public async Task TestCommandActivityType()
         {
             // Arrange
@@ -817,6 +842,12 @@ namespace Microsoft.Bot.Builder.Tests
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(new AdaptiveCardInvokeResponse());
+            }
+
+            protected override Task<SearchInvokeResponse> OnSearchInvokeAsync(ITurnContext<IInvokeActivity> turnContext, SearchInvokeValue invokeValue, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return Task.FromResult(new SearchInvokeResponse());
             }
         }
 

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Bot.Builder.Tests
             // Assert
             Assert.Equal(2, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
-            Assert.Equal("OnSearchQueryInvokeAsync", bot.Record[1]);
+            Assert.Equal("OnSearchInvokeAsync", bot.Record[1]);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Schema.Tests/SearchQueryTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/SearchQueryTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests
+{
+    public class SearchQueryTests
+    {
+        [Fact]
+        public void SearchInvokeValue()
+        {
+            var kind = SearchInvokeTypes.Typeahead;
+            var context = "Microsoft.Graph";
+            var options = new SearchInvokeOptions { Skip = 10, Top = 5 };
+            var text = "the query text";
+
+            var value = new SearchInvokeValue()
+            {
+                Kind = kind,
+                Context = context,
+                QueryOptions = options, 
+                QueryText = text
+            };
+
+            Assert.Equal(kind, value.Kind);
+            Assert.Equal(context, value.Context);
+            Assert.Equal(options, value.QueryOptions);
+            Assert.Equal(text, value.QueryText);
+        }
+
+        [Fact]
+        public void SearchInvokeResponse()
+        {
+            var statusCode = 200;
+            var type = "myType";
+            var value = new { };
+
+            var res = new SearchInvokeResponse()
+            {
+                StatusCode = statusCode,
+                Type = type,
+                Value = value,
+            };
+
+            Assert.Equal(statusCode, res.StatusCode);
+            Assert.Equal(type, res.Type);
+            Assert.Equal(value, res.Value);
+        }
+
+        [Fact]
+        public void SearchQueryOptions()
+        {
+            int skip = 10;
+            int top = 5;
+
+            var options = new SearchInvokeOptions
+            {
+                Skip = skip,
+                Top = top
+            };
+            
+            Assert.Equal(skip, options.Skip);
+            Assert.Equal(top, options.Top);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5643

`OnInvokeActivityAsync` here: 
https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/bot-type-ahead-search-adaptive-cards/csharp/TypeaheadSearch/Bots/ActivityBot.cs#L85

Would be changed to:

```cs
protected override async Task<SearchInvokeResponse> OnSearchInvokeAsync(ITurnContext<IInvokeActivity> turnContext, SearchInvokeValue invokeValue, CancellationToken cancellationToken)
{
    var packageResult = JObject.Parse(await(new HttpClient()).GetStringAsync($"https://azuresearch-usnc.nuget.org/query?q=id:{invokeValue.QueryText}&prerelease=true"));
    if (packageResult == null)
    {
        // no results available, return 204
        return new SearchInvokeResponse
        {
            Type = "application/vnd.microsoft.search.searchResponse",
            StatusCode = 204
        };
    }
    else
    {
        var packageList = packageResult["data"]
            .Skip(invokeValue.QueryOptions.Skip)
            .Take(invokeValue.QueryOptions.Top)
            .Select(item => (item["id"].ToString(), item["description"].ToString()))
            .Select(item => new { title = item.Item1, value = item.Item1 + " - " + item.Item2 })
            .ToList();
        
        return new SearchInvokeResponse
        {
            Type = "application/vnd.microsoft.search.searchResponse",
            Value = JObject.FromObject(new { results = packageList }),
            StatusCode = 200
        };
    }
}
```