### PR TITLE
Do not check for streaming activity if ServiceUrl is null.

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -262,6 +262,16 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
             public bool HandlesActivity(Activity activity)
             {
+                if (string.IsNullOrWhiteSpace(_requestHandler.ServiceUrl))
+                {
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(activity.ServiceUrl))
+                {
+                    return false;
+                }
+
                 return _requestHandler.ServiceUrl.Equals(activity.ServiceUrl, StringComparison.OrdinalIgnoreCase) &&
                        _requestHandler.HasConversation(activity.Conversation.Id);
             }


### PR DESCRIPTION
Fixes #6281 

## Description
When checking for an active web socket connection to send a proactive message, the ServiceUrl on the connection is compared to the ServiceUrl on the activity. This check is failing when the ServiceUrl is null. This PR will ignore the connection that has no ServiceUrl.