### PR TITLE
Log error message from Streaming web socket response.

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -425,7 +425,7 @@ namespace Microsoft.Bot.Builder.Streaming
             }
             else
             {
-                throw new Exception($"Failed to send request through streaming transport. Status code: {serverResponse.StatusCode}.");
+                throw new Exception($"Failed to send request through streaming transport. Status code: {serverResponse.StatusCode}.\n{await serverResponse.ReadBodyAsStringAsync().ConfigureAwait(false)}");
             }
         }
 


### PR DESCRIPTION
Fixes #6278 

## Description
When sending an activity over web sockets, if we encounter a non 200 status code, we are only logging the status code. This change logs the detailed error message along with the status code to enable better debugging.