### PR TITLE
[#6292] Add unit tests for AzureBlobStorage

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+// Allows us to access some internal methods from the Microsoft.Bot.Builder.Azure.Tests unit tests so we don't have to use reflection and we get compile checks.
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -14,6 +15,8 @@ using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 using Microsoft.WindowsAzure.Storage.Core;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Newtonsoft.Json;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure
 {
@@ -42,6 +45,7 @@ namespace Microsoft.Bot.Builder.Azure
         private readonly CloudStorageAccount _storageAccount;
         private readonly string _containerName;
         private int _checkforContainerExistance;
+        private readonly CloudBlobClient _blobClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureBlobStorage"/> class.
@@ -87,6 +91,18 @@ namespace Microsoft.Bot.Builder.Azure
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AzureBlobStorage"/> class.
+        /// </summary>
+        /// <param name="storageAccount">Azure CloudStorageAccount instance.</param>
+        /// <param name="containerName">Name of the Blob container where entities will be stored.</param>
+        /// <param name="blobClient">Custom implementation of CloudBlobClient.</param>
+        internal AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, CloudBlobClient blobClient)
+            : this(storageAccount, containerName, JsonSerializer)
+        {
+            _blobClient = blobClient;
+        }
+
+        /// <summary>
         /// Deletes entity blobs from the configured container.
         /// </summary>
         /// <param name="keys">An array of entity keys.</param>
@@ -100,7 +116,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobClient = _blobClient ?? _storageAccount.CreateCloudBlobClient();
             var blobContainer = blobClient.GetContainerReference(_containerName);
             foreach (var key in keys)
             {
@@ -124,7 +140,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(keys));
             }
 
-            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobClient = _blobClient ?? _storageAccount.CreateCloudBlobClient();
             var blobContainer = blobClient.GetContainerReference(_containerName);
 
             var items = new Dictionary<string, object>();
@@ -168,7 +184,7 @@ namespace Microsoft.Bot.Builder.Azure
                 throw new ArgumentNullException(nameof(changes));
             }
 
-            var blobClient = _storageAccount.CreateCloudBlobClient();
+            var blobClient = _blobClient ?? _storageAccount.CreateCloudBlobClient();
             var blobContainer = blobClient.GetContainerReference(_containerName);
 
             // this should only happen once - assuming this is a singleton

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -15,8 +14,6 @@ using Microsoft.WindowsAzure.Storage.Blob.Protocol;
 using Microsoft.WindowsAzure.Storage.Core;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Newtonsoft.Json;
-
-[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure
 {


### PR DESCRIPTION
Addresses #6292
#minor

## Description
This PR removes the existing Functional tests for the `AzureBlobStorage` class and replaces them with unit tests that don't require the use of the Azure Storage Emulator.

## Specific Changes
- Updates the `AzureBlobStorage` class, adding a new internal constructor that receives an instance of _CloudBlobClient_. This constructor is for the use of the tests only.
- Replaces the existing tests in the `AzureBlobStorageTests` class with unit tests for each method, constructor, method validations, etc, reaching 89% of code coverage.

## Testing
The following images show the new unit tests and the code coverage.
![image](https://user-images.githubusercontent.com/44245136/164520229-25c5ade0-a990-4a11-a6fc-c7f04c4f5596.png)
