### PR TITLE
[#6292] Update CosmosDbPartitionedStorage from Functional to Unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+// Allows us to access some internal methods from the Microsoft.Bot.Builder.Azure.Tests unit tests so we don't have to use reflection and we get compile checks.
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -5,14 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
-[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure
 {

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -5,11 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure
 {
@@ -94,6 +97,18 @@ namespace Microsoft.Bot.Builder.Azure
             : this(cosmosDbStorageOptions)
         {
             _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosDbPartitionedStorage"/> class.
+        /// using the provided CosmosDB credentials, database ID, and collection ID.
+        /// </summary>
+        /// <param name="client">The custom implementation of CosmosClient.</param>
+        /// <param name="cosmosDbStorageOptions">Cosmos DB partitioned storage configuration options.</param>
+        internal CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions)
+            : this(cosmosDbStorageOptions)
+        {
+            _client = client;
         }
 
         /// <summary>
@@ -445,40 +460,58 @@ namespace Microsoft.Bot.Builder.Azure
         /// <summary>
         /// Internal data structure for storing items in a CosmosDB Collection.
         /// </summary>
-        private class DocumentStoreItem : IStoreItem
+        internal class DocumentStoreItem : IStoreItem
         {
             /// <summary>
             /// Gets the PartitionKey path to be used for this document type.
             /// </summary>
+            /// <value>
+            /// The PartitionKey path to be used for this document type.
+            /// </value>
             public static string PartitionKeyPath => "/id";
 
             /// <summary>
             /// Gets or sets the sanitized Id/Key used as PrimaryKey.
             /// </summary>
+            /// <value>
+            /// The sanitized Id/Key used as PrimaryKey.
+            /// </value>
             [JsonProperty("id")]
             public string Id { get; set; }
 
             /// <summary>
             /// Gets or sets the un-sanitized Id/Key.
             /// </summary>
+            /// <value>
+            /// The un-sanitized Id/Key.
+            /// </value>
             [JsonProperty("realId")]
             public string RealId { get; internal set; }
 
             /// <summary>
             /// Gets or sets the persisted object.
             /// </summary>
+            /// <value>
+            /// The persisted object.
+            /// </value>
             [JsonProperty("document")]
             public JObject Document { get; set; }
 
             /// <summary>
             /// Gets or sets the ETag information for handling optimistic concurrency updates.
             /// </summary>
+            /// <value>
+            /// The ETag information for handling optimistic concurrency updates.
+            /// </value>
             [JsonProperty("_etag")]
             public string ETag { get; set; }
 
             /// <summary>
             /// Gets the PartitionKey value for the document.
             /// </summary>
+            /// <value>
+            /// The PartitionKey value for the document.
+            /// </value>
             public string PartitionKey => this.Id;
         }
     }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionedStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionedStorageTests.cs
@@ -1,0 +1,380 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Bot.Builder.Dialogs;
+using Moq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    [Trait("TestCategory", "Storage")]
+    [Trait("TestCategory", "Storage - CosmosDB Partitioned")]
+    public class CosmosDbPartitionedStorageTests
+    {
+        private CosmosDbPartitionedStorage _storage;
+        private readonly Mock<Container> _container = new Mock<Container>();
+        
+        [Fact]
+        public void ConstructorValidation()
+        {
+            // Should work.
+            _ = new CosmosDbPartitionedStorage(
+                cosmosDbStorageOptions: new CosmosDbPartitionedStorageOptions
+                {
+                    CosmosDbEndpoint = "CosmosDbEndpoint",
+                    AuthKey = "AuthKey",
+                    DatabaseId = "DatabaseId",
+                    ContainerId = "ContainerId",
+                },
+                jsonSerializer: JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }));
+
+            // No Options. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbPartitionedStorage(null));
+
+            // No Endpoint. Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                CosmosDbEndpoint = null,
+            }));
+
+            // No Auth Key. Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                CosmosDbEndpoint = "CosmosDbEndpoint",
+                AuthKey = null,
+            }));
+
+            // No Database Id. Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                CosmosDbEndpoint = "CosmosDbEndpoint",
+                AuthKey = "AuthKey",
+                DatabaseId = null,
+            }));
+
+            // No Container Id. Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                CosmosDbEndpoint = "CosmosDbEndpoint",
+                AuthKey = "AuthKey",
+                DatabaseId = "DatabaseId",
+                ContainerId = null,
+            }));
+
+            // No JsonSerializer. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new CosmosDbPartitionedStorage(
+                new CosmosDbPartitionedStorageOptions()
+                {
+                    CosmosDbEndpoint = "CosmosDbEndpoint",
+                    AuthKey = "AuthKey",
+                    DatabaseId = "DatabaseId",
+                    ContainerId = "ContainerId",
+                }, null));
+
+            // KeySuffix with CompatibilityMode == "true". Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                CosmosDbEndpoint = "CosmosDbEndpoint",
+                AuthKey = "AuthKey",
+                DatabaseId = "DatabaseId",
+                ContainerId = "ContainerId",
+                KeySuffix = "KeySuffix",
+                CompatibilityMode = true
+            }));
+
+            // KeySuffix with CompatibilityMode == "false" and invalid characters. Should throw.
+            Assert.Throws<ArgumentException>(() => new CosmosDbPartitionedStorage(new CosmosDbPartitionedStorageOptions()
+            {
+                CosmosDbEndpoint = "CosmosDbEndpoint",
+                AuthKey = "AuthKey",
+                DatabaseId = "DatabaseId",
+                ContainerId = "ContainerId",
+                KeySuffix = "?#*test",
+                CompatibilityMode = false
+            }));
+        }
+        
+        [Fact]
+        public async void ReadAsyncValidation()
+        {
+            InitStorage();
+
+            // No keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.ReadAsync(null));
+
+            // Empty keys. Should return empty.
+            var empty = await _storage.ReadAsync(new string[] { });
+            Assert.Empty(empty);
+        }
+
+        [Fact]
+        public async void ReadAsync()
+        {
+            InitStorage();
+
+            var resource = new CosmosDbPartitionedStorage.DocumentStoreItem
+            {
+                RealId = "RealId",
+                ETag = "ETag1",
+                Document = JObject.Parse("{ \"ETag\":\"ETag2\" }")
+            };
+            var itemResponse = new DocumentStoreItemResponseMock(resource);
+
+            _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(itemResponse);
+
+            var items = await _storage.ReadAsync(new string[] { "key" });
+
+            Assert.Single(items);
+            _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ReadAsyncPartitionKey()
+        {
+            InitStorage("/_partitionKey");
+
+            var resource = new CosmosDbPartitionedStorage.DocumentStoreItem
+            {
+                RealId = "RealId",
+                ETag = "ETag1",
+                Document = JObject.Parse("{ \"ETag\":\"ETag2\" }")
+            };
+            var itemResponse = new DocumentStoreItemResponseMock(resource);
+
+            _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(itemResponse);
+
+            var items = await _storage.ReadAsync(new string[] { "key" });
+
+            Assert.Single(items);
+            _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ReadAsyncNotFound()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("NotFound", HttpStatusCode.NotFound, 0, "0", 0));
+
+            var items = await _storage.ReadAsync(new string[] { "key" });
+
+            Assert.Empty(items);
+            _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ReadAsyncFailure()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
+
+            await Assert.ThrowsAsync<CosmosException>(() => _storage.ReadAsync(new string[] { "key" }));
+            _container.Verify(e => e.ReadItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void ReadAsyncCustomPartitionKeyFailure()
+        {
+            InitStorage("/customKey");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.ReadAsync(new string[] { "key" }));
+        }
+
+        [Fact]
+        public async void WriteAsyncValidation()
+        {
+            InitStorage();
+
+            // No changes. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.WriteAsync(null));
+
+            // Empty changes. Should return.
+            await _storage.WriteAsync(new Dictionary<string, object>());
+        }
+
+        [Fact]
+        public async void WriteAsync()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()));
+
+            var changes = new Dictionary<string, object>
+            {
+                { "key1", new CosmosDbPartitionedStorage.DocumentStoreItem() },
+                { "key2", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = "*" } },
+                { "key3", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = "ETag" } },
+            };
+
+            await _storage.WriteAsync(changes);
+
+            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+
+        [Fact]
+        public async void WriteAsyncEmptyTagFailure()
+        {
+            InitStorage();
+
+            var changes = new Dictionary<string, object>
+            {
+                { "key", new CosmosDbPartitionedStorage.DocumentStoreItem { ETag = string.Empty } },
+            };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => _storage.WriteAsync(changes));
+        }
+
+        [Fact]
+        public async void WriteAsyncFailure()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
+
+            var changes = new Dictionary<string, object> { { "key", new { } } };
+
+            await Assert.ThrowsAsync<CosmosException>(() => _storage.WriteAsync(changes));
+            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void WriteAsyncWithNestedFailure()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
+
+            var nestedJson = GenerateNestedDict();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(nestedJson));
+            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void WriteAsyncWithNestedDialogFailure()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
+
+            var nestedJson = GenerateNestedDict();
+
+            var dialogInstance = new DialogInstance { State = nestedJson };
+            var dialogState = new DialogState(new List<DialogInstance> { dialogInstance });
+            var changes = new Dictionary<string, object> { { "state", dialogState } };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(changes));
+            _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void DeleteAsyncValidation()
+        {
+            InitStorage();
+
+            // No keys. Should throw.
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.DeleteAsync(null));
+        }
+
+        [Fact]
+        public async void DeleteAsync()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()));
+
+            await _storage.DeleteAsync(new string[] { "key" });
+
+            _container.Verify(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void DeleteAsyncNotFound()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("NotFound", HttpStatusCode.NotFound, 0, "0", 0));
+
+            await _storage.DeleteAsync(new string[] { "key" });
+
+            _container.Verify(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async void DeleteAsyncFailure()
+        {
+            InitStorage();
+
+            _container.Setup(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new CosmosException("InternalServerError", HttpStatusCode.InternalServerError, 0, "0", 0));
+
+            await Assert.ThrowsAsync<CosmosException>(() => _storage.DeleteAsync(new string[] { "key" }));
+            _container.Verify(e => e.DeleteItemAsync<CosmosDbPartitionedStorage.DocumentStoreItem>(It.IsAny<string>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private void InitStorage(string partitionKey = "/id", CosmosDbPartitionedStorageOptions storageOptions = default)
+        {
+            var client = new Mock<CosmosClient>();
+            var containerProperties = new ContainerProperties("id", partitionKey);
+            var containerResponse = new Mock<ContainerResponse>();
+
+            containerResponse.SetupGet(e => e.Resource)
+                .Returns(containerProperties);
+            client.Setup(e => e.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(_container.Object);
+            _container.Setup(e => e.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerResponse.Object);
+
+            var options = storageOptions ?? new CosmosDbPartitionedStorageOptions
+            {
+                CosmosDbEndpoint = "CosmosDbEndpoint",
+                AuthKey = "AuthKey",
+                DatabaseId = "DatabaseId",
+                ContainerId = "ContainerId",
+            };
+            _storage = new CosmosDbPartitionedStorage(client.Object, options);
+        }
+
+        private Dictionary<string, object> GenerateNestedDict()
+        {
+            var nested = new Dictionary<string, object>();
+            var current = new Dictionary<string, object>();
+
+            nested.Add("0", current);
+            for (var i = 1; i <= 127; i++)
+            {
+                var child = new Dictionary<string, object>();
+                current.Add(i.ToString(), child);
+                current = child;
+            }
+
+            return nested;
+        }
+
+        private class DocumentStoreItemResponseMock : ItemResponse<CosmosDbPartitionedStorage.DocumentStoreItem>
+        {
+            public DocumentStoreItemResponseMock(CosmosDbPartitionedStorage.DocumentStoreItem resource)
+            {
+                Resource = resource;
+            }
+
+            public override CosmosDbPartitionedStorage.DocumentStoreItem Resource { get; }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #6292
#minor

## Description
This PR removes the existing Functional tests and as a replacement, it adds support for internal testing to the `CosmosDbPartitionedStorage` class, and introduces all the necessary unit tests, increasing the **code coverage up to 86%**.

## Specific Changes
- Updates the `CosmosDbPartitionedStorage` class, adding a new internal constructor.
- Updates the `CosmosDbPartitionedStorage.DocumentStoreItem` class accessibility from `private` to `internal`, so it can be accessed from the tests.
- Adds new unit tests to the `CosmosDbPartitionedStorageTests` class for each method, constructor, method validations, etc.

## Testing
The following image shows the new unit tests and the code coverage.
![image](https://user-images.githubusercontent.com/62260472/163820003-5aa51cb1-d84d-40de-892f-9058d24a57b5.png)