### PR TITLE
[#6292] Update Azure Queues from Functional to Unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/AssemblyInfo.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+// Allows us to access some internal methods from the Microsoft.Bot.Builder.Azure.Tests unit tests so we don't have to use reflection and we get compile checks.
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
+#endif

--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,8 +9,6 @@ using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
-
-[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure.Queues
 {

--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,8 @@ using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+
+[assembly: InternalsVisibleTo("Microsoft.Bot.Builder.Azure.Tests")]
 
 namespace Microsoft.Bot.Builder.Azure.Queues
 {
@@ -50,6 +53,25 @@ namespace Microsoft.Bot.Builder.Azure.Queues
             };
 
             _queueClient = new QueueClient(queuesStorageConnectionString, queueName);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureQueueStorage"/> class.
+        /// </summary>
+        /// <param name="queueClient">The custom implementation of QueueClient.</param>
+        /// <param name="jsonSerializerSettings">If passing in custom JsonSerializerSettings, we 
+        /// recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Ignore.</para>
+        /// </param>
+        internal AzureQueueStorage(QueueClient queueClient, JsonSerializerSettings jsonSerializerSettings = null)
+        {
+            _queueClient = queueClient;
+            _jsonSettings = jsonSerializerSettings ?? new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.None,
+                NullValueHandling = NullValueHandling.Ignore
+            };
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueStorageTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Azure;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.Bot.Builder.Azure.Queues;
+using Microsoft.Bot.Schema;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Azure.Tests
+{
+    public class AzureQueueStorageTests
+    {
+        private const string ConnectionString = @"UseDevelopmentStorage=true";
+
+        [Fact]
+        public void ConstructorValidation()
+        {
+            // Should work.
+            _ = new AzureQueueStorage(ConnectionString, "queueName");
+
+            // No ConnectionString. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new AzureQueueStorage(null, "queueName"));
+
+            // No QueueName. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new AzureQueueStorage(ConnectionString, null));
+        }
+
+        [Fact]
+        public async void QueueActivityAsync()
+        {
+            var client = new Mock<QueueClient>();
+            var response = new Mock<Response<SendReceipt>>();
+
+            var receipt = QueuesModelFactory.SendReceipt("messageId", DateTimeOffset.MinValue, DateTimeOffset.MinValue, "popReceipt", DateTimeOffset.MinValue);
+            response.SetupGet(e => e.Value).Returns(receipt);
+            client.Setup(e => e.CreateIfNotExistsAsync(It.IsAny<IDictionary<string, string>>(), It.IsAny<CancellationToken>()));
+            client.Setup(e => e.SendMessageAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response.Object);
+
+            var storage = new AzureQueueStorage(client.Object);
+            var activity = Activity.CreateMessageActivity() as Activity;
+            var result = await storage.QueueActivityAsync(activity, TimeSpan.Zero, TimeSpan.Zero, CancellationToken.None);
+
+            Assert.NotNull(result);
+            client.Verify(e => e.CreateIfNotExistsAsync(It.IsAny<IDictionary<string, string>>(), It.IsAny<CancellationToken>()), Times.Once());
+            client.Verify(e => e.SendMessageAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()), Times.Once());
+        }
+    }
+}


### PR DESCRIPTION
Addresses #6292
#minor

## Description
This PR removes the existing Functional tests and as a replacement, it adds support for internal testing to the `AzureQueueStorage` class, and introduces all the necessary unit tests, increasing the **code coverage up to 100%**.

## Specific Changes
- Updates the `AzureQueueStorage` class, adding a new internal constructor.
- Adds new unit tests to the `AzureQueueStorageTests` class for each method, constructor, method validations, etc.

## Testing
The following image shows the new unit tests and the code coverage.
![image](https://user-images.githubusercontent.com/62260472/163818806-c7322059-4329-455e-b23c-bc8184de249a.png)
