### PR TITLE
Fix sku values in ARM template

### DIFF
--- a/FunctionalTests/ExportedTemplate/LinuxDotNet/template-with-preexisting-rg.json
+++ b/FunctionalTests/ExportedTemplate/LinuxDotNet/template-with-preexisting-rg.json
@@ -6,7 +6,14 @@
             "defaultValue": "nightly-build-linux",
             "type": "String"
         },
-		"appId": {
+        "botSku": {
+          "defaultValue": "F0",
+          "type": "string",
+          "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+          }
+        },
+        "appId": {
             "type": "string",
             "metadata": {
                 "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
@@ -30,10 +37,10 @@
             "name": "[parameters('botName')]",
             "location": "West US",
             "sku": {
-                "name": "B1",
-                "tier": "Basic",
-                "size": "B1",
-                "family": "B",
+                "name": "S1",
+                "tier": "Standard",
+                "size": "S1",
+                "family": "S",
                 "capacity": 1
             },
             "kind": "linux",
@@ -192,7 +199,7 @@
 			"location": "global",
 			"kind": "bot",
 			"sku": {
-				"name": "[parameters('botName')]"
+				"name": "[parameters('botSku')]"
 			},
 			"properties": {
 				"name": "[parameters('botName')]",


### PR DESCRIPTION
Fixes #minor

## Description
This fixes pipeline BotBuilder-DotNet-Functional-Tests-Linux-yaml.
##[error]InvalidResourceEntity: Invalid sku name for ABS. Allowed values: F0, S1.

Fix is the same as in https://github.com/microsoft/BotBuilder-Samples/pull/3732