### PR TITLE
Update pipeline to coveralls.net v 3.0.0

### DIFF
--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -11,7 +11,7 @@ Param(
 Write-Host Install tools
 $basePath = (get-item $pathToCoverageFiles ).parent.FullName
 $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
-dotnet tool install coveralls.net --version 1.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
+dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
 # Download temporary version of Archive module that fixes issue on macOS/Linux with path separator

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -58,13 +58,6 @@ steps:
   continueOnError: true
   condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 2.1, required for Upload Coverage Files task'
-  inputs:
-    packageType: sdk
-    version: 2.1.x
-  condition: and(succeeded(), eq(variables['PublishCoverage'], 'true'), ne(variables['System.PullRequest.IsFork'], 'True'))
-
 - task: PowerShell@2
   displayName: 'Upload Coverage Files to Coveralls.io https://coveralls.io/github/microsoft/botbuilder-dotnet'
   inputs:


### PR DESCRIPTION
Fixes #minor

## Description
The current coveralls.net relies on the outdated .NET Core sdk 2.1.

## Changes
Update build\PublishToCoveralls.ps1 to use coveralls.net 3.0.0.

Drop task "Use .NET Core sdk 2.1" which was required by the older version.
