### PR TITLE
[#6317] Add `SkipGovernance` parameter support to CI pipeline

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -14,6 +14,12 @@ pool:
 trigger: none # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
+parameters:
+  - name: SkipGovernance
+    displayName: Skip Governance
+    type: boolean
+    default: false
+
 variables:
   ApiCompatVersion: 4.6.3
   BotBuilderDll: Microsoft.Bot.Builder.AI.Luis,Microsoft.Bot.Builder.AI.QnA,Microsoft.Bot.Builder.ApplicationInsights,Microsoft.Bot.Builder.Azure,Microsoft.Bot.Builder.Dialogs,Microsoft.Bot.Builder.Integration.ApplicationInsights.Core,Microsoft.Bot.Builder.Integration.AspNet.Core,Microsoft.Bot.Builder.TemplateManager,Microsoft.Bot.Builder.Testing,Microsoft.Bot.Builder,Microsoft.Bot.Configuration,Microsoft.Bot.Connector,Microsoft.Bot.Schema,Microsoft.Bot.Streaming
@@ -46,8 +52,11 @@ stages:
       BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
     steps:
     - template: ci-build-steps.yml
+      parameters:
+        SkipGovernance: ${{ parameters.SkipGovernance }}
     - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
+    - ${{ if not(parameters.SkipGovernance) }}:
+      - template: ci-component-detection-steps.yml
   - job: Release_Windows_Configuration_31
     variables:
       BuildConfiguration: Release-Windows
@@ -55,8 +64,11 @@ stages:
       PublishCoverage: true
     steps:
     - template: ci-build-steps.yml
+      parameters:
+        SkipGovernance: ${{ parameters.SkipGovernance }}
     - template: ci-test-steps.yml
-    - template: ci-component-detection-steps.yml
+    - ${{ if not(parameters.SkipGovernance) }}:
+      - template: ci-component-detection-steps.yml
 
 - stage: API_Compatibility_Validation
   dependsOn: Build

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -1,3 +1,9 @@
+parameters:
+  - name: SkipGovernance
+    displayName: Skip Governance
+    type: boolean
+    default: false
+
 steps:
 - powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
   displayName: 'Display env vars'
@@ -27,11 +33,12 @@ steps:
     configuration: '$(BuildConfiguration)'
     maximumCpuCount: true
     logProjectEvents: false
-    
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  inputs:
-    failOnAlert: true
+
+- ${{ if not(parameters.SkipGovernance) }}:
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    inputs:
+      failOnAlert: true
 
 - script: |
    cd ..


### PR DESCRIPTION
Fixes #6317

## Description
This PR adds support to skip the Governance (`ComponentGovernanceComponentDetection@0`) task at compile-time, allowing to run the pipeline in organizations that doesn't have the task installed, due to not be publicly available.

## Specific Changes
- Adds `Skip Governance` parameter, with `false` as default value, meaning it will execute the Governance task as part of the normal process, otherwise will skip it.
- Adds conditionals to each Governance task based on the new parameter's value.

## Testing
The following images show a simple case when selected and when isn't.
![image](https://user-images.githubusercontent.com/62260472/166475470-bb2d28aa-384f-4306-a398-0e5361dae30d.png)