### PR TITLE
[#5977] Update projects to .Net 6

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/DirectLineClientTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
             int retries = 3;
 
             // Poll the bot for replies once per second.
-            while (answer.Equals(string.Empty) && retries-- > 0)
+            while (answer.Equals(string.Empty, StringComparison.Ordinal) && retries-- > 0)
             {
                 // Retrieve the activity sent from the bot.
                 var activitySet = await client.Conversations.GetActivitiesAsync(conversationId, watermark);
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
                     }
                 }
 
-                if (answer.Equals(string.Empty))
+                if (answer.Equals(string.Empty, StringComparison.Ordinal))
                 {
                     // Wait for one second before polling the bot again.
                     await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Builder.FunctionalTests
 
             //Accept response from either primary or secondary test bot.
             Assert.IsTrue(
-                response.Equals($"Echo: {echoGuid}") || response.Equals($"Echo Secondary: {echoGuid}"),
+                response.Equals($"Echo: {echoGuid}", StringComparison.Ordinal) || response.Equals($"Echo Secondary: {echoGuid}", StringComparison.Ordinal),
                 $"Expected:<Echo...{echoGuid}>. Actual:<{response}>.");
         }
 

--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release;</Configurations>
   </PropertyGroup>
@@ -11,11 +12,8 @@
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AdaptiveCards" Version="1.2.3" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.7.0" />

--- a/build/yaml/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/botbuilder-dotnet-ci-mac.yml
@@ -19,6 +19,11 @@ variables:
 steps:
 # Note: Template ci-build-steps.yml is not supported in macOS because it calls VSBuild@1 in order to build the Windows-only ASP.NET Desktop assemblies.
 - task: UseDotNet@2
+  displayName: 'Use .Net sdk 6.0'
+  inputs:
+    version: 6.0.x
+
+- task: UseDotNet@2
   displayName: 'Use .Net Core sdk 3.1.101'
   inputs:
     version: 3.1.101

--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   demands:
   - msbuild
   - visualstudio
@@ -48,10 +48,26 @@ stages:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     - template: ci-component-detection-steps.yml
+  - job: Debug_Windows_Configuration_6
+    variables:
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'net6' # set the TargetFramework property for tests to use net6.0
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
   - job: Release_Windows_Configuration_31
     variables:
       BuildConfiguration: Release-Windows
       BuildTarget: 'netcoreapp31' # set the TargetFramework property for tests to use netcoreapp3.1
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    - template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_6
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'net6' # set the TargetFramework property for tests to use net6.0
       PublishCoverage: true
     steps:
     - template: ci-build-steps.yml

--- a/build/yaml/botbuilder-dotnet-sign.yml
+++ b/build/yaml/botbuilder-dotnet-sign.yml
@@ -6,7 +6,7 @@
 name: $(Date:yyyyMMdd).$(Build.BuildId)
 
 pool:
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   demands:
   - msbuild
   - visualstudio

--- a/build/yaml/botbuilder-dotnet-simple-build-test.yml
+++ b/build/yaml/botbuilder-dotnet-simple-build-test.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
 
 trigger: none
 
@@ -21,6 +21,13 @@ variables:
 
 steps:
 - template: ci-build-steps.yml
+
+- task: Npm@1
+  displayName: 'install botframework-cli to set up for Schema merge tests'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'install -g @microsoft/botframework-cli@next'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet test'

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -21,7 +21,7 @@ steps:
   displayName: 'Build solution Microsoft.Bot.Builder.sln'
   inputs:
     solution: '$(Parameters.solution)'
-    vsVersion: 16.0
+    vsVersion: 17.0
     msbuildArgs: '$(MSBuildArguments)'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/build/yaml/ci-test-steps.yml
+++ b/build/yaml/ci-test-steps.yml
@@ -37,6 +37,16 @@ steps:
     arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
 
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 6.0'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+
+    arguments: '-v n  -f net6.0 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
+
 - powershell: |
    # This task copies the code coverage file created by dotnet test into a well known location. In all
    # checks I've done, dotnet test ALWAYS outputs the coverage file to the temp directory. 

--- a/build/yaml/vnextprototype/botbuilder-dotnet-ci-mac.yml
+++ b/build/yaml/vnextprototype/botbuilder-dotnet-ci-mac.yml
@@ -17,9 +17,9 @@ variables:
 steps:
 # Note: Template ci-build-steps.yml is not supported in macOS because it calls VSBuild@1 in order to build the Windows-only ASP.NET Desktop assemblies.
 - task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
+  displayName: 'Use .Net sdk 6.0'
   inputs:
-    version: 2.1.x
+    version: 6.0.x
 
 - task: UseDotNet@2
   displayName: 'Use .Net Core sdk 3.1.101'

--- a/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
+++ b/build/yaml/vnextprototype/botbuilder-dotnet-ci.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2022' ) ] # or 'windows-latest' or 'vs2017-win2016'
   demands:
   - msbuild
   - visualstudio
@@ -44,6 +44,13 @@ stages:
     steps:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
+  - job: Debug_Windows_Configuration_6
+    variables:
+      BuildConfiguration: Debug-Windows
+      BuildTarget: 'net6' # set the TargetFramework property for tests to use net6.0
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
   - job: Release_Windows_Configuration_31
     variables:
       BuildConfiguration: Release-Windows
@@ -53,3 +60,12 @@ stages:
     - template: ci-build-steps.yml
     - template: ci-test-steps.yml
     #- template: ci-component-detection-steps.yml
+  - job: Release_Windows_Configuration_6
+    variables:
+      BuildConfiguration: Release-Windows
+      BuildTarget: 'net6' # set the TargetFramework property for tests to use net6.0
+      PublishCoverage: false
+    steps:
+    - template: ci-build-steps.yml
+    - template: ci-test-steps.yml
+    # - template: ci-component-detection-steps.yml

--- a/build/yaml/vnextprototype/ci-build-steps.yml
+++ b/build/yaml/vnextprototype/ci-build-steps.yml
@@ -16,7 +16,7 @@ steps:
   displayName: 'Build solution Microsoft.Bot.Builder.sln'
   inputs:
     solution: '$(Parameters.solution)'
-    vsVersion: 16.0
+    vsVersion: 17.0
     msbuildArgs: '$(MSBuildArguments)'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'

--- a/build/yaml/vnextprototype/ci-test-steps.yml
+++ b/build/yaml/vnextprototype/ci-test-steps.yml
@@ -32,6 +32,16 @@ steps:
     arguments: '-v n  -f netcoreapp3.1 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
   condition: and(eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'netcoreapp31'))
 
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet test (release) 6.0'
+  inputs:
+    command: test
+    projects: |
+     Tests/**/*Tests.csproj
+
+    arguments: '-v n  -f net6.0 --configuration release --no-build --no-restore --filter "TestCategory!=IgnoreInAutomatedBuild&TestCategory!=FunctionalTests" --collect:"Code Coverage" --settings $(Build.SourcesDirectory)\CodeCoverage.runsettings'
+  condition: and(succeeded(), eq(variables['BuildConfiguration'],'Release-Windows'), eq(variables['BuildTarget'],'net6'))
+
 - powershell: |
    # This task copies the code coverage file created by dotnet test into a well known location. In all
    # checks I've done, dotnet test ALWAYS outputs the coverage file to the temp directory. 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime</PackageId>
     <Description>Library for building Adaptive Runtime bots using the Bot Framework SDK</Description>
     <Summary>Library for building Adaptive Runtime bots using the Bot Framework SDK</Summary>
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core/Microsoft.Bot.Builder.Integration.ApplicationInsights.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Builder.Integration.ApplicationInsights.Core</PackageId>
     <Description>This library integrates the Microsoft Bot Builder SDK with Application Insights.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and Application Insights.</Summary>
@@ -21,6 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/Microsoft.Bot.Builder.Integration.AspNet.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <Description>This library integrates the Microsoft Bot Builder SDK with ASP.NET Core. It offers idiomatic configuration APIs in addition to providing all the plumbing to direct incoming bot messages to a configured bot.</Description>
     <Summary>This library provides integration between the Microsoft Bot Builder SDK and ASP.NET Core.</Summary>
   </PropertyGroup>
@@ -23,6 +23,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <!-- Explicitly set to 5.0.1 for those built against 2.0-->
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.PrimaryTestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>594af4a1-e396-4609-8198-d665eb0c1f78</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Bots/SecondaryBot.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.Bots
             {
                 var metadata = ((FacebookThreadControl)turnContext.Activity.Value).Metadata;
 
-                if (metadata.Equals(HandoverConstants.MetadataPassThreadControl))
+                if (metadata.Equals(HandoverConstants.MetadataPassThreadControl, System.StringComparison.Ordinal))
                 {
                     var activity = MessageFactory.Text("Hello, I'm the secondary bot. How can I help you?");
                     await turnContext.SendActivityAsync(activity, cancellationToken);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot/Microsoft.Bot.Builder.Adapters.Facebook.SecondaryTestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dae2bae8-b3c8-4b83-8b3c-4022669c7a20</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -13,11 +14,8 @@
     <StartupObject />
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.TestBot/Microsoft.Bot.Builder.Adapters.Slack.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- The SlackAPI package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY SlackAPI. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
     <UserSecretsId>3c783a33-e2a5-4acd-99dd-581d563d47e3</UserSecretsId>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,11 +16,8 @@
     <NoWarn>$(NoWarn),CS8002</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.TestBot/Microsoft.Bot.Builder.Adapters.Twilio.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 
@@ -11,11 +12,8 @@
     <NoWarn>$(NoWarn),CS8002</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.TestBot/Microsoft.Bot.Builder.Adapters.Webex.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- The WebExTeams package isn't signed, so supress the warning. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
     <UserSecretsId>63730bc1-f7d4-4b32-8efe-ce03907b3e0a</UserSecretsId>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -2,18 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <!-- The Thrzn41.WebexTeams package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY Thrzn41.WebexTeams. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
+++ b/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -1047,7 +1047,11 @@ namespace AdaptiveExpressions.Tests
             Test("lastIndexOf(newGuid(), '-')", 23),
             Test("lastIndexOf(hello, '-')", -1),
             Test("lastIndexOf(nullObj, '-')", -1),
+#if NET5_0_OR_GREATER
+            Test("lastIndexOf(hello, nullObj)", 5),
+#else
             Test("lastIndexOf(hello, nullObj)", 4),
+#endif
             Test("lastIndexOf(json('[\"a\", \"b\", \"a\"]'), 'a')", 2),
             Test("lastIndexOf(json('[\"a\", \"b\"]'), 'c')", -1),
             Test("lastIndexOf(createArray('abc', 'def', 'ghi', 'def'), 'def')", 3),

--- a/tests/Auth/bot-authentication/AuthenticationBot.csproj
+++ b/tests/Auth/bot-authentication/AuthenticationBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
@@ -9,15 +10,12 @@
     <NoWarn>$(NoWarn),CS8002</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Include="..\Microsoft.Bot.Builder.Dialogs.Adaptive.Tests\TestUtils.cs" Link="TestUtils.cs" />
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Microsoft.Bot.Builder.AI.Luis.TestUtils.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Utils.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Luis.TestUtils/Utils.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.TestUtils
                 {
                     if (expectedToken.Type == JTokenType.String)
                     {
-                        withinDelta = expectedToken.Value<string>().Equals(actualToken.Value<string>(), StringComparison.InvariantCultureIgnoreCase);
+                        withinDelta = expectedToken.Value<string>().Equals(actualToken.Value<string>(), StringComparison.OrdinalIgnoreCase);
                     }
                     else
                     {

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling/Microsoft.Bot.Builder.Dialogs.Adaptive.Profiling.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -2,17 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/TestDataGenerator.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/TestDataGenerator.cs
@@ -5,16 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
-using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Microsoft.Bot.Builder.Runtime.Tests.Resources;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Runtime.Tests
 {
@@ -34,42 +29,9 @@ namespace Microsoft.Bot.Builder.Runtime.Tests
 
         internal static IConfigurationBuilder AddRuntimeSettings(this IConfigurationBuilder builder, RuntimeSettings runtimeSettings)
         {
-            var memoryFileProvider = new InMemoryFileProvider(JsonConvert.SerializeObject(new { runtimeSettings = runtimeSettings }));
-            return builder.AddJsonFile(memoryFileProvider, "appsettings.json", false, false);
-        }
-
-        private class InMemoryFileProvider : IFileProvider
-        {
-            private readonly IFileInfo _fileInfo;
-
-            public InMemoryFileProvider(string json) => _fileInfo = new InMemoryFile(json);
-
-            public IFileInfo GetFileInfo(string f) => _fileInfo;
-
-            public IDirectoryContents GetDirectoryContents(string f) => null;
-
-            public IChangeToken Watch(string f) => NullChangeToken.Singleton;
-
-            private class InMemoryFile : IFileInfo
-            {
-                private readonly byte[] _data;
-
-                public InMemoryFile(string json) => _data = Encoding.UTF8.GetBytes(json);
-
-                public bool Exists { get; } = true;
-
-                public long Length => _data.Length;
-
-                public string PhysicalPath { get; } = string.Empty;
-
-                public string Name { get; } = string.Empty;
-
-                public DateTimeOffset LastModified { get; } = DateTimeOffset.UtcNow;
-
-                public bool IsDirectory { get; } = false;
-
-                public Stream CreateReadStream() => new MemoryStream(_data);
-            }
+            var serializeSettings = JsonConvert.SerializeObject(new { runtimeSettings });
+            var stream = new MemoryStream(Encoding.ASCII.GetBytes(serializeSettings));
+            return builder.AddJsonStream(stream);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
     <!-- The MockHttp package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/JsonLoadTests.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
 
                     retries = -1;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     retries--;
                     if (retries > 0)
@@ -367,7 +367,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Loader.Tests
                     } 
                     else
                     {
-                        throw ex;
+                        throw;
                     }
                 }
             }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/SchemaTestsFixture.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 {
                     // Check if the new schema file has changed.
                     var newSchema = File.Exists(schemaPath) ? File.ReadAllText(schemaPath) : string.Empty;
-                    if (!newSchema.Equals(oldSchema))
+                    if (!newSchema.Equals(oldSchema, StringComparison.Ordinal))
                     {
                         throw new InvalidOperationException("tests.schema has changed when running tests on the build server.");
                     }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/TextPromptTests.cs
@@ -113,8 +113,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                 {
                     // If the input message is empty after a .Trim() operation, character the comparison will fail because the reply message will be a
                     // Message Activity with null as Text, this is expected behavior
-                    var messageIsBlank = e.Message.Equals(" :\nExpected: \nReceived:", StringComparison.CurrentCultureIgnoreCase) && naughtyString.Equals(" ", StringComparison.CurrentCultureIgnoreCase);
-                    var messageIsEmpty = e.Message.Equals(":\nExpected:\nReceived:", StringComparison.CurrentCultureIgnoreCase) && naughtyString.IsNullOrEmpty();
+                    var messageIsBlank = e.Message.Equals(" :\nExpected: \nReceived:", StringComparison.OrdinalIgnoreCase) && naughtyString.Equals(" ", StringComparison.OrdinalIgnoreCase);
+                    var messageIsEmpty = e.Message.Equals(":\nExpected:\nReceived:", StringComparison.OrdinalIgnoreCase) && naughtyString.IsNullOrEmpty();
                     if (!(messageIsBlank || messageIsEmpty))
                     {
                         throw;

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/Microsoft.Bot.Builder.TestBot.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>TestBot</UserSecretsId>
     <Configurations>Debug;Release</Configurations>
     <!-- The Jurrasic package isn't signed, so supress the warning. -->

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Bot.Builder.TestBot.Tests</AssemblyName>
     <RootNamespace>Microsoft.BotBuilderSamples.Tests</RootNamespace>
@@ -20,11 +21,8 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot/Microsoft.Bot.Builder.TestBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/Microsoft.Bot.Builder.TestBot/wwwroot/default.htm
+++ b/tests/Microsoft.Bot.Builder.TestBot/wwwroot/default.htm
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
 </head>
 <body style="font-family:'Segoe UI'">
-    <h1>TestBot using ASP.Net Core 2</h1>
+    <h1>TestBot using ASP.Net 6</h1>
     <p>Describe your bot here and your terms of use etc.</p>
     <p>To debug your bot using the Bot Framework Emulator, paste this URL into the Emulator window:</p>
     <div style="padding-left: 50px;" id="botBaseUrl"></div>

--- a/tests/Microsoft.Bot.Builder.TestProtocol/Microsoft.Bot.Builder.TestProtocol.csproj
+++ b/tests/Microsoft.Bot.Builder.TestProtocol/Microsoft.Bot.Builder.TestProtocol.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>1ae6e573-b022-4bd5-b6b5-7ea57e4977f8</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.Tests
                 textActions.SetEquals(message.SuggestedActions.Actions.Select(action => action.Title)),
                 "The message's suggested actions have the wrong set of titles.");
             Assert.True(
-                message.SuggestedActions.Actions.All(action => action.Type.Equals(ActionTypes.ImBack)),
+                message.SuggestedActions.Actions.All(action => action.Type.Equals(ActionTypes.ImBack, StringComparison.Ordinal)),
                 "The message's suggested actions are of the wrong action type.");
         }
 
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Tests
                 titles.SetEquals(message.SuggestedActions.Actions.Select(action => action.Title)),
                 "The message's suggested actions have the wrong set of titles.");
             Assert.True(
-                message.SuggestedActions.Actions.All(action => action.Type.Equals(ActionTypes.ImBack)),
+                message.SuggestedActions.Actions.All(action => action.Type.Equals(ActionTypes.ImBack, StringComparison.Ordinal)),
                 "The message's suggested actions are of the wrong action type.");
         }
 

--- a/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/SkillConversationIdFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/SkillConversationIdFactoryTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
                     return false;
                 }
 
-                return x.Conversation.Id.Equals(y.Conversation?.Id) && x.ServiceUrl.Equals(y.ServiceUrl);
+                return x.Conversation.Id.Equals(y.Conversation?.Id, StringComparison.Ordinal) && x.ServiceUrl.Equals(y.ServiceUrl, StringComparison.Ordinal);
             }
 
             public override int GetHashCode(ConversationReference obj)

--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Tests
             }
 
             string content;
-            if (string.Equals(Path.GetExtension(path), ".chat", StringComparison.InvariantCultureIgnoreCase))
+            if (string.Equals(Path.GetExtension(path), ".chat", StringComparison.OrdinalIgnoreCase))
             {
                 content = ExecuteChatdownTool(path);
             }
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Tests
         /// <returns>A valid conversation reference to the activity provides.</returns>
         public static ConversationReference GetConversationReference(this IActivity activity)
         {
-            bool IsReply(IActivity act) => string.Equals("bot", act.From?.Role, StringComparison.InvariantCultureIgnoreCase);
+            bool IsReply(IActivity act) => string.Equals("bot", act.From?.Role, StringComparison.OrdinalIgnoreCase);
             var bot = IsReply(activity) ? activity.From : activity.Recipient;
             var user = IsReply(activity) ? activity.Recipient : activity.From;
             return new ConversationReference

--- a/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Transcripts.Tests/Microsoft.Bot.Builder.Transcripts.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Configuration.Tests/ConnectionTests.cs
+++ b/tests/Microsoft.Bot.Configuration.Tests/ConnectionTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Bot.Configuration.Tests
             // Choose a duplicated service and remove the correct one.
             // We should have at least an ABS and generic service with the name "testAbs".
             const string name = "testAbs";
-            var duplicateServices = config2.Services.Where(s => s.Name.Equals(name)).ToArray();
+            var duplicateServices = config2.Services.Where(s => s.Name.Equals(name, StringComparison.Ordinal)).ToArray();
             Assert.True(duplicateServices.Length > 1, "Should have at least two services with this name.");
 
             var botService = config2.DisconnectServiceByNameOrId<BotService>(name);

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Connector.Streaming.Perf/Microsoft.Bot.Connector.Streaming.Perf.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Perf/Microsoft.Bot.Connector.Streaming.Perf.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests.Client/Microsoft.Bot.Connector.Streaming.Tests.Client.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests.Client/Microsoft.Bot.Connector.Streaming.Tests.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests.Server/Microsoft.Bot.Connector.Streaming.Tests.Server.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests.Server/Microsoft.Bot.Connector.Streaming.Tests.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -2,25 +2,19 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Remove="Resources\architecture-resize.png" />
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
     <!-- The MockHttp package isn't signed, so supress the warning. -->
-    <NoWarn>$(NoWarn),CS8002,NU1608</NoWarn>
+    <NoWarn>$(NoWarn),CS8002,NU1608,CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/OAuthConnectorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build does not throw an exception.
                 await client.UserToken.GetTokenAsync("dummyUserid", "dummyConnectionName", "dummyChannelId", "dummyCode");
@@ -99,7 +99,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await Assert.ThrowsAsync<ErrorResponseException>(() => client.UserToken.SignOutAsync(
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await Assert.ThrowsAsync<Microsoft.Rest.HttpOperationException>(() => client.BotSignIn.GetSignInUrlAsync(
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
  
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await Assert.ThrowsAsync<Microsoft.Bot.Schema.ErrorResponseException>(() => client.UserToken.GetTokenStatusAsync(
@@ -198,7 +198,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await Assert.ThrowsAsync<Microsoft.Bot.Schema.ErrorResponseException>(() => client.UserToken.GetAadTokensAsync(
@@ -226,7 +226,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await OAuthClientConfig.SendEmulateOAuthCardsAsync(client, true);
@@ -255,7 +255,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await Assert.ThrowsAsync<Microsoft.Rest.HttpOperationException>(() => client.GetSignInResourceAsync(
@@ -308,7 +308,7 @@ namespace Microsoft.Bot.Connector.Tests
             ServiceClientTracing.IsEnabled = true;
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_OS")) &&
-                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT"))
+                Environment.GetEnvironmentVariable("AGENT_OS").Equals("Windows_NT", StringComparison.Ordinal))
             {
                 // Automated Windows build exception:
                 await client.ExchangeAsyncAsync(

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -10,16 +11,8 @@
     <Compile Remove="ReceiveBaseTests.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Parser/LuParserTests.cs
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Parser/LuParserTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Bot.Builder.Parsers.LU.Tests.Parser
             var luContent = File.ReadAllText(path);
             luContent = luContent.Substring(0, luContent.Length);
             var result = LuParser.Parse(luContent);
-            if (string.Equals(fileName, "LU_Sections") || string.Equals(fileName, "SectionsLU"))
+            if (string.Equals(fileName, "LU_Sections", StringComparison.Ordinal) || string.Equals(fileName, "SectionsLU", StringComparison.Ordinal))
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {

--- a/tests/Skills/Bot1/Bot1.csproj
+++ b/tests/Skills/Bot1/Bot1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Bot2/Bot2.csproj
+++ b/tests/Skills/Bot2/Bot2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Bot3/Bot3.csproj
+++ b/tests/Skills/Bot3/Bot3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Skills/Child/Child.csproj
+++ b/tests/Skills/Child/Child.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/Skills/Parent/Parent.csproj
+++ b/tests/Skills/Parent/Parent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>f277272c-9113-411f-addd-a4acfa9701a2</UserSecretsId>
     <RootNamespace>Microsoft.BotBuilderSamples</RootNamespace>
   </PropertyGroup>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -2,18 +2,23 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.6" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
+  </ItemGroup>
+  
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -2,17 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.Mocks;
-using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -274,15 +273,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 [Fact]
                 public void DoesntReplaceExistingAdapterIntegration()
                 {
-                    var serviceCollectionMock = CreateServiceCollectionMock();
+                    var serviceCollection = new ServiceCollection();
                     var adapterIntegration = Mock.Of<IAdapterIntegration>();
 
-                    serviceCollectionMock.Object.AddSingleton<IAdapterIntegration>(adapterIntegration);
+                    serviceCollection.AddSingleton(adapterIntegration);
+                    serviceCollection.AddBot<ServiceRegistrationTestBot>();
 
-                    serviceCollectionMock.Object.AddBot<ServiceRegistrationTestBot>();
-
-                    serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IAdapterIntegration))), Times.Once());
-                    serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IAdapterIntegration) && sd.ImplementationInstance == adapterIntegration)));
+                    Assert.Equal(2, serviceCollection.Count);
+                    Assert.Equal("IAdapterIntegration", serviceCollection[0].ServiceType.Name);
+                    Assert.Equal("IBot", serviceCollection[1].ServiceType.Name);
                 }
 
                 private void VerifyExpectedBotServicesAreRegistered(Mock<IServiceCollection> serviceCollectionMock)
@@ -361,15 +360,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 [Fact]
                 public void DoesntReplaceExistingAdapterIntegration()
                 {
-                    var serviceCollectionMock = CreateServiceCollectionMock();
+                    var serviceCollection = new ServiceCollection();
                     var adapterIntegration = Mock.Of<IAdapterIntegration>();
 
-                    serviceCollectionMock.Object.AddSingleton<IAdapterIntegration>(adapterIntegration);
+                    serviceCollection.AddSingleton(adapterIntegration);
+                    serviceCollection.AddBot(sp => new ServiceRegistrationTestBot());
 
-                    serviceCollectionMock.Object.AddBot<ServiceRegistrationTestBot>(sp => new ServiceRegistrationTestBot());
-
-                    serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IAdapterIntegration))), Times.Once());
-                    serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IAdapterIntegration) && sd.ImplementationInstance == adapterIntegration)));
+                    Assert.Equal(2, serviceCollection.Count);
+                    Assert.Equal("IAdapterIntegration", serviceCollection[0].ServiceType.Name);
+                    Assert.Equal("IBot", serviceCollection[1].ServiceType.Name);
                 }
 
                 private void VerifyExpectedBotServicesAreRegistered(Mock<IServiceCollection> serviceCollectionMock)
@@ -446,15 +445,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 [Fact]
                 public void DoesntReplaceExistingAdapterIntegration()
                 {
-                    var serviceCollectionMock = CreateServiceCollectionMock();
+                    var serviceCollection = new ServiceCollection();
                     var adapterIntegration = Mock.Of<IAdapterIntegration>();
 
-                    serviceCollectionMock.Object.AddSingleton<IAdapterIntegration>(adapterIntegration);
+                    serviceCollection.AddSingleton(adapterIntegration);
+                    serviceCollection.AddBot(new ServiceRegistrationTestBot());
 
-                    serviceCollectionMock.Object.AddBot(new ServiceRegistrationTestBot());
-
-                    serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IAdapterIntegration))), Times.Once());
-                    serviceCollectionMock.Verify(sc => sc.Add(It.Is<ServiceDescriptor>(sd => sd.ServiceType == typeof(IAdapterIntegration) && sd.ImplementationInstance == adapterIntegration)));
+                    Assert.Equal(2, serviceCollection.Count);
+                    Assert.Equal("IAdapterIntegration", serviceCollection[0].ServiceType.Name);
+                    Assert.Equal("IBot", serviceCollection[1].ServiceType.Name);
                 }
 
                 private void VerifyExpectedBotServicesAreRegistered(Mock<IServiceCollection> serviceCollectionMock)


### PR DESCRIPTION
Addresses #5977
#minor

## Description
This PR updates the test projects, the test bots, and the CI pipelines to target .NET6.
All these changes need to be done in one PR in order for the build checks to pass. 
We divided the changes into three commits to ease the review:

- Updated test projects ([930e801](https://github.com/southworks/botbuilder-dotnet/pull/458/commits/930e80153977b1204b5ac2cde55fb624b3f7f174))
- Updated test bots ([53265ad](https://github.com/southworks/botbuilder-dotnet/pull/458/commits/53265ad41a26b6f2f28e3bbb723ddc1b466285e8))
- Updated CI yamls ([edcb92c](https://github.com/southworks/botbuilder-dotnet/pull/458/commits/edcb92c26bcaa2c4489cdcdb86b843ef962a833a))

_Note: The FunctionalTests pipelines will be updated in a separate PR._

## Specific Changes
- **For the test projects:**
   - Update projects to target net6.0 as well as netcoreapp3.1.
   - Fixed [CA1309](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1309) issues with StringComparison.
   - Added a condition to evaluate _lastIndexOf_ in _ExpressionParserTests.cs_ as it's different in Net5 or higher.
   - Adapted test in _ServiceCollectionExtensionsTests.cs_ due to a change in the use of _GetEnumerator_ in _TryAddSingleton_ method.
   - Replaced obsolete _WebClient_ with _HttpClient_ in _WebexClientTests.cs_.

- **For the bots projects:**
   - Updated all the bots to target .NET6 instead of netcoreapp3.1.
   - Fixed [CA1309](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1309) issues with StringComparison.

- **For the CI pipelines yamls:**
   - Updated the _vmImages_ from windows-2019 to windows-2022.
   - Added steps to build and test targeting .NET6.
   - Changed _vsVersion_ from 16.0 to 17.0.
   - Added step to install bf cli in `botbuilder-dotnet-simple-build-test.yml` to avoid the _Microsoft.Bot.Builder.Dialogs.Declarative.Tests_ to fail

## Testing
These images show some of the updated bots working as expected.
![image](https://user-images.githubusercontent.com/44245136/167473690-0948e5e0-e89b-4698-98f9-6a84a513cafb.png)

Here we can see the pipelines working after the changes.
![image](https://user-images.githubusercontent.com/44245136/168093094-8b15b502-81c5-4de7-852c-3d0abc8f5c3f.png)