### PR TITLE
[#6323] Update generators and vsix to target Net 6 by default

### DIFF
--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/.template.config/template.json
@@ -46,12 +46,12 @@
         "datatype": "choice",
         "choices": [
           {
-            "choice": "netcoreapp3.1",
-            "description": "Target netcoreapp3.1"
+            "choice": "net6.0",
+            "description": "Target net6.0"
           }
         ],
         "replaces": "__NETCOREAPP_VERSION__",
-        "defaultValue": "netcoreapp3.1"
+        "defaultValue": "net6.0"
       },
       "IncludeTests": {
         "type": "parameter",
@@ -69,8 +69,8 @@
           "evaluator": "C++",
           "cases": [
             {
-              "condition": "(Framework==\"netcoreapp3.1\")",
-              "value": "3.1"
+              "condition": "(Framework==\"net6.0\")",
+              "value": "6.0"
             }
           ]
         }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.CoreBot/content/CoreBot/README.md
@@ -17,9 +17,9 @@ This sample **requires** prerequisites in order to run.
 
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
 
-### Install .NET Core CLI
+### Install .NET CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) __NETCORE_VERSION__
+- [.NET SDK](https://dotnet.microsoft.com/download) __NETCORE_VERSION__
 
   ```bash
   # determine dotnet version

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/.template.config/template.json
@@ -45,12 +45,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1"
+          "choice": "net6.0",
+          "description": "Target net6.0"
         }
       ],
       "replaces": "__NETCOREAPP_VERSION__",
-      "defaultValue": "netcoreapp3.1"
+      "defaultValue": "net6.0"
     },
     "ReadmeNetCorePrereqVersion": {
       "type":"generated",
@@ -61,8 +61,8 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(Framework==\"netcoreapp3.1\")",
-            "value": "3.1"
+            "condition": "(Framework==\"net6.0\")",
+            "value": "6.0"
           }
         ]
       }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EchoBot/content/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version __NETCORE_VERSION__
+- [.NET SDK](https://dotnet.microsoft.com/download) version __NETCORE_VERSION__
 
   ```bash
   # determine dotnet version

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/.template.config/template.json
@@ -45,12 +45,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1"
+          "choice": "net6.0",
+          "description": "Target net6.0"
         }
       ],
       "replaces": "__NETCOREAPP_VERSION__",
-      "defaultValue": "netcoreapp3.1"
+      "defaultValue": "net6.0"
     },
     "ReadmeNetCorePrereqVersion": {
       "type":"generated",
@@ -61,8 +61,8 @@
         "evaluator": "C++",
         "cases": [
           {
-            "condition": "(Framework==\"netcoreapp3.1\")",
-            "value": "3.1"
+            "condition": "(Framework==\"net6.0\")",
+            "value": "6.0"
           }
         ]
       }

--- a/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
+++ b/generators/dotnet-templates/Microsoft.BotFramework.CSharp.EmptyBot/content/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version __NETCORE_VERSION__
+- [.NET SDK](https://dotnet.microsoft.com/download) version __NETCORE_VERSION__
 
   ```bash
   # determine dotnet version

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/CoreBot.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Core Bot (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Core Bot (Bot Framework v4 - .NET 6)</Name>
     <Description>Core Bot Template for Bot Framework v4.  Our most feature rich template, it shows how to use LUIS and multi-turn conversational patterns.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBot/README.md
@@ -17,9 +17,9 @@ This sample **requires** prerequisites in order to run.
 
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
 
-### Install .NET Core CLI
+### Install .NET CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot.tests/CoreBot.Tests.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot.tests/CoreBot.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/CoreBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBot/README.md
@@ -17,9 +17,9 @@ This sample **requires** prerequisites in order to run.
 
 This bot uses [LUIS](https://www.luis.ai), an AI based cognitive service, to implement language understanding.
 
-### Install .NET Core CLI
+### Install .NET CLI
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBotWithTests.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/CoreBotWithTests/CoreBotWithTests.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="ProjectGroup">
   <TemplateData>
-    <Name>Core Bot with Tests (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Core Bot with Tests (Bot Framework v4 - .NET 6.0)</Name>
     <Description>Core Bot Template with Unit Tests for Bot Framework v4.  Same features as Core Bot, plus a full unit test project.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/EchoBot.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Echo Bot (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Echo Bot (Bot Framework v4 - .NET 6.0)</Name>
     <Description>Echo Bot Template for Bot Framework v4.  A good template if you want a little more than "Hello World!".  Echo Bot simply "echoes" back to the user anything the user says to the bot.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EchoBot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.vstemplate
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/EmptyBot.vstemplate
@@ -1,6 +1,6 @@
 <VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Project">
   <TemplateData>
-    <Name>Empty Bot (Bot Framework v4 - .NET Core 3.1)</Name>
+    <Name>Empty Bot (Bot Framework v4 - .NET 6.0)</Name>
     <Description>Empty Bot Template for Bot Framework v4.  A good template if you want a skeleton project or want to take sample code from the documentation and paste it into a minimal bot in order to learn.
     </Description>
     <ProjectType>CSharp</ProjectType>

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/README.md
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/UncompressedProjectTemplates/EmptyBot/README.md
@@ -6,7 +6,7 @@ This bot has been created using [Bot Framework](https://dev.botframework.com), i
 
 ## Prerequisites
 
-- [.NET Core SDK](https://dotnet.microsoft.com/download) version 3.1
+- [.NET SDK](https://dotnet.microsoft.com/download) version 6.0
 
   ```bash
   # determine dotnet version


### PR DESCRIPTION
Fixes #6323

## Description
This PR updates the bot templates in `dotnet-templates` and `vsix-vs-win` to target .NET6 as default.
It also updates the README file of each bot.

## Specific Changes
- Updated template.json of the following bots to target .NET6:
   - dotnet-templates
      - EchoBot
      - CoreBot
      - EmptyBot
   - vsix-vs-win
      - EchoBot
      - CoreBot
      - CoreBot with tests
      - EmptyBot
- Updated .csproj of the vsix-vs-win bots
- Updated the README files' _Install .NET CLI_ section 

## Testing
![image](https://user-images.githubusercontent.com/44245136/167471453-2e2ba2c9-eac7-4047-b45e-047fb6e00bb5.png)
