### PR TITLE
fix: Add oAuthEndpoint to _oAuthClients cache key (#6298)

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Bot.Builder
         private readonly ConcurrentDictionary<string, ConnectorClient> _connectorClients = new ConcurrentDictionary<string, ConnectorClient>();
 
         // Cache for OAuthClient to speed up OAuth operations
-        // _oAuthClients is a cache using [appId + oAuthCredentialAppId]
+        // _oAuthClients is a cache using [appId + oAuthCredentialAppId + oAuthEndpoint]
         private readonly ConcurrentDictionary<string, OAuthClient> _oAuthClients = new ConcurrentDictionary<string, OAuthClient>();
 
         /// <summary>
@@ -1396,7 +1396,6 @@ namespace Microsoft.Bot.Builder
 
             var appId = GetBotAppId(turnContext);
 
-            var clientKey = $"{appId}:{oAuthAppCredentials?.MicrosoftAppId}";
             var oAuthScope = GetBotFrameworkOAuthScope();
 
             var appCredentials = oAuthAppCredentials ?? await GetAppCredentialsAsync(appId, oAuthScope).ConfigureAwait(false);
@@ -1408,6 +1407,8 @@ namespace Microsoft.Bot.Builder
                 OAuthClientConfig.EmulateOAuthCards = true;
             }
 
+            var oAuthEndpoint = OAuthClientConfig.OAuthEndpoint;
+            var clientKey = $"{appId}:{oAuthAppCredentials?.MicrosoftAppId}:{oAuthEndpoint}";
             var oAuthClient = _oAuthClients.GetOrAdd(clientKey, (key) =>
             {
                 OAuthClient oAuthClientInner;
@@ -1419,7 +1420,7 @@ namespace Microsoft.Bot.Builder
                 }
                 else
                 {
-                    oAuthClientInner = new OAuthClient(new Uri(OAuthClientConfig.OAuthEndpoint), appCredentials);
+                    oAuthClientInner = new OAuthClient(new Uri(oAuthEndpoint), appCredentials);
                 }
 
                 return oAuthClientInner;

--- a/tests/Microsoft.Bot.Builder.Tests/MockAppCredentials.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MockAppCredentials.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    public class MockAppCredentials : AppCredentials
+    {
+        public MockAppCredentials(string channelAuthTenant = null, HttpClient customHttpClient = null, ILogger logger = null)
+            : base(channelAuthTenant, customHttpClient, logger)
+        {
+        }
+
+        protected override Lazy<AdalAuthenticator> BuildAuthenticator()
+        {
+            return new Lazy<AdalAuthenticator>();
+        }
+    }
+}


### PR DESCRIPTION
#minor

* Add oAuthEndpoint to _oAuthClients cache key

* Add CreateOAuthClientWithDifferentEndpoints test

Authored-by: Craig Jensen <crjens@hotmail.com>

