### PR TITLE
[#6265] NullReferenceException when passing dialog name as variable to Microsoft.BeginDialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -95,8 +96,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             // NOTE: we want the result of the expression as a string so we can look up the string using external FindDialog().
             var se = new StringExpression($"={this.Dialog.ExpressionText}");
-            var dialogId = se.GetValue(dc.State);
-            return dc.FindDialog(dialogId ?? throw new InvalidOperationException($"{this.Dialog.ToString()} not found."));
+            var dialogId = se.GetValue(dc.State) ?? throw new InvalidOperationException($"{this.Dialog.ToString()} not found.");
+            var dialog = dc.FindDialog(dialogId);
+            var resourceExplorer = dc.Context.TurnState.Get<ResourceExplorer>();
+            
+            if (resourceExplorer != null && dialog == null)
+            {
+                dialog = resourceExplorer.LoadType<AdaptiveDialog>($"{dialogId}.dialog");
+                dc.Dialogs.Add(dialog);
+            }
+
+            return dialog;
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -96,6 +96,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task AdaptiveDialog_LoadDialogFromProperty()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task AdaptiveDialog_BeginDialog()
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_LoadDialogFromProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_LoadDialogFromProperty.test.dialog
@@ -1,0 +1,35 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "outer",
+        "autoEndDialog": false,
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "value": "TellJokeDialog",
+                        "property": "turn.dialogToStart"
+                    },
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "dialog": "=turn.dialogToStart"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Why did the chicken cross the road?"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #6265
#minor

## Description
This PR adds the ability for the Dialog to be loaded automatically from an expression property when isn't registered manually.
Once the dialog is loaded into the dialogs stack, the next time the dialog is required, it will be already available.

## Specific Changes
- Adds a step to gather the dialog resource when isn't found in the dialogs stack from the `ResourceExplorer` to be loaded automatically into the dialogs stack.
- Adds a new unit test that corroborates the dialog is being loaded correctly from an expression property.

## Testing
The following image shows the dialog working from a Composer bot and the new unit test passing.
![image](https://user-images.githubusercontent.com/62260472/169308038-9f8c6ada-7577-4a24-aced-745252c9c878.png)