### PR TITLE
[#6339] Mark deprecated channels as obsolete in Channels enum

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -22,11 +22,13 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Console channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Console = "console";
 
         /// <summary>
         /// Cortana channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Cortana = "cortana";
 
         /// <summary>
@@ -62,6 +64,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Kik channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Kik = "kik";
 
         /// <summary>
@@ -82,6 +85,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Skype for Business channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Skypeforbusiness = "skypeforbusiness";
 
         /// <summary>
@@ -118,6 +122,7 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Telephony channel.
         /// </summary>
+        [Obsolete("This channel is deprecated.")]
         public const string Telephony = "telephony";
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Console channel.
         /// </summary>
-        [Obsolete("This channel is deprecated.")]
         public const string Console = "console";
 
         /// <summary>
@@ -52,6 +51,12 @@ namespace Microsoft.Bot.Connector
         public const string Emulator = "emulator";
 
         /// <summary>
+        /// EnterpriseChannel channel.
+        /// </summary>
+        [Obsolete("This channel is deprecated.")]
+        public const string EnterpriseChannel = "enterprisechannel";
+
+        /// <summary>
         /// Facebook channel.
         /// </summary>
         public const string Facebook = "facebook";
@@ -60,6 +65,12 @@ namespace Microsoft.Bot.Connector
         /// Group Me channel.
         /// </summary>
         public const string Groupme = "groupme";
+
+        /// <summary>
+        /// Kaizala channel.
+        /// </summary>
+        [Obsolete("This channel is deprecated.")]
+        public const string Kaizala = "kaizala";
 
         /// <summary>
         /// Kik channel.
@@ -122,7 +133,6 @@ namespace Microsoft.Bot.Connector
         /// <summary>
         /// Telephony channel.
         /// </summary>
-        [Obsolete("This channel is deprecated.")]
         public const string Telephony = "telephony";
 
         /// <summary>


### PR DESCRIPTION
Fixes #6339

## Description
This PR marks the unsupported channels as deprecated.
Unsupported channels:
- Cortana
- EnterpriseChannel
- Kaizala
- Kik
- SkypeForBusiness

## Specific Changes
- Unsupported channels are marked as deprecated in Microsoft.Bot.Connector/Channels.cs

## Testing
This screenshot shows the unit tests passing
<img width="498" alt="image" src="https://user-images.githubusercontent.com/64815358/169897665-377b3037-e0ad-4742-8ce5-7dbd25167427.png">
