### PR TITLE
[#5837] Fix sentiment values not being set for None / Unknown intent

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/CrossTrainedRecognizerSet.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                         return new RecognizerResult()
                         {
                             Text = recognizerResults[recognizer.Id].Text,
-                            Intents = new Dictionary<string, IntentScore>() { { NoneIntent, new IntentScore() { Score = 1.0 } } }
+                            Intents = new Dictionary<string, IntentScore>() { { NoneIntent, new IntentScore() { Score = 1.0 } } },
+                            Properties = recognizerResults[recognizer.Id].Properties,
                         };
                     }
                 }
@@ -196,11 +197,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             }
 
             // return none.
+            var recognizerResult = recognizerResults.Values.First();
             return new RecognizerResult()
             {
-                Text = recognizerResults.Values.First().Text,
+                Text = recognizerResult.Text,
                 Intents = new Dictionary<string, IntentScore>() { { NoneIntent, new IntentScore() { Score = 1.0 } } },
-                Entities = mergedEntities
+                Entities = mergedEntities,
+                Properties = recognizerResult.Properties
             };
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
@@ -126,11 +126,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         protected static RecognizerResult CreateChooseIntentResult(Dictionary<string, RecognizerResult> recognizerResults)
         {
             string text = null;
+            IDictionary<string, object> properties = null;
             var candidates = new List<JObject>();
 
             foreach (var recognizerResult in recognizerResults)
             {
                 text = recognizerResult.Value.Text;
+                properties = recognizerResult.Value.Properties;
                 var (intent, score) = recognizerResult.Value.GetTopScoringIntent();
                 if (intent != NoneIntent)
                 {
@@ -145,12 +147,14 @@ namespace Microsoft.Bot.Builder.Dialogs
 
             if (candidates.Any())
             {
+                properties.Add("candidates", candidates);
+
                 // return ChooseIntent with candidates array
                 return new RecognizerResult()
                 {
                     Text = text,
                     Intents = new Dictionary<string, IntentScore>() { { ChooseIntent, new IntentScore() { Score = 1.0 } } },
-                    Properties = new Dictionary<string, object>() { { "candidates", candidates } },
+                    Properties = properties
                 };
             }
 
@@ -158,7 +162,8 @@ namespace Microsoft.Bot.Builder.Dialogs
             return new RecognizerResult()
             {
                 Text = text,
-                Intents = new Dictionary<string, IntentScore>() { { NoneIntent, new IntentScore() { Score = 1.0 } } }
+                Intents = new Dictionary<string, IntentScore>() { { NoneIntent, new IntentScore() { Score = 1.0 } } },
+                Properties = properties
             };
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestTelemetryProperties.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/TestTelemetryProperties.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 { "TopIntentScore", "1.0" },
                 { "Intents", "{\"ChooseIntent\":{\"score\":1.0}}" },
                 { "Entities", "{}" },
-                { "AdditionalProperties", "{\"candidates\":[{\"id\":\"y\",\"intent\":\"y\",\"score\":1.0,\"result\":{\"text\":\"criss-cross applesauce\",\"alteredText\":null,\"intents\":{\"y\":{\"score\":1.0,\"pattern\":\"criss-cross applesauce\"}},\"entities\":{},\"id\":\"y\"}},{\"id\":\"z\",\"intent\":\"z\",\"score\":1.0,\"result\":{\"text\":\"criss-cross applesauce\",\"alteredText\":null,\"intents\":{\"z\":{\"score\":1.0,\"pattern\":\"criss-cross applesauce\"}},\"entities\":{},\"id\":\"z\"}}]}" },
+                { "AdditionalProperties", "{\"id\":\"z\",\"candidates\":[{\"id\":\"y\",\"intent\":\"y\",\"score\":1.0,\"result\":{\"text\":\"criss-cross applesauce\",\"alteredText\":null,\"intents\":{\"y\":{\"score\":1.0,\"pattern\":\"criss-cross applesauce\"}},\"entities\":{},\"id\":\"y\"}},{\"id\":\"z\",\"intent\":\"z\",\"score\":1.0,\"result\":{\"text\":\"criss-cross applesauce\",\"alteredText\":null,\"intents\":{\"z\":{\"score\":1.0,\"pattern\":\"criss-cross applesauce\"}},\"entities\":{},\"id\":\"z\"}}]}" },
             };
         }
 


### PR DESCRIPTION
Fixes #5837

## Description
This PR adds the `properties` object into the `RecognizerResult` instances in the `CrossTrainedRecognizerSet` and `Recognizer` classes, and also adds unit tests to corroborate the `properties` object is being set correctly.

## Specific Changes
- Adds the `Properties` attribute value into multiple `RecognizerResult` instances from the `CrossTrainedRecognizerSet` and `Recognizer` classes.
- Adds unit tests for multiple cases to corroborate the `Properties` attribute is being set correctly.

## Testing
The following images show the new unit tests passing and the bot responding with the included properties in the trace activity.
![image](https://user-images.githubusercontent.com/62260472/171017656-797b251e-a622-40ec-96f8-45ecf12af907.png)
![image](https://user-images.githubusercontent.com/62260472/171017525-830fc3db-0be8-47cb-b30c-0ee1c03706ca.png)