### PR TITLE
Add QnAId in value attribute of multi-turn prompts.

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -645,8 +645,19 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
         private static void ResetOptions(DialogContext dc, QnAMakerDialogOptions dialogOptions)
         {
-            // Resetting context and QnAId
-            dialogOptions.QnAMakerOptions.QnAId = 0;
+            // Initializing qnaId if present in value, otherwise resetting to 0
+            var qnaIdFromContext = dc.Context.Activity.Value;
+
+            if (qnaIdFromContext != null)
+            {
+                dialogOptions.QnAMakerOptions.QnAId = (int)(long)qnaIdFromContext;
+            }
+            else
+            {
+                dialogOptions.QnAMakerOptions.QnAId = 0;
+            }
+
+            // Resetting context;
             dialogOptions.QnAMakerOptions.Context = new QnARequestContext();
 
             // -Check if previous context is present, if yes then put it with the query

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
@@ -117,9 +117,11 @@ namespace Microsoft.Bot.Builder.AI.QnA
                     buttonList.Add(
                         new CardAction()
                         {
-                            Value = prompt.DisplayText,
-                            Type = "imBack",
+                            Value = prompt.QnaId,
+                            Type = "messageBack",
                             Title = prompt.DisplayText,
+                            Text = prompt.DisplayText,
+                            DisplayText = prompt.DisplayText,
                         });
                 }
             }


### PR DESCRIPTION
Fixes #6351

## Description
Store qnaId in the prompts so that its readily available everytime the prompt is clicked

## Specific Changes
- Changed prompt type from "imBack" to "messageBack"
- pass qnaId as value in prompts
- Check if value has qnaId before resetting dialogOptions.

## Testing
