### PR TITLE
[#6367] Telemetry not working inside child dialogs using latest Adaptive Runtime

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         private DialogContext CreateChildContext(DialogContext dc, DialogState childDialogState)
         {
             var dialogSet = new DialogSet();
-            dialogSet.TelemetryClient = TelemetryClient ?? dc.Context.TurnState.Get<IBotTelemetryClient>();
+            dialogSet.TelemetryClient = TelemetryClient ?? dc.Context.TurnState.Get<IBotTelemetryClient>() ?? NullBotTelemetryClient.Instance;
             dialogSet.Add(_scope);
 
             var childDc = new DialogContext(dialogSet, dc.Parent ?? dc, childDialogState);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
@@ -249,7 +249,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
         private DialogContext CreateChildContext(DialogContext dc, DialogState childDialogState)
         {
-            var childDc = new DialogContext(new DialogSet().Add(_scope), dc.Parent ?? dc, childDialogState);
+            var dialogSet = new DialogSet();
+            dialogSet.TelemetryClient = TelemetryClient ?? dc.Context.TurnState.Get<IBotTelemetryClient>();
+            dialogSet.Add(_scope);
+
+            var childDc = new DialogContext(dialogSet, dc.Parent ?? dc, childDialogState);
             childDc.Parent = dc.Parent;
 
             if (dc.Services != null)


### PR DESCRIPTION
Fixes #6367

## Description
This PR fixes an issue where the `ForEachElement` Telemetry Client doesn't log the activity properly due to not being set properly, and have a default `NullBotTelemetryClient` instance assigned instead.

## Specific Changes
- Adds `DialogSet.TelemetryClient` assignment to be gathered from the `ForEachElement (Dialog)` telemetry client property.

## Testing
The following image shows the reproduced issue, the before and after result of the `ForEachElement` and the new implementation.
![image](https://user-images.githubusercontent.com/62260472/175102266-f7a0bb72-4e1d-4c89-bbf2-a5cebfbf635f.png)