### PR TITLE
[#6392] Bump Newtonsoft.Json from 12.0.3 to 13.0.1 - Set MaxDepth property (2/4)

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                 {
                     using (BlobDownloadInfo download = await blobReference.DownloadAsync(cancellationToken).ConfigureAwait(false))
                     {
-                        using (var jsonReader = new JsonTextReader(new StreamReader(download.Content)))
+                        using (var jsonReader = new JsonTextReader(new StreamReader(download.Content)) { MaxDepth = null })
                         {
                             var obj = _jsonSerializer.Deserialize(jsonReader);
 

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -126,12 +126,13 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         public async Task LogActivityAsync(IActivity activity)
         {
             BotAssert.ActivityNotNull(activity);
+            var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
 
             switch (activity.Type)
             {
                 case ActivityTypes.MessageUpdate:
                     {
-                        var updatedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+                        var updatedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, serializerSettings), serializerSettings);
                         updatedActivity.Type = ActivityTypes.Message; // fixup original type (should be Message)
 
                         var activityAndBlob = await InnerReadBlobAsync(activity).ConfigureAwait(false);
@@ -416,7 +417,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         private async Task<Activity> GetActivityFromBlobClientAsync(BlobClient blobClient)
         {
             using BlobDownloadInfo download = await blobClient.DownloadAsync().ConfigureAwait(false);
-            using var jsonReader = new JsonTextReader(new StreamReader(download.Content));
+            using var jsonReader = new JsonTextReader(new StreamReader(download.Content)) { MaxDepth = null };
             return _jsonSerializer.Deserialize(jsonReader, typeof(Activity)) as Activity;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Bot.Builder.Azure.Queues
             _jsonSettings = jsonSerializerSettings ?? new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.None,
-                NullValueHandling = NullValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                MaxDepth = null
             };
 
             _queueClient = new QueueClient(queuesStorageConnectionString, queueName);
@@ -95,7 +96,7 @@ namespace Microsoft.Bot.Builder.Azure.Queues
             var message = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity, _jsonSettings)));
             var receipt = await _queueClient.SendMessageAsync(message, visibilityTimeout, timeToLive, cancellationToken).ConfigureAwait(false);
 
-            return JsonConvert.SerializeObject(receipt.Value);
+            return JsonConvert.SerializeObject(receipt.Value, new JsonSerializerSettings { MaxDepth = null });
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Bot.Builder.Azure
                     var options = new BlobRequestOptions { RetryPolicy = new LinearRetry(TimeSpan.FromSeconds(20), 4) };
 
                     using (var blobStream = await blobReference.OpenReadAsync(null, options, new OperationContext(), cancellationToken).ConfigureAwait(false))
-                    using (var jsonReader = new JsonTextReader(new StreamReader(blobStream)))
+                    using (var jsonReader = new JsonTextReader(new StreamReader(blobStream)) { MaxDepth = null })
                     {
                         var obj = _jsonSerializer.Deserialize(jsonReader);
 

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Bot.Builder.Azure
 
                     using (var sr = new StreamReader(stream))
                     {
-                        using (var jsonTextReader = new JsonTextReader(sr))
+                        using (var jsonTextReader = new JsonTextReader(sr) { MaxDepth = null })
                         {
                             var jsonSerializer = GetSerializer();
                             return jsonSerializer.Deserialize<T>(jsonTextReader);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/AssertReplyActivity.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions
                 var (result, error) = Expression.Parse(assertion).TryEvaluate<bool>(activity);
                 if (result != true)
                 {
-                    throw new InvalidOperationException($"{Description} {assertion}\n{JsonConvert.SerializeObject(activity, Formatting.Indented)}");
+                    throw new InvalidOperationException($"{Description} {assertion}\n{JsonConvert.SerializeObject(activity, Formatting.Indented, new JsonSerializerSettings { MaxDepth = null })}");
                 }
             }
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         [JsonProperty("$kind")]
         public const string Kind = "Microsoft.HttpRequest";
 
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpRequest"/> class.
         /// </summary>
@@ -352,13 +354,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 switch (ResponseType.GetValue(dc.State))
                 {
                     case ResponseTypes.Activity:
-                        var activity = JsonConvert.DeserializeObject<Activity>((string)content);
+                        var activity = JsonConvert.DeserializeObject<Activity>((string)content, _settings);
                         requestResult.Content = JObject.FromObject(activity);
                         await dc.Context.SendActivityAsync(activity, cancellationToken: cancellationToken).ConfigureAwait(false);
                         break;
 
                     case ResponseTypes.Activities:
-                        var activities = JsonConvert.DeserializeObject<Activity[]>((string)content);
+                        var activities = JsonConvert.DeserializeObject<Activity[]>((string)content, _settings);
                         requestResult.Content = JArray.FromObject(activities);
                         await dc.Context.SendActivitiesAsync(activities, cancellationToken: cancellationToken).ConfigureAwait(false);
                         break;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/LogAction.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/LogAction.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             var properties = new Dictionary<string, string>()
             {
-                { "template", JsonConvert.SerializeObject(Text) },
+                { "template", JsonConvert.SerializeObject(Text, new JsonSerializerSettings { MaxDepth = null }) },
                 { "result", text ?? string.Empty },
                 { "context", TelemetryLoggerConstants.LogActionResultEvent }
             };

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendActivity.cs
@@ -94,8 +94,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var activity = await Activity.BindAsync(dc, dc.State).ConfigureAwait(false);
             var properties = new Dictionary<string, string>()
             {
-                { "template", JsonConvert.SerializeObject(Activity) },
-                { "result", activity == null ? string.Empty : JsonConvert.SerializeObject(activity, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                { "template", JsonConvert.SerializeObject(Activity, new JsonSerializerSettings { MaxDepth = null }) },
+                { "result", activity == null ? string.Empty : JsonConvert.SerializeObject(activity, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                 { "context", TelemetryLoggerConstants.SendActivityResultEvent }
             };
             TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/UpdateActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/UpdateActivity.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 
             var properties = new Dictionary<string, string>()
             {
-                { "template", JsonConvert.SerializeObject(Activity) },
-                { "result", activity == null ? string.Empty : JsonConvert.SerializeObject(activity, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                { "template", JsonConvert.SerializeObject(Activity, new JsonSerializerSettings { MaxDepth = null }) },
+                { "result", activity == null ? string.Empty : JsonConvert.SerializeObject(activity, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                 { "context", TelemetryLoggerConstants.UpdateActivityResultEvent }
             };
             TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
 
         private SchemaHelper dialogSchema;
 
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveDialog"/> class.
         /// </summary>
@@ -168,7 +170,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             // replace initial activeDialog.State with clone of options
             if (options != null)
             {
-                dc.ActiveDialog.State = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(options));
+                dc.ActiveDialog.State = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(options, _settings), _settings);
             }
 
             if (!dc.State.ContainsKey(DialogPath.EventCounter))
@@ -394,7 +396,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             // change version if the schema has changed.
             if (this.Schema != null)
             {
-                sb.Append(JsonConvert.SerializeObject(this.Schema));
+                sb.Append(JsonConvert.SerializeObject(this.Schema, _settings));
             }
 
             // change if triggers type/constraint change 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         internal override void TrackGeneratorResultEvent(DialogContext dc, ITemplate<Activity> activityTemplate, IMessageActivity msg)
         {
             var options = dc.State.GetValue<ChoiceInputOptions>(ThisPath.Options);
-            var serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
+            var serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null };
             var properties = new Dictionary<string, string>()
             {
-                { "template", JsonConvert.SerializeObject(activityTemplate) },
+                { "template", JsonConvert.SerializeObject(activityTemplate, new JsonSerializerSettings { MaxDepth = null }) },
                 { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, serializationSettings) },
                 { "choices", options.Choices == null ? string.Empty : JsonConvert.SerializeObject(options.Choices, serializationSettings) },
                 { "context", TelemetryLoggerConstants.InputDialogResultEvent }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceOptionsSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceOptionsSet.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             {
                 try
                 {
-                    var jObj = (JArray)JsonConvert.DeserializeObject(str);
+                    var jObj = (JArray)JsonConvert.DeserializeObject(str, new JsonSerializerSettings { MaxDepth = null });
 
                     var options = new ChoiceFactoryOptions
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceSet.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceSet.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             {
                 try
                 {
-                    var jObj = (JToken)JsonConvert.DeserializeObject(str);
+                    var jObj = (JToken)JsonConvert.DeserializeObject(str, new JsonSerializerSettings { MaxDepth = null });
 
                     if (jObj is JArray jarr)
                     {

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 #pragma warning restore CA1707 // Identifiers should not contain underscores
 #pragma warning restore SA1310 // Field should not contain underscore.
 
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Gets or sets a value indicating whether the input should always prompt the user regardless of there being a value or not.
         /// </summary>
@@ -276,8 +278,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
                         var properties = new Dictionary<string, string>()
                         {
-                            { "template", JsonConvert.SerializeObject(DefaultValueResponse) },
-                            { "result", response == null ? string.Empty : JsonConvert.SerializeObject(response, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                            { "template", JsonConvert.SerializeObject(DefaultValueResponse, _settings) },
+                            { "result", response == null ? string.Empty : JsonConvert.SerializeObject(response, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                             { "context", TelemetryLoggerConstants.InputDialogResultEvent }
                         };
                         TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);
@@ -322,8 +324,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         {
             var properties = new Dictionary<string, string>()
             {
-                { "template", JsonConvert.SerializeObject(activityTemplate) },
-                { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                { "template", JsonConvert.SerializeObject(activityTemplate, _settings) },
+                { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                 { "context", TelemetryLoggerConstants.InputDialogResultEvent }
             };
             TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);
@@ -415,7 +417,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             if (prompt != null)
             {
                 // clone the prompt the set in the options (note ActivityEx has Properties so this is the safest mechanism)
-                prompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt));
+                prompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt, _settings), _settings);
 
                 prompt.Text = msg.Text;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/OAuthInput.cs
@@ -249,8 +249,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                             var response = await this.DefaultValueResponse.BindAsync(dc, cancellationToken: cancellationToken).ConfigureAwait(false);
                             var properties = new Dictionary<string, string>()
                             {
-                                { "template", JsonConvert.SerializeObject(this.DefaultValueResponse) },
-                                { "result", response == null ? string.Empty : JsonConvert.SerializeObject(response, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                                { "template", JsonConvert.SerializeObject(this.DefaultValueResponse, new JsonSerializerSettings { MaxDepth = null }) },
+                                { "result", response == null ? string.Empty : JsonConvert.SerializeObject(response, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                                 { "context", TelemetryLoggerConstants.OAuthInputResultEvent }
                             };
                             TelemetryClient.TrackEvent(TelemetryLoggerConstants.GeneratorResultEvent, properties);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Memory/Expressions/Converters/DialogExpressionConverter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
                 {
                     try
                     {
-                        using (var jsonTextReader = new JsonTextReader(new StringReader($"\"{id}\"")))
+                        using (var jsonTextReader = new JsonTextReader(new StringReader($"\"{id}\"")) { MaxDepth = null })
                         {
                             var dialog = (Dialog)converter.ReadJson(jsonTextReader, objectType, existingValue, serializer);
                             result = UpdateOrCreateExpression(id, dialog);
@@ -87,7 +87,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Converters
             }
             else
             {
-                using (var jTokenReader = new JTokenReader(jToken))
+                using (var jTokenReader = new JTokenReader(jToken) { MaxDepth = null })
                 {
                     var dialog = (Dialog)this.converter.ReadJson(jTokenReader, objectType, existingValue, serializer);
                     result = UpdateOrCreateExpression(dialog?.Id, dialog);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/AdaptiveRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/AdaptiveRecognizer.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
     /// </summary>
     public abstract class AdaptiveRecognizer : Recognizer
     {
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AdaptiveRecognizer"/> class.
         /// </summary>
@@ -55,9 +57,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
             {
                 { "TopIntent", recognizerResult.Intents.Any() ? recognizerResult.Intents.First().Key : null },
                 { "TopIntentScore", recognizerResult.Intents.Any() ? recognizerResult.Intents.First().Value?.Score?.ToString("N1", CultureInfo.InvariantCulture) : null },
-                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents) : null },
+                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents, _settings) : null },
                 { "Entities", recognizerResult.Entities?.ToString() },
-                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties) : null },
+                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties, _settings) : null },
             };
 
             var (logPersonalInfo, error) = LogPersonalInformation.TryGetValue(dialogContext.State);

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/SchemaHelper.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/SchemaHelper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
         public PropertySchema Property { get; }
 
         public static SchemaHelper ReadSchema(string path)
-            => new SchemaHelper(JsonConvert.DeserializeObject<JObject>(File.ReadAllText(path)));
+            => new SchemaHelper(JsonConvert.DeserializeObject<JObject>(File.ReadAllText(path), new JsonSerializerSettings { MaxDepth = null }));
 
         public IEnumerable<PropertySchema> Properties()
             => Property.Children;

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
                         return unKnownResult;
                     }
 
-                    throw new ArgumentNullException($"$kind was not found: {JsonConvert.SerializeObject(jToken)}");
+                    throw new ArgumentNullException($"$kind was not found: {JsonConvert.SerializeObject(jToken, new JsonSerializerSettings { MaxDepth = null })}");
                 }
 
                 // if reference resolution made a source context available for the JToken, then add it to the context stack

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -518,7 +518,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
             }
 
             using (var readerText = new StreamReader(await resource.OpenStreamAsync().ConfigureAwait(false)))
-            using (var readerJson = new JsonTextReader(readerText) { DateParseHandling = DateParseHandling.None })
+            using (var readerJson = new JsonTextReader(readerText) { DateParseHandling = DateParseHandling.None, MaxDepth = null })
             {
                 if (advanceJsonReader)
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -17,12 +17,13 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public static class ObjectPath
     {
-        private static readonly JsonSerializerSettings _cloneSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All };
+        private static readonly JsonSerializerSettings _cloneSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, MaxDepth = null };
 
         private static readonly JsonSerializerSettings _expressionCaseSettings = new JsonSerializerSettings
         {
             ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() },
             NullValueHandling = NullValueHandling.Ignore,
+            MaxDepth = null
         };
 
         /// <summary>
@@ -463,7 +464,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 return (T)val;
             }
 
-            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(val, _expressionCaseSettings));
+            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(val, _expressionCaseSettings), new JsonSerializerSettings { MaxDepth = null });
         }
 
         /// <summary>
@@ -738,7 +739,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                 }
                 else
                 {
-                    val = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value, _expressionCaseSettings));
+                    val = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(value, _expressionCaseSettings), new JsonSerializerSettings { MaxDepth = null });
                 }
             }
             else

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -313,8 +313,10 @@ namespace Microsoft.Bot.Builder.Dialogs
             // Update prompt with text, actions and attachments
             if (prompt != null)
             {
+                var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
+                
                 // clone the prompt the set in the options (note ActivityEx has Properties so this is the safest mechanism)
-                prompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt));
+                prompt = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(prompt, serializerSettings), serializerSettings);
 
                 prompt.Text = msg.Text;
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Recognizer.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </remarks>
         public const string NoneIntent = "None";
 
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Recognizer"/> class to recognize user input.
         /// </summary>
@@ -182,9 +184,9 @@ namespace Microsoft.Bot.Builder.Dialogs
                 { "AlteredText", recognizerResult.AlteredText },
                 { "TopIntent", recognizerResult.Intents.Any() ? recognizerResult.Intents.First().Key : null },
                 { "TopIntentScore", recognizerResult.Intents.Any() ? recognizerResult.Intents.First().Value?.Score?.ToString("N1", CultureInfo.InvariantCulture) : null },
-                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents) : null },
+                { "Intents", recognizerResult.Intents.Any() ? JsonConvert.SerializeObject(recognizerResult.Intents, _settings) : null },
                 { "Entities", recognizerResult.Entities?.ToString() },
-                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties) : null },
+                { "AdditionalProperties", recognizerResult.Properties.Any() ? JsonConvert.SerializeObject(recognizerResult.Properties, _settings) : null },
             };
 
             // Additional Properties can override "stock" properties.

--- a/libraries/Microsoft.Bot.Builder.Testing/XUnit/TestDataObject.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/XUnit/TestDataObject.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
     public class TestDataObject : IXunitSerializable
     {
         private const string TestObjectKey = "TestObjectKey";
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDataObject"/> class.
@@ -33,7 +34,7 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
         /// <param name="testData">An object with the data to be used in the test.</param>
         public TestDataObject(object testData)
         {
-            TestObject = JsonConvert.SerializeObject(testData);
+            TestObject = JsonConvert.SerializeObject(testData, _settings);
         }
 
         /// <summary>
@@ -67,7 +68,7 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
         /// <returns>The test object instance.</returns>
         public T GetObject<T>()
         {
-            return JsonConvert.DeserializeObject<T>(TestObject);
+            return JsonConvert.DeserializeObject<T>(TestObject, _settings);
         }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.Testing/XUnit/XUnitDialogTestLogger.cs
+++ b/libraries/Microsoft.Bot.Builder.Testing/XUnit/XUnitDialogTestLogger.cs
@@ -135,6 +135,7 @@ namespace Microsoft.Bot.Builder.Testing.XUnit
             var s = new JsonSerializerSettings
             {
                 Formatting = Formatting.Indented,
+                MaxDepth = null
             };
             Output.WriteLine(JsonConvert.SerializeObject(activity, s));
         }

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Bot.Builder
         private readonly RetryPolicy _connectorClientRetryPolicy;
         private readonly AppCredentials _appCredentials;
         private readonly AuthenticationConfiguration _authConfiguration;
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings { MaxDepth = null };
 
         // Cache for appCredentials to speed up token acquisition (a token is not requested unless is expired)
         // AppCredentials are cached using appId + skillId (this last parameter is only used if the app credentials are used to call a skill)
@@ -850,7 +851,7 @@ namespace Microsoft.Bot.Builder
                 MsAppId = appId,
             };
 
-            var serializedState = JsonConvert.SerializeObject(tokenExchangeState);
+            var serializedState = JsonConvert.SerializeObject(tokenExchangeState, _settings);
             var encodedState = Encoding.UTF8.GetBytes(serializedState);
             var state = Convert.ToBase64String(encodedState);
 
@@ -918,7 +919,7 @@ namespace Microsoft.Bot.Builder
                 MsAppId = appId,
             };
 
-            var serializedState = JsonConvert.SerializeObject(tokenExchangeState);
+            var serializedState = JsonConvert.SerializeObject(tokenExchangeState, _settings);
             var encodedState = Encoding.UTF8.GetBytes(serializedState);
             var state = Convert.ToBase64String(encodedState);
 
@@ -1124,7 +1125,7 @@ namespace Microsoft.Bot.Builder
                 MsAppId = appId,
             };
 
-            var serializedState = JsonConvert.SerializeObject(tokenExchangeState);
+            var serializedState = JsonConvert.SerializeObject(tokenExchangeState, _settings);
             var encodedState = Encoding.UTF8.GetBytes(serializedState);
             var state = Convert.ToBase64String(encodedState);
 

--- a/libraries/Microsoft.Bot.Builder/BotState.cs
+++ b/libraries/Microsoft.Bot.Builder/BotState.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Bot.Builder
 
             internal static string ComputeHash(object obj)
             {
-                return JsonConvert.SerializeObject(obj);
+                return JsonConvert.SerializeObject(obj, new JsonSerializerSettings { MaxDepth = null });
             }
 
             internal bool IsChanged()

--- a/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/FileTranscriptLogger.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Bot.Builder
         {
             Formatting = Formatting.Indented,
             NullValueHandling = NullValueHandling.Ignore,
+            MaxDepth = null
         };
 
         private readonly string _folder;
@@ -194,7 +195,7 @@ namespace Microsoft.Bot.Builder
                     using (var reader = new StreamReader(stream) as TextReader)
                     {
                         var json = await reader.ReadToEndAsync().ConfigureAwait(false);
-                        return JsonConvert.DeserializeObject<Activity[]>(json);
+                        return JsonConvert.DeserializeObject<Activity[]>(json, new JsonSerializerSettings { MaxDepth = null });
                     }
                 }
             }
@@ -230,7 +231,8 @@ namespace Microsoft.Bot.Builder
                 var originalActivity = transcript[i];
                 if (originalActivity.Id == activity.Id)
                 {
-                    var updatedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+                    var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
+                    var updatedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, serializerSettings), serializerSettings);
                     updatedActivity.Type = originalActivity.Type; // fixup original type (should be Message)
                     updatedActivity.LocalTimestamp = originalActivity.LocalTimestamp;
                     updatedActivity.Timestamp = originalActivity.Timestamp;

--- a/libraries/Microsoft.Bot.Builder/MemoryTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryTranscriptStore.cs
@@ -82,7 +82,8 @@ namespace Microsoft.Bot.Builder
                             var originalActivity = transcript[i];
                             if (originalActivity.Id == activity.Id)
                             {
-                                var updatedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity));
+                                var serializerSettings = new JsonSerializerSettings { MaxDepth = null };
+                                var updatedActivity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, serializerSettings), serializerSettings);
                                 updatedActivity.Type = originalActivity.Type; // fixup original type (should be Message)
                                 updatedActivity.LocalTimestamp = originalActivity.LocalTimestamp;
                                 updatedActivity.Timestamp = originalActivity.Timestamp;

--- a/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TelemetryLoggerMiddleware.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Bot.Builder
 
                 if (activity.Attachments != null && activity.Attachments.Any())
                 {
-                    properties.Add(TelemetryConstants.AttachmentsProperty, JsonConvert.SerializeObject(activity.Attachments));
+                    properties.Add(TelemetryConstants.AttachmentsProperty, JsonConvert.SerializeObject(activity.Attachments,  new JsonSerializerSettings { MaxDepth = null }));
                 }
             }
 
@@ -385,7 +385,7 @@ namespace Microsoft.Bot.Builder
 
                     if (teamsChannelData?.Team != null)
                     {
-                        properties.Add("TeamsTeamInfo", JsonConvert.SerializeObject(teamsChannelData.Team));
+                        properties.Add("TeamsTeamInfo", JsonConvert.SerializeObject(teamsChannelData.Team,  new JsonSerializerSettings { MaxDepth = null }));
                     }
 
                     break;

--- a/libraries/Microsoft.Bot.Builder/TraceTranscriptLogger.cs
+++ b/libraries/Microsoft.Bot.Builder/TraceTranscriptLogger.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Bot.Builder
     /// </summary>
     public class TraceTranscriptLogger : ITranscriptLogger
     {
-        private static readonly JsonSerializerSettings _serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented };
+        private static readonly JsonSerializerSettings _serializationSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented, MaxDepth = null };
 
         private readonly bool _traceActivity;
 

--- a/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/TranscriptLoggerMiddleware.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Bot.Builder
     /// </summary>
     public class TranscriptLoggerMiddleware : IMiddleware
     {
-        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null };
         private readonly ITranscriptLogger _logger;
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Microsoft.Bot.Builder
 
         private static IActivity CloneActivity(IActivity activity)
         {
-            activity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, _jsonSettings));
+            activity = JsonConvert.DeserializeObject<Activity>(JsonConvert.SerializeObject(activity, _jsonSettings),  new JsonSerializerSettings { MaxDepth = null });
             var activityWithId = EnsureActivityHasId(activity);
 
             return activityWithId;


### PR DESCRIPTION
Addresses #6392
#minor

## Description
This PR adds the setting of the `MaxDepth` property in all the JSON Serialize/Deserialize operations.

## Specific Changes
- Set MaxDepth = null in **_JsonConvert.SerializeObject_**, **_JsonConvert.DeserializeObject_**, and **_JsonTextReader_** instances of the following projects:
   - Microsoft.Bot.Builder.Azure.Blobs
   - Microsoft.Bot.Builder.Azure.Queues
   - Microsoft.Bot.Builder.Azure
   - Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
   - Microsoft.Bot.Builder.Dialogs.Adaptive
   - Microsoft.Bot.Builder.Dialogs.Declarative
   - Microsoft.Bot.Builder.Dialogs
   - Microsoft.Bot.Builder.Testing
   - Microsoft.Bot.Builder

## Testing
These images show the unit tests and the FunctionalTests pipeline successfully executed.
![image](https://user-images.githubusercontent.com/44245136/176904203-6f6809b5-c8bc-43d2-8525-7a08bfc678bc.png)
