### PR TITLE
fix for #6407 and #6350 - check existence of blob before uploading to…

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -457,15 +457,18 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             await streamWriter.FlushAsync().ConfigureAwait(false);
             memoryStream.Seek(0, SeekOrigin.Begin);
 
-            var blobExist = await blobClient.ExistsAsync().ConfigureAwait(false);
             try 
             {
                 await blobClient.UploadAsync(memoryStream, options).ConfigureAwait(false);
             }
             catch (RequestFailedException ex)
-                    when ((HttpStatusCode)ex.Status == HttpStatusCode.Conflict && blobExist == false)
+                    when ((HttpStatusCode)ex.Status == HttpStatusCode.Conflict)
             {
                 // ignore the conflict led by transient error when uploading
+                if(overwrite || await blobClient.ExistsAsync().ConfigureAwait(false) == false)
+                {
+                    throw;
+                }
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                     when ((HttpStatusCode)ex.Status == HttpStatusCode.Conflict)
             {
                 // ignore the conflict led by transient error when uploading
-                if(overwrite || await blobClient.ExistsAsync().ConfigureAwait(false) == false)
+                if (overwrite || await blobClient.ExistsAsync().ConfigureAwait(false) == false)
                 {
                     throw;
                 }


### PR DESCRIPTION
… ignore the exception led by transient error

Fixes #6407 and #6350 

## Description
Handle the conflict triggered from the network transient error. Add a Azure Blob existence check first before doing upload.

## Specific Changes
  - Check the existence of the blob before doing the upload operation, so we could know whether it is a transient error or not
  - If it is a transient error leading to the exception, we can ignore it (maybe we can also print some logs)
