### PR TITLE
[#6434] Priority broken for RegexRecognizer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Recognizers/RegexRecognizer.cs
@@ -131,9 +131,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers
                             }
                         }
                     }
-
-                    // found
-                    break;
                 }
             }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/RegexRecognizerTests.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
+        public async Task RegexRecognizerTests_Priority()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public async Task RegexRecognizerTests_Intents()
         {
             var recognizer = GetRecognizer();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/RegexRecognizerTests/RegexRecognizerTests_Priority.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/RegexRecognizerTests/RegexRecognizerTests_Priority.test.dialog
@@ -1,0 +1,95 @@
+﻿{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "recognizer": {
+      "$kind": "Microsoft.RegexRecognizer",
+      "id": "x",
+      "intents": [
+        {
+          "intent": "cancel",
+          "pattern": "^(?:cancel|quit|stop|end)"
+        },
+        {
+          "intent": "MyCommand",
+          "pattern": "."
+        },
+        {
+          "intent": "help",
+          "pattern": "^(?:support|advice|help|\\?)"
+        }
+      ]
+    },
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "cancel",
+        "priority": 0,
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${turn.recognized.intent}"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "MyCommand",
+        "priority": 1,
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${turn.recognized.intent}"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnIntent",
+        "intent": "help",
+        "priority": 0,
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${turn.recognized.intent}"
+          }
+        ]
+      }
+    ]
+  },
+  "locale": "en-us",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "help"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "help"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "?"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "help"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "cancel"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "cancel"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "random-text"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "MyCommand"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #6434

## Description
This PR updates the AdaptiveDialog's OnRecognizeAsync method to take into consideration the priority set for the intents when there is more than one result with the same score.

## Specific Changes
- Updated the `OnRecognizeAsync` method to choose the topIntent considering both score and priority.
- Removed the break from the `RecognizeAsync` method to return all the intents that match the pattern.
- Added a unit test to cover the priority scenario in `RegexRecognizerTests`.
- Added test script `RegexRecognizerTests_Priority.test.dialog`

## Testing
These images show the bot not recognizing the correct intent before and the bot returning the right intent according to its priority after the changes.
![image](https://user-images.githubusercontent.com/44245136/182451320-bf755b74-86b9-4564-92b3-95fcc29010f5.png)
