### PR TITLE
Fix PublishToCoveralls.ps1

### DIFF
--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -16,7 +16,7 @@ if (-not (Test-Path $coverageAnalyzer)) {
   $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
 }
 
-dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
+dotnet tool install coveralls.net --version 4.0.1 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
 Write-Host "Analyze coverage [$coverageAnalyzer] with args:"

--- a/build/PublishToCoveralls.ps1
+++ b/build/PublishToCoveralls.ps1
@@ -19,10 +19,6 @@ if (-not (Test-Path $coverageAnalyzer)) {
 dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
-# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
-Import-Module .\archive.psm1
-
 Write-Host "Analyze coverage [$coverageAnalyzer] with args:"
 $coverageFiles = Get-ChildItem -Path "$pathToCoverageFiles" -Include "*.coverage" -Recurse | Select -Exp FullName
 $analyzeArgs = @(


### PR DESCRIPTION
Fixes #minor

## Description
Coveralls code coverage report uploads to coveralls.io are failing for BotBuilder-DotNet-CI-PR-yaml.

## Specific Changes
This fixes PublishToCoveralls.ps1 which was installing a Powershell patch for a path separator bug. The patch is no longer available for download. That broke PublishToCoveralls.ps1,

Also upgrade coveralls.net to 4.0.1 was required.
