### PR TITLE
[#6433] Error in AdaptiveDialog.ContinueActionAsync with native dialog SDK

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -98,19 +98,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var se = new StringExpression($"={this.Dialog.ExpressionText}");
             var dialogId = se.GetValue(dc.State) ?? throw new InvalidOperationException($"{this.Dialog.ToString()} not found.");
             var dialog = dc.FindDialog(dialogId);
-
-            if (dialog == null)
-            {
-                var resourceExplorer = dc.Context.TurnState.Get<ResourceExplorer>();
-                var resourceId = $"{dialogId}.dialog";
-                var foundResource = resourceExplorer?.TryGetResource(resourceId, out _) ?? false;
-                if (foundResource)
-                {
-                    dialog = resourceExplorer.LoadType<AdaptiveDialog>(resourceId);
-                    dc.Dialogs.Add(dialog);
-                }
-            }
-
             return dialog;
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/BaseInvokeDialog.cs
@@ -102,9 +102,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             if (dialog == null)
             {
                 var resourceExplorer = dc.Context.TurnState.Get<ResourceExplorer>();
-                if (resourceExplorer != null)
+                var resourceId = $"{dialogId}.dialog";
+                var foundResource = resourceExplorer?.TryGetResource(resourceId, out _) ?? false;
+                if (foundResource)
                 {
-                    dialog = resourceExplorer.LoadType<AdaptiveDialog>($"{dialogId}.dialog");
+                    dialog = resourceExplorer.LoadType<AdaptiveDialog>(resourceId);
                     dc.Dialogs.Add(dialog);
                 }
             }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialog.cs
@@ -686,9 +686,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                     if (dialog == null)
                     {
                         var resourceExplorer = actionDC.Context.TurnState.Get<ResourceExplorer>();
-                        if (resourceExplorer != null)
+                        var resourceId = $"{actionDC.ActiveDialog.Id}.dialog";
+                        var foundResource = resourceExplorer?.TryGetResource(resourceId, out _) ?? false;
+                        if (foundResource)
                         {
-                            dialog = resourceExplorer.LoadType<AdaptiveDialog>($"{actionDC.ActiveDialog.Id}.dialog");
+                            dialog = resourceExplorer.LoadType<AdaptiveDialog>(resourceId);
                             actionDC.Dialogs.Add(dialog);
                         }
                     }

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContainer.cs
@@ -98,6 +98,17 @@ namespace Microsoft.Bot.Builder.Dialogs
         }
 
         /// <summary>
+        /// Finds a child dialog that was previously added to the container. Uses DialogContext as fallback to gather the dialog.
+        /// </summary>
+        /// <param name="dialogId">The ID of the dialog to lookup.</param>
+        /// <param name="dc">The dialog context fallback where to find the dialog.</param>
+        /// <returns>The Dialog if found; otherwise null.</returns>
+        public virtual Dialog FindDialog(string dialogId, DialogContext dc = null)
+        {
+            return Dialogs.Find(dialogId) ?? dc?.Dialogs?.Find(dialogId);
+        }
+
+        /// <summary>
         /// Called when an event has been raised, using `DialogContext.emitEvent()`, by either the current dialog or a dialog that the current dialog started.
         /// </summary>
         /// <param name="dc">The dialog context for the current turn of conversation.</param>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/DialogContext.cs
@@ -578,7 +578,19 @@ namespace Microsoft.Bot.Builder.Dialogs
 
                 if (this.Parent != null)
                 {
-                    return this.Parent.FindDialog(dialogId);
+                    var dialog = Parent.FindDialog(dialogId);
+                    
+                    if (dialog != null)
+                    {
+                        return dialog;
+                    }
+
+                    var parentDialog = Parent.ActiveDialog?.Id != null ? Parent.FindDialog(Parent.ActiveDialog.Id) : null;
+                    if (parentDialog is DialogContainer)
+                    {
+                        dialog = (parentDialog as DialogContainer).FindDialog(dialogId, this);
+                        return dialog;
+                    }
                 }
 
                 return null;

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/AdaptiveDialogTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Runtime.CompilerServices;
 using System.Linq;
+using System.IO;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Actions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Templates;
@@ -22,6 +23,7 @@ using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing.TestActions;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Generators;
 using Moq;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
 {
@@ -1009,9 +1011,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         [Fact]
         public async Task AdaptiveDialog_BeginDialog_With_ComponentDialog()
         {
-            var convoState = new ConversationState(new MemoryStorage());
-            var dialogState = convoState.CreateProperty<DialogState>("dialogState");
-
             var storage = new MemoryStorage();
             var adapter = new TestAdapter()
                 .UseStorage(storage)
@@ -1043,6 +1042,89 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
                 .SendConversationUpdate()
                 .Send("hi")
                     .AssertReply("Send me some text.")
+                .StartTestAsync();
+        }
+
+        [Fact]
+        public async Task AdaptiveDialog_LoadDialogFromProperty_With_BotRestart()
+        {
+            var storage = new MemoryStorage();
+            var adapter = new TestAdapter()
+                .UseStorage(storage)
+                .UseBotState(new UserState(storage), new ConversationState(storage));
+
+            var rootDialog = new AdaptiveDialog("root")
+            {
+                AutoEndDialog = false,
+                Recognizer = new RegexRecognizer
+                {
+                    Intents = new List<IntentPattern>
+                    {
+                        new IntentPattern
+                        {
+                            Intent = "Start",
+                            Pattern = "start"
+                        }
+                    }
+                },
+                Triggers = new List<OnCondition>()
+                {
+                    new OnIntent()
+                    {
+                        Intent = "Start",
+                        Actions = new List<Dialog>()
+                        {
+                            new SetProperty
+                            {
+                                Property = "turn.dialogToStart",
+                                Value = "AskNameDialog"
+                            },
+                            new BeginDialog("=turn.dialogToStart")
+                        }
+                    },
+                    new OnDialogEvent(DialogEvents.VersionChanged)
+                    {
+                        Actions = new List<Dialog>()
+                        {
+                            new SetProperty
+                            {
+                                Property = "user.name",
+                                Value = $"John Doe ({DialogEvents.VersionChanged})"
+                            },
+                        }
+                    }
+                },
+            };
+
+            var resourceExplorer = new ResourceExplorer();
+            var folderPath = Path.Combine(TestUtils.GetProjectPath(), "Tests", "ActionTests");
+            resourceExplorer = resourceExplorer.AddFolder(folderPath, monitorChanges: false);
+
+            var dialogManager = new DialogManager(rootDialog)
+                .UseResourceExplorer(resourceExplorer);
+
+            await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
+            {
+                await dialogManager.OnTurnAsync(turnContext, cancellationToken);
+            })
+                .Send("start")
+                    .AssertReply("Hello, what is your name?")
+                .StartTestAsync();
+
+            // Simulate bot restart, maintaining storage information.
+            adapter = new TestAdapter()
+                .UseStorage(storage)
+                .UseBotState(new UserState(storage), new ConversationState(storage));
+
+            dialogManager = new DialogManager(rootDialog)
+                .UseResourceExplorer(resourceExplorer);
+
+            await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
+            {
+                await dialogManager.OnTurnAsync(turnContext, cancellationToken);
+            })
+                .Send("John Doe")
+                    .AssertReply($"Hello John Doe ({DialogEvents.VersionChanged}), nice to meet you!")
                 .StartTestAsync();
         }
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_LoadDialogFromProperty.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/AdaptiveDialogTests/AdaptiveDialog_LoadDialogFromProperty.test.dialog
@@ -5,13 +5,42 @@
         "$kind": "Microsoft.AdaptiveDialog",
         "id": "outer",
         "autoEndDialog": false,
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "TellJokeDialog",
+                    "pattern": "joke"
+                },
+                {
+                    "intent": "UnknownDialog",
+                    "pattern": "unknown"
+                }
+            ]
+        },
         "triggers": [
             {
-                "$kind": "Microsoft.OnBeginDialog",
+                "$kind": "Microsoft.OnIntent",
+                "intent": "TellJokeDialog",
                 "actions": [
                     {
                         "$kind": "Microsoft.SetProperty",
                         "value": "TellJokeDialog",
+                        "property": "turn.dialogToStart"
+                    },
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "dialog": "=turn.dialogToStart"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "UnknownDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "value": "UnknownDialog",
                         "property": "turn.dialogToStart"
                     },
                     {
@@ -25,11 +54,19 @@
     "script": [
         {
             "$kind": "Microsoft.Test.UserSays",
-            "text": "hi"
+            "text": "joke"
         },
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "Why did the chicken cross the road?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "unknown"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Object reference not set to an instance of an object."
         }
     ]
 }


### PR DESCRIPTION
Fixes #6433

## Description
This PR fixes an issue where the `ComponentDialog` cannot be found in the `Dialogs stack` and in the `ResourceExplorer` when using `AdaptiveDialogs`, adding a condition to evaluate the resource existence before trying to load it into the dialogs stack.
Additionally, it reworks the solution to load the dialog resource from the DialogContext instead when it cannot find the dialog (more information can be found in this [comment](https://github.com/microsoft/botbuilder-dotnet/issues/6355#issuecomment-1222208111)).

## Specific Changes
- Adds a pre-condition before trying to load the dialog from the `ResourceExplorer`.
- Added a unit test validating the new condition when using `ComponentDialogs` with `AdaptiveDialogs`.
- Added `FindDialog` method in the `AdaptiveDialog` class, that detects when there is no Dialog in the stack, it loads it from the `ResourceExplorer`.
- Added unit test that handles bot reconnection and resumes the conversation.
- Updated the `DialogContext.FindDialog` method to detect when the `AdaptiveDialog` cannot be found, delegate the search to the `AdaptiveDialog` class.
- Updated the `AdaptiveDialog_LoadDialogFromProperty.test.dialog` unit test, validating the new condition.
- Removed previous implementation in `BaseInvokeDialog` and `AdaptiveDialog` related to the PRs (# 6338, # 6365).

## Testing
The following image shows the new unit tests passing and the conversation samples detecting the LUIS Activity.
![image](https://user-images.githubusercontent.com/62260472/186739297-227e89f8-7f81-44b4-9b83-f714b5ca907a.png)