### PR TITLE
[#6428] Adaptive ForEachElement loop's incorrectly when changes cause ContinueDialogAsync to be recalled

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/ForEachElement.cs
@@ -204,6 +204,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 else
                 {
                     turnResult = await childDc.ContinueDialogAsync(cancellationToken).ConfigureAwait(false);
+                    childDialogState = GetActionScopeState(dc);
                 }
 
                 if (turnResult.Status == DialogTurnStatus.Waiting)


### PR DESCRIPTION
Fixes #6428

## Description
This PR fixes the malfunctioning of the ForEachElement loop when there're recursive calls to the _ContinueDialogAsync_ method by reacquiring the child dialog state after finishing the _ContinueDialogAsync_ execution. 

## Specific Changes
- Updated the `RunItemsAsync` method of the **_ForEachElement_** class to call the _GetActionScopeState_ method again after finishing the _ContinueDialogAsync_ execution.
- Added a unit test in the `AdaptiveDialogTests` class to cover the scenario with recursive calls to the _ContinueDialogAsync_ method.

## Testing
These images show the _ForEachElement_'s behavior before and after the fix.

![image](https://user-images.githubusercontent.com/44245136/186224223-34bdb217-73ba-4a00-a428-36192e1a0d02.png)
