### PR TITLE
Support passing sas token url's for token service

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/OAuthPrompt.cs
@@ -177,6 +177,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                             },
                         },
                         TokenExchangeResource = signInResource.TokenExchangeResource,
+                        TokenPostResource = signInResource.TokenPostResource
                     },
                 });
             }

--- a/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/Adapters/TestAdapter.cs
@@ -810,7 +810,7 @@ namespace Microsoft.Bot.Builder.Adapters
         /// <param name="finalRedirect">A final redirect URL.</param>
         /// <param name="cancellationToken">The cancellationToken.</param>
         /// <returns>A SignInResource with the link and token exchange info.</returns>
-        public Task<SignInResource> GetSignInResourceAsync(ITurnContext turnContext, AppCredentials oAuthAppCredentials, string connectionName, string userId, string finalRedirect = null, CancellationToken cancellationToken = default)
+        public virtual Task<SignInResource> GetSignInResourceAsync(ITurnContext turnContext, AppCredentials oAuthAppCredentials, string connectionName, string userId, string finalRedirect = null, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new SignInResource()
             {

--- a/libraries/Microsoft.Bot.Schema/OAuthCard.cs
+++ b/libraries/Microsoft.Bot.Schema/OAuthCard.cs
@@ -58,6 +58,13 @@ namespace Microsoft.Bot.Schema
         public TokenExchangeResource TokenExchangeResource { get; set; }
 
         /// <summary>
+        /// Gets or sets the resource to directly post a token to token service.
+        /// </summary>
+        /// <value>The resource to directly post a token to token service.</value>
+        [JsonProperty(PropertyName = "tokenPostResource")]
+        public TokenPostResource TokenPostResource { get; set; }
+        
+        /// <summary>
         /// Gets or sets action to use to perform signin.
         /// </summary>
         /// <value>The actions used to perform sign-in.</value>

--- a/libraries/Microsoft.Bot.Schema/SignInResource.cs
+++ b/libraries/Microsoft.Bot.Schema/SignInResource.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Bot.Schema
         public TokenExchangeResource TokenExchangeResource { get; set; }
 
         /// <summary>
+        /// Gets or sets additional properties that can be used for direct token posting operations.
+        /// </summary>
+        /// <value>The additional properties can be used for token posting operations.</value>
+        [JsonProperty(PropertyName = "tokenPostResource")]
+        public TokenPostResource TokenPostResource { get; set; }
+        
+        /// <summary>
         /// An initialization method that performs custom operations like setting defaults.
         /// </summary>
         partial void CustomInit();

--- a/libraries/Microsoft.Bot.Schema/TokenPostResource.cs
+++ b/libraries/Microsoft.Bot.Schema/TokenPostResource.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema
+{
+    /// <summary>
+    /// Response schema sent back from Bot Framework Token Service required to initiate a user token direct post.
+    /// </summary>
+    public partial class TokenPostResource
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenPostResource"/> class.
+        /// </summary>
+        public TokenPostResource()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the shared access signature url used to directly post a token to Bot Framework Token Service.
+        /// </summary>
+        /// <value>The URI.</value>
+        [JsonProperty(PropertyName = "sasUrl")]
+#pragma warning disable CA1056 // Uri properties should not be strings
+        public string SasUrl { get; set; }
+#pragma warning restore CA1056 // Uri properties should not be strings
+
+        partial void CustomInit();
+    }
+}


### PR DESCRIPTION
Fixes #minor
N/A

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR introduces support for passing through a token post resource via botbuilder. The token post resource contains a sas url for directly posting a token from a client to the bot framework token service. Botbuilder gets this url from token service and passes it onto the client.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Add support for token post resource
  - Support optional token post resource inside oauthcard


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
- Added unit tests