### PR TITLE
[#6462] Set Human Handoff event context from Composer

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendHandoffActivity.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SendHandoffActivity.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
 {
@@ -59,8 +60,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
         public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var handoffContext = HandoffContext?.GetValue(dc.State);
+            var context = (JObject)handoffContext;
+            var contextResult = ((ValueExpression)context).EvaluateExpression(dc.State);
             var transcript = Transcript?.GetValue(dc.State);
-            var eventActivity = EventFactory.CreateHandoffInitiation(dc.Context, handoffContext, transcript);
+            var eventActivity = EventFactory.CreateHandoffInitiation(dc.Context, contextResult, transcript);
             await dc.Context.SendActivityAsync(eventActivity, cancellationToken).ConfigureAwait(false);
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SendHandoffActivity.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ActionTests/Action_SendHandoffActivity.test.dialog
@@ -10,9 +10,15 @@
                 "actions": [
                     {
                       "$kind": "Microsoft.SetProperty",
+                      "property": "user.name",
+                      "value": "John Doe"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
                       "property": "$context",
-                      "value": "={\"context\": \"test-context\"}"
-                    },{
+                      "value": "={\"user\": \"${user.name}\"}"
+                    },
+                    {
                       "$kind": "Microsoft.SetProperty",
                       "property": "$transcript",
                       "value": "={\"activities\": [{\"id\": \"activity1\"}, {\"id\": \"activity2\"}]}"
@@ -37,7 +43,7 @@
             "$kind": "Microsoft.Test.AssertReplyActivity",
             "assertions": [
                 "type == 'event'",
-                "value.context == 'test-context'",
+                "value.user == 'John Doe'",
                 "attachments[0].name == 'Transcript'",
                 "attachments[0].content.activities[0].id == 'activity1'"
             ]


### PR DESCRIPTION
Fixes #6462

## Description
This PR updates the SendHandoffActivity action to evaluate adaptive expressions in the HandoffContext value.

## Specific Changes
- Updates the _BeginDialogAsync_ method in the `SendHandoffActivity` class to evaluate the content of the _HandoffContext_ property using the _EvaluateExpression_ method.
- Updates the `Action_SendHandoffActivity.test.dialog` test script to include adaptive expressions in the handoff context.

## Testing
These images show the Context property set using an expression and the activity sent by the bot with the resolved expression.
![image](https://user-images.githubusercontent.com/44245136/188202536-9fb81d57-0718-48be-9809-2d6b3e4d082c.png)

