### PR TITLE
Fix typo in botbuilder-dotnet-ci.yml

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -27,7 +27,8 @@ variables:
   runCodesignValidationInjection: false # Disables unnecessary CodeSign Validation step
   system_accesstoken: $(System.AccessToken)
   LGTM.UploadSnapshot: true
-  Semmle.SkipAnalysis: true#  ApiCompatExcludeClasses: (optional) define this in Azure
+  Semmle.SkipAnalysis: true
+#  ApiCompatExcludeClasses: (optional) define this in Azure
 #  DisableApiCompatibityValidation: (optional) define this in Azure
 #  DotNetCoverallsToken: define this in Azure
 #  GitHubCommentApiKey: define this in Azure


### PR DESCRIPTION
Fixes #minor

## Description
Pipeline is broken. This should fix it.