### PR TITLE
Update API compatibility contract version to 4.17.1

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci.yml
+++ b/build/yaml/botbuilder-dotnet-ci.yml
@@ -15,7 +15,7 @@ trigger: none # ci trigger is set in ADO
 pr: none # pr trigger is set in ADO
 
 variables:
-  ApiCompatVersion: 4.6.3
+  ApiCompatVersion: 4.17.1
   BotBuilderDll: Microsoft.Bot.Builder.AI.Luis,Microsoft.Bot.Builder.AI.QnA,Microsoft.Bot.Builder.ApplicationInsights,Microsoft.Bot.Builder.Azure,Microsoft.Bot.Builder.Dialogs,Microsoft.Bot.Builder.Integration.ApplicationInsights.Core,Microsoft.Bot.Builder.Integration.AspNet.Core,Microsoft.Bot.Builder.TemplateManager,Microsoft.Bot.Builder.Testing,Microsoft.Bot.Builder,Microsoft.Bot.Configuration,Microsoft.Bot.Connector,Microsoft.Bot.Schema,Microsoft.Bot.Streaming
   BuildConfiguration: Debug-Windows
   BuildPlatform: any cpu

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -6,10 +6,10 @@ steps:
     targetPath: '$(System.ArtifactsDirectory)/Artifacts'
 
 - task: NuGetCommand@2
-  displayName: 'Install Compatability Target Contract: $(BotBuilderDll) version $(ApiCompatVersion)'
+  displayName: 'Install Compatability Target Contract: $(BotBuilderDll) v $(ApiCompatVersion)'
   inputs:
     command: custom
-    arguments: 'install $(BotBuilderDll) -Version $(ApiCompatVersion) -OutputDirectory $(System.DefaultWorkingDirectory)\DownloadedNuGet'
+    arguments: 'install $(BotBuilderDll) -Version $(ApiCompatVersion) -OutputDirectory $(System.DefaultWorkingDirectory)\TargetContract'
 
 - task: CmdLine@1
   displayName: 'Run dir'
@@ -21,7 +21,7 @@ steps:
 - task: SOUTHWORKS.binaries-comparer.custom-build-release-task.binaries-comparer@0
   displayName: 'Compare Binaries'
   inputs:
-    contractsRootFolder: 'DownloadedNuGet\$(BotBuilderDll).$(ApiCompatVersion)\lib\netstandard2.0'
+    contractsRootFolder: 'TargetContract\$(BotBuilderDll).$(ApiCompatVersion)\lib\netstandard2.0'
     contractsFileName: '$(BotBuilderDll).dll'
     implFolder: '$(System.ArtifactsDirectory)/Artifacts'
     failOnIssue: false

--- a/build/yaml/ci-api-validation-steps.yml
+++ b/build/yaml/ci-api-validation-steps.yml
@@ -6,7 +6,7 @@ steps:
     targetPath: '$(System.ArtifactsDirectory)/Artifacts'
 
 - task: NuGetCommand@2
-  displayName: 'NuGet Install of Compatability Target Package: $(BotBuilderDll)'
+  displayName: 'Install Compatability Target Contract: $(BotBuilderDll) version $(ApiCompatVersion)'
   inputs:
     command: custom
     arguments: 'install $(BotBuilderDll) -Version $(ApiCompatVersion) -OutputDirectory $(System.DefaultWorkingDirectory)\DownloadedNuGet'


### PR DESCRIPTION
Fixes #minor

## Description
This eliminates the false API compatibility errors generated in the [current DotNet CI-PR pipeline](https://dev.azure.com/FuseLabs/SDK_Public/_build/results?buildId=322972&view=results).

The current DotNet SDK no longer supports CosmosDB storage. That change came out with the release of v 4.17. Because the API compatibility check compares against version 4.6.3, it is generating these API compatibility errors:

```
Compat issues with assembly Microsoft.Bot.Builder.Azure:
TypesMustExist : Type 'Microsoft.Bot.Builder.Azure.CosmosDbCustomClientOptions' does not exist in the implementation but it does exist in the contract.
TypesMustExist : Type 'Microsoft.Bot.Builder.Azure.CosmosDbStorage' does not exist in the implementation but it does exist in the contract.
TypesMustExist : Type 'Microsoft.Bot.Builder.Azure.CosmosDbStorageOptions' does not exist in the implementation but it does exist in the contract.
Total Issues: 3
```

## Specific Changes
Change var ApiCompatVersion to 4.17.1.
Also a couple of minor tweaks.