### PR TITLE
Add task 'Use NuGet latest' to pipelines

### DIFF
--- a/build/yaml/botbuilder-dotnet-ci-facebook-test-secondary.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test-secondary.yml
@@ -105,6 +105,7 @@ steps:
     restoreSolution: '**/*.sln'
     feedsToUse: 'select'
     verbosityRestore: 'Detailed'
+  displayName: 'NuGet restore'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish secondarytestbot'

--- a/build/yaml/botbuilder-dotnet-ci-facebook-test-secondary.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test-secondary.yml
@@ -95,6 +95,10 @@ steps:
    $content.FacebookAccessToken = "$(FacebookTestBotFacebookAccessToken)";
    $content | ConvertTo-Json | Set-Content $file;
   displayName: 'Set values in appsettings.json file.'
+
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 - task: NuGetCommand@2
   inputs:
     command: 'restore'

--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -105,6 +105,7 @@ steps:
     restoreSolution: '**/*.sln'
     feedsToUse: 'select'
     verbosityRestore: 'Detailed'
+  displayName: 'NuGet restore'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish primarytestbot'

--- a/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-facebook-test.yml
@@ -95,6 +95,10 @@ steps:
    $content.FacebookAccessToken = "$(FacebookTestBotFacebookAccessToken)";
    $content | ConvertTo-Json | Set-Content $file;
   displayName: 'Set values in appsettings.json file.'
+
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 - task: NuGetCommand@2
   inputs:
     command: 'restore'

--- a/build/yaml/botbuilder-dotnet-ci-slack-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-slack-test.yml
@@ -68,12 +68,17 @@ steps:
    "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
   displayName: 'Create DateTimeTag for Resource Group'
   # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
+
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 - task: NuGetCommand@2
   inputs:
     command: 'restore'
     restoreSolution: '**/*.sln'
     feedsToUse: 'select'
     verbosityRestore: 'Detailed'
+  displayName: 'NuGet restore'
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -138,6 +138,7 @@ steps:
     restoreSolution: '**/*.sln'
     feedsToUse: 'select'
     verbosityRestore: 'Detailed'
+  displayName: 'NuGet restore'
 
 - task: DotNetCoreCLI@2
   displayName: 'dotnet publish'

--- a/build/yaml/botbuilder-dotnet-ci-webex-test.yml
+++ b/build/yaml/botbuilder-dotnet-ci-webex-test.yml
@@ -128,6 +128,9 @@ steps:
      Set-PSDebug -Trace 0;
   condition: and(succeeded(), or( endsWith(variables['Build.BuildId'], 1), endsWith(variables['Build.BuildId'], 3), endsWith(variables['Build.BuildId'], 5), endsWith(variables['Build.BuildId'], 7), endsWith(variables['Build.BuildId'], 9)))
 
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 # The next tasks are put here before "Deploy the bot" to give time for the new Azure resources to settle.
 - task: NuGetCommand@2
   inputs:

--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -69,6 +69,9 @@ steps:
     scriptLocation: inlineScript
     inlineScript: 'call az bot directline create -n "$(LinuxTestBotBotName)" -g "$(LinuxTestBotBotGroup)" > "$(System.DefaultWorkingDirectory)\DirectLineCreate.json"'
 
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 # The next tasks are put here before "Git bot deployment" to give time for the new Azure resources to settle.
 - task: NuGetCommand@2
   inputs:
@@ -76,6 +79,7 @@ steps:
     restoreSolution: '**/*.sln'
     feedsToUse: 'select'
     verbosityRestore: 'Detailed'
+  displayName: 'NuGet restore'
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet publish test bot'

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -112,6 +112,9 @@ steps:
      ::call az group create --location westus --name $(BotGroup) --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)"
      ::call az deployment group create --resource-group "$(BotGroup)" --template-file "$(System.DefaultWorkingDirectory)\FunctionalTests\ExportedTemplate\template-with-preexisting-rg.json" --parameters appId=$(AppId) appSecret="$(AppSecret)" botId="$(BotName)" botSku=F0 newAppServicePlanName="$(BotName)" newWebAppName="$(BotName)" appServicePlanLocation="westus" --name "$(BotName)"
 
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 # The next tasks are put here before "Deploy the bot" to give time for the new Azure resources to settle.
 - task: NuGetCommand@2
   inputs:

--- a/build/yaml/botbuilder-dotnet-functional-test-windows.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-windows.yml
@@ -122,6 +122,7 @@ steps:
     restoreSolution: '**/*.sln'
     feedsToUse: 'select'
     verbosityRestore: 'Detailed'
+  displayName: 'NuGet restore'
 
 - task: DotNetCoreCLI@2
   displayName: 'Dotnet Publish TestBot'

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -19,6 +19,7 @@ steps:
     feedsToUse: 'config'
     nugetConfigPath: 'nuget.config'
     restoreSolution: '$(Parameters.solution)'
+  displayName: 'NuGet restore'
 
 - task: VSBuild@1
   displayName: 'Build solution Microsoft.Bot.Builder.sln'

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -9,6 +9,9 @@ steps:
 
 - template: sdk_dotnet_v4_org-feed-setup-steps.yml
 
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet latest'
+
 - task: NuGetCommand@2
   displayName: 'NuGet restore'
   inputs:

--- a/build/yaml/ci-build-steps.yml
+++ b/build/yaml/ci-build-steps.yml
@@ -13,7 +13,6 @@ steps:
   displayName: 'Use NuGet latest'
 
 - task: NuGetCommand@2
-  displayName: 'NuGet restore'
   inputs:
     command: 'restore'
     feedsToUse: 'config'


### PR DESCRIPTION
Fixes #minor

## Description
Using the latest NuGet fixes "NuGet restore" error "Project ... is not compatible with net60". The error results from using an old version.
