### PR TITLE
Fix NamedPipe reconnection

### DIFF
--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingConnection.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingConnection.cs
@@ -38,14 +38,6 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         }
 
         /// <summary>
-        /// Gets a value indicating whether this server is currently connected.
-        /// </summary>
-        /// <value>
-        /// True if this server is currently connected, otherwise false.
-        /// </value>
-        public bool IsConnected { get; private set; } = false;
-
-        /// <summary>
         /// Gets the <see cref="ILogger"/> instance for the streaming connection.
         /// </summary>
         /// <value>A <see cref="ILogger"/> for the streaming connection.</value>
@@ -104,7 +96,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
             _session = new StreamingSession(requestHandler, _application, Logger, cancellationToken);
 
             // Start transport and application
-            var transportTask = _transport.ConnectAsync(connect => IsConnected = connect, cancellationToken);
+            var transportTask = _transport.ConnectAsync(default, cancellationToken);
             var applicationTask = _application.ListenAsync(cancellationToken);
 
             var tasks = new List<Task> { transportTask, applicationTask };

--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         public async Task ConnectAsync(IDictionary<string, string> requestHeaders, CancellationToken cancellationToken)
         {
             await ConnectImplAsync(
-                    connectFunc: transport => transport.ConnectAsync(_url, requestHeaders, cancellationToken),
+                    connectFunc: (transport, connectionStatusChanged) => transport.ConnectAsync(_url, connectionStatusChanged, requestHeaders, cancellationToken),
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -137,7 +137,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
         internal async Task ConnectInternalAsync(CancellationToken cancellationToken)
         {
             await ConnectImplAsync(
-                    connectFunc: transport => transport.ConnectAsync(cancellationToken),
+                    connectFunc: (transport, connectionStatusChanged) => transport.ConnectAsync(connectionStatusChanged, cancellationToken),
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -182,9 +182,12 @@ namespace Microsoft.Bot.Connector.Streaming.Application
             return response != null && response.StatusCode >= 200 && response.StatusCode <= 299;
         }
 
-        private async Task ConnectImplAsync(Func<StreamingTransport, Task> connectFunc, CancellationToken cancellationToken)
+        private async Task ConnectImplAsync(Func<StreamingTransport, Action<bool>, Task> connectFunc, CancellationToken cancellationToken)
         {
             CheckDisposed();
+
+            _transport?.Dispose();
+            _application?.Dispose();
 
             TimerAwaitable timer = null;
             Task timerTask = null;
@@ -207,7 +210,7 @@ namespace Microsoft.Bot.Connector.Streaming.Application
                 _disconnectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
                 // Start transport and application
-                var transportTask = connectFunc(_transport);
+                var transportTask = connectFunc(_transport, connect => IsConnected = connect);
                 var applicationTask = _application.ListenAsync(_disconnectCts.Token);
                 var combinedTask = Task.WhenAll(transportTask, applicationTask);
 
@@ -220,9 +223,6 @@ namespace Microsoft.Bot.Connector.Streaming.Application
                     timer = new TimerAwaitable(_keepAlive.Value, _keepAlive.Value);
                     timerTask = TimerLoopAsync(timer);
                 }
-
-                // We are connected!
-                IsConnected = true;
 
                 // Block until transport or application ends.
                 await combinedTask.ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/NamedPipeTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/NamedPipeTransport.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
             _tryTimes = 0;
 
             // TryTimes exhausted happens when customers use the app.UsedNamedPipe in their bot, but do not enable ase.
-            while (!cancellationToken.IsCancellationRequested && _tryTimes > 100)
+            while (!cancellationToken.IsCancellationRequested && _tryTimes < 100)
             {
                 _tryTimes++;
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/NamedPipeTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/NamedPipeTransport.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
         private PipeStream _receiver;
         private PipeStream _sender;
         private bool _disposedValue;
+        private int _tryTimes;
 
         public NamedPipeTransport(string pipeName, IDuplexPipe application, ILogger logger)
             : base(application, logger)
@@ -34,64 +35,44 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
             _pipeName = pipeName;
         }
 
-        public override async Task ConnectAsync(CancellationToken cancellationToken)
+        public override async Task ConnectAsync(Action<bool> connectionStatusChanged = null, CancellationToken cancellationToken = default)
         {
             Log.NamedPipeOpened(Logger);
 
             try
             {
-                _receiver = new NamedPipeServerStream(
-                    pipeName: _pipeName + ServerIncomingPath,
-                    PipeDirection.In,
-                    NamedPipeServerStream.MaxAllowedServerInstances,
-                    PipeTransmissionMode.Byte,
-                    options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
-
-                await ((NamedPipeServerStream)_receiver).WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
-
-                _sender = new NamedPipeServerStream(
-                    pipeName: _pipeName + ServerOutgoingPath,
-                    PipeDirection.Out,
-                    NamedPipeServerStream.MaxAllowedServerInstances,
-                    PipeTransmissionMode.Byte,
-                    options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
-
-                await ((NamedPipeServerStream)_sender).WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
-
+                await RetryToSucceedAsync(CreateNamedPipeServerAsync, cancellationToken).ConfigureAwait(false);
+                connectionStatusChanged?.Invoke(true);
                 await ProcessAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                throw;
             }
             finally
             {
                 Log.NamedPipeClosed(Logger);
+                connectionStatusChanged?.Invoke(false);
             }
         }
 
-        public override async Task ConnectAsync(string url, IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default)
+        public override async Task ConnectAsync(string url, Action<bool> connectionStatusChanged = null, IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default)
         {
             Log.NamedPipeOpened(Logger);
 
             try
             {
-                _sender = new NamedPipeClientStream(
-                    serverName: ".",
-                    pipeName: _pipeName + ServerIncomingPath,
-                    PipeDirection.Out,
-                    options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
-
-                await ((NamedPipeClientStream)_sender).ConnectAsync(cancellationToken).ConfigureAwait(false);
-
-                _receiver = new NamedPipeClientStream(
-                    serverName: ".",
-                    pipeName: _pipeName + ServerOutgoingPath,
-                    PipeDirection.In,
-                    options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
-
-                await ((NamedPipeClientStream)_receiver).ConnectAsync(cancellationToken).ConfigureAwait(false);
-
+                await RetryToSucceedAsync(CreateNamedPipeClientAsync, cancellationToken).ConfigureAwait(false);
+                connectionStatusChanged?.Invoke(true);
                 await ProcessAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                throw;
             }
             finally
             {
+                connectionStatusChanged?.Invoke(false);
                 Log.NamedPipeClosed(Logger);
             }
         }
@@ -106,11 +87,12 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                 var result = await _receiver.ReadAsync(temp, offset: 0, count, cancellationToken).ConfigureAwait(false);
                 temp.CopyTo(buffer.Span);
 
-                return result;
+                // NamedPipe disconnection not aloway throw InvalidOperationException
+                return _receiver.IsConnected ? result : -1;
             }
             catch (InvalidOperationException)
             {
-                // Named Pipe is disconnected
+                // NamedPipe is disconnected
                 return -1;
             }
         }
@@ -152,6 +134,97 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
             }
         }
 
+        private async Task RetryToSucceedAsync(Func<CancellationToken, Task> createNamedPipeFactory, CancellationToken cancellationToken)
+        {
+            _tryTimes = 0;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                _tryTimes++;
+
+                // happends when customers use app.UsedNamedPipe in their bot, but do not enable ase.
+                if (_tryTimes > 100)
+                {
+                    return;
+                }
+
+                // To avoid NamedPipeServer and NamedPipeClient dead lock, add timeout when create NamePipe
+                using (var source = new CancellationTokenSource())
+                {
+                    try
+                    {
+                        // NamedPipeServer and NamedPipeClient dead lock can be break by time out
+                        // Add this random to avoid a special dead lock when machine run slow.
+                        // At least 5 seconds, because :
+                        // if ASE update to new version but customer still use old version bot(SDK). Quick retry will make this connection never connect.
+                        var timeoutTask = Task.Delay(TimeSpan.FromSeconds((new Random(DateTime.Now.Millisecond).NextDouble() * _tryTimes * 2) + 5), cancellationToken);
+                        var createTask = createNamedPipeFactory(source.Token);
+
+                        if (timeoutTask == await Task.WhenAny(timeoutTask, createTask).ConfigureAwait(false))
+                        {
+                            Log.NamedPipeCreateTimeout(Logger);
+                            source.Cancel();
+                            continue;
+                        }
+
+                        // check createTask finish code. (Task.WhenAny can't catch exception in createTask)
+                        await createTask.ConfigureAwait(false);
+
+                        // connect succeed
+                        return;
+                    }
+#pragma warning disable CA1031 // Catch all exceptions and retry
+                    catch (Exception e)
+#pragma warning restore CA1031
+                    {
+                        Log.NamedPipeCreateException(Logger, e);
+                        source.Cancel();
+                    }
+                }
+            }
+        }
+
+        private async Task CreateNamedPipeClientAsync(CancellationToken cancellationToken)
+        {
+            _sender?.Dispose();
+            _receiver?.Dispose();
+
+            _sender = new NamedPipeClientStream(
+                serverName: ".",
+                pipeName: _pipeName + ServerIncomingPath,
+                PipeDirection.Out,
+                options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
+            await ((NamedPipeClientStream)_sender).ConnectAsync(cancellationToken).ConfigureAwait(false);
+
+            _receiver = new NamedPipeClientStream(
+                serverName: ".",
+                pipeName: _pipeName + ServerOutgoingPath,
+                PipeDirection.In,
+                options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
+            await ((NamedPipeClientStream)_receiver).ConnectAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task CreateNamedPipeServerAsync(CancellationToken cancellationToken)
+        {
+            _sender?.Dispose();
+            _receiver?.Dispose();
+
+            _receiver = new NamedPipeServerStream(
+                pipeName: _pipeName + ServerIncomingPath,
+                PipeDirection.In,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
+            await ((NamedPipeServerStream)_receiver).WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+            _sender = new NamedPipeServerStream(
+                pipeName: _pipeName + ServerOutgoingPath,
+                PipeDirection.Out,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                options: System.IO.Pipes.PipeOptions.WriteThrough | System.IO.Pipes.PipeOptions.Asynchronous);
+            await ((NamedPipeServerStream)_sender).WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Log messages for <see cref="NamedPipeTransport"/>.
         /// </summary>
@@ -161,11 +234,21 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
         /// </remarks>
         private static class Log
         {
+            private static readonly Action<ILogger, Exception> _namedPipeCreateTimeout = LoggerMessage.Define(
+                LogLevel.Information, new EventId(1, nameof(NamedPipeOpened)), "Create NamedPipe Timeout.");
+
+            private static readonly Action<ILogger, Exception> _namedPipeCreateException = (_, e) => LoggerMessage.Define(
+                LogLevel.Information, new EventId(1, nameof(NamedPipeOpened)), $"Create NamedPipe with exception:{e}");
+
             private static readonly Action<ILogger, Exception> _namedPipeOpened = LoggerMessage.Define(
                 LogLevel.Information, new EventId(1, nameof(NamedPipeOpened)), "Named Pipe transport connection opened.");
 
             private static readonly Action<ILogger, Exception> _namedPipeClosed = LoggerMessage.Define(
                 LogLevel.Information, new EventId(2, nameof(NamedPipeClosed)), "Named Pipe transport connection closed.");
+
+            public static void NamedPipeCreateException(ILogger logger, Exception e) => _namedPipeCreateException(logger, e);
+
+            public static void NamedPipeCreateTimeout(ILogger logger) => _namedPipeCreateTimeout(logger, null);
 
             public static void NamedPipeOpened(ILogger logger) => _namedPipeOpened(logger, null);
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/StreamingTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/StreamingTransport.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
 
         protected ILogger Logger { get; }
 
-        public abstract Task ConnectAsync(CancellationToken cancellationToken);
+        public abstract Task ConnectAsync(Action<bool> connectionStatusChanged = null, CancellationToken cancellationToken = default);
 
-        public abstract Task ConnectAsync(string url, IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default);
+        public abstract Task ConnectAsync(string url, Action<bool> connectionStatusChanged = null, IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default);
 
         /// <inheritdoc />
         public void Dispose()

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/WebSocketTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/WebSocketTransport.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                     await ProcessAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
-                {                    
+                {
                     throw new InvalidOperationException("Only client web socket can connect to server. Please instantiate the 'WebSocketTransport' with a 'ClientWebSocket' instance.");
                 }
             }

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/WebSocketTransport.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/WebSocketTransport.cs
@@ -24,21 +24,23 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
             _socket = socket ?? throw new ArgumentNullException(nameof(socket));
         }
 
-        public override async Task ConnectAsync(CancellationToken cancellationToken)
+        public override async Task ConnectAsync(Action<bool> connectionStatusChanged = null, CancellationToken cancellationToken = default)
         {
             Log.SocketOpened(Logger);
 
             try
             {
+                connectionStatusChanged?.Invoke(true);
                 await ProcessAsync(cancellationToken).ConfigureAwait(false);
             }
             finally
             {
+                connectionStatusChanged?.Invoke(false);
                 Log.SocketClosed(Logger);
             }
         }
 
-        public override async Task ConnectAsync(string url, IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default)
+        public override async Task ConnectAsync(string url, Action<bool> connectionStatusChanged = null, IDictionary<string, string> requestHeaders = null, CancellationToken cancellationToken = default)
         {
             Log.SocketOpened(Logger);
 
@@ -55,16 +57,17 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
                     }
 
                     await clientSocket.ConnectAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
-
+                    connectionStatusChanged?.Invoke(true);
                     await ProcessAsync(cancellationToken).ConfigureAwait(false);
                 }
                 else
-                {
+                {                    
                     throw new InvalidOperationException("Only client web socket can connect to server. Please instantiate the 'WebSocketTransport' with a 'ClientWebSocket' instance.");
                 }
             }
             finally
             {
+                connectionStatusChanged?.Invoke(false);
                 Log.SocketClosed(Logger);
             }
         }

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/WebSocketTransportClientServerTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/WebSocketTransportClientServerTests.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 var serverTransport = new WebSocketTransport(await webSocketFeature.AcceptAsync(), serverPipePair.Application, NullLogger.Instance);
 
                 // Accept server web socket, start receiving / sending at the transport level
-                var serverTask = serverTransport.ConnectAsync(CancellationToken.None);
+                var serverTask = serverTransport.ConnectAsync();
 
                 var clientTransport = new WebSocketTransport(webSocketFeature.Client, clientPipePair.Application, NullLogger.Instance);
-                var clientTask = clientTransport.ConnectAsync(CancellationToken.None);
+                var clientTask = clientTransport.ConnectAsync();
 
                 // Send a frame client -> server
                 await clientPipePair.Transport.Output.WriteAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("Hello")));

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Transport/WebSocketTransportTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Transport/WebSocketTransportTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 var transport = new WebSocketTransport(await webSocketFeature.AcceptAsync(), pipePair.Application, NullLogger.Instance);
 
                 // Accept web socket, start receiving / sending at the transport level
-                var processTask = transport.ConnectAsync(CancellationToken.None);
+                var processTask = transport.ConnectAsync();
 
                 // Start a socket client that will capture traffic for posterior analysis
                 var clientTask = webSocketFeature.Client.ExecuteAndCaptureFramesAsync();
@@ -103,7 +103,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     var transport = new WebSocketTransport(await feature.AcceptAsync(), pair.Application, NullLogger.Instance);
 
                     // Accept web socket, start receiving / sending at the transport level
-                    var processTask = transport.ConnectAsync(CancellationToken.None);
+                    var processTask = transport.ConnectAsync();
 
                     // Start a socket client that will capture traffic for posterior analysis
                     var clientTask = feature.Client.ExecuteAndCaptureFramesAsync();
@@ -135,7 +135,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     var transport = new WebSocketTransport(await feature.AcceptAsync(), pair.Application, NullLogger.Instance);
 
                     // Accept web socket, start receiving / sending at the transport level
-                    var processTask = transport.ConnectAsync(CancellationToken.None);
+                    var processTask = transport.ConnectAsync();
 
                     // Start a socket client that will capture traffic for posterior analysis
                     var clientTask = feature.Client.ExecuteAndCaptureFramesAsync();
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     var transport = new WebSocketTransport(serverSocket, pair.Application, NullLogger.Instance);
 
                     // Accept web socket, start receiving / sending at the transport level
-                    var processTask = transport.ConnectAsync(CancellationToken.None);
+                    var processTask = transport.ConnectAsync();
 
                     // Start a socket client that will capture traffic for posterior analysis
                     var clientTask = feature.Client.ExecuteAndCaptureFramesAsync();
@@ -197,7 +197,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     var transport = new WebSocketTransport(serverSocket, pair.Application, NullLogger.Instance);
 
                     // Accept web socket, start receiving / sending at the transport level
-                    var processTask = transport.ConnectAsync(CancellationToken.None);
+                    var processTask = transport.ConnectAsync();
 
                     // Start a socket client that will capture traffic for posterior analysis
                     var clientTask = feature.Client.ExecuteAndCaptureFramesAsync();
@@ -225,7 +225,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     var transport = new WebSocketTransport(serverSocket, pair.Application, NullLogger.Instance);
 
                     // Accept web socket, start receiving / sending at the transport level
-                    var processTask = transport.ConnectAsync(CancellationToken.None);
+                    var processTask = transport.ConnectAsync();
 
                     // Start a socket client that will capture traffic for posterior analysis
                     var clientTask = feature.Client.ExecuteAndCaptureFramesAsync();
@@ -257,7 +257,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     var transport = new WebSocketTransport(serverSocket, pair.Application, NullLogger.Instance);
 
                     // Accept web socket, start receiving / sending at the transport level
-                    var processTask = transport.ConnectAsync(CancellationToken.None);
+                    var processTask = transport.ConnectAsync();
 
                     // Start a socket client that will capture traffic for posterior analysis
                     var clientTask = feature.Client.ExecuteAndCaptureFramesAsync();
@@ -335,7 +335,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 httpContext.Setup(c => c.WebSockets).Returns(webSocketManager.Object);
 
                 var sut = new WebSocketTransport(httpContext.Object.WebSockets.AcceptWebSocketAsync().GetAwaiter().GetResult(), new DuplexPipe(toTransport.Reader, fromTransport.Writer), logger);
-                var serverTransportRunning = sut.ConnectAsync(CancellationToken.None);
+                var serverTransportRunning = sut.ConnectAsync();
 
                 var messages = new List<byte[]> { Encoding.UTF8.GetBytes("foo"), Encoding.UTF8.GetBytes("bar") };
                 SendBinaryAsync(client, messages).Wait();
@@ -370,7 +370,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 httpContext.Setup(c => c.WebSockets).Returns(webSocketManager.Object);
 
                 var sut = new WebSocketTransport(httpContext.Object.WebSockets.AcceptWebSocketAsync().GetAwaiter().GetResult(), new DuplexPipe(toTransport.Reader, fromTransport.Writer), logger);
-                var serverTransportRunning = sut.ConnectAsync(CancellationToken.None);
+                var serverTransportRunning = sut.ConnectAsync();
 
                 var messages = new List<byte[]> { Encoding.UTF8.GetBytes("foo") };
                 WriteAsync(toTransport.Writer, messages).Wait();
@@ -399,7 +399,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 var listenerRunning = ListenAsync(fromTransport.Reader);
 
                 var sut = new WebSocketTransport(client, new DuplexPipe(toTransport.Reader, fromTransport.Writer), logger);
-                var clientTransportRunning = sut.ConnectAsync(CancellationToken.None);
+                var clientTransportRunning = sut.ConnectAsync();
 
                 var messages = new List<byte[]> { Encoding.UTF8.GetBytes("foo") };
                 SendBinaryAsync(server, messages).Wait();
@@ -428,7 +428,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 var toTransport = new Pipe(PipeOptions.Default);
 
                 var sut = new WebSocketTransport(client, new DuplexPipe(toTransport.Reader, fromTransport.Writer), logger);
-                var clientTransportRunning = sut.ConnectAsync(CancellationToken.None);
+                var clientTransportRunning = sut.ConnectAsync();
 
                 var messages = new List<byte[]> { Encoding.UTF8.GetBytes("foo") };
                 WriteAsync(toTransport.Writer, messages).Wait();


### PR DESCRIPTION
Fixes #6306

## Description
NamedPipe Reconnection did not fix well by the previous PR for this issue(#6306), the disconnect issue(ib/ob false) still occur.
This pr add retry in NamedPipeTransport, and will fix NamedPipe ib/ob false issue, after customer update their SDK and I publish new version of DL-ASE.
This change is backward compatibility, verified in Testing.

## Specific Changes
1.  Add a callback in  NamedPipeTransport.ConnectAsync to correctly set the IsConnect property.
Because NamedPipeTransport.ConnectAsync implemetations handle both connectAsync and processAsync, can't find out the correct time to set the IsConnected status outside.
2. Add retry logic in NamedPipeTransport.ConnectAsync, to avoid connect exception. This does happen sometimes in Azure.
5. Add random timeout in retry logic, to avoid dead lock when NamePipeServer and NamedPipeClient connect/reconnect.
This does happen sometimes in Azure.
6. Add a connection  double check in NamedPipeTransport line 91, previous code missed lots of disconnection scenarios. 


## Testing
We have two program, bot and ase, they use namedPipeTransport as a pipe to comunicate.
This pr will update the SDK which is used by both bot and ase.
So I call the program before this change "**old bot**"/ "**old ase**".
And call the program after this change "**new bot**"/ "**new ase**".
There are more than one bugs in the NamedPipe connect/reconnect.
Some were fixed in BotBuild SDK4.17, and some were fixed in our ase version 1.1.0.0 which was published early this year. But still connection issue hanppends.
Below I verified all kinds of scenarios I can think of. Because some scenarios were hardly reproduce in Azure, so I verified them locally.
Here is my verified scenarios.
My conclusion is: **after both bot and ase update their SDK, all issue will be fixed. And if customer just update one of them, won't bring in any harm to their service**.
![image](https://user-images.githubusercontent.com/22291967/197485306-87ff8a53-057d-4333-b02d-14def2232705.png)
