### PR TITLE
[#6518] CodeQL alert SM02200: Weak hmacs in microsoft/microsoft/botbuilder-dotnet/botbuilder-dotnet

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/FacebookChatTests.cs
@@ -91,11 +91,10 @@ namespace Microsoft.Bot.Builder.FunctionalTests
         {
             var hashResult = string.Empty;
 
-            using (var hmac = new System.Security.Cryptography.HMACSHA1(Encoding.UTF8.GetBytes(_appSecret)))
+            using (var hmac = new System.Security.Cryptography.HMACSHA256(Encoding.UTF8.GetBytes(_appSecret)))
             {
-                hmac.Initialize();
                 var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(bodyMessage));
-                var hash = $"SHA1={BitConverter.ToString(hashArray).Replace("-", string.Empty)}";
+                var hash = BitConverter.ToString(hashArray).Replace("-", string.Empty);
 
                 hashResult = hash;
             }

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs
@@ -115,16 +115,12 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook
 
             var expected = request.Headers["x-hub-signature"].ToString().ToUpperInvariant();
 
-#pragma warning disable CA5350 // Facebook uses SHA1 as cryptographic algorithm.
-            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(_options.FacebookAppSecret)))
+            using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_options.FacebookAppSecret)))
             {
-                hmac.Initialize();
                 var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
-                var hash = $"SHA1={BitConverter.ToString(hashArray).Replace("-", string.Empty)}";
-
+                var hash = BitConverter.ToString(hashArray).Replace("-", string.Empty);
                 return expected == hash;
             }
-#pragma warning restore CA5350 // Facebook uses SHA1 as cryptographic algorithm.
         }
 
         /// <summary>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         [Fact]
         public void VerifySignatureShouldReturnTrueWithValidRequestHash()
         {
-            const string requestHash = "SHA1=70C0E1B415F16D986EB839144FC85A941A5899C7";
+            const string requestHash = "13870D954C7CB3A6725C7C8DC58260E6EEE77D538DAFEA1A3703DCC2AE21E97F";
             var facebookWrapper = new FacebookClientWrapper(_testOptions);
             var request = new Mock<HttpRequest>();
             var stringifyBody = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/RequestResponse.json");


### PR DESCRIPTION
Fixes #6518

## Description
This PR fixes the SM02200 CodeQL alert by replacing the deprecated HMAC algorithm with a SHA2-based HMAC instead in the [VerifySignature](https://github.com/microsoft/botbuilder-dotnet/blob/main?path=/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Facebook/FacebookClientWrapper.cs#L119&amp;lineStartColumn=31&amp;lineEndColumn=95) method of the **_FacebookClientWrapper_** class.

## Specific Changes
- Replaced HMAC algorithm with SHA256 in the _VerifySignature_ method of the _FacebookClientWrapper_ class.
- Updated expected hash in _FacebookWrapperTests_.
- Replaced HMAC with SHA256 in the _CreateHubSignature_ method of the _FacebookChatTests_ class.

## Testing
These images show the unit tests and the functional tests successfully executed after the changes.
![image](https://user-images.githubusercontent.com/44245136/197602725-91c65c4c-9b79-4b72-bee0-fbb7dd23fd75.png)