### PR TITLE
[#6511] CodeQL alert SM02200: Weak hmacs - Suppress alert for WebexClientWrapper

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 : throw new InvalidOperationException($"HttpRequest is missing \"{SparkSignature}\"");
 
 #pragma warning disable CA5350 // Webex API uses SHA1 as cryptographic algorithm.
-            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(Options.WebexSecret)))
+            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(Options.WebexSecret))) //lgtm[cs/weak-encryption]
             {
                 var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(jsonPayload));
                 var hash = BitConverter.ToString(hashArray).Replace("-", string.Empty).ToUpperInvariant();


### PR DESCRIPTION
Fixes #6511

## Description
This PR suppresses the CodeQL SM02200 alert related to using the SHA1 encryption algorithm in **_WebexClientWrapper_** class.
The alert can't be fixed because the [Webex API](https://developer.webex.com/docs/api/guides/webhooks#handling-requests-from-webex) uses SHA1 encryption for the messages' signature.

## Specific Changes
- Added comment to suppress SM02200 alert in the _ValidateSignature_ method.

## Testing
The unit tests passed after the change.
![image](https://user-images.githubusercontent.com/44245136/199810618-74db2d6a-5e6b-478d-8535-2488b1ea19bd.png)
