### PR TITLE
[#6512] CodeQL alert SM00431: Information exposure through an exception

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/StreamingRequestHandler.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Bot.Builder.Streaming
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 response.StatusCode = (int)HttpStatusCode.InternalServerError;
-                response.SetBody(ex.ToString());
+                response.SetBody(ex.Message);
                 _logger.LogError(ex.ToString());
             }
 


### PR DESCRIPTION
Fixes #6512

## Description
This PR fixes the CodeQL SM00431 alert related to exposing an exception to the end user ([more information](https://codeql.github.com/codeql-query-help/csharp/cs-information-exposure-through-exception/)).

## Specific Changes
- Updates response SetBody parameter usage, changing from the whole exception to just the message.

## Testing
The following image shows the before and after the applied fix, using the CodeQL query tool.
![imagen](https://user-images.githubusercontent.com/62260472/200572050-861ad38f-0bd5-4b66-8112-b69fce9e1ad4.png)