### PR TITLE
Fix CodeQL SM02211 alert

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -709,7 +709,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
 
             var serializer = JsonSerializer.Create(new JsonSerializerSettings()
             {
-                TypeNameHandling = TypeNameHandling.Auto,
                 Converters = converters,
                 Error = (sender, args) =>
                 {

--- a/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/ObjectPath.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Bot.Builder.Dialogs
     /// </summary>
     public static class ObjectPath
     {
-        private static readonly JsonSerializerSettings _cloneSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, MaxDepth = null };
-
         private static readonly JsonSerializerSettings _expressionCaseSettings = new JsonSerializerSettings
         {
             ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() },
@@ -347,7 +345,10 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <returns>The object as Json.</returns>
         public static T Clone<T>(T obj)
         {
-            return JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(obj, _cloneSettings), _cloneSettings);
+            var settings = new JsonSerializerSettings { MaxDepth = null };
+            var serialized = JsonConvert.SerializeObject(obj, settings);
+            var result = JsonConvert.DeserializeObject<T>(serialized, settings);
+            return result;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
+++ b/libraries/Microsoft.Bot.Builder/MemoryStorage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Bot.Builder
     {
         private static readonly JsonSerializer StateJsonSerializer = new JsonSerializer()
         {
-            TypeNameHandling = TypeNameHandling.All,
+            TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
             ReferenceLoopHandling = ReferenceLoopHandling.Error,
         };
 

--- a/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/BotStateTests.cs
@@ -38,6 +38,23 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [Fact]
+        public async Task State_WriteAsyncStoreItem()
+        {
+            var dictionary = new Dictionary<string, JObject>();
+            var memory = new MemoryStorage(dictionary);
+
+            var changes = new Dictionary<string, object>()
+            {
+                { "customState", new CustomState() },
+            };
+            await memory.WriteAsync(changes, CancellationToken.None);
+            var result = await memory.ReadAsync(new string[] { "customState" }, CancellationToken.None);
+
+            Assert.Equal("0", dictionary["customState"]["eTag"]);
+            Assert.Equal("0", (result["customState"] as CustomState).ETag);
+        }
+
+        [Fact]
         public async Task MakeSureStorageNotCalledNoChangesAsync()
         {
             // Mock a storage provider, which counts read/writes


### PR DESCRIPTION
Fixes #6506 #6508 #6509

## Description
This PR fixes the CodeQL SM02211 alert related to unsafe `JsonSerializer` `TypeNameHandling` usage.

## Specific Changes
- Updates the `MemoryStorage` disabling the alert.
    - Added a unit test validating that the setting is required.
- Updates the `ObjectPath`, removing the global serialization setting and setting the `TypeNameHandling` to the default `None`.
- Updates the `ResourceExplorer`, removing the `TypeNameHandling` property defaulting to `None`.

## Testing
The following image shows the tests for the three classes passing successfully.
![imagen](https://user-images.githubusercontent.com/62260472/200928659-0e09d0bb-7f81-4d06-a068-4faf10a6e52f.png)