### PR TITLE
Fix CodeQL SM02211 alert - SerializationBinder

### DIFF
--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Webex/WebexClientWrapper.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex
                 : throw new InvalidOperationException($"HttpRequest is missing \"{SparkSignature}\"");
 
 #pragma warning disable CA5350 // Webex API uses SHA1 as cryptographic algorithm.
-            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(Options.WebexSecret)))
+            using (var hmac = new HMACSHA1(Encoding.UTF8.GetBytes(Options.WebexSecret))) //lgtm[cs/weak-encryption]
             {
                 var hashArray = hmac.ComputeHash(Encoding.UTF8.GetBytes(jsonPayload));
                 var hash = BitConverter.ToString(hashArray).Replace("-", string.Empty).ToUpperInvariant();

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Bot.Builder.Azure.Blobs
 {
@@ -29,6 +31,13 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
     /// </remarks>
     public class BlobsStorage : IStorage
     {
+        private static readonly AllowedTypesSerializationBinder _allowedTypesBinder = new AllowedTypesSerializationBinder(
+            new List<Type>
+            {
+                typeof(IStoreItem),
+                typeof(Dictionary<string, object>)
+            });
+
         // If a JsonSerializer is not provided during construction, this will be the default JsonSerializer.
         private readonly JsonSerializer _jsonSerializer;
         private readonly BlobContainerClient _containerClient;
@@ -44,6 +53,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
         /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
         /// </param>
         public BlobsStorage(string dataConnectionString, string containerName, JsonSerializer jsonSerializer = null)
             : this(dataConnectionString, containerName, default, jsonSerializer)
@@ -60,6 +70,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
         /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
         /// </param>
         public BlobsStorage(string dataConnectionString, string containerName, StorageTransferOptions storageTransferOptions, JsonSerializer jsonSerializer = null)
         {
@@ -77,7 +88,8 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
                                                 {
-                                                    TypeNameHandling = TypeNameHandling.All,
+                                                    TypeNameHandling = TypeNameHandling.Objects, // lgtm [cs/unsafe-type-name-handling]
+                                                    SerializationBinder = _allowedTypesBinder,
                                                 });
 
             // Triggers a check for the existence of the container
@@ -94,6 +106,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
         /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
         /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
         /// </param>
         internal BlobsStorage(BlobContainerClient containerClient, JsonSerializer jsonSerializer = null)
         {
@@ -101,7 +114,8 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
             _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
             {
-                TypeNameHandling = TypeNameHandling.All,
+                TypeNameHandling = TypeNameHandling.Objects, // lgtm [cs/unsafe-type-name-handling]
+                SerializationBinder = _allowedTypesBinder,
             });
 
             // Triggers a check for the existence of the container
@@ -212,7 +226,19 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                 {
                     using var memoryStream = new MemoryStream();
                     using var streamWriter = new StreamWriter(memoryStream);
-                    _jsonSerializer.Serialize(streamWriter, newValue);
+                    using var jsonWriter = new JsonTextWriter(streamWriter);
+                    
+                    var json = JToken.FromObject(newValue, _jsonSerializer);
+                    if (json.Type == JTokenType.Object || json.Type == JTokenType.Array)
+                    {
+                        (_jsonSerializer.SerializationBinder as AllowedTypesSerializationBinder)?.CleanupTypes((JContainer)json);
+                        await json.WriteToAsync(jsonWriter).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        _jsonSerializer.Serialize(streamWriter, newValue);
+                    }
+
                     await streamWriter.FlushAsync().ConfigureAwait(false);
                     memoryStream.Seek(0, SeekOrigin.Begin);
 

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsTranscriptStore.cs
@@ -80,7 +80,6 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                                                 {            
                                                     NullValueHandling = NullValueHandling.Ignore,
                                                     Formatting = Formatting.Indented,
-                                                    TypeNameHandling = TypeNameHandling.None,
                                                 });
 
             // Triggers a check for the existance of the container
@@ -112,10 +111,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
         {
             _containerClient = new Lazy<BlobContainerClient>(() => containerClient);
 
-            _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All,
-            });
+            _jsonSerializer = jsonSerializer ?? JsonSerializer.Create();
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -101,8 +101,14 @@ namespace Microsoft.Bot.Builder.Azure
         /// <param name="storageAccount">Azure CloudStorageAccount instance.</param>
         /// <param name="containerName">Name of the Blob container where entities will be stored.</param>
         /// <param name="blobClient">Custom implementation of CloudBlobClient.</param>
-        internal AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, CloudBlobClient blobClient)
-            : this(storageAccount, containerName, JsonSerializer)
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.All.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
+        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
+        /// </param>
+        internal AzureBlobStorage(CloudStorageAccount storageAccount, string containerName, CloudBlobClient blobClient, JsonSerializer jsonSerializer = default)
+            : this(storageAccount, containerName, jsonSerializer ?? JsonSerializer)
         {
             _blobClient = blobClient;
         }

--- a/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/AzureBlobStorage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;

--- a/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure/CosmosDbPartitionedStorage.cs
@@ -117,10 +117,20 @@ namespace Microsoft.Bot.Builder.Azure
         /// </summary>
         /// <param name="client">The custom implementation of CosmosClient.</param>
         /// <param name="cosmosDbStorageOptions">Cosmos DB partitioned storage configuration options.</param>
-        internal CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions)
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.All.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
+        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
+        /// </param>
+        internal CosmosDbPartitionedStorage(CosmosClient client, CosmosDbPartitionedStorageOptions cosmosDbStorageOptions, JsonSerializer jsonSerializer = default)
             : this(cosmosDbStorageOptions)
         {
             _client = client;
+            if (jsonSerializer != null)
+            {
+                _jsonSerializer = jsonSerializer;
+            }
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/AllowedTypesSerializationBinder.cs
+++ b/libraries/Microsoft.Bot.Builder/AllowedTypesSerializationBinder.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Bot.Builder
+{
+    /// <summary>
+    /// An implementation of the <see cref="DefaultSerializationBinder"/>,
+    /// capable of allowing only desired <see cref="Type"/>s to be serialized and deserialized.
+    /// </summary>
+    public class AllowedTypesSerializationBinder : DefaultSerializationBinder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AllowedTypesSerializationBinder"/> class.
+        /// </summary>
+        /// <param name="allowedTypes">A list of types to allow this binder to assign upon deserialization.</param>
+        public AllowedTypesSerializationBinder(IList<Type> allowedTypes = default)
+        {
+            AllowedTypes = allowedTypes ?? new List<Type>();
+        }
+
+        /// <summary>
+        /// Gets the collection of the allowed types.
+        /// </summary>
+        /// <value>
+        /// A <see cref="IList{T}"/> of allowed <see cref="Type"/> classes.
+        /// </value>
+        public IList<Type> AllowedTypes { get; }
+
+        /// <summary>
+        /// <para>
+        /// Given the <paramref name="serializedType"/> parameter,
+        /// it evaluates if the <see cref="Type"/> is allowed by this SerializationBinder.
+        /// </para>
+        /// <para>
+        /// Either allowed or not allowed, it will output the name of the <see cref="Type"/> through the <paramref name="typeName"/> parameter.
+        /// </para>
+        /// <para>
+        /// When allowed, it will add the <see cref="Type"/> to the <see cref="AllowedTypes"/> collection.
+        /// </para>
+        /// </summary>
+        /// <param name="serializedType">The type of the object the formatter creates a new instance of.</param>
+        /// <param name="assemblyName">Specifies the System.Reflection.Assembly name of the serialized object.</param>
+        /// <param name="typeName">Specifies the System.Type name of the serialized object.</param>
+        public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        {
+            assemblyName = null;
+            typeName = serializedType?.AssemblyQualifiedName;
+
+            if (serializedType == null || AllowedTypes.Count == 0)
+            {
+                return;
+            }
+            
+            if (IsTypeAllowed(serializedType))
+            {
+                AllowType(serializedType);
+            }
+        }
+
+        /// <summary>
+        /// Given the <paramref name="assemblyName"/> and <paramref name="typeName"/> parameters,
+        /// it validates if the resulted <see cref="Type"/> is found in the <see cref="AllowedTypes"/> collection.
+        /// <para>
+        /// When found, it will return the serialized <see cref="Type"/>.
+        /// </para>
+        /// <para>
+        /// When not found, it will throw an <see cref="InvalidOperationException"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="assemblyName">Specifies the System.Reflection.Assembly name of the serialized object.</param>
+        /// <param name="typeName">Specifies the System.Type name of the serialized object.</param>
+        /// <returns>The <see cref="Type"/> found in the <see cref="AllowedTypes"/> collection.</returns>
+        /// <exception cref="InvalidOperationException">When the resulted <see cref="Type"/>
+        /// from the <paramref name="assemblyName"/> and <paramref name="typeName"/> parameters
+        /// is not found in the <see cref="AllowedTypes"/> collection.</exception>
+        public override Type BindToType(string assemblyName, string typeName)
+        {
+            var resolvedTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", typeName, assemblyName);
+            var type = Type.GetType(resolvedTypeName);
+
+            // Preload related type.
+            if (IsTypeAllowed(type))
+            {
+                AllowType(type);
+            }
+
+            if (!AllowedTypes.Contains(type))
+            {
+                ThrowDisallowedTypesError(new List<Type> { type });
+            }
+
+            return type;
+        }
+
+        /// <summary>
+        /// Finds and remove all the '$type' properties within the provided <paramref name="json"/> parameter,
+        /// that are not included in the <see cref="AllowedTypes"/> collection.
+        /// </summary>
+        /// <param name="json">A JSON object.</param>
+        public void CleanupTypes(JContainer json)
+        {
+            if (AllowedTypes.Count == 0)
+            {
+                return;
+            }
+
+            var disallowedTypes = new List<Type>();
+            var allowedTypes = AllowedTypes.ToDictionary(e => e.AssemblyQualifiedName);
+
+            // Remove AllowedTypes nested types from the object.
+            json.Descendants()
+                .OfType<JProperty>()
+                .Where(attr => attr.Name == "$type")
+                .Select(attr => new
+                {
+                    Property = attr,
+                    Type = Type.GetType(attr.Value.ToString())
+                })
+                .Where(attr =>
+                {
+                    if (AllowedTypes.Contains(attr.Type))
+                    {
+                        return false;
+                    }
+
+                    var shouldRemove = attr.Type == null || ShouldRemoveType(attr.Type, attr.Property.Parent, allowedTypes);
+                    if (shouldRemove)
+                    {
+                        return true;
+                    }
+
+                    disallowedTypes.Add(attr.Type);
+                    return false;
+                })
+                .ToList()
+                .ForEach(attr => attr.Property.Remove());
+
+            if (disallowedTypes.Count > 0)
+            {
+                ThrowDisallowedTypesError(disallowedTypes);
+            }
+        }
+
+        private void ThrowDisallowedTypesError(List<Type> types)
+        {
+            var items = types.Select(type => $"  - {type.AssemblyQualifiedName}");
+            var typeOfs = types.Select(type => $"typeof({type.Name}),");
+            var message = $"Unable to find the following types in the '{nameof(AllowedTypes)}' collection." + Environment.NewLine +
+                        string.Join(Environment.NewLine, items) + Environment.NewLine +
+                        Environment.NewLine +
+                        $"Please provide the '{nameof(AllowedTypesSerializationBinder)}' in the custom '{nameof(JsonSerializerSettings)}' instance, with the list of types to allow." + Environment.NewLine +
+                        Environment.NewLine +
+                        "Example:" + Environment.NewLine +
+                        "    new JsonSerializerSettings" + Environment.NewLine +
+                        "    {" + Environment.NewLine +
+                        "        SerializationBinder = new AllowedTypesSerializationBinder(" + Environment.NewLine +
+                        "            new List<Type>" + Environment.NewLine +
+                        "            {" + Environment.NewLine +
+                        $"                {string.Join(Environment.NewLine + "                ", typeOfs)}" + Environment.NewLine +
+                        "            })," + Environment.NewLine +
+                        "    }";
+            throw new InvalidOperationException(message);
+        }
+
+        private bool ShouldRemoveType(Type child, JContainer parent, IDictionary<string, Type> memory)
+        {
+            if (parent == null)
+            {
+                return false;
+            }
+
+            var parentTypeName = parent.Type == JTokenType.Object ? parent?.Value<string>("$type") : string.Empty;
+            var parentType = Type.GetType(parentTypeName);
+            if (parentType == null)
+            {
+                return ShouldRemoveType(child, parent.Parent, memory);
+            }
+
+            if (memory.ContainsKey(parentType.AssemblyQualifiedName))
+            {
+                var reference = $"{parentType.AssemblyQualifiedName} / {child.AssemblyQualifiedName}";
+                if (!memory.ContainsKey(reference))
+                {
+                    memory.Add(reference, child);
+                }
+
+                return true;
+            }
+
+            return ShouldRemoveType(parentType, parent.Parent, memory);
+        }
+
+        private bool IsTypeAllowed(Type serializedType)
+        {
+            if (serializedType == null)
+            {
+                return false;
+            }
+
+            // Return Type when found.
+            var typeFound = AllowedTypes.FirstOrDefault(e => e.AssemblyQualifiedName == serializedType.AssemblyQualifiedName);
+            if (typeFound != null)
+            {
+                return true;
+            }
+
+            // Return Type when it's inside another Type.
+            if (serializedType.IsNested)
+            {
+                if (IsTypeAllowed(serializedType.ReflectedType))
+                {
+                    return true;
+                }
+            }
+
+            // Return Type when it have Interfaces.
+            var interfaces = serializedType.GetInterfaces();
+            var interfaceFound = AllowedTypes.FirstOrDefault(t => interfaces.Any(e => e.AssemblyQualifiedName == t.AssemblyQualifiedName));
+            if (interfaceFound != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void AllowType(Type type)
+        {
+            if (type == null)
+            {
+                return;
+            }
+
+            if (!AllowedTypes.Contains(type))
+            {
+                AllowedTypes.Add(type);
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/AllowedTypesSerializationBinder.cs
+++ b/libraries/Microsoft.Bot.Builder/AllowedTypesSerializationBinder.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Bot.Builder
                 }
             }
 
-            // Return Type when it have Interfaces.
+            // Return Type when it has Interfaces.
             var interfaces = serializedType.GetInterfaces();
             var interfaceFound = AllowedTypes.FirstOrDefault(t => interfaces.Any(e => e.AssemblyQualifiedName == t.AssemblyQualifiedName));
             if (interfaceFound != null)

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -257,7 +257,20 @@ namespace Microsoft.Bot.Builder.Azure.Tests
 
             _mockAccount = new Mock<CloudStorageAccount>(new StorageCredentials("accountName", "S2V5VmFsdWU=", "key"), false);
 
-            _blobStorage = new AzureBlobStorage(_mockAccount.Object, ContainerName, _mockBlobClient.Object);
+            var jsonSerializer = new JsonSerializer
+            {
+                TypeNameHandling = TypeNameHandling.Objects, // lgtm [cs/unsafe-type-name-handling]
+                MaxDepth = null,
+                SerializationBinder = new AllowedTypesSerializationBinder(
+                    new List<Type>
+                    {
+                        typeof(IStoreItem),
+                        typeof(Dictionary<string, object>),
+                        typeof(Activity)
+                    }),
+            };
+
+            _blobStorage = new AzureBlobStorage(_mockAccount.Object, ContainerName, _mockBlobClient.Object, jsonSerializer);
         }
         
         private class StoreItem : IStoreItem

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Bot.Schema;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -177,12 +178,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async Task WriteAsyncTwoChanges()
+        public async Task WriteAsyncMultipleChanges()
         {
             var changes = new Dictionary<string, object>
             {
                 { "key1", "value1" },
-                { "key2", "value2" }
+                { "key2", 0 },
+                { "key3", true },
+                { "key4", new StoreItem() },
+                { "key5", new List<StoreItem>() { new StoreItem() } },
+                { "key6", new Activity() }
             };
 
             InitStorage();
@@ -190,7 +195,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             await _blobStorage.WriteAsync(changes, CancellationToken.None);
 
             _mockBlobClient.Verify(x => x.GetContainerReference(It.IsAny<string>()), Times.Once);
-            _mockContainer.Verify(x => x.GetBlockBlobReference(It.IsAny<string>()), Times.Exactly(2));
+            _mockContainer.Verify(x => x.GetBlockBlobReference(It.IsAny<string>()), Times.Exactly(6));
             _mockBlockBlob.Verify(
                 x => x.UploadFromStreamAsync(
                     It.IsAny<MultiBufferMemoryStream>(),
@@ -198,7 +203,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     It.IsAny<BlobRequestOptions>(),
                     It.IsAny<OperationContext>(),
                     It.IsAny<CancellationToken>()),
-                Times.Exactly(2));
+                Times.Exactly(6));
         }
 
         [Fact]
@@ -253,6 +258,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             _mockAccount = new Mock<CloudStorageAccount>(new StorageCredentials("accountName", "S2V5VmFsdWU=", "key"), false);
 
             _blobStorage = new AzureBlobStorage(_mockAccount.Object, ContainerName, _mockBlobClient.Object);
+        }
+        
+        private class StoreItem : IStoreItem
+        {
+            public string ETag { get; set; }
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 { "key1", new StoreItem() },
                 { "key2", new StoreItem { ETag = "*" } },
                 { "key3", new StoreItem { ETag = "ETag" } },
+                { "key4", "value1" },
             };
 
             await _storage.WriteAsync(changes);
@@ -87,7 +88,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     It.IsAny<AccessTier?>(),
                     It.IsAny<StorageTransferOptions>(),
                     It.IsAny<CancellationToken>()),
-                Times.Exactly(3));
+                Times.Exactly(4));
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Tests/AllowedTypesSerializationBinderTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/AllowedTypesSerializationBinderTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Bot.Schema;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Builder.Tests
+{
+    public class AllowedTypesSerializationBinderTests
+    {
+        [Fact]
+        public void ConstructorValidation()
+        {
+            // Empty AllowedTypes.
+            Assert.NotNull(new AllowedTypesSerializationBinder().AllowedTypes);
+            Assert.Empty(new AllowedTypesSerializationBinder().AllowedTypes);
+
+            // Null AllowedTypes.
+            Assert.Empty(new AllowedTypesSerializationBinder(null).AllowedTypes);
+            Assert.NotNull(new AllowedTypesSerializationBinder(null).AllowedTypes);
+
+            // With AllowedTypes.
+            Assert.NotNull(new AllowedTypesSerializationBinder(new List<Type> { typeof(ExampleType) }).AllowedTypes);
+            Assert.Single(new AllowedTypesSerializationBinder(new List<Type> { typeof(ExampleType) }).AllowedTypes);
+        }
+
+        [Fact]
+        public void BindToNameWithEmptyAllowedTypes()
+        {
+            var binder = new AllowedTypesSerializationBinder();
+            binder.BindToName(null, out var assemblyName, out var typeName);
+
+            Assert.Null(assemblyName);
+            Assert.Null(typeName);
+        }
+
+        [Fact]
+        public void BindToNameWithoutAllowedType()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { typeof(string) });
+            binder.BindToName(expectedType, out var assemblyName, out var typeName);
+
+            Assert.Null(assemblyName);
+            Assert.NotNull(typeName);
+        }
+
+        [Fact]
+        public void BindToNameWithType()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { expectedType });
+            binder.BindToName(expectedType, out var assemblyName, out var typeName);
+
+            Assert.Null(assemblyName);
+            Assert.Equal(expectedType.AssemblyQualifiedName, typeName);
+        }
+
+        [Fact]
+        public void BindToNameWithNestedType()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { typeof(AllowedTypesSerializationBinderTests) });
+            binder.BindToName(expectedType, out var assemblyName, out var typeName);
+
+            Assert.Null(assemblyName);
+            Assert.Equal(expectedType.AssemblyQualifiedName, typeName);
+            Assert.Contains(binder.AllowedTypes, e => e.AssemblyQualifiedName == typeName);
+        }
+
+        [Fact]
+        public void BindToNameWithInterfaces()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { typeof(IDisposable) });
+            binder.BindToName(expectedType, out var assemblyName, out var typeName);
+
+            Assert.Null(assemblyName);
+            Assert.Equal(expectedType.AssemblyQualifiedName, typeName);
+            Assert.Contains(binder.AllowedTypes, e => e.AssemblyQualifiedName == typeName);
+        }
+
+        [Fact]
+        public void BindToTypeWithAllowedType()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { expectedType });
+            var resultType = binder.BindToType(expectedType.Assembly.GetName().Name, expectedType.FullName);
+
+            Assert.Equal(expectedType, resultType);
+        }
+
+        [Fact]
+        public void BindToTypeWithoutProcessedAllowedType()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { typeof(AllowedTypesSerializationBinderTests) });
+            var resultType = binder.BindToType(expectedType.Assembly.GetName().Name, expectedType.FullName);
+
+            Assert.Equal(expectedType, resultType);
+        }
+
+        [Fact]
+        public void BindToTypeWithoutAllowedType()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { typeof(string) });
+            Assert.Throws<InvalidOperationException>(() => binder.BindToType(expectedType.Assembly.GetName().Name, expectedType.FullName));
+        }
+
+        [Fact]
+        public void CleanupTypesWithAllowedTypes()
+        {
+            var expectedType = typeof(ExampleType);
+            var unknownType = typeof(string);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { expectedType });
+            var resolvedTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", expectedType.FullName, expectedType.Assembly.GetName().Name);
+            var unknownTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", unknownType.FullName, unknownType.Assembly.GetName().Name);
+            var obj = JObject.Parse(@$"{{'$type':'{resolvedTypeName}', 'inner': {{ '$type': '{unknownTypeName}' }} }}");
+            binder.CleanupTypes(obj);
+
+            Assert.Equal(resolvedTypeName, obj["$type"]);
+            Assert.Null(obj["inner"]["$type"]);
+        }
+        
+        [Fact]
+        public void CleanupTypesWithoutAllowedTypes()
+        {
+            var expectedType = typeof(ExampleType);
+            var stringType = typeof(string);
+            var activityType = typeof(Activity);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { expectedType });
+            var resolvedTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", expectedType.FullName, expectedType.Assembly.GetName().Name);
+            var stringTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", stringType.FullName, stringType.Assembly.GetName().Name);
+            var activityTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", activityType.FullName, activityType.Assembly.GetName().Name);
+            var obj = (JContainer)JToken.Parse(@$"[
+                {{'$type':'{resolvedTypeName}', 'inner': {{ '$type': '{stringTypeName}' }}, 'activity': {{ '$type': '{activityTypeName}' }} }},
+                {{'$type':'{stringTypeName}', 'inner': {{ '$type': '{resolvedTypeName}' }} }},
+                {{'$type':'{activityTypeName}', 'inner': {{ '$type': '{resolvedTypeName}' }} }}
+            ]");
+            Assert.Throws<InvalidOperationException>(() => binder.CleanupTypes(obj));
+        }
+        
+        [Fact]
+        public void CleanupTypesWithEmptyObject()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { expectedType });
+            var obj = (JContainer)JToken.Parse("{}");
+            binder.CleanupTypes(obj);
+        }
+
+        [Fact]
+        public void CleanupTypesWithEmptyArray()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder(new List<Type> { expectedType });
+            var obj = (JContainer)JToken.Parse("[]");
+            binder.CleanupTypes(obj);
+        }
+
+        [Fact]
+        public void CleanupTypesWithEmptyAllowedTypes()
+        {
+            var expectedType = typeof(ExampleType);
+            var binder = new AllowedTypesSerializationBinder();
+            var resolvedTypeName = string.Format(CultureInfo.InvariantCulture, "{0}, {1}", expectedType.FullName, expectedType.Assembly.GetName().Name);
+            var obj = JObject.Parse(@$"{{'$type':'{resolvedTypeName}'}}");
+            binder.CleanupTypes(obj);
+
+            Assert.Equal(resolvedTypeName, obj["$type"]);
+        }
+
+        private class ExampleType : IDisposable
+        {
+            public void Dispose()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6515 #6516 #6517 #6519 #6520

## Description
This PR fixes the CodeQL SM02211 alert related to unsafe `JsonSerializer` `TypeNameHandling` usage.
For these cases, it implements a custom [SerializationBinder](https://www.newtonsoft.com/json/help/html/SerializeSerializationBinder.htm), allowing only the types that are defined in the configuration or related ones.

## Specific Changes
- Adds the `AllowedTypesSerializationBinder` class to allow only types that are defined in the instance.
- Adds tests for the `AllowedTypesSerializationBinder` class.
- Updated `BlobsStorage`, `AzureBlobStorage`, and `CosmosDbPartitionedStorage` classes to implement the binder.
- Updated `BlobsTranscriptStore` setting the `TypeNameHandling` to None.

## Testing
The following image shows the tests passing successfully and the error message when a type isn't allowed by the process.
![image](https://user-images.githubusercontent.com/62260472/201351257-5b7ebd7c-3712-4767-abaf-d7bb0b678d34.png)
![image](https://user-images.githubusercontent.com/62260472/201351262-2b76cae3-9b0b-4462-a772-9dde452731c9.png)