### PR TITLE
[#6531] Prompt validation of confirm prompt in chatbot is not working for newly added language

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -189,7 +189,8 @@ namespace Microsoft.Bot.Builder.Dialogs
                 }
 
                 var culture = DetermineCulture(turnContext.Activity);
-                var results = ChoiceRecognizer.RecognizeBoolean(utterance, culture);
+                
+                var results = ChoiceRecognizer.RecognizeBoolean(utterance, options.RecognizeLanguage ?? culture);
                 if (results.Count > 0)
                 {
                     var first = results[0];

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/PromptOptions.cs
@@ -51,5 +51,15 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </summary>
         /// <value>Additional options for use with a prompt validator.</value>
         public object Validations { get; set; }
+
+        /// <summary>
+        /// Gets or sets the locale used for recognizing the user's choice.
+        /// </summary>
+        /// <value>The locale to be use for recognizing the utterance.</value>
+        /// <remarks>
+        /// When using a translator middleware, the user's choice is translated and it doesn't match the prompt's options.
+        /// Setting this property with the translator's target language allows the prompt to recognize the utterance.
+        /// </remarks>
+        public string RecognizeLanguage { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #6531

## Description
This PR adds the new _RecognizeLanguage_ property in the **_PromptOptions_** class to be used in the _onRecognizedAsync_ method allowing a different language than the one determined by the activity.
It also updates the _onRecognizedAsync_ method of the **_ConfirmPrompt_** class to use this property solving the issue when a ConfirmPrompt is used along with a TranslationMiddleware.

## Specific Changes
- Updated **_PromptOptions_** class adding the **_RecognizeLanguage_** property.
- Updated the **_onRecognizedAsync_** method of the **_ConfirmPrompt_** class using the new property.
- Added a unit test in **_ConfirmPromptTests_** to cover the new test case.

## Testing
These images show a bot using the translator service and the confirm prompt working as expected.
![image](https://user-images.githubusercontent.com/44245136/202021111-bc195ad4-0520-4659-bee6-2f5d70d3895f.png)
