### PR TITLE
[#6510] Suppress CodeQL SM03926 alerts

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/ParameterizedBotFrameworkAuthentication.cs
@@ -292,7 +292,9 @@ namespace Microsoft.Bot.Connector.Authentication
                     "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/",                    // Auth for US Gov, 1.0 token
                     "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0", // Auth for US Gov, 2.0 token
                     },
-                    ValidateAudience = false,   // Audience validation takes place manually in code.
+
+                    // Audience validation takes place manually in code.
+                    ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                     ValidateLifetime = true,
                     ClockSkew = TimeSpan.FromMinutes(5),
                     RequireSignedTokens = true,

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenExtractorTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 ValidIssuers = new[] { AuthenticationConstants.ToBotFromChannelTokenIssuer },
 
                 // Audience validation takes place in JwtTokenExtractor
-                ValidateAudience = false,
+                ValidateAudience = false, // lgtm[cs/web/missing-token-validation]
                 ValidateLifetime = true,
                 ValidateIssuerSigningKey = true,
                 ClockSkew = TimeSpan.FromMinutes(5),


### PR DESCRIPTION
Fixes #6510

## Description
This PR suppresses the CodeQL SM03926 alerts related to disabled _ValidateAudience_ properties in _TokenValidationParameters_ class.
The alert can't be fixed because the validations take place manually in the code.

## Specific Changes
- Added comment to suppress SM03926 alerts in the following classes:
    - ParameterizedBotFrameworkAuthentication
    - JwtTokenExtractorTests


## Testing
Unit tests passed.
![image](https://user-images.githubusercontent.com/94375175/201724289-8dadaf03-db44-48af-86eb-ed39b5e40f5e.png)