### PR TITLE
[CodeQL] Fix remaining SM00431 alerts

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.WebApi/BotFrameworkHttpAdapter.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.WebApi
             catch (Exception ex)
             {
                 httpResponse.StatusCode = HttpStatusCode.InternalServerError;
-                httpResponse.Content = new StringContent($"Unable to create transport server. Error: {ex}");
+                httpResponse.Content = new StringContent($"Unable to create transport server. Error: {ex.Message}");
                 throw;
             }
         }

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
                     }
                     catch (Exception e)
                     {
-                        return Task.FromResult(StreamingResponse.InternalServerError(new StringContent(e.ToString())));
+                        return Task.FromResult(StreamingResponse.InternalServerError(new StringContent(e.Message)));
                     }
                 });
 
@@ -372,7 +372,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
                     }
                     catch (Exception e)
                     {
-                        return Task.FromResult(StreamingResponse.InternalServerError(new StringContent(e.ToString())));
+                        return Task.FromResult(StreamingResponse.InternalServerError(new StringContent(e.Message)));
                     }
                 });
 


### PR DESCRIPTION
Fixes #6543

## Description
This PR fixes the CodeQL SM00431 alert related to exposing an exception to the end user ([more information](https://codeql.github.com/codeql-query-help/csharp/cs-information-exposure-through-exception/)).

## Specific Changes
- Update response _ConnectWebSocketAsync_ usage, passing exception message.
- Update _EndToEndMiniLoadTests_ not to expose exception bodies.

## Testing
CodeQL local report for exception exposure with no alerts:
![image](https://user-images.githubusercontent.com/94375175/202480568-8de35372-f2e0-43cd-beaf-91970151f2ad.png)
Tests passed after the changes:
![image](https://user-images.githubusercontent.com/94375175/202480631-cd050ba0-edfc-4887-a5e2-33ab5b14912e.png)
