### PR TITLE
Support Teams message edit, message soft delete, message undelete activities

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/ActivityHandler.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Bot.Builder
         /// <see cref="OnTurnAsync(ITurnContext, CancellationToken)"/> method.
         /// </remarks>
         /// <seealso cref="OnMessageActivityAsync(ITurnContext{IMessageActivity}, CancellationToken)"/>
+        /// <seealso cref="OnMessageUpdateActivityAsync(ITurnContext{IMessageUpdateActivity}, CancellationToken)"/>
+        /// <seealso cref="OnMessageDeleteActivityAsync(ITurnContext{IMessageDeleteActivity}, CancellationToken)"/>
         /// <seealso cref="OnConversationUpdateActivityAsync(ITurnContext{IConversationUpdateActivity}, CancellationToken)"/>
         /// <seealso cref="OnMessageReactionActivityAsync(ITurnContext{IMessageReactionActivity}, CancellationToken)"/>
         /// <seealso cref="OnEventActivityAsync(ITurnContext{IEventActivity}, CancellationToken)"/>
@@ -68,6 +70,14 @@ namespace Microsoft.Bot.Builder
             {
                 case ActivityTypes.Message:
                     await OnMessageActivityAsync(new DelegatingTurnContext<IMessageActivity>(turnContext), cancellationToken).ConfigureAwait(false);
+                    break;
+                
+                case ActivityTypes.MessageUpdate:
+                    await OnMessageUpdateActivityAsync(new DelegatingTurnContext<IMessageUpdateActivity>(turnContext), cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case ActivityTypes.MessageDelete:
+                    await OnMessageDeleteActivityAsync(new DelegatingTurnContext<IMessageDeleteActivity>(turnContext), cancellationToken).ConfigureAwait(false);
                     break;
 
                 case ActivityTypes.ConversationUpdate:
@@ -143,6 +153,42 @@ namespace Microsoft.Bot.Builder
         /// </remarks>
         /// <seealso cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
         protected virtual Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Override this in a derived class to provide logic specific to
+        /// <see cref="ActivityTypes.MessageUpdate"/> activities, such as the conversational logic.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>
+        /// When the <see cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
+        /// method receives a message update activity, it calls this method.
+        /// </remarks>
+        /// <seealso cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
+        protected virtual Task OnMessageUpdateActivityAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Override this in a derived class to provide logic specific to
+        /// <see cref="ActivityTypes.MessageDelete"/> activities, such as the conversational logic.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>
+        /// When the <see cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
+        /// method receives a message delete activity, it calls this method.
+        /// </remarks>
+        /// <seealso cref="OnTurnAsync(ITurnContext, CancellationToken)"/>
+        protected virtual Task OnMessageDeleteActivityAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -826,6 +826,111 @@ namespace Microsoft.Bot.Builder.Teams
         }
 
         /// <summary>
+        /// Invoked when an message update activity is received.
+        /// <see cref="ActivityTypes.MessageUpdate"/> activities, such as the conversational logic.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>
+        /// In a derived class, override this method to add logic that applies to all message update activities.
+        /// </remarks>
+        protected override Task OnMessageUpdateActivityAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            if (turnContext.Activity.ChannelId == Channels.Msteams)
+            {
+                var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
+
+                if (channelData != null)
+                {
+                    switch (channelData.EventType)
+                    {
+                        case "editMessage":
+                            return OnTeamsMessageEditAsync(turnContext, cancellationToken);
+
+                        case "undeleteMessage":
+                            return OnTeamsMessageUndeleteAsync(turnContext, cancellationToken);
+
+                        default:
+                            return base.OnMessageUpdateActivityAsync(turnContext, cancellationToken);
+                    }
+                }
+            }
+
+            return base.OnMessageUpdateActivityAsync(turnContext, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invoked when an message delete activity is received.
+        /// <see cref="ActivityTypes.MessageDelete"/> activities, such as the conversational logic.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>
+        /// In a derived class, override this method to add logic that applies to all message update activities.
+        /// </remarks>
+        protected override Task OnMessageDeleteActivityAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
+        {
+            if (turnContext.Activity.ChannelId == Channels.Msteams)
+            {
+                var channelData = turnContext.Activity.GetChannelData<TeamsChannelData>();
+
+                if (channelData != null)
+                {
+                    switch (channelData.EventType)
+                    {
+                        case "softDeleteMessage":
+                            return OnTeamsMessageSoftDeleteAsync(turnContext, cancellationToken);
+
+                        default:
+                            return base.OnMessageDeleteActivityAsync(turnContext, cancellationToken);
+                    }
+                }
+            }
+
+            return base.OnMessageDeleteActivityAsync(turnContext, cancellationToken);
+        }
+
+        /// <summary>
+        /// Invoked when a edit message event activity is received.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMessageEditAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a undo soft delete message event activity is received.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMessageUndeleteAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Invoked when a soft delete message event activity is received.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        protected virtual Task OnTeamsMessageSoftDeleteAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Safely casts an object to an object of type <typeparamref name="T"/> .
         /// </summary>
         /// <param name="value">The object to be casted.</param>

--- a/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/ActivityHandlerTests.cs
@@ -39,6 +39,38 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [Fact]
+        public async Task TestMessageUpdateActivity()
+        {
+            // Arrange
+            var activity = new Activity { Type = ActivityTypes.MessageUpdate };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(bot.Record);
+            Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+        }
+
+        [Fact]
+        public async Task TestMessageDeleteActivity()
+        {
+            // Arrange
+            var activity = new Activity { Type = ActivityTypes.MessageDelete };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(bot.Record);
+            Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+        }
+
+        [Fact]
         public async Task TestEndOfConversationActivity()
         {
             // Arrange
@@ -796,6 +828,18 @@ namespace Microsoft.Bot.Builder.Tests
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return base.OnMessageActivityAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnMessageUpdateActivityAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnMessageUpdateActivityAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnMessageDeleteActivityAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnMessageDeleteActivityAsync(turnContext, cancellationToken);
             }
 
             protected override Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -1204,6 +1204,152 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             Assert.Equal("10101010", activitiesToSend[0].Text);
         }
 
+        [Fact]
+        public async Task TestMessageUpdateActivityTeamsMessageEdit()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelData = new TeamsChannelData { EventType = "editMessage" },
+                ChannelId = Channels.Msteams,
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(2, bot.Record.Count);
+            Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+            Assert.Equal("OnTeamsMessageEditAsync", bot.Record[1]);
+        }
+
+        [Fact]
+        public async Task TestMessageUpdateActivityTeamsMessageUndelete()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelData = new TeamsChannelData { EventType = "undeleteMessage" },
+                ChannelId = Channels.Msteams,
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(2, bot.Record.Count);
+            Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+            Assert.Equal("OnTeamsMessageUndeleteAsync", bot.Record[1]);
+        }
+
+        [Fact]
+        public async Task TestMessageUpdateActivityTeamsMessageUndelete_NoMsteams()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelData = new TeamsChannelData { EventType = "undeleteMessage" },
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(bot.Record);
+            Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+        }
+
+        [Fact]
+        public async Task TestMessageUpdateActivityTeams_NoChannelData()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageUpdate,
+                ChannelId = Channels.Msteams,
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(bot.Record);
+            Assert.Equal("OnMessageUpdateActivityAsync", bot.Record[0]);
+        }
+
+        [Fact]
+        public async Task TestMessageDeleteActivityTeamsMessageSoftDelete()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageDelete,
+                ChannelData = new TeamsChannelData { EventType = "softDeleteMessage" },
+                ChannelId = Channels.Msteams
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Equal(2, bot.Record.Count);
+            Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+            Assert.Equal("OnTeamsMessageSoftDeleteAsync", bot.Record[1]);
+        }
+
+        [Fact]
+        public async Task TestMessageDeleteActivityTeamsMessageSoftDelete_NoMsteams()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageDelete,
+                ChannelData = new TeamsChannelData { EventType = "softMessage" }
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(bot.Record);
+            Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+        }
+
+        [Fact]
+        public async Task TestMessageDeleteActivityTeams_NoChannelData()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.MessageDelete,
+                ChannelId = Channels.Msteams,
+            };
+            var turnContext = new TurnContext(new NotImplementedAdapter(), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.Single(bot.Record);
+            Assert.Equal("OnMessageDeleteActivityAsync", bot.Record[0]);
+        }
+
         private class NotImplementedAdapter : BotAdapter
         {
             public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
@@ -1481,6 +1627,36 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 turnContext.SendActivityAsync(meeting.EndTime.ToString());
                 return Task.CompletedTask;
+            }
+
+            protected override Task OnMessageUpdateActivityAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnMessageUpdateActivityAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnTeamsMessageEditAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnTeamsMessageEditAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnTeamsMessageUndeleteAsync(ITurnContext<IMessageUpdateActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnTeamsMessageUndeleteAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnMessageDeleteActivityAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnMessageDeleteActivityAsync(turnContext, cancellationToken);
+            }
+
+            protected override Task OnTeamsMessageSoftDeleteAsync(ITurnContext<IMessageDeleteActivity> turnContext, CancellationToken cancellationToken)
+            {
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return base.OnTeamsMessageSoftDeleteAsync(turnContext, cancellationToken);
             }
         }
 


### PR DESCRIPTION
This PR aims to extend the Bot SDK so that developers can consume newly added events that Teams will emit to the bot. They are:

`TeamsMessageEdit` - a user editing a message in Teams.
`TeamsMessageUndelete` - a user undo a deleted message in Teams.
`TeamsMessageSoftDelete` - a user soft deleting a message in Teams.

closes: https://github.com/microsoft/botbuilder-dotnet/issues/6565

## Description
Extended `ActivityHandler `to handle `MessageUpdate `and `MessageDelete` activity types and dispatch functions for activity types.

Extended `TeamsActivityHandler `to handle `MessageUpdate `(with subtypes `TeamsMessageEdit `and `TeamsMessageUndelete`) and `MessageDelete `(with subtype `TeamsMessageSoftDelete`) teams events.

## Specific Changes

**ActivityHandler Class**
  - Added `OnMessageUpdateActivityAsync `method and `OnMessageDeleteActivityAsync `method

**TeamsActivityHandler Class**
  - Overrided the above two methods and add logic based to eventType
  - `OnMessageUpdateActivityAsync `could call `OnTeamsMessageEditAsync` or `OnTeamsMessageUndeleteAsync`
  - `OnMessageDeleteActivityAsync `could call `OnTeamsMessageSoftDeleteAsync`

## Testing
In **ActivityHandlerTest** class, added the following 2 unit tests

- TestMessageUpdateActivity
- TestMessageDeleteActivity

In **TeamsActivityHandlerTests** class, added the following 3 unit tests

- TestMessageUpdateActivityTeamsMessageEdit
- TestMessageUpdateActivityTeamsMessageUndelete
- TestMessageDeleteActivityTeamsMessageSoftDelete
