### PR TITLE
Support bot sdk dot net for targeted meeting notification

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Bot.Builder.Teams
 {
     /// <summary>
-    /// The TeamsInfo
+    /// The TeamsInfo Test If Build Remote Successful
     /// provides utility methods for the events and interactions that occur within Microsoft Teams.
     /// </summary>
     public static class TeamsInfo

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -317,6 +317,27 @@ namespace Microsoft.Bot.Builder.Teams
             return new Tuple<ConversationReference, string>(conversationReference, newActivityId);
         }
 
+        /// <summary>
+        /// Sends a notification to meeting participants. This functionality is available only in teams meeting scoped conversations. 
+        /// </summary>
+        /// <param name="turnContext">Turn context.</param>
+        /// <param name="notification">The notification to send to Teams.</param>
+        /// <param name="meetingId">The id of the Teams meeting. TeamsChannelData.Meeting.Id will be used if none provided.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <remarks>InvalidOperationException will be thrown if meetingId or notification have not been
+        /// provided, and also cannot be retrieved from turnContext.Activity.</remarks>
+        /// <returns>List of <see cref="TeamsMeetingNotificationRecipientFailureInfo"/> for whom the notification failed.</returns>
+        public static async Task<TeamsMeetingNotificationRecipientFailureInfos> SendMeetingNotificationAsync(ITurnContext turnContext, TeamsMeetingNotification notification, string meetingId = null, CancellationToken cancellationToken = default)
+        {
+            meetingId ??= turnContext.Activity.TeamsGetMeetingInfo()?.Id ?? throw new InvalidOperationException("This method is only valid within the scope of a MS Teams Meeting.");
+            notification = notification ?? throw new InvalidOperationException($"{nameof(notification)} is required.");
+
+            using (var teamsClient = GetTeamsConnectorClient(turnContext))
+            {
+                return await teamsClient.Teams.SendMeetingNotificationAsync(meetingId, notification, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private static async Task<IEnumerable<TeamsChannelAccount>> GetMembersAsync(IConnectorClient connectorClient, string conversationId, CancellationToken cancellationToken)
         {
             if (conversationId == null)

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <param name="participantId">The id of the Teams meeting participant. From.AadObjectId will be used if none provided.</param>
         /// <param name="tenantId">The id of the Teams meeting Tenant. TeamsChannelData.Tenant.Id will be used if none provided.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <remarks>InvalidOperationException will be thrown if meetingId, participantId or tenantId have not been
+        /// <remarks> <see cref="InvalidOperationException"/> will be thrown if meetingId, participantId or tenantId have not been
         /// provided, and also cannot be retrieved from turnContext.Activity.</remarks>
         /// <returns>Team participant channel account.</returns>
         public static async Task<TeamsMeetingParticipant> GetMeetingParticipantAsync(ITurnContext turnContext, string meetingId = null, string participantId = null, string tenantId = null, CancellationToken cancellationToken = default)

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -408,11 +408,10 @@ namespace Microsoft.Bot.Connector.Teams
 
                 if ((int)statusCode == 207)
                 {
-                    /* 207: if the notifications are sent only to parital number of recipients because 
-                            the validation on some recipients’ ids failed or some recipients were not found in the roster. 
-                        • In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot 
-                            (ex: if a bot sent encrypted user MRIs, return encrypted one).
-                     */
+                    // 207: if the notifications are sent only to parital number of recipients because
+                    //    the validation on some recipients’ ids failed or some recipients were not found in the roster.
+                    // In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot
+                    // (ex: if a bot sent encrypted user MRIs, return encrypted one).
 
                     responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                     try
@@ -431,20 +430,18 @@ namespace Microsoft.Bot.Connector.Teams
                 }
                 else if ((int)statusCode != 202)
                 {
-                    /* 
-                        400: when Meeting Notification request payload validation fails. For instance, 
-                            • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
-                            • Surface: 
-                                o Surface list is empty or null 
-                                o Surface type is invalid 
-                                o Duplicative surface type exists in one payload
-                        401: if the bot token is invalid 
-                        403: if the bot is not allowed to send the notification.
-                            In this case, the payload should contain more detail error message.
-                            There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
-                            the bot does not have a correct RSC permission for a specific surface type, etc
-                        404: if a meeting chat is not found || None of the receipients were found in the roster. 
-                     */
+                    // 400: when Meeting Notification request payload validation fails. For instance, 
+                    //    • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
+                    //    • Surface: 
+                    //        o Surface list is empty or null 
+                    //        o Surface type is invalid 
+                    //        o Duplicative surface type exists in one payload
+                    // 401: if the bot token is invalid 
+                    // 403: if the bot is not allowed to send the notification.
+                    //     In this case, the payload should contain more detail error message.
+                    //     There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
+                    //     the bot does not have a correct RSC permission for a specific surface type, etc
+                    // 404: if a meeting chat is not found || None of the receipients were found in the roster. 
 
                     // invalid/unexpected status code
                     var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperations.cs
@@ -287,6 +287,202 @@ namespace Microsoft.Bot.Connector.Teams
             return await GetResponseAsync<TeamsMeetingParticipant>(url, shouldTrace, invocationId, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Send a teams meeting notification.
+        /// </summary>
+        /// <remarks>
+        /// Send a notification to teams meeting particpants.
+        /// </remarks>
+        /// <param name='meetingId'>
+        /// Teams meeting id.
+        /// </param>
+        /// <param name='notification'>
+        /// Teams notification object.
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when an input value does not match the expected data type, range or pattern.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <returns>
+        /// A response object containing the response body and response headers.
+        /// </returns>
+        public async Task<HttpOperationResponse<TeamsMeetingNotificationRecipientFailureInfos>> SendMeetingNotificationMessageAsync(string meetingId, TeamsMeetingNotification notification, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (meetingId == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, nameof(meetingId));
+            }
+
+            // Tracing
+            bool shouldTrace = ServiceClientTracing.IsEnabled;
+            string invocationId = null;
+            if (shouldTrace)
+            {
+                invocationId = ServiceClientTracing.NextInvocationId.ToString(CultureInfo.InvariantCulture);
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("meetingId", meetingId);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(invocationId, this, "SendMeetingNotification", tracingParameters);
+            }
+
+            // Construct URL
+            var baseUrl = Client.BaseUri.AbsoluteUri;
+            var url = new System.Uri(new System.Uri(baseUrl + (baseUrl.EndsWith("/", System.StringComparison.InvariantCulture) ? string.Empty : "/")), "v1/meetings/{meetingId}/notification").ToString();
+            url = url.Replace("{meetingId}", System.Uri.EscapeDataString(meetingId));
+            using var httpRequest = new HttpRequestMessage();
+            httpRequest.Method = new HttpMethod("POST");
+            httpRequest.RequestUri = new System.Uri(url);
+
+            HttpResponseMessage httpResponse = null;
+
+            // Create HTTP transport objects
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var result = new HttpOperationResponse<TeamsMeetingNotificationRecipientFailureInfos>();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            try
+            {
+                // Set Headers
+                if (customHeaders != null)
+                {
+                    foreach (var header in customHeaders)
+                    {
+                        if (httpRequest.Headers.Contains(header.Key))
+                        {
+                            httpRequest.Headers.Remove(header.Key);
+                        }
+
+                        httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                    }
+                }
+
+                // Serialize Request
+                string requestContent = null;
+                if (notification != null)
+                {
+                    requestContent = Rest.Serialization.SafeJsonConvert.SerializeObject(notification, Client.SerializationSettings);
+                    httpRequest.Content = new StringContent(requestContent, System.Text.Encoding.UTF8);
+                    httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+                }
+
+                // Set Credentials
+                if (Client.Credentials != null)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Client.Credentials.ProcessHttpRequestAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Send Request
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.SendRequest(invocationId, httpRequest);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                httpResponse = await Client.HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+                if (shouldTrace)
+                {
+                    ServiceClientTracing.ReceiveResponse(invocationId, httpResponse);
+                }
+
+                HttpStatusCode statusCode = httpResponse.StatusCode;
+                cancellationToken.ThrowIfCancellationRequested();
+                string responseContent = null;
+
+                // Create Result
+                result.Request = httpRequest;
+                result.Response = httpResponse;
+
+                if ((int)statusCode == 207)
+                {
+                    /* 207: if the notifications are sent only to parital number of recipients because 
+                            the validation on some recipients’ ids failed or some recipients were not found in the roster. 
+                        • In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot 
+                            (ex: if a bot sent encrypted user MRIs, return encrypted one).
+                     */
+
+                    responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    try
+                    {
+                        result.Body = Rest.Serialization.SafeJsonConvert.DeserializeObject<TeamsMeetingNotificationRecipientFailureInfos>(responseContent, Client.DeserializationSettings);
+                    }
+                    catch (JsonException ex)
+                    {
+                        if (shouldTrace)
+                        {
+                            ServiceClientTracing.Error(invocationId, ex);
+                        }
+
+                        throw new SerializationException("Unable to deserialize the response.", responseContent, ex);
+                    }
+                }
+                else if ((int)statusCode != 202)
+                {
+                    /* 
+                        400: when Meeting Notification request payload validation fails. For instance, 
+                            • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
+                            • Surface: 
+                                o Surface list is empty or null 
+                                o Surface type is invalid 
+                                o Duplicative surface type exists in one payload
+                        401: if the bot token is invalid 
+                        403: if the bot is not allowed to send the notification.
+                            In this case, the payload should contain more detail error message.
+                            There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
+                            the bot does not have a correct RSC permission for a specific surface type, etc
+                        404: if a meeting chat is not found || None of the receipients were found in the roster. 
+                     */
+
+                    // invalid/unexpected status code
+                    var ex = new HttpOperationException($"Operation returned an invalid status code '{statusCode}'");
+                    if (httpResponse.Content != null)
+                    {
+                        responseContent = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        responseContent = string.Empty;
+                    }
+
+                    ex.Request = new HttpRequestMessageWrapper(httpRequest, requestContent);
+                    ex.Response = new HttpResponseMessageWrapper(httpResponse, responseContent);
+                    if (shouldTrace)
+                    {
+                        ServiceClientTracing.Error(invocationId, ex);
+                    }
+
+                    throw ex;
+                }
+            }
+            finally
+            {
+                if (httpResponse != null)
+                {
+                    httpResponse.Dispose();
+                }
+            }
+
+            if (shouldTrace)
+            {
+                ServiceClientTracing.Exit(invocationId, result);
+            }
+
+            return result;
+        }
+
         private async Task<HttpOperationResponse<T>> GetResponseAsync<T>(string url, bool shouldTrace, string invocationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Create HTTP transport objects

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Bot.Connector.Teams
             }
             else
             {
-                throw new InvalidOperationException("TeamsOperations with GetParticipantWithHttpMessagesAsync is required for FetchParticipantAsync.");
+                throw new InvalidOperationException("TeamsOperations with SendMeetingNotificationWithHttpMessagesAsync is required for SendMeetingNotificationAsync.");
             }
         }
     }

--- a/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/Teams/TeamsOperationsExtensions.cs
@@ -112,5 +112,36 @@ namespace Microsoft.Bot.Connector.Teams
                 throw new InvalidOperationException("TeamsOperations with GetParticipantWithHttpMessagesAsync is required for FetchParticipantAsync.");
             }
         }
+
+        /// <summary>
+        /// Sends a notification to participants of a Teams meeting.
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='meetingId'>
+        /// Team meeting Id.
+        /// </param>
+        /// <param name='notification'>
+        /// Team meeting notification.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>Information regarding which participant notifications failed.</returns>
+        public static async Task<TeamsMeetingNotificationRecipientFailureInfos> SendMeetingNotificationAsync(this ITeamsOperations operations, string meetingId, TeamsMeetingNotification notification, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (operations is TeamsOperations teamsOperations)
+            {
+                using (var result = await teamsOperations.SendMeetingNotificationMessageAsync(meetingId, notification, null, cancellationToken).ConfigureAwait(false))
+                {
+                    return result.Body;
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("TeamsOperations with GetParticipantWithHttpMessagesAsync is required for FetchParticipantAsync.");
+            }
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/OnBehalfOf.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/OnBehalfOf.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Specifies attribution for notifications.
+    /// </summary>
+    public partial class OnBehalfOf
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OnBehalfOf"/> class.
+        /// </summary>
+        public OnBehalfOf()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the identification of the item. Default is 0.
+        /// </summary>
+        /// <value>The item id.</value>
+        [JsonProperty(PropertyName = "itemId")]
+        public int ItemId { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the mention type. Default is "person".
+        /// </summary>
+        /// <value>The mention type.</value>
+        [JsonProperty(PropertyName = "mentionType")]
+        public string MentionType { get; set; } = "person";
+
+        /// <summary>
+        /// Gets or sets message resource identifier (MRI) of the person on whose behalf the message is sent.
+        /// Message sender name would appear as "[user] through [bot name]".
+        /// </summary>
+        /// <value>The message resource identifier of the person.</value>
+        [JsonProperty(PropertyName = "mri")]
+        public string Mri { get; set; }
+
+        /// <summary>
+        /// Gets or sets name of the person. Used as fallback in case name resolution is unavailable.
+        /// </summary>
+        /// <value>The name of the person.</value>
+        [JsonProperty(PropertyName = "displayName")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotification.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotification.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Specifies meeting notification including channel data, type and value. 
+    /// </summary>
+    public partial class TeamsMeetingNotification
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsMeetingNotification"/> class.
+        /// </summary>
+        public TeamsMeetingNotification()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets Activty type.
+        /// </summary>
+        /// <value>
+        /// Activity type.
+        /// </value>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; } = "targetedMeetingNotification";
+
+        /// <summary>
+        /// Gets or sets Teams meeting notification information.
+        /// </summary>
+        /// <value>
+        /// Teams meeting notification information.
+        /// </value>
+        [JsonProperty(PropertyName = "value")]
+        public TeamsMeetingNotificationInfo Value { get; set; }
+
+        /// <summary>
+        /// Gets or sets Teams meeting notification channel data.
+        /// </summary>
+        /// <value>
+        /// Teams meeting notification channel data.
+        /// </value>
+        [JsonProperty(PropertyName = "channelData")]
+        public TeamsMeetingNotificationChannelData ChannelData { get; set; }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationChannelData.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Container for list of <see cref="OnBehalfOf"/> information for a meeting <see cref="TeamsMeetingNotificationChannelData"/>.
+    /// </summary>
+    public partial class TeamsMeetingNotificationChannelData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsMeetingNotificationChannelData"/> class.
+        /// </summary>
+        public TeamsMeetingNotificationChannelData()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="OnBehalfOf"/> for user attribution.
+        /// </summary>
+        /// <value>The meeting notification's <see cref="OnBehalfOf"/>.</value>
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)>
+        [JsonProperty(PropertyName = "OnBehalfOf")]
+        public IList<OnBehalfOf> OnBehalfOf { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationChannelData.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationChannelData.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value>The meeting notification's <see cref="OnBehalfOf"/>.</value>
 #pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)>
         [JsonProperty(PropertyName = "OnBehalfOf")]
-        public IList<OnBehalfOf> OnBehalfOf { get; set; }
+        public IList<TeamsMeetingNotificationOnBehalfOf> OnBehalfOf { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationInfo.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specifies the container for what is required to send a meeting notification to recipients.
+    /// </summary>
+    public partial class TeamsMeetingNotificationInfo
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsMeetingNotificationInfo"/> class.
+        /// </summary>
+        public TeamsMeetingNotificationInfo()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the collection of recipients of the notification.
+        /// </summary>
+        /// <value>
+        /// The collection of recipients of the notification.
+        /// </value>
+        [JsonProperty(PropertyName = "recipients")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)
+        public IList<string> Recipients { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of surfaces on which to show the notification.
+        /// </summary>
+        /// <value>
+        /// The collection of surfaces on which to show the notification.
+        /// </value>
+        [JsonProperty(PropertyName = "surfaces")]
+        public IList<TeamsMeetingNotificationSurface> Surfaces { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationOnBehalfOf.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationOnBehalfOf.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Specifies attribution for notifications.
+    /// </summary>
+    public partial class TeamsMeetingNotificationOnBehalfOf
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsMeetingNotificationOnBehalfOf"/> class.
+        /// </summary>
+        public TeamsMeetingNotificationOnBehalfOf()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the identification of the item. Default is 0.
+        /// </summary>
+        /// <value>The item id.</value>
+        [JsonProperty(PropertyName = "itemId")]
+        public int ItemId { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the mention type. Default is "person".
+        /// </summary>
+        /// <value>The mention type.</value>
+        [JsonProperty(PropertyName = "mentionType")]
+        public string MentionType { get; set; } = "person";
+
+        /// <summary>
+        /// Gets or sets message resource identifier (MRI) of the person on whose behalf the message is sent.
+        /// Message sender name would appear as "[user] through [bot name]".
+        /// </summary>
+        /// <value>The message resource identifier of the person.</value>
+        [JsonProperty(PropertyName = "mri")]
+        public string Mri { get; set; }
+
+        /// <summary>
+        /// Gets or sets name of the person. Used as fallback in case name resolution is unavailable.
+        /// </summary>
+        /// <value>The name of the person.</value>
+        [JsonProperty(PropertyName = "displayName")]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationRecipientFailureInfo.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationRecipientFailureInfo.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Information regarding failure to notify a recipient of a <see cref="TeamsMeetingNotification"/>.
+    /// </summary>
+    public class TeamsMeetingNotificationRecipientFailureInfo
+    {
+        /// <summary>
+        /// Gets or sets the mri for a recipient <see cref="TeamsMeetingNotification"/> failure.
+        /// </summary>
+        /// <value>The type of this notification container.</value>
+        [JsonProperty(PropertyName = "recipientMri")]
+        public string RecipientMri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error code for a <see cref="TeamsMeetingNotification"/>.
+        /// </summary>
+        /// <value>The error code for a <see cref="TeamsMeetingNotification"/>.</value>
+        [JsonProperty(PropertyName = "errorcode")]
+        public string ErrorCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the failure reason for a <see cref="TeamsMeetingNotification"/> failure.
+        /// </summary>
+        /// <value>The reason why a participant <see cref="TeamsMeetingNotification"/> failed.</value>
+        [JsonProperty(PropertyName = "failureReason")]
+        public string FailureReason { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationRecipientFailureInfos.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationRecipientFailureInfos.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Container for <see cref="TeamsMeetingNotificationRecipientFailureInfo"/>, which is the result of a
+    /// failure to notify recipients of a <see cref="TeamsMeetingNotification"/>.
+    /// </summary>
+    public partial class TeamsMeetingNotificationRecipientFailureInfos
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsMeetingNotificationRecipientFailureInfos"/> class.
+        /// </summary>
+        public TeamsMeetingNotificationRecipientFailureInfos()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the list of <see cref="TeamsMeetingNotificationRecipientFailureInfos"/>.
+        /// </summary>
+        /// <value>The list of recipients who did not receive a <see cref="TeamsMeetingNotification"/> including error information.</value>
+        [JsonProperty(PropertyName = "recipientsFailureInfo")]
+#pragma warning disable CA2227 // Collection properties should be read only (we can't change this without breaking binary compat)>
+        public IList<TeamsMeetingNotificationRecipientFailureInfo> RecipientsFailureInfo { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationSurface.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/TeamsMeetingNotificationSurface.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Specifies if a notification is to be sent for the mentions.
+    /// </summary>
+    public partial class TeamsMeetingNotificationSurface
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamsMeetingNotificationSurface"/> class.
+        /// </summary>
+        public TeamsMeetingNotificationSurface()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating where the signal will be rendered in the meeting UX.
+        /// Note: only one instance of surface type is allowed per request.
+        /// </summary>
+        /// <value>
+        /// The value indicating where the signal will be rendered in the meeting UX.
+        /// </value>
+        [JsonProperty(PropertyName = "surface")]
+        public string Surface { get; set; } = "meetingStage";
+
+        /// <summary>
+        /// Gets or sets the content type of this <see cref="TeamsMeetingNotificationSurface"/>.
+        /// </summary>
+        /// <value>
+        /// The content type of this <see cref="TeamsMeetingNotificationSurface"/>.
+        /// </value>
+        [JsonProperty(PropertyName = "contentType")]
+        public string ContentType { get; set; } = "task";
+
+        /// <summary>
+        /// Gets or sets the content for this <see cref="TeamsMeetingNotificationSurface"/>.
+        /// </summary>
+        /// <value>
+        /// The content type of this <see cref="TeamsMeetingNotificationSurface"/>.
+        /// </value>
+        [JsonProperty(PropertyName = "content")]
+        public TaskModuleContinueResponse Content { get; set; }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -360,24 +360,22 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         [InlineData("403")]
         public async Task TestSendMeetingNotificationAsync(string statusCode)
         {
-            /* 
-               202: accepted
-               207: if the notifications are sent only to parital number of recipients because 
-                            the validation on some recipients’ ids failed or some recipients were not found in the roster. 
-                        • In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot 
-                            (ex: if a bot sent encrypted user MRIs, return encrypted one).
-             
-                400: when Meeting Notification request payload validation fails. For instance, 
-                    • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
-                    • Surface: 
-                        o Surface list is empty or null 
-                        o Surface type is invalid 
-                        o Duplicative surface type exists in one payload
-                403: if the bot is not allowed to send the notification.
-                    In this case, the payload should contain more detail error message.
-                    There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
-                    the bot does not have a correct RSC permission for a specific surface type, etc
-             */
+            // 202: accepted
+            // 207: if the notifications are sent only to parital number of recipients because 
+            //             the validation on some recipients’ ids failed or some recipients were not found in the roster. 
+            //         • In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot 
+            //             (ex: if a bot sent encrypted user MRIs, return encrypted one).
+
+            // 400: when Meeting Notification request payload validation fails. For instance, 
+            //     • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
+            //     • Surface: 
+            //         o Surface list is empty or null 
+            //         o Surface type is invalid 
+            //         o Duplicative surface type exists in one payload
+            // 403: if the bot is not allowed to send the notification.
+            //     In this case, the payload should contain more detail error message.
+            //     There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
+            //     the bot does not have a correct RSC permission for a specific surface type, etc
 
             var baseUri = new Uri("https://test.coffee");
             var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
@@ -548,7 +546,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
 
                 var obo = new TeamsMeetingNotificationOnBehalfOf
                 {
-                    DisplayName = from.Name, 
+                    DisplayName = from.Name,
                     Mri = from.Id
                 };
 

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     Surfaces = new[] { surface }
                 };
 
-                var obo = new OnBehalfOf
+                var obo = new TeamsMeetingNotificationOnBehalfOf
                 {
                     DisplayName = from.Name, 
                     Mri = from.Id

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -12,7 +13,9 @@ using Microsoft.Bot.Connector;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Bot.Schema;
 using Microsoft.Bot.Schema.Teams;
+using Microsoft.Rest;
 using Moq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -350,6 +353,61 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             await handler.OnTurnAsync(turnContext);
         }
 
+        [Theory]
+        [InlineData("202")]
+        [InlineData("207")]
+        [InlineData("400")]
+        [InlineData("403")]
+        public async Task TestSendMeetingNotificationAsync(string statusCode)
+        {
+            /* 
+               202: accepted
+               207: if the notifications are sent only to parital number of recipients because 
+                            the validation on some recipients’ ids failed or some recipients were not found in the roster. 
+                        • In this case, SMBA will return the user MRIs of those failed recipients in a format that was given to a bot 
+                            (ex: if a bot sent encrypted user MRIs, return encrypted one).
+             
+                400: when Meeting Notification request payload validation fails. For instance, 
+                    • Recipients: # of recipients is greater than what the API allows || all of recipients’ user ids were invalid
+                    • Surface: 
+                        o Surface list is empty or null 
+                        o Surface type is invalid 
+                        o Duplicative surface type exists in one payload
+                403: if the bot is not allowed to send the notification.
+                    In this case, the payload should contain more detail error message.
+                    There can be many reasons: bot disabled by tenant admin, blocked during live site mitigation,
+                    the bot does not have a correct RSC permission for a specific surface type, etc
+             */
+
+            var baseUri = new Uri("https://test.coffee");
+            var customHttpClient = new HttpClient(new RosterHttpMessageHandler());
+
+            // Set a special base address so then we can make sure the connector client is honoring this http client
+            customHttpClient.BaseAddress = baseUri;
+            var connectorClient = new ConnectorClient(new Uri("http://localhost/"), new MicrosoftAppCredentials(string.Empty, string.Empty), customHttpClient);
+
+            var activity = new Activity
+            {
+                Type = "targetedMeetingNotification",
+                Text = "Test-SendMeetingNotificationAsync",
+                ChannelId = Channels.Msteams,
+                ServiceUrl = "https://test.coffee",
+                From = new ChannelAccount()
+                {
+                    Id = "id-1",
+
+                    // Hack for test. use the Name field to pass expected status code to test code
+                    Name = statusCode
+                },
+                Conversation = new ConversationAccount() { Id = "conversation-id" }
+            };
+
+            var turnContext = new TurnContext(new SimpleAdapter(), activity);
+            turnContext.TurnState.Add<IConnectorClient>(connectorClient);
+            var handler = new TestTeamsActivityHandler();
+            await handler.OnTurnAsync(turnContext);
+        }
+
         private class TestTeamsActivityHandler : TeamsActivityHandler
         {
             public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
@@ -381,6 +439,9 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                         break;
                     case "Test-GetMeetingInfoAsync":
                         await CallTeamsInfoGetMeetingInfoAsync(turnContext);
+                        break;
+                    case "Test-SendMeetingNotificationAsync":
+                        await CallSendMeetingNotificationAsync(turnContext);
                         break;
                     default:
                         Assert.True(false);
@@ -457,6 +518,91 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 Assert.Equal("meetingConversationId-1", meeting.Conversation.Id);
             }
 
+            private TeamsMeetingNotification GetTeamsMeetingNotification(ChannelAccount from)
+            {
+                var recipients = new List<string> { from.Id };
+
+                if (from.Name == "207")
+                {
+                    recipients.Add("failingid");
+                }
+
+                var surface = new TeamsMeetingNotificationSurface
+                {
+                    Content = new TaskModuleContinueResponse
+                    {
+                        Value = new TaskModuleTaskInfo
+                        {
+                            Title = "title here",
+                            Height = 3,
+                            Width = 2,
+                        }
+                    }
+                };
+
+                var value = new TeamsMeetingNotificationInfo
+                {
+                    Recipients = recipients,
+                    Surfaces = new[] { surface }
+                };
+
+                var obo = new OnBehalfOf
+                {
+                    DisplayName = from.Name, 
+                    Mri = from.Id
+                };
+
+                var channelData = new TeamsMeetingNotificationChannelData
+                {
+                    OnBehalfOf = new[] { obo }
+                };
+
+                return new TeamsMeetingNotification
+                {
+                    Value = value,
+                    ChannelData = channelData
+                };
+            }
+
+            private async Task CallSendMeetingNotificationAsync(ITurnContext turnContext)
+            {
+                var from = turnContext.Activity.From;
+
+                try
+                {
+                    var failedParticipants = await TeamsInfo.SendMeetingNotificationAsync(turnContext, GetTeamsMeetingNotification(from), "meeting-id").ConfigureAwait(false);
+
+                    switch (from.Name)
+                    {
+                        case "207":
+                            Assert.Equal("failingid", failedParticipants.RecipientsFailureInfo.First().RecipientMri);
+                            break;
+                        case "202":
+                            Assert.Null(failedParticipants);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
+                    }
+                }
+                catch (HttpOperationException ex)
+                {
+                    Assert.Equal(from.Name, ((int)ex.Response.StatusCode).ToString());
+                    var errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(ex.Response.Content);
+
+                    switch (from.Name)
+                    {
+                        case "400":
+                            Assert.Equal("BadSyntax", errorResponse.Error.Code);
+                            break;
+                        case "403":
+                            Assert.Equal("BotNotInConversationRoster", errorResponse.Error.Code);
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Expected {nameof(HttpOperationException)} with response status code {from.Name}.");
+                    }
+                }
+            }
+
             private async Task CallGroupChatGetMembersAsync(ITurnContext turnContext)
             {
                 var members = (await TeamsInfo.GetMembersAsync(turnContext)).ToArray();
@@ -490,7 +636,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
 
         private class RosterHttpMessageHandler : HttpMessageHandler
         {
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
                 var response = new HttpResponseMessage(HttpStatusCode.OK);
 
@@ -639,7 +785,41 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     response.Content = new StringContent(content.ToString());
                 }
 
-                return Task.FromResult(response);
+                // Post meeting notification
+                else if (request.RequestUri.PathAndQuery.EndsWith("v1/meetings/meeting-id/notification"))
+                {
+                    var responseBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var notification = JsonConvert.DeserializeObject<TeamsMeetingNotification>(responseBody);
+                    var obo = notification.ChannelData.OnBehalfOf.First();
+
+                    // hack displayname as expected status code, for testing
+                    switch (obo.DisplayName)
+                    {
+                        case "207":
+                            var failureInfo = new TeamsMeetingNotificationRecipientFailureInfo { RecipientMri = notification.Value.Recipients.First(r => !r.Equals(obo.Mri, StringComparison.OrdinalIgnoreCase)) };
+                            var infos = new TeamsMeetingNotificationRecipientFailureInfos
+                            {
+                                RecipientsFailureInfo = new List<TeamsMeetingNotificationRecipientFailureInfo> { failureInfo }
+                            };
+
+                            response.Content = new StringContent(JsonConvert.SerializeObject(infos));
+                            response.StatusCode = HttpStatusCode.MultiStatus;
+                            break;
+                        case "403":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BotNotInConversationRoster\"}}");
+                            response.StatusCode = HttpStatusCode.Forbidden;
+                            break;
+                        case "400":
+                            response.Content = new StringContent("{\"error\":{\"code\":\"BadSyntax\"}}");
+                            response.StatusCode = HttpStatusCode.BadRequest;
+                            break;
+                        default:
+                            response.StatusCode = HttpStatusCode.Accepted;
+                            break;
+                    }
+                }
+
+                return response;
             }
         }
 


### PR DESCRIPTION
**Description**
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This feature aims to extend the dot Net Bot SDK so that developers can send targeted meeting notifications in Microsoft Teams meetings.

Add `TeamsInfo.SendMeetingNotificationAsync`

Closes  #6571

**Changes**

`Microsoft.Bot.Builder/Teams`
- add `SendMeetingNotificationAsync `method in `TeamsInfo.cs`

`Microsoft.Bot.Connector/Teams`
- Construct and send meeting notification request 

`Microsft.Bot.Schema/Teams`
- Create classes for Teams meeting notification



**Testing**

Test `SendMeetingNotificationAsync` for different status codes in `TeamsInfoTests.cs`.