### PR TITLE
[#6577] Can you add a log line for this exception?

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -112,10 +112,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     httpResponse.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
                 }
             }
-            catch (UnauthorizedAccessException)
+            catch (UnauthorizedAccessException ex)
             {
                 // handle unauthorized here as this layer creates the http response
                 httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+
+                Logger.LogWarning(ex.ToString());
             }
         }
 

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                 // handle unauthorized here as this layer creates the http response
                 httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
 
-                Logger.LogWarning(ex.ToString());
+                Logger.LogError(ex.ToString());
             }
         }
 

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -848,7 +848,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
             loggerMock.Verify(
                x => x.Log(
-                   LogLevel.Warning,
+                   LogLevel.Error,
                    It.IsAny<EventId>(),
                    It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("The token has expired")),
                    It.IsAny<Exception>(),

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -826,21 +826,11 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             httpResponseMock.Setup(r => r.Body).Returns(response);
 
             var loggerMock = new Mock<ILogger<CloudAdapter>>();
-            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
-            mockHttpMessageHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .Returns((HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(CreateInternalHttpResponse()));
-
-            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
-
-            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
-            httpClientFactoryMock.Setup(cf => cf.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
             var bot = new InvokeResponseBot();
 
             // Act
-            var cloudEnvironment = BotFrameworkAuthenticationFactory.Create(null, false, null, null, null, null, null, null, null, new PasswordServiceClientCredentialFactory(), new AuthenticationConfiguration(), httpClientFactoryMock.Object, null);
-            var adapter = new CloudAdapter(cloudEnvironment, loggerMock.Object);
+            var adapter = new CloudAdapter(BotFrameworkAuthenticationFactory.Create(), loggerMock.Object);
             await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
 
             // Assert

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -825,10 +825,22 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
             var httpResponseMock = new Mock<HttpResponse>().SetupAllProperties();
             httpResponseMock.Setup(r => r.Body).Returns(response);
 
+            var loggerMock = new Mock<ILogger<CloudAdapter>>();
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns((HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(CreateInternalHttpResponse()));
+
+            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock.Setup(cf => cf.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
             var bot = new InvokeResponseBot();
 
             // Act
-            var adapter = new CloudAdapter();
+            var cloudEnvironment = BotFrameworkAuthenticationFactory.Create(null, false, null, null, null, null, null, null, null, new PasswordServiceClientCredentialFactory(), new AuthenticationConfiguration(), httpClientFactoryMock.Object, null);
+            var adapter = new CloudAdapter(cloudEnvironment, loggerMock.Object);
             await adapter.ProcessAsync(httpRequestMock.Object, httpResponseMock.Object, bot);
 
             // Assert

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -845,6 +845,15 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
 
             // Assert
             Assert.Equal((int)HttpStatusCode.Unauthorized, httpResponseMock.Object.StatusCode);
+
+            loggerMock.Verify(
+               x => x.Log(
+                   LogLevel.Warning,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("The token has expired")),
+                   It.IsAny<Exception>(),
+                   (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()),
+               Times.Once);
         }
 
         private static Stream CreateMessageActivityStream(string userId, string channelId, string conversationId, string recipient, string relatesToActivityId)


### PR DESCRIPTION
Fixes #6577 

## Description
This PR adds a log in the `ProcessAsync` method of the `CloudAdapter` class to show more information about the `UnauthorizedAccessException` exceptions.
Additionally, it updates the `CloudAdapter` unit tests.

## Specific Changes
  - Added log to `ProcessAsync` method in `CloudAdapter.cs`.
  - Updated `ExpiredTokenShouldThrowUnauthorizedAccessException` unit test in `CloudAdapterTests.cs`.

## Testing
_The following image shows the error message with the new log._
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/64815358/217619149-d148b510-285d-46a4-954b-097c949ad0b3.png">

_The updated test passing._
![image](https://user-images.githubusercontent.com/64815358/217619822-1da6c7ea-2b03-4c4c-9afc-42c01f5c7d3b.png)