### PR TITLE
[#6591] Concurrency issue with TimeZoneConverter

### DIFF
--- a/libraries/AdaptiveExpressions/TimeZoneConverter.cs
+++ b/libraries/AdaptiveExpressions/TimeZoneConverter.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Reflection;
 
@@ -18,8 +18,8 @@ namespace AdaptiveExpressions
     /// </summary>
     public static class TimeZoneConverter
     {
-        private static IDictionary<string, string> ianaToWindowsMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        private static IDictionary<string, string> windowsToIanaMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private static ConcurrentDictionary<string, string> ianaToWindowsMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private static ConcurrentDictionary<string, string> windowsToIanaMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// convert IANA timezone format to windows timezone format.
@@ -69,14 +69,14 @@ namespace AdaptiveExpressions
                     var ianaIdList = table[2].Split(' ');
                     if (!windowsToIanaMap.ContainsKey($"{territory}|{windowsId}"))
                     {
-                        windowsToIanaMap.Add($"{territory}|{windowsId}", ianaIdList[0]);
+                        windowsToIanaMap.TryAdd($"{territory}|{windowsId}", ianaIdList[0]);
                     }
 
                     foreach (var ianaId in ianaIdList)
                     {
                         if (!ianaToWindowsMap.ContainsKey(ianaId))
                         {
-                            ianaToWindowsMap.Add(ianaId, windowsId);
+                            ianaToWindowsMap.TryAdd(ianaId, windowsId);
                         }
                     }
                 }

--- a/libraries/AdaptiveExpressions/TimeZoneConverter.cs
+++ b/libraries/AdaptiveExpressions/TimeZoneConverter.cs
@@ -21,6 +21,11 @@ namespace AdaptiveExpressions
         private static ConcurrentDictionary<string, string> ianaToWindowsMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static ConcurrentDictionary<string, string> windowsToIanaMap = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        static TimeZoneConverter()
+        {
+            LoadData();
+        }
+
         /// <summary>
         /// convert IANA timezone format to windows timezone format.
         /// </summary>
@@ -28,7 +33,6 @@ namespace AdaptiveExpressions
         /// <returns>windows timezone format.</returns>
         public static string IanaToWindows(string ianaTimeZoneId)
         {
-            LoadData();
             if (ianaToWindowsMap.ContainsKey(ianaTimeZoneId))
             {
                 return ianaToWindowsMap[ianaTimeZoneId];
@@ -44,7 +48,6 @@ namespace AdaptiveExpressions
         /// <returns>Iana timezone format.</returns>
         public static string WindowsToIana(string windowsTimeZoneId)
         {
-            LoadData();
             if (windowsToIanaMap.ContainsKey($"001|{windowsTimeZoneId}"))
             {
                 return windowsToIanaMap[$"001|{windowsTimeZoneId}"];


### PR DESCRIPTION
Fixes #6591

## Description
This PR fixes the concurrency issue in the _TimeZoneConverter_ class by changing the Dictionaries to be thread-safe and also adding a static constructor to the class to execute the _LoadData_ method only once.

## Specific Changes
- Updated **_TimeZoneConverter_** class adding a static constructor and using _ConcurrentDictionary_.

## Testing
Here we can see concurrent tests failing before the changes and the same tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/220951480-b891cc20-dbd4-409a-a1e6-d34e4c8df496.png)
