### PR TITLE
fix: Custom Question Answering in MS Teams

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -657,8 +657,6 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 dialogOptions.QnAMakerOptions.QnAId = 0;
             }
 
-
-
             // Resetting context;
             dialogOptions.QnAMakerOptions.Context = new QnARequestContext();
 

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -650,12 +650,14 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
 
             if (qnaIdFromContext != null)
             {
-                dialogOptions.QnAMakerOptions.QnAId = (int)(long)qnaIdFromContext;
+                dialogOptions.QnAMakerOptions.QnAId = long.TryParse(qnaIdFromContext.ToString(), out long qnaId) ? (int)qnaId : 0;
             }
             else
             {
                 dialogOptions.QnAMakerOptions.QnAId = 0;
             }
+
+
 
             // Resetting context;
             dialogOptions.QnAMakerOptions.Context = new QnARequestContext();


### PR DESCRIPTION
Fixes #6599 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
The `ResetOption` method in the `QnAMakerDialog` class attempts to cast the QnAId from the context into an int64. Microsoft Teams sends back a JObject which causes this conversion to fail. This PR modifies the casting logic to attempt a `long.TryParse` first, and defaults the QnAId to 0 if the conversion is not possible.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Add a TryParse of the QnAId object. Take the casted variable if it succeeds, or a default value of 0 if it fails.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
All QnA tests passing.
<img width="369" alt="image" src="https://user-images.githubusercontent.com/33945547/225707794-80a34642-7afd-4979-ab03-7a844d6fb0ba.png">
