### PR TITLE
Update GetValue to throw on error - HOLD

### DIFF
--- a/libraries/AdaptiveExpressions/ExpressionProperties/ExpressionProperty.cs
+++ b/libraries/AdaptiveExpressions/ExpressionProperties/ExpressionProperty.cs
@@ -120,9 +120,17 @@ namespace AdaptiveExpressions.Properties
         /// </summary>
         /// <param name="data">data to use for expression binding.</param>
         /// <returns>Value or default(T) if not found.</returns>
+        /// <remarks>An error will be thrown if data is an invalid expression.</remarks>
         public virtual T GetValue(object data)
         {
-            return this.TryGetValue(data).Value;
+            var (value, error) = TryGetValue(data);
+
+            if (error != null)
+            {
+                throw new ArgumentException(error);
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -131,7 +131,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                 {
                     // First check whether the prompt was sent to the user with numbers - if it was we should recognize numbers
                     var defaults = DefaultChoiceOptions[culture];
-                    var choiceOptions = ChoiceOptions?.GetValue(dc.State) ?? defaults.Item3;
+                    var opts = await GetChoiceOptionsAsync(dc, defaults).ConfigureAwait(false);
+                    var choiceOptions = opts ?? defaults.Item3;
 
                     // This logic reflects the fact that IncludeNumbers is nullable and True is the default set in Inline style
                     if (!choiceOptions.IncludeNumbers.HasValue || choiceOptions.IncludeNumbers.Value)


### PR DESCRIPTION
#minor

## Description
This PR updates the **_GetValue_** method in _ExpressionProperty_ to throw when there's an invalid expression.
This was reported as part of an issue in Composer where an invalid expression was causing an error in JS while .NET was letting it pass.
This PR also fixes an issue in the _ConfirmInput_ class where an invalid expression was being ignored.

# Specific Changes
- Updated the **_GetValue_** method in _ExpressionProperty_ to throw in case of an error.
- Updated **_OnRecognizeInputAsync_** in _ConfirmInput_ to use the _GetChoiceOptionsAsync_ to retrieve the options from an lg template.

## Testing
These images show the related unit tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/225943599-23225c0d-cea5-4056-9457-33f66047bbd2.png)