### PR TITLE
[#6086] Teams is adding support for suggested actions in 1-1 chats

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ChoiceInput.cs
@@ -230,8 +230,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
             var opts = await GetChoiceOptionsAsync(dc, locale).ConfigureAwait(false);
             var choiceOptions = opts ?? DefaultChoiceOptions[locale];
             var options = dc.State.GetValue<ChoiceInputOptions>(ThisPath.Options);
+            var conversationType = dc.Context.Activity.Conversation?.ConversationType;
+            var recipient = dc.Context.Activity.From?.Id;
+            var toList = string.IsNullOrEmpty(recipient) ? null : new List<string>() { recipient };
 
-            return AppendChoices(prompt.AsMessageActivity(), channelId, options.Choices, Style.GetValue(dc.State), choiceOptions);
+            return AppendChoices(prompt.AsMessageActivity(), channelId, options.Choices, Style.GetValue(dc.State), choiceOptions, conversationType, toList);
         }
 
         private async Task<ChoiceSet> GetChoiceSetAsync(DialogContext dc)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/ConfirmInput.cs
@@ -175,7 +175,10 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
 
             var prompt = await base.OnRenderPromptAsync(dc, state, cancellationToken).ConfigureAwait(false);
             var (style, _) = Style.TryGetValue(dc.State);
-            return AppendChoices(prompt.AsMessageActivity(), channelId, confirmChoices, style, choiceOptions);
+            var conversationType = dc.Context.Activity.Conversation?.ConversationType;
+            var recipient = dc.Context.Activity.From?.Id;
+            var toList = string.IsNullOrEmpty(recipient) ? null : new List<string>() { recipient };
+            return AppendChoices(prompt.AsMessageActivity(), channelId, confirmChoices, style, choiceOptions, conversationType, toList);
         }
 
         private string DetermineCulture(DialogContext dc)

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -376,6 +376,21 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="choices">choices to present.</param>
         /// <param name="style">listType.</param>
         /// <param name="options">options to control the choice rendering.</param>
+        /// <param name="cancellationToken">cancellation Token.</param>
+        /// <returns>bound activity ready to send to the user.</returns>
+        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return AppendChoices(prompt, channelId, choices, style, options, null, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// AppendChoices is utility method to build up a message activity given all of the options.
+        /// </summary>
+        /// <param name="prompt">prompt.</param>
+        /// <param name="channelId">channelId.</param>
+        /// <param name="choices">choices to present.</param>
+        /// <param name="style">listType.</param>
+        /// <param name="options">options to control the choice rendering.</param>
         /// <param name="conversationType">the type of the conversation.</param>
         /// <param name="toList">the list of recipients.</param>
         /// <param name="cancellationToken">cancellation Token.</param>
@@ -398,7 +413,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     break;
 
                 case ListStyle.SuggestedAction:
-                    msg = ChoiceFactory.SuggestedAction(choices, text);
+                    msg = ChoiceFactory.SuggestedAction(choices, text, null, toList);
                     break;
 
                 case ListStyle.HeroCard:

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Input/InputDialog.cs
@@ -376,9 +376,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
         /// <param name="choices">choices to present.</param>
         /// <param name="style">listType.</param>
         /// <param name="options">options to control the choice rendering.</param>
+        /// <param name="conversationType">the type of the conversation.</param>
+        /// <param name="toList">the list of recipients.</param>
         /// <param name="cancellationToken">cancellation Token.</param>
         /// <returns>bound activity ready to send to the user.</returns>
-        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, string conversationType = default, IList<string> toList = default, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Get base prompt text (if any)
             var text = prompt != null && !string.IsNullOrEmpty(prompt.Text) ? prompt.Text : string.Empty;
@@ -409,7 +411,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Input
                     break;
 
                 default:
-                    msg = ChoiceFactory.ForChannel(channelId, choices, text, null, options);
+                    msg = ChoiceFactory.ForChannel(channelId, choices, text, null, options, conversationType, toList);
                     break;
             }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -17,6 +17,17 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// </summary>
         /// <param name="channelId">The Channel to check the if Suggested Actions are supported in.</param>
         /// <param name="buttonCnt">(Optional) The number of Suggested Actions to check for the Channel.</param>
+        /// <returns>True if the Channel supports the buttonCnt total Suggested Actions, False if the Channel does not support that number of Suggested Actions.</returns>
+        public static bool SupportsSuggestedActions(string channelId, int buttonCnt = 100)
+        {
+            return SupportsSuggestedActions(channelId, buttonCnt, null);
+        }
+
+        /// <summary>
+        /// Determine if a number of Suggested Actions are supported by a Channel.
+        /// </summary>
+        /// <param name="channelId">The Channel to check the if Suggested Actions are supported in.</param>
+        /// <param name="buttonCnt">(Optional) The number of Suggested Actions to check for the Channel.</param>
         /// <param name="conversationType">(Optional) The type of the conversation.</param>
         /// <returns>True if the Channel supports the buttonCnt total Suggested Actions, False if the Channel does not support that number of Suggested Actions.</returns>
         public static bool SupportsSuggestedActions(string channelId, int buttonCnt = 100, string conversationType = default)

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/Channel.cs
@@ -17,8 +17,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// </summary>
         /// <param name="channelId">The Channel to check the if Suggested Actions are supported in.</param>
         /// <param name="buttonCnt">(Optional) The number of Suggested Actions to check for the Channel.</param>
+        /// <param name="conversationType">(Optional) The type of the conversation.</param>
         /// <returns>True if the Channel supports the buttonCnt total Suggested Actions, False if the Channel does not support that number of Suggested Actions.</returns>
-        public static bool SupportsSuggestedActions(string channelId, int buttonCnt = 100)
+        public static bool SupportsSuggestedActions(string channelId, int buttonCnt = 100, string conversationType = default)
         {
             switch (channelId)
             {
@@ -41,6 +42,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
                 case Connector.Channels.DirectlineSpeech:
                 case Connector.Channels.Webchat:
                     return buttonCnt <= 100;
+
+                // https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/conversation-messages?tabs=dotnet1%2Cdotnet2%2Cdotnet3%2Cdotnet4%2Cdotnet5%2Cdotnet#send-suggested-actions
+                case Connector.Channels.Msteams:
+                    if (conversationType == "personal")
+                    {
+                        return buttonCnt <= 3;
+                    }
+
+                    return false;
 
                 default:
                     return false;

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -23,6 +23,25 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="text">Optional, the text of the message to send.</param>
         /// <param name="speak">Optional, the text to be spoken by your bot on a speech-enabled channel.</param>
         /// <param name="options">Optional, the formatting options to use when rendering as a list.</param>
+        /// <returns>The created message activity.</returns>
+        /// <remarks>The algorithm prefers to format the supplied list of choices as suggested actions but can decide
+        /// to use a text based list if suggested actions aren't natively supported by the channel, there are too many
+        /// choices for the channel to display, or the title of any choice is too long.
+        /// <para>If the algorithm decides to use a list, for 3 or fewer choices with short titles it will use an inline
+        /// list; otherwise, a numbered list.</para></remarks>
+        public static IMessageActivity ForChannel(string channelId, IList<Choice> list, string text = null, string speak = null, ChoiceFactoryOptions options = null)
+        {
+            return ForChannel(channelId, list, text, speak, options, null, null);
+        }
+
+        /// <summary>
+        /// Creates a message activity that includes a list of choices formatted based on the capabilities of a given channel.
+        /// </summary>
+        /// <param name="channelId">A channel ID. The <see cref="Connector.Channels"/> class contains known channel IDs.</param>
+        /// <param name="list">The list of choices to include.</param>
+        /// <param name="text">Optional, the text of the message to send.</param>
+        /// <param name="speak">Optional, the text to be spoken by your bot on a speech-enabled channel.</param>
+        /// <param name="options">Optional, the formatting options to use when rendering as a list.</param>
         /// <param name="conversationType">Optional, the type of the conversation.</param>
         /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>The created message activity.</returns>
@@ -197,11 +216,36 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="choices">List of strings representing the choices to add.</param>
         /// <param name="text">Optional, text of the message.</param>
         /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <returns>An activity with choices as suggested actions.</returns>
+        public static IMessageActivity SuggestedAction(IList<string> choices, string text = null, string speak = null)
+        {
+            return SuggestedAction(ToChoices(choices), text, speak, null);
+        }
+
+        /// <summary>
+        /// Creates a message activity containing a list of choices that have been added as suggested actions.
+        /// </summary>
+        /// <param name="choices">List of strings representing the choices to add.</param>
+        /// <param name="text">Optional, text of the message.</param>
+        /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
         /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>An activity with choices as suggested actions.</returns>
         public static IMessageActivity SuggestedAction(IList<string> choices, string text = null, string speak = null, IList<string> toList = default)
         {
             return SuggestedAction(ToChoices(choices), text, speak, toList);
+        }
+
+        /// <summary>
+        /// Creates a message activity containing a list of choices that have been added as suggested actions.
+        /// </summary>
+        /// <param name="choices">The list of choices to add.</param>
+        /// <param name="text">Optional, text of the message.</param>
+        /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <returns>An activity with choices as suggested actions.</returns>
+        public static IMessageActivity SuggestedAction(IList<Choice> choices, string text = null, string speak = null)
+        {
+            // Return activity with choices as suggested actions
+            return SuggestedAction(choices, text, speak, null);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Choices/ChoiceFactory.cs
@@ -23,13 +23,15 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="text">Optional, the text of the message to send.</param>
         /// <param name="speak">Optional, the text to be spoken by your bot on a speech-enabled channel.</param>
         /// <param name="options">Optional, the formatting options to use when rendering as a list.</param>
+        /// <param name="conversationType">Optional, the type of the conversation.</param>
+        /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>The created message activity.</returns>
         /// <remarks>The algorithm prefers to format the supplied list of choices as suggested actions but can decide
         /// to use a text based list if suggested actions aren't natively supported by the channel, there are too many
         /// choices for the channel to display, or the title of any choice is too long.
         /// <para>If the algorithm decides to use a list, for 3 or fewer choices with short titles it will use an inline
         /// list; otherwise, a numbered list.</para></remarks>
-        public static IMessageActivity ForChannel(string channelId, IList<Choice> list, string text = null, string speak = null, ChoiceFactoryOptions options = null)
+        public static IMessageActivity ForChannel(string channelId, IList<Choice> list, string text = null, string speak = null, ChoiceFactoryOptions options = null, string conversationType = default, IList<string> toList = default)
         {
             channelId ??= string.Empty;
             list ??= new List<Choice>();
@@ -46,7 +48,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             }
 
             // Determine list style
-            var supportsSuggestedActions = Channel.SupportsSuggestedActions(channelId, list.Count);
+            var supportsSuggestedActions = Channel.SupportsSuggestedActions(channelId, list.Count, conversationType);
             var supportsCardActions = Channel.SupportsCardActions(channelId, list.Count);
             var maxActionTitleLength = Channel.MaxActionTitleLength(channelId);
             var hasMessageFeed = Channel.HasMessageFeed(channelId);
@@ -63,7 +65,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
             {
                 // We always prefer showing choices using suggested actions. If the titles are too long, however,
                 // we'll have to show them as a text list.
-                return SuggestedAction(list, text, speak);
+                return SuggestedAction(list, text, speak, toList);
             }
 
             if (!longTitles && list.Count <= 3)
@@ -195,10 +197,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="choices">List of strings representing the choices to add.</param>
         /// <param name="text">Optional, text of the message.</param>
         /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>An activity with choices as suggested actions.</returns>
-        public static IMessageActivity SuggestedAction(IList<string> choices, string text = null, string speak = null)
+        public static IMessageActivity SuggestedAction(IList<string> choices, string text = null, string speak = null, IList<string> toList = default)
         {
-            return SuggestedAction(ToChoices(choices), text, speak);
+            return SuggestedAction(ToChoices(choices), text, speak, toList);
         }
 
         /// <summary>
@@ -207,11 +210,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Choices
         /// <param name="choices">The list of choices to add.</param>
         /// <param name="text">Optional, text of the message.</param>
         /// <param name="speak">Optional, SSML text to be spoken by the bot on a speech-enabled channel.</param>
+        /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>An activity with choices as suggested actions.</returns>
-        public static IMessageActivity SuggestedAction(IList<Choice> choices, string text = null, string speak = null)
+        public static IMessageActivity SuggestedAction(IList<Choice> choices, string text = null, string speak = null, IList<string> toList = default)
         {
             // Return activity with choices as suggested actions
-            return MessageFactory.SuggestedActions(ExtractActions(choices), text, speak, InputHints.ExpectingInput);
+            return MessageFactory.SuggestedActions(ExtractActions(choices), text, speak, InputHints.ExpectingInput, toList);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ChoicePrompt.cs
@@ -138,13 +138,16 @@ namespace Microsoft.Bot.Builder.Dialogs
             var channelId = turnContext.Activity.ChannelId;
             var choiceOptions = ChoiceOptions ?? _choiceDefaults[culture];
             var choiceStyle = options.Style ?? Style;
+            var conversationType = turnContext.Activity.Conversation?.ConversationType;
+            var recipient = turnContext.Activity.From?.Id;
+            var toList = string.IsNullOrEmpty(recipient) ? null : new List<string>() { recipient };
             if (isRetry && options.RetryPrompt != null)
             {
-                prompt = AppendChoices(options.RetryPrompt, channelId, choices, choiceStyle, choiceOptions);
+                prompt = AppendChoices(options.RetryPrompt, channelId, choices, choiceStyle, choiceOptions, conversationType, toList);
             }
             else
             {
-                prompt = AppendChoices(options.Prompt, channelId, choices, choiceStyle, choiceOptions);
+                prompt = AppendChoices(options.Prompt, channelId, choices, choiceStyle, choiceOptions, conversationType, toList);
             }
 
             // Send prompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs
@@ -143,13 +143,16 @@ namespace Microsoft.Bot.Builder.Dialogs
             var confirmChoices = ConfirmChoices ?? Tuple.Create(defaults.Item1, defaults.Item2);
             var choices = new List<Choice> { confirmChoices.Item1, confirmChoices.Item2 };
             var style = options.Style ?? Style;
+            var conversationType = turnContext.Activity.Conversation?.ConversationType;
+            var recipient = turnContext.Activity.From?.Id;
+            var toList = string.IsNullOrEmpty(recipient) ? null : new List<string>() { recipient };
             if (isRetry && options.RetryPrompt != null)
             {
-                prompt = AppendChoices(options.RetryPrompt, channelId, choices, style, choiceOptions);
+                prompt = AppendChoices(options.RetryPrompt, channelId, choices, style, choiceOptions, conversationType, toList);
             }
             else
             {
-                prompt = AppendChoices(options.Prompt, channelId, choices, style, choiceOptions);
+                prompt = AppendChoices(options.Prompt, channelId, choices, style, choiceOptions, conversationType, toList);
             }
 
             // Send prompt

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -271,6 +271,23 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="choices">The choices to append.</param>
         /// <param name="style">Indicates how the choices should be presented to the user.</param>
         /// <param name="options">The formatting options to use when presenting the choices.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <remarks>If the task is successful, the result contains the updated activity.</remarks>
+        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, CancellationToken cancellationToken = default)
+        {
+            return AppendChoices(prompt, channelId, choices, style, options, null, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, appends choices to the activity when the user is prompted for input.
+        /// </summary>
+        /// <param name="prompt">The activity to append the choices to.</param>
+        /// <param name="channelId">The ID of the user's channel.</param>
+        /// <param name="choices">The choices to append.</param>
+        /// <param name="style">Indicates how the choices should be presented to the user.</param>
+        /// <param name="options">The formatting options to use when presenting the choices.</param>
         /// <param name="conversationType">The type of the conversation.</param>
         /// <param name="toList">The list of recipients.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
@@ -295,7 +312,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     break;
 
                 case ListStyle.SuggestedAction:
-                    msg = ChoiceFactory.SuggestedAction(choices, text);
+                    msg = ChoiceFactory.SuggestedAction(choices, text, null, toList);
                     break;
 
                 case ListStyle.HeroCard:

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/Prompt.cs
@@ -271,11 +271,13 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// <param name="choices">The choices to append.</param>
         /// <param name="style">Indicates how the choices should be presented to the user.</param>
         /// <param name="options">The formatting options to use when presenting the choices.</param>
+        /// <param name="conversationType">The type of the conversation.</param>
+        /// <param name="toList">The list of recipients.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks>If the task is successful, the result contains the updated activity.</remarks>
-        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, CancellationToken cancellationToken = default)
+        protected virtual IMessageActivity AppendChoices(IMessageActivity prompt, string channelId, IList<Choice> choices, ListStyle style, ChoiceFactoryOptions options = null, string conversationType = default, IList<string> toList = default, CancellationToken cancellationToken = default)
         {
             // Get base prompt text (if any)
             var text = prompt != null && !string.IsNullOrEmpty(prompt.Text) ? prompt.Text : string.Empty;
@@ -306,7 +308,7 @@ namespace Microsoft.Bot.Builder.Dialogs
                     break;
 
                 default:
-                    msg = ChoiceFactory.ForChannel(channelId, choices, text, null, options);
+                    msg = ChoiceFactory.ForChannel(channelId, choices, text, null, options, conversationType, toList);
                     break;
             }
 

--- a/libraries/Microsoft.Bot.Builder/MessageFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/MessageFactory.cs
@@ -84,6 +84,44 @@ namespace Microsoft.Bot.Builder
         /// expecting, or ignoring user input after the message is delivered to the client.
         /// One of: "acceptingInput", "ignoringInput", or "expectingInput".
         /// Default is "acceptingInput".</param>
+        /// <returns>A message activity containing the suggested actions.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="actions"/> is <c>null</c>.</exception>
+        /// <remarks>This method creates a suggested action for each string in <paramref name="actions"/>.
+        /// The created action uses the text for the <see cref="CardAction.Value"/> and
+        /// <see cref="CardAction.Title"/> and sets the <see cref="CardAction.Type"/> to
+        /// <see cref="Microsoft.Bot.Schema.ActionTypes.ImBack"/>.
+        /// </remarks>
+        /// <seealso cref="SuggestedActions(IEnumerable{CardAction}, string, string, string)"/>
+        public static IMessageActivity SuggestedActions(IEnumerable<string> actions, string text = null, string ssml = null, string inputHint = null)
+        {
+            return SuggestedActions(actions, text, ssml, inputHint, null);
+        }
+
+        /// <summary>
+        /// Returns a message that includes a set of suggested actions and optional text.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Create the activity and add suggested actions.
+        /// var activity = MessageFactory.SuggestedActions(
+        ///     new string[] { "red", "green", "blue" },
+        ///     text: "Choose a color");
+        ///
+        /// // Send the activity as a reply to the user.
+        /// await context.SendActivity(activity);
+        /// </code>
+        /// </example>
+        /// <param name="actions">
+        /// The text of the actions to create.
+        /// </param>
+        /// <param name="text">The text of the message to send.</param>
+        /// <param name="ssml">Optional, text to be spoken by your bot on a speech-enabled
+        /// channel.</param>
+        /// <param name="inputHint">Optional, indicates whether your bot is accepting,
+        /// expecting, or ignoring user input after the message is delivered to the client.
+        /// One of: "acceptingInput", "ignoringInput", or "expectingInput".
+        /// Default is "acceptingInput".</param>
         /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>A message activity containing the suggested actions.</returns>
         /// <exception cref="ArgumentNullException">
@@ -112,6 +150,42 @@ namespace Microsoft.Bot.Builder
             }
 
             return SuggestedActions(cardActions, text, ssml, inputHint, toList);
+        }
+
+        /// <summary>
+        /// Returns a message that includes a set of suggested actions and optional text.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Create the activity and add suggested actions.
+        /// var activity = MessageFactory.SuggestedActions(
+        ///     new CardAction[]
+        ///     {
+        ///         new CardAction(title: "red", type: ActionTypes.ImBack, value: "red"),
+        ///         new CardAction( title: "green", type: ActionTypes.ImBack, value: "green"),
+        ///         new CardAction(title: "blue", type: ActionTypes.ImBack, value: "blue")
+        ///     }, text: "Choose a color");
+        ///
+        /// // Send the activity as a reply to the user.
+        /// await context.SendActivity(activity);
+        /// </code>
+        /// </example>
+        /// <param name="cardActions">
+        /// The card actions to include.
+        /// </param>
+        /// <param name="text">Optional, the text of the message to send.</param>
+        /// <param name="ssml">Optional, text to be spoken by your bot on a speech-enabled
+        /// channel.</param>
+        /// <param name="inputHint">Optional, indicates whether your bot is accepting,
+        /// expecting, or ignoring user input after the message is delivered to the client.
+        /// One of: "acceptingInput", "ignoringInput", or "expectingInput".
+        /// Default is "acceptingInput".</param>
+        /// <returns>A message activity that contains the suggested actions.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="cardActions"/> is <c>null</c>.</exception>
+        public static IMessageActivity SuggestedActions(IEnumerable<CardAction> cardActions, string text = null, string ssml = null, string inputHint = null)
+        {
+            return SuggestedActions(cardActions, text, ssml, inputHint, null);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/MessageFactory.cs
+++ b/libraries/Microsoft.Bot.Builder/MessageFactory.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Bot.Builder
         /// expecting, or ignoring user input after the message is delivered to the client.
         /// One of: "acceptingInput", "ignoringInput", or "expectingInput".
         /// Default is "acceptingInput".</param>
+        /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>A message activity containing the suggested actions.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="actions"/> is <c>null</c>.</exception>
@@ -92,8 +93,8 @@ namespace Microsoft.Bot.Builder
         /// <see cref="CardAction.Title"/> and sets the <see cref="CardAction.Type"/> to
         /// <see cref="Microsoft.Bot.Schema.ActionTypes.ImBack"/>.
         /// </remarks>
-        /// <seealso cref="SuggestedActions(IEnumerable{CardAction}, string, string, string)"/>
-        public static IMessageActivity SuggestedActions(IEnumerable<string> actions, string text = null, string ssml = null, string inputHint = null)
+        /// <seealso cref="SuggestedActions(IEnumerable{CardAction}, string, string, string, IList{string})"/>
+        public static IMessageActivity SuggestedActions(IEnumerable<string> actions, string text = null, string ssml = null, string inputHint = null, IList<string> toList = default)
         {
             actions = actions ?? throw new ArgumentNullException(nameof(actions));
 
@@ -110,7 +111,7 @@ namespace Microsoft.Bot.Builder
                 cardActions.Add(ca);
             }
 
-            return SuggestedActions(cardActions, text, ssml, inputHint);
+            return SuggestedActions(cardActions, text, ssml, inputHint, toList);
         }
 
         /// <summary>
@@ -141,18 +142,18 @@ namespace Microsoft.Bot.Builder
         /// expecting, or ignoring user input after the message is delivered to the client.
         /// One of: "acceptingInput", "ignoringInput", or "expectingInput".
         /// Default is "acceptingInput".</param>
+        /// <param name="toList">Optional, the list of recipients.</param>
         /// <returns>A message activity that contains the suggested actions.</returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="cardActions"/> is <c>null</c>.</exception>
-        /// <seealso cref="SuggestedActions(IEnumerable{string}, string, string, string)"/>
-        public static IMessageActivity SuggestedActions(IEnumerable<CardAction> cardActions, string text = null, string ssml = null, string inputHint = null)
+        public static IMessageActivity SuggestedActions(IEnumerable<CardAction> cardActions, string text = null, string ssml = null, string inputHint = null, IList<string> toList = default)
         {
             cardActions = cardActions ?? throw new ArgumentNullException(nameof(cardActions));
 
             var ma = Activity.CreateMessageActivity();
             SetTextAndSpeak(ma, text, ssml, inputHint);
 
-            ma.SuggestedActions = new SuggestedActions { Actions = cardActions.ToList() };
+            ma.SuggestedActions = new SuggestedActions { Actions = cardActions.ToList(), To = toList };
 
             return ma;
         }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [Fact]
         public void ShouldRenderChoicesAsSuggestedActions()
         {
-            var activity = ChoiceFactory.SuggestedAction(colorChoices, "select from:");
+            var activity = ChoiceFactory.SuggestedAction(colorChoices, "select from:", null, null);
             Assert.Equal("select from:", activity.Text);
             Assert.NotNull(activity.SuggestedActions);
             Assert.Equal(3, activity.SuggestedActions.Actions.Count);
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [Fact]
         public void ShouldAutomaticallyChooseRenderStyleBasedOnChannelType()
         {
-            var activity = ChoiceFactory.ForChannel(Channels.Emulator, colorChoices, "select from:");
+            var activity = ChoiceFactory.ForChannel(Channels.Emulator, colorChoices, "select from:", null, null);
             Assert.Equal("select from:", activity.Text);
             Assert.NotNull(activity.SuggestedActions);
             Assert.Equal(3, activity.SuggestedActions.Actions.Count);
@@ -104,7 +104,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [Fact]
         public void ShouldChooseCorrectStylesForCortana()
         {
-            var activity = ChoiceFactory.ForChannel(Channels.Cortana, colorChoices, "select from:");
+            var activity = ChoiceFactory.ForChannel(Channels.Cortana, colorChoices, "select from:", null, null);
 
             Assert.NotNull(activity.Attachments);
 
@@ -167,7 +167,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         [Fact]
         public void ShouldIncludeChoiceActionsInSuggestedActions()
         {
-            var activity = ChoiceFactory.SuggestedAction(choicesWithActions, "select from:");
+            var activity = ChoiceFactory.SuggestedAction(choicesWithActions, "select from:", null, null);
             Assert.Equal("select from:", activity.Text);
             Assert.NotNull(activity.SuggestedActions);
             Assert.Equal(3, activity.SuggestedActions.Actions.Count);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoiceFactoryTests.cs
@@ -123,9 +123,30 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
-        public void ShouldChooseCorrectStylesForTeams()
+        public void ShouldChooseCorrectStylesForTeamsPersonalChat()
         {
-            var activity = ChoiceFactory.ForChannel(Channels.Msteams, colorChoices, "select from:");
+            var recipientsList = new List<string>() { "UserId" };
+            var activity = ChoiceFactory.ForChannel(Channels.Msteams, colorChoices, "select from:", conversationType: "personal", toList: recipientsList);
+
+            Assert.Equal("select from:", activity.Text);
+            Assert.NotNull(activity.SuggestedActions);
+            Assert.Equal(3, activity.SuggestedActions.Actions.Count);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[0].Type);
+            Assert.Equal("red", activity.SuggestedActions.Actions[0].Value);
+            Assert.Equal("red", activity.SuggestedActions.Actions[0].Title);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[1].Type);
+            Assert.Equal("green", activity.SuggestedActions.Actions[1].Value);
+            Assert.Equal("green", activity.SuggestedActions.Actions[1].Title);
+            Assert.Equal(ActionTypes.ImBack, activity.SuggestedActions.Actions[2].Type);
+            Assert.Equal("blue", activity.SuggestedActions.Actions[2].Value);
+            Assert.Equal("blue", activity.SuggestedActions.Actions[2].Title);
+            Assert.Equal("UserId", activity.SuggestedActions.To[0]);
+        }
+
+        [Fact]
+        public void ShouldChooseCorrectStylesForTeamsGroupChat()
+        {
+            var activity = ChoiceFactory.ForChannel(Channels.Msteams, colorChoices, "select from:", conversationType: "groupChat");
 
             Assert.NotNull(activity.Attachments);
 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/ChoicesChannelTests.cs
@@ -76,6 +76,27 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         }
 
         [Fact]
+        public void ShouldReturnTrueForSupportsSuggestedActionsWithTeamsAndPersonalAnd3()
+        {
+            var supports = Channel.SupportsSuggestedActions(Channels.Msteams, 3, "personal");
+            Assert.True(supports);
+        }
+
+        [Fact]
+        public void ShouldReturnFalseForSupportsSuggestedActionsWithTeamsAndPersonalAnd4()
+        {
+            var supports = Channel.SupportsSuggestedActions(Channels.Msteams, 4, "personal");
+            Assert.False(supports);
+        }
+
+        [Fact]
+        public void ShouldReturnFalseForSupportsSuggestedActionsWithTeamsAndGroupChat()
+        {
+            var supports = Channel.SupportsSuggestedActions(Channels.Msteams, 3, "groupChat");
+            Assert.False(supports);
+        }
+
+        [Fact]
         public void ShouldReturnTrueForSupportsCardActionsWithDirectLineSpeechAnd99()
         {
             var supports = Channel.SupportsCardActions(Channels.DirectlineSpeech, 99);

--- a/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
@@ -223,13 +223,13 @@ namespace Microsoft.Bot.Builder.Tests
         [Fact]
         public void SuggestedActionsCardActionCollectionNull()
         {
-            Assert.Throws<ArgumentNullException>(() => MessageFactory.SuggestedActions((IEnumerable<CardAction>)null));
+            Assert.Throws<ArgumentNullException>(() => MessageFactory.SuggestedActions((IEnumerable<CardAction>)null, null, null, null));
         }
 
         [Fact]
         public void SuggestedActionsStringCollectionNull()
         {
-            Assert.Throws<ArgumentNullException>(() => MessageFactory.SuggestedActions((IEnumerable<string>)null));
+            Assert.Throws<ArgumentNullException>(() => MessageFactory.SuggestedActions((IEnumerable<string>)null, null, null, null));
         }
 
         [Fact]
@@ -432,7 +432,9 @@ namespace Microsoft.Bot.Builder.Tests
                         {
                             new CardAction(type: "imBack", text: "red", title: "redTitle"),
                         },
-                        inputText);
+                        inputText,
+                        null,
+                        null);
 
                     await ctx.SendActivityAsync((Activity)activity);
                 }


### PR DESCRIPTION
Fixes #6086

## Description
This PR enables Suggested Actions for _MSTeams_ in Dialogs Prompts and Adaptive Dialogs Inputs.

## Specific Changes
  - Updated **_ChoiceInput_** , **_ConfirmInput_** , **_ChoicePrompt_**, and **_ConfirmPrompt_** classes to pass to the  _AppendChoices_ method the _conversationType_ and the list of recipient's ids, necessary to send suggested actions in the _MSTeams_ channel.
  - Updated _AppendChoices_ method in **_InputDialog_** and **_Prompt_** overloading it to receive the new parameters _conversationType_ and _toList_ and pass them to the _ForChannel_ method.
  - Updated _SupportsSuggestedActions_ method in **_Channel_** class to include the MSTeams channel in the switch case.
  - Overloaded the _ForChannel_ method in **_ChoiceFactory_** and the _SuggestedActions_ method of the **_MessageFactory_** to add the new parameters _conversationType_ and _toList_.
  - Added unit tests in **_ChoiceFactoryTests_** and **_ChoiceChannelTests_** test classes.
  - Updated **_MessageFactoryTests_** to disambiguate the calls to _SuggestedActions_.

## Testing
These images show how MSTeams displays the choices in a group chat (hero card) and in a personal chat (suggested actions).
![image](https://user-images.githubusercontent.com/44245136/226939787-08e31e59-50b9-4da1-aec5-2cae85450432.png)
