### PR TITLE
USER scope variable values do not transfer to skill when SSO is configured

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperties.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Dialogs.Memory;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -83,6 +84,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                 var value = propValue.Value?.EvaluateExpression(dc.State);
                 dc.State.SetValue(propValue.Property.GetValue(dc.State), value);
             }
+
+            // save all state scopes to their respective botState locations.
+            await dc.Context.TurnState.Get<DialogStateManager>().SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
 
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/SetProperty.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Dialogs.Memory;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -87,6 +88,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             var value = Value?.EvaluateExpression(dc.State);
 
             dc.State.SetValue(this.Property.GetValue(dc.State), value);
+
+            // save all state scopes to their respective botState locations.
+            await dc.Context.TurnState.Get<DialogStateManager>().SaveAllChangesAsync(cancellationToken).ConfigureAwait(false);
 
             return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
#minor

## Description
This PR updates the **_SetProperty_** and **_SetProperties_** actions to save the state after setting the properties to avoid user scope properties losing their value.

Related Composer issue [#9533](https://github.com/microsoft/BotFramework-Composer/issues/9533)

## Specific Changes
  - Added a call to [DialogStateManager's SaveAllChanges](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs/Memory/DialogStateManager.cs#L426) method after setting the property value in **_SetProperty_** and **_SetProperties_** adaptive actions.

## Testing
These images show the User scope variable keeping its value after performing a token exchange operation.
![image](https://user-images.githubusercontent.com/44245136/229220656-ea560e87-ccf1-4cb2-a3de-05123759e787.png)