### PR TITLE
Support MeetingTabIconSurface in Meeting Notification API

### DIFF
--- a/libraries/Microsoft.Bot.Schema/Converters/SurfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Schema/Converters/SurfaceConverter.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Bot.Schema.Converters
                     var contentType = jsonObject.GetValue("contentType", StringComparison.OrdinalIgnoreCase)?.ToObject<ContentType>();
                     parsedSurface = CreateMeetingStageSurfaceWithContentType(contentType);
                     break;
+                case SurfaceType.MeetingTabIcon:
+                    parsedSurface = new MeetingTabIconSurface();
+                    break;
                 default:
                     throw new ArgumentException($"Invalid surface type: {surfaceType}");
             }

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingTabIconSurface.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingTabIconSurface.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Bot.Schema.Teams
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Specifies meeting stage surface.
+    /// Specifies meeting tab icon surface.
     /// </summary>
     public class MeetingTabIconSurface : Surface
     {
@@ -19,7 +19,7 @@ namespace Microsoft.Bot.Schema.Teams
         }
 
         /// <summary>
-        /// Gets or sets the tab entity Id of this <see cref="MeetingTabIconSurface"/>.
+        /// Gets or sets optional field tab entity Id of this <see cref="MeetingTabIconSurface"/>.
         /// </summary>
         /// <value>
         /// The tab entity Id of this <see cref="MeetingTabIconSurface"/>.

--- a/libraries/Microsoft.Bot.Schema/Teams/MeetingTabIconSurface.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/MeetingTabIconSurface.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Specifies meeting stage surface.
+    /// </summary>
+    public class MeetingTabIconSurface : Surface
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeetingTabIconSurface"/> class.
+        /// </summary>
+        public MeetingTabIconSurface()
+            : base(SurfaceType.MeetingTabIcon)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the tab entity Id of this <see cref="MeetingTabIconSurface"/>.
+        /// </summary>
+        /// <value>
+        /// The tab entity Id of this <see cref="MeetingTabIconSurface"/>.
+        /// </value>
+        [JsonProperty("tabEntityId")]
+        public string TabEntityId { get; set; }
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/SurfaceType.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/SurfaceType.cs
@@ -17,5 +17,10 @@ namespace Microsoft.Bot.Schema.Teams
         /// TeamsSurfaceType is MeetingStage.
         /// </summary>
         MeetingStage,
+
+        /// <summary>
+        /// TeamsSurfaceType is MeetingTabIcon.
+        /// </summary>
+        MeetingTabIcon
     }
 }

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs
@@ -525,7 +525,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     recipients.Add("failingid");
                 }
 
-                var surface = new MeetingStageSurface<TaskModuleContinueResponse>
+                var meetingStageSurface = new MeetingStageSurface<TaskModuleContinueResponse>
                 {
                     Content = new TaskModuleContinueResponse
                     {
@@ -539,10 +539,15 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                     ContentType = ContentType.Task
                 };
 
+                var meetingTabIconSurface = new MeetingTabIconSurface
+                {
+                    TabEntityId = "test tab entity id"
+                };
+
                 var value = new TargetedMeetingNotificationValue
                 {
                     Recipients = recipients,
-                    Surfaces = new[] { surface }
+                    Surfaces = new List<Surface> { meetingStageSurface, meetingTabIconSurface }
                 };
 
                 var obo = new OnBehalfOf


### PR DESCRIPTION
Fixes #6622

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Support MeetingTabIconSurface in Meeting Notification API

## Specific Changes
  - Support MeetingTabIconSurface 
  - Update surface converter with MeetingTabIconSurface
  - Update unit test

## Testing
Updated unit test TestSendMeetingNotificationAsync with an additional surface that surface type is MeetingTabIcon