### PR TITLE
Add support for Teams Adaptive cards in QnA Dialog

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -629,7 +629,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             var response = (List<QueryResult>)stepContext.Result;
             if (response.Count > 0 && response[0].Id != -1)
             {
-                var message = QnACardBuilder.GetQnADefaultResponse(response.First(), dialogOptions.ResponseOptions.DisplayPreciseAnswerOnly);
+                var message = QnACardBuilder.GetQnADefaultResponse(response.First(), dialogOptions.ResponseOptions.DisplayPreciseAnswerOnly, UseTeamsAdaptiveCard);
                 await stepContext.Context.SendActivityAsync(message).ConfigureAwait(false);
             }
             else
@@ -644,7 +644,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                     if (response.Count == 1 && response[0].Id == -1)
                     {
                         // Nomatch Response from service.
-                        var message = QnACardBuilder.GetQnADefaultResponse(response.First(), dialogOptions.ResponseOptions.DisplayPreciseAnswerOnly);
+                        var message = QnACardBuilder.GetQnADefaultResponse(response.First(), dialogOptions.ResponseOptions.DisplayPreciseAnswerOnly, UseTeamsAdaptiveCard);
                         await stepContext.Context.SendActivityAsync(message).ConfigureAwait(false);
                     }
                     else
@@ -854,7 +854,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                     ObjectPath.SetPathValue(stepContext.ActiveDialog.State, Options, dialogOptions);
 
                     // Get multi-turn prompts card activity.
-                    var message = QnACardBuilder.GetQnADefaultResponse(answer, dialogOptions.ResponseOptions.DisplayPreciseAnswerOnly);
+                    var message = QnACardBuilder.GetQnADefaultResponse(answer, dialogOptions.ResponseOptions.DisplayPreciseAnswerOnly, UseTeamsAdaptiveCard);
                     await stepContext.Context.SendActivityAsync(message).ConfigureAwait(false);
 
                     return new DialogTurnResult(DialogTurnStatus.Waiting);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// of the source file that contains the caller.</param>
         /// <param name="sourceLineNumber">The line number, for debugging. Defaults to the line number
         /// in the source file at which the method is called.</param>
-        /// <param name="useTeamsAdaptiveCard"> Boolean value to determine whether an Adaptive card formatted for Teams should be used for responses </param>
+        /// <param name="useTeamsAdaptiveCard"> Boolean value to determine whether an Adaptive card formatted for Teams should be used for responses.</param>
         public QnAMakerDialog(
             string dialogId,
             string knowledgeBaseId,
@@ -172,7 +172,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// of the source file that contains the caller.</param>
         /// <param name="sourceLineNumber">The line number, for debugging. Defaults to the line number
         /// in the source file at which the method is called.</param>
-        /// <param name="useTeamsAdaptiveCard"> Boolean value to determine whether an Adaptive card formatted for Teams should be used for responses </param>
+        /// <param name="useTeamsAdaptiveCard"> Boolean value to determine whether an Adaptive card formatted for Teams should be used for responses.</param>
         public QnAMakerDialog(
             string knowledgeBaseId,
             string endpointKey,

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// of the source file that contains the caller.</param>
         /// <param name="sourceLineNumber">The line number, for debugging. Defaults to the line number
         /// in the source file at which the method is called.</param>
+        /// <param name="useTeamsAdaptiveCard"> Boolean value to determine whether an Adaptive card formatted for Teams should be used for responses </param>
         public QnAMakerDialog(
             string dialogId,
             string knowledgeBaseId,
@@ -118,7 +119,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             ServiceType qnAServiceType = ServiceType.QnAMaker,
             HttpClient httpClient = null,
             [CallerFilePath] string sourceFilePath = "",
-            [CallerLineNumber] int sourceLineNumber = 0)
+            [CallerLineNumber] int sourceLineNumber = 0,
+            bool useTeamsAdaptiveCard = false)
             : base(dialogId)
         {
             this.RegisterSourceLocation(sourceFilePath, sourceLineNumber);
@@ -135,6 +137,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             Filters = filters;
             QnAServiceType = qnAServiceType;
             this.HttpClient = httpClient;
+            this.UseTeamsAdaptiveCard = useTeamsAdaptiveCard;
 
             // add waterfall steps
             this.AddStep(CallGenerateAnswerAsync);
@@ -169,6 +172,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// of the source file that contains the caller.</param>
         /// <param name="sourceLineNumber">The line number, for debugging. Defaults to the line number
         /// in the source file at which the method is called.</param>
+        /// <param name="useTeamsAdaptiveCard"> Boolean value to determine whether an Adaptive card formatted for Teams should be used for responses </param>
         public QnAMakerDialog(
             string knowledgeBaseId,
             string endpointKey,
@@ -184,7 +188,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             ServiceType qnAServiceType = ServiceType.QnAMaker,
             HttpClient httpClient = null,
             [CallerFilePath] string sourceFilePath = "",
-            [CallerLineNumber] int sourceLineNumber = 0)
+            [CallerLineNumber] int sourceLineNumber = 0,
+            bool useTeamsAdaptiveCard = false)
             : this(
                 nameof(QnAMakerDialog),
                 knowledgeBaseId,
@@ -201,7 +206,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 qnAServiceType,
                 httpClient,
                 sourceFilePath,
-                sourceLineNumber)
+                sourceLineNumber,
+                useTeamsAdaptiveCard)
         {
         }
 
@@ -394,6 +400,15 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// </value>
         [JsonProperty("displayPreciseAnswerOnly")]
         public BoolExpression DisplayPreciseAnswerOnly { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the dialog response should use a MS Teams formatted Adaptive Card instead of a Hero Card.
+        /// </summary>
+        /// <value>
+        /// True/False, defaults to False.
+        /// </value>
+        [JsonProperty("useTeamsAdaptiveCard")]
+        public BoolExpression UseTeamsAdaptiveCard { get; set; } = false;
 
         /// <summary>
         /// Gets or sets QnA Service type to query either QnAMaker or Custom Question Answering Knowledge Base.

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
@@ -158,40 +158,47 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <returns>Attachment.</returns>
         private static Attachment GetAdaptiveCardAttachment(string cardText, List<CardAction> buttonList)
         {
+            // Create a list of buttons. Each button is represented by a Dictionary containing the required adaptive card fields
             var cardButtons = new List<Dictionary<string, object>>();
 
             if (buttonList != null)
             {
                 foreach (var button in buttonList)
                 {
+                    // Create the initial dictionary
                     var adaptiveAction = new Dictionary<string, object>
-                {
-                    { "type", "Action.Submit" },
-                    { "title", button.Title }
-                };
+                    {
+                        { "type", "Action.Submit" },
+                        { "title", button.Title }
+                    };
 
                     // Create the "data" Dictionary, and add to it a Dictionary representing the "msteams" object
                     var data = new Dictionary<string, object>
-                {
                     {
-                        "msteams",
-                        new Dictionary<string, object>
                         {
-                            { "type", "messageBack" },
-                            { "displayText", button.DisplayText },
-                            { "text", button.Text },
-                            { "value", button.Value },
-                            { "width", "full" }
+                            "msteams",
+                            new Dictionary<string, object>
+                            {
+                                { "type", "messageBack" },
+                                { "displayText", button.DisplayText },
+                                { "text", button.Text },
+                                { "value", button.Value },
+                                { "width", "full" }
+                            }
                         }
-                    }
-                };
+                    };
 
+                    // Add the data dictionary to the cardAction
                     adaptiveAction.Add("data", data);
 
+                    // Add to the list of buttons
                     cardButtons.Add(adaptiveAction);
                 }
             }
 
+            // Create a dictionary to represent the completed Adaptive card
+            // msteams field is also a dictionary
+            // body field is an array containing a dictionary
             var card = new Dictionary<string, object>
             {
                 { "$schema", "http://adaptivecards.io/schemas/adaptive-card.json" },
@@ -212,17 +219,19 @@ namespace Microsoft.Bot.Builder.AI.QnA
                         new Dictionary<string, string>
                         {
                             { "type", "TextBlock" },
-                            { "text", cardText }
+                            { "text", (!string.IsNullOrWhiteSpace(cardText) ? cardText : string.Empty) }
                         }
                     }
                 }
             };
 
+            // If there are buttons, add the buttons to the card as an array
             if (buttonList != null)
             {
                 card.Add("actions", cardButtons.ToArray());
             }
 
+            // Create and return the card as an attachment
             Attachment adaptiveCard = new Attachment()
             {
                 ContentType = "application/vnd.microsoft.card.adaptive",
@@ -240,6 +249,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <returns>Attachment.</returns>
         private static Attachment GetHeroCardAttachment(string cardText, List<CardAction> buttonList) 
         {
+            // Create a new hero card, add the text and buttons if they exist
             var card = new HeroCard();
 
             if (buttonList != null) 
@@ -252,6 +262,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 card.Text = cardText;
             }
 
+            // Return the card as an attachment
             return card.ToAttachment();
         }
     }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/QnACardBuilder.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
             if (buttonList != null || !string.IsNullOrWhiteSpace(cardText))
             {
-                bool useAdaptive = useTeamsAdaptiveCard == null ? false : useTeamsAdaptiveCard.Value;
+                var useAdaptive = useTeamsAdaptiveCard == null ? false : useTeamsAdaptiveCard.Value;
                 var cardAttachment = useAdaptive ? CreateAdaptiveCardAttachment(cardText, buttonList) : CreateHeroCardAttachment(cardText, buttonList);
 
                 chatActivity.Attachments.Add(cardAttachment);
@@ -153,35 +153,35 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// <summary>
         /// Get a Teams-formatted Adaptive Card as Attachment to be returned in the QnA response. Max width and height of response are controlled by Teams.
         /// </summary>
-        /// <param name="cardText">string of text to be added to the card.</param>
+        /// <param name="cardText">String of text to be added to the card.</param>
         /// <param name="buttonList">List of CardAction representing buttons to be added to the card.</param>
         /// <returns>Attachment.</returns>
         private static Attachment CreateAdaptiveCardAttachment(string cardText, List<CardAction> buttonList)
         {
             // If there are buttons, create an array of buttons for the card.
             // Each button is represented by a Dictionary containing the required fields for each button.
-            var cardButtons = buttonList != null ? buttonList.Select(button =>
-            new Dictionary<string, object> 
-            {
-                { "type", "Action.Submit" },
-                { "title", button.Title },
-                { 
-                    "data",
-                    new Dictionary<string, object>
-                    {
+            var cardButtons = buttonList?.Select(button =>
+                new Dictionary<string, object> 
+                {
+                    { "type", "Action.Submit" },
+                    { "title", button.Title },
+                    { 
+                        "data",
+                        new Dictionary<string, object>
                         {
-                            "msteams",
-                            new Dictionary<string, object>
                             {
-                                { "type", "messageBack" },
-                                { "displayText", button.DisplayText },
-                                { "text", button.Text },
-                                { "value", button.Value }
+                                "msteams",
+                                new Dictionary<string, object>
+                                {
+                                    { "type", "messageBack" },
+                                    { "displayText", button.DisplayText },
+                                    { "text", button.Text },
+                                    { "value", button.Value }
+                                }
                             }
-                        }
-                    } 
-                }
-            }).ToArray() : null;
+                        } 
+                    }
+                }).ToArray();
 
             // Create a dictionary to represent the completed Adaptive card
             // msteams field is also a dictionary
@@ -219,7 +219,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             }
 
             // Create and return the card as an attachment
-            Attachment adaptiveCard = new Attachment()
+            var adaptiveCard = new Attachment()
             {
                 ContentType = "application/vnd.microsoft.card.adaptive",
                 Content = card

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -190,6 +190,145 @@ namespace Microsoft.Bot.Builder.AI.Tests
         }
 
         /// <summary>
+        /// The QnAMakerAction_ActiveLearningDialogBase_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="AdaptiveDialog"/>.</returns>
+        public AdaptiveDialog QnAMakerAction_ActiveLearningDialogBase_AdaptiveCard()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+            mockHttp.When(HttpMethod.Post, GetTrainRequestUrl())
+                .Respond(HttpStatusCode.NoContent, "application/json", "{ }");
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Q12\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":30.0,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
+               .Respond("application/json", GetResponse("QnaMaker_ReturnsAnswer_WhenNoAnswerFoundInKb.json"));
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Q11\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":30.0,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
+               .Respond("application/json", GetResponse("QnaMaker_TopNAnswer.json"));
+            return CreateQnAMakerActionDialog_AdaptiveCard(mockHttp);
+        }
+
+        /// <summary>
+        /// The QnAMakerAction_ActiveLearningDialog_WithProperResponse_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Fact]
+        public async Task QnAMakerAction_ActiveLearningDialog_WithProperResponse_AdaptiveCard()
+        {
+            var rootDialog = QnAMakerAction_ActiveLearningDialogBase_AdaptiveCard();
+
+            var suggestionList = new List<string> { "Q1", "Q2", "Q3" };
+            var suggestionActivity = QnACardBuilder.GetSuggestionsCard(suggestionList, "Did you mean:", "None of the above.");
+            var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
+
+            await CreateFlow(rootDialog, "QnAMakerAction_ActiveLearningDialog_WithProperResponse")
+            .Send("Q11")
+                .AssertReply(suggestionActivity, equalityComparer: qnAMakerCardEqualityComparer)
+            .Send("Q1")
+                .AssertReply("A1")
+            .StartTestAsync();
+        }
+
+        /// <summary>
+        /// The QnAMakerAction_ActiveLearningDialog_WithNoResponse_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Fact]
+        public async Task QnAMakerAction_ActiveLearningDialog_WithNoResponse_AdaptiveCard()
+        {
+            var rootDialog = QnAMakerAction_ActiveLearningDialogBase_AdaptiveCard();
+
+            const string noAnswerActivity = "No match found, please ask another question.";
+
+            var suggestionList = new List<string> { "Q1", "Q2", "Q3" };
+            var suggestionActivity = QnACardBuilder.GetSuggestionsCard(suggestionList, "Did you mean:", "None of the above.");
+            var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
+
+            await CreateFlow(rootDialog, "QnAMakerAction_ActiveLearningDialog_WithNoResponse")
+            .Send("Q11")
+                .AssertReply(suggestionActivity, equalityComparer: qnAMakerCardEqualityComparer)
+            .Send("Q12")
+                .AssertReply(noAnswerActivity)
+            .StartTestAsync();
+        }
+
+        /// <summary>
+        /// The QnAMakerAction_ActiveLearningDialog_WithNoneOfAboveQuery_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Fact]
+        public async Task QnAMakerAction_ActiveLearningDialog_WithNoneOfAboveQuery_AdaptiveCard()
+        {
+            var rootDialog = QnAMakerAction_ActiveLearningDialogBase_AdaptiveCard();
+
+            var suggestionList = new List<string> { "Q1", "Q2", "Q3" };
+            var suggestionActivity = QnACardBuilder.GetSuggestionsCard(suggestionList, "Did you mean:", "None of the above.");
+            var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
+
+            await CreateFlow(rootDialog, "QnAMakerAction_ActiveLearningDialog_WithNoneOfAboveQuery")
+            .Send("Q11")
+                .AssertReply(suggestionActivity, equalityComparer: qnAMakerCardEqualityComparer)
+            .Send("None of the above.")
+                .AssertReply("Thanks for the feedback.")
+            .StartTestAsync();
+        }
+
+        /// <summary>
+        /// The QnAMakerAction_MultiTurnDialogBase_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="AdaptiveDialog"/>.</returns>
+        public AdaptiveDialog QnAMakerAction_MultiTurnDialogBase_AdaptiveCard()
+        {
+            var mockHttp = new MockHttpMessageHandler();
+
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"I have issues related to KB\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":30.0,\"context\":{\"previousQnAId\":0,\"previousUserQuery\":\"\"},\"qnaId\":0,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
+                .Respond("application/json", GetResponse("QnaMaker_ReturnAnswer_withPrompts.json"));
+            mockHttp.When(HttpMethod.Post, GetRequestUrl()).WithContent("{\"question\":\"Accidently deleted KB\",\"top\":3,\"strictFilters\":[],\"scoreThreshold\":30.0,\"context\":{\"previousQnAId\":27,\"previousUserQuery\":\"\"},\"qnaId\":1,\"isTest\":false,\"rankerType\":\"Default\",\"StrictFiltersCompoundOperationType\":0}")
+                .Respond("application/json", GetResponse("QnaMaker_ReturnAnswer_MultiTurnLevel1.json"));
+
+            return CreateQnAMakerActionDialog_AdaptiveCard(mockHttp);
+        }
+
+        /// <summary>
+        /// The QnAMakerAction_MultiTurnDialogBase_WithAnswer_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Fact]
+        public async Task QnAMakerAction_MultiTurnDialogBase_WithAnswer_AdaptiveCard()
+        {
+            var rootDialog = QnAMakerAction_MultiTurnDialogBase_AdaptiveCard();
+
+            var response = JsonConvert.DeserializeObject<QueryResults>(File.ReadAllText(GetFilePath("QnaMaker_ReturnAnswer_withPrompts.json")));
+            var promptsActivity = QnACardBuilder.GetQnAPromptsCard(response.Answers[0]);
+            var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
+
+            await CreateFlow(rootDialog, nameof(QnAMakerAction_MultiTurnDialogBase_WithAnswer_AdaptiveCard))
+            .Send("I have issues related to KB")
+                .AssertReply(promptsActivity, equalityComparer: qnAMakerCardEqualityComparer)
+            .Send("Accidently deleted KB")
+                .AssertReply("All deletes are permanent, including question and answer pairs, files, URLs, custom questions and answers, knowledge bases, or Azure resources. Make sure you export your knowledge base from the Settings**page before deleting any part of your knowledge base.")
+            .StartTestAsync();
+        }
+
+        /// <summary>
+        /// The QnAMakerAction_MultiTurnDialogBase_WithNoAnswer_AdaptiveCard. Tests QnAMakerDialog with Adaptive Cards.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        [Fact]
+        public async Task QnAMakerAction_MultiTurnDialogBase_WithNoAnswer_AdaptiveCard()
+        {
+            var rootDialog = QnAMakerAction_MultiTurnDialogBase_AdaptiveCard();
+
+            var response = JsonConvert.DeserializeObject<QueryResults>(File.ReadAllText(GetFilePath("QnaMaker_ReturnAnswer_withPrompts.json")));
+            var promptsActivity = QnACardBuilder.GetQnAPromptsCard(response.Answers[0]);
+            var qnAMakerCardEqualityComparer = new QnAMakerCardEqualityComparer();
+
+            await CreateFlow(rootDialog, nameof(QnAMakerAction_MultiTurnDialogBase_WithNoAnswer_AdaptiveCard))
+            .Send("I have issues related to KB")
+                .AssertReply(promptsActivity, equalityComparer: qnAMakerCardEqualityComparer)
+            .Send("None of the above.")
+                .AssertReply("Thanks for the feedback.")
+            .StartTestAsync();
+        }
+
+        /// <summary>
         /// The QnaMaker_TraceActivity.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>
@@ -1940,6 +2079,72 @@ namespace Microsoft.Bot.Builder.AI.Tests
                                 NoAnswer = noAnswerActivity,
                                 ActiveLearningCardTitle = activeLearningCardTitle,
                                 CardNoMatchText = "None of the above.",
+                            }
+                        }
+                    }
+                }
+            };
+
+            var rootDialog = new AdaptiveDialog("root")
+            {
+                Triggers = new List<OnCondition>
+                {
+                    new OnBeginDialog
+                    {
+                        Actions = new List<Dialog>
+                        {
+                            new BeginDialog(outerDialog.Id)
+                        }
+                    },
+                    new OnDialogEvent
+                    {
+                        Event = "UnhandledUnknownIntent",
+                        Actions = new List<Dialog>
+                        {
+                            new EditArray(),
+                            new SendActivity("magenta")
+                        }
+                    }
+                }
+            };
+            rootDialog.Dialogs.Add(outerDialog);
+            return rootDialog;
+        }
+
+        /// <summary>
+        /// The CreateQnAMakerActionDialog_AdaptiveCard. Tests Adaptive Cards in QnAMakerDialog. 
+        /// </summary>
+        /// <param name="mockHttp">The mockHttp<see cref="MockHttpMessageHandler"/>.</param>
+        /// <returns>The <see cref="AdaptiveDialog"/>.</returns>
+        private AdaptiveDialog CreateQnAMakerActionDialog_AdaptiveCard(MockHttpMessageHandler mockHttp)
+        {
+            var client = new HttpClient(mockHttp);
+
+            var noAnswerActivity = new ActivityTemplate("No match found, please ask another question.");
+            const string host = "https://dummy-hostname.azurewebsites.net/qnamaker";
+            const string knowledgeBaseId = "dummy-id";
+            const string endpointKey = "dummy-key";
+            const string activeLearningCardTitle = "QnAMaker Active Learning";
+
+            var outerDialog = new AdaptiveDialog("outer")
+            {
+                AutoEndDialog = false,
+                Triggers = new List<OnCondition>
+                {
+                    new OnBeginDialog
+                    {
+                        Actions = new List<Dialog>
+                        {
+                            new QnAMakerDialog
+                            {
+                                KnowledgeBaseId = knowledgeBaseId,
+                                HostName = host,
+                                EndpointKey = endpointKey,
+                                HttpClient = client,
+                                NoAnswer = noAnswerActivity,
+                                ActiveLearningCardTitle = activeLearningCardTitle,
+                                CardNoMatchText = "None of the above.",
+                                UseTeamsAdaptiveCard = true
                             }
                         }
                     }


### PR DESCRIPTION
Fixes Internal IcM Issue #373550043
Port of changes from https://github.com/microsoft/botbuilder-js/pull/4467
Fixes #6630 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR allows for choosing Adaptive Cards formatted for use in Microsoft Teams instead of the default Hero Cards. This is done to support markdown formatting in QnA and CQA responses since Teams only supports markdown in Adaptive Cards. Changes are made in `QnACardBuilder.cs` and `QnAMakerDialog.cs`.

Using the new cards simple requires adding code in the bot to take in a new environment variable: UseTeamsAdaptiveCard = "true" and pass it to the QnA dialog constructor. If no changes are made, the bot will default to a Hero card.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

- Create new methods to generate adaptive and hero cards
- Modify the card builder class to take in a new bool field to allow for choosing whether or not to use an adaptive card
- Modify the dialog class to accept the aforementioned bool field and pass it to the card builder.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Tests tun successfully.
![Screenshot 2023-04-27 114013](https://user-images.githubusercontent.com/33945547/234968961-007afb4f-8a68-46d7-a8e4-9152f284bd7f.png)
