### PR TITLE
[#5577] BotFrameworkClientImpl.PostActivityAsync() doesn't support null fromBotId and toBotId values

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/BotFrameworkClientImpl.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Bot.Connector.Authentication
 
         public async override Task<InvokeResponse<T>> PostActivityAsync<T>(string fromBotId, string toBotId, Uri toUrl, Uri serviceUrl, string conversationId, Activity activity, CancellationToken cancellationToken = default)
         {
-            _ = fromBotId ?? throw new ArgumentNullException(nameof(fromBotId));
-            _ = toBotId ?? throw new ArgumentNullException(nameof(toBotId));
+            fromBotId = fromBotId ?? string.Empty;
+            toBotId = toBotId ?? string.Empty;
             _ = toUrl ?? throw new ArgumentNullException(nameof(toUrl));
             _ = serviceUrl ?? throw new ArgumentNullException(nameof(serviceUrl));
             _ = conversationId ?? throw new ArgumentNullException(nameof(conversationId));


### PR DESCRIPTION
Fixes #5577

## Description
This PR updates the _PostActivityAsync_ method in _BotFrameworkClientImpl_ to allow using null values for _fromBotId_ and _toBotId_ arguments. This will avoid failures when anonymous skill bots don't have the _AppId_ property in their settings.

## Specific Changes
  - Replaced the throw errors by the assignation of an empty string as the default value in the method _PostActivityAsync_ in _BotFrameworkClientImpl_.

## Testing
The following images show Composer and SDK bots working with anonymous skills.
![image](https://user-images.githubusercontent.com/122501764/234941793-a2688483-3e7b-49e9-89ed-c9b9773d7048.png)
