### PR TITLE
[#6624] port: [#4452][#4456][#4460][botframework-streaming] Should reject pending requests on disconnection

### DIFF
--- a/libraries/Microsoft.Bot.Streaming/Payloads/RequestManager.cs
+++ b/libraries/Microsoft.Bot.Streaming/Payloads/RequestManager.cs
@@ -77,5 +77,19 @@ namespace Microsoft.Bot.Streaming.Payloads
                 _responseTasks.TryRemove(requestId, out responseTask);
             }
         }
+
+        /// <summary>
+        /// Rejects all requests pending a response.
+        /// </summary>
+        /// <param name="reason">The reason for rejection.</param>
+        public void RejectAllResponses(Exception reason = null)
+        {
+            foreach (var responseTask in _responseTasks)
+            {
+                responseTask.Value.TrySetException(reason);
+            }
+
+            _responseTasks.Clear();
+        }
     }
 }

--- a/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketClient.cs
+++ b/libraries/Microsoft.Bot.Streaming/Transport/WebSocket/WebSocketClient.cs
@@ -243,6 +243,9 @@ namespace Microsoft.Bot.Streaming.Transport.WebSockets
 
         private void OnConnectionDisconnected(object sender, EventArgs e)
         {
+            // Rejects all pending requests on disconnect.
+            _requestManager.RejectAllResponses(new Exception("Disconnect was called."));
+
             if (!_isDisconnecting)
             {
                 _isDisconnecting = true;

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/RequestManagerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/RequestManagerTests.cs
@@ -210,5 +210,23 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
                 }
             });
         }
+
+        [Fact]
+        public void RequestManager_RejectAllResponses_RejectsAllRequests()
+        {
+            var exception = new Exception("Disconnected");
+            var task1 = new TaskCompletionSource<ReceiveResponse>();
+            var task2 = new TaskCompletionSource<ReceiveResponse>();
+            var d = new ConcurrentDictionary<Guid, TaskCompletionSource<ReceiveResponse>>();
+            d.TryAdd(Guid.NewGuid(), task1);
+            d.TryAdd(Guid.NewGuid(), task2);
+            var rm = new RequestManager(d);
+
+            rm.RejectAllResponses(exception);
+
+            Assert.Equal(exception, task1.Task.Exception.InnerException);
+            Assert.Equal(exception, task2.Task.Exception.InnerException);
+            Assert.Empty(d);
+        }
     }
 }

--- a/tests/Microsoft.Bot.Streaming.Tests/Utilities/FauxSock.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Utilities/FauxSock.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Streaming.Tests.Utilities
+{
+    public class FauxSock : WebSocket
+    {
+        public ArraySegment<byte> SentArray { get; set; }
+
+        public ArraySegment<byte> ReceivedArray { get; set; }
+
+        public WebSocketState RealState { get; set; }
+
+        public override WebSocketCloseStatus? CloseStatus => throw new NotImplementedException();
+
+        public override string CloseStatusDescription => throw new NotImplementedException();
+
+        public override WebSocketState State { get => RealState; }
+
+        public override string SubProtocol => throw new NotImplementedException();
+
+        public override void Abort()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            RealState = WebSocketState.Closed;
+
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Dispose()
+        {
+            RealState = WebSocketState.Closed;
+
+            return;
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            ReceivedArray = buffer;
+
+            return new WebSocketReceiveResult(buffer.Count, WebSocketMessageType.Close, true);
+        }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            SentArray = buffer;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Streaming.Tests/WebSocketClientServerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/WebSocketClientServerTests.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Streaming.Payloads;
+using Microsoft.Bot.Streaming.Tests.Utilities;
+using Microsoft.Bot.Streaming.Transport.WebSockets;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Streaming.UnitTests
+{
+    public class WebSocketClientServerTests
+    {
+        [Fact]
+        public async Task WebSocketServer_Connects()
+        {
+            // Arrange
+            var requestHandlerMock = new Mock<RequestHandler>();
+            requestHandlerMock.Setup(
+                rh => rh.ProcessRequestAsync(It.IsAny<ReceiveRequest>(), It.IsAny<ILogger<RequestHandler>>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new StreamingResponse { StatusCode = 200 });
+
+            // TaskCompletionSource will complete when the first receive is executed and this must happen AFTER the IsConnected state is set
+            var sock = new FauxSocketTaskCompletionSource();
+
+            // Set the faux-socket state because otherwise the background task might check it and disconnected before this test completes
+            sock.RealState = WebSocketState.Open;
+
+            var writer = new WebSocketServer(sock, requestHandlerMock.Object);
+
+            // Act
+
+            var task = writer.StartAsync();
+
+            // wait for a socket receive to actually happen to eliminate a race
+            await sock.TaskCompletionSource.Task;
+
+            // now check the connected state
+            bool isConnectedAfterStart = writer.IsConnected;
+
+            // we should be able to safely wait for the Start to complete now
+            await task;
+
+            // disconnect will stop the receive loop
+            writer.Disconnect();
+
+            // now check the connected state
+            bool isConnectedAfterDisconnect = writer.IsConnected;
+
+            // Assert
+            Assert.True(isConnectedAfterStart);
+            Assert.False(isConnectedAfterDisconnect);
+        }
+
+        [Fact]
+        public void WebSocketServer_ctor_With_No_Socket()
+        {
+            var requestHandlerMock = new Mock<RequestHandler>();
+
+            Assert.Throws<ArgumentNullException>(() => new WebSocketServer(null, requestHandlerMock.Object));
+        }
+
+        [Fact]
+        public void WebSocketServer_ctor_With_No_RequestHandler()
+        {
+            var requestHandlerMock = new Mock<RequestHandler>();
+            var socketMock = new Mock<WebSocket>();
+
+            Assert.Throws<ArgumentNullException>(() => new WebSocketServer(socketMock.Object, null));
+        }
+
+        [Fact]
+        public async void WebSocketServer_SendAsync_With_No_Message()
+        {
+            var socketMock = new Mock<WebSocket>();
+            var requestHandlerMock = new Mock<RequestHandler>();
+            var server = new WebSocketServer(socketMock.Object, requestHandlerMock.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => server.SendAsync(null));
+        }
+
+        [Fact]
+        public async void WebSocketServer_SendAsync_With_No_Connected_Client()
+        {
+            var socketMock = new Mock<WebSocket>();
+            var requestHandlerMock = new Mock<RequestHandler>();
+            var server = new WebSocketServer(socketMock.Object, requestHandlerMock.Object);
+            var message = new StreamingRequest();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendAsync(message));
+        }
+
+        [Fact]
+        public void WebSocketClient_ThrowsOnEmptyUrl()
+        {
+            Exception result = null;
+
+            try
+            {
+                var reader = new WebSocketClient(string.Empty);
+            }
+            catch (Exception ex)
+            {
+                result = ex;
+            }
+
+            Assert.IsType<ArgumentNullException>(result);
+        }
+
+        [Fact]
+        public async void WebSocketClient_SendAsync_With_No_Message()
+        {
+            var client = new WebSocketClient("url");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SendAsync(null));
+        }
+
+        [Fact]
+        public async void WebSocketClient_SendAsync_With_No_Connected_Client()
+        {
+            var client = new WebSocketClient("url");
+            var message = new StreamingRequest();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(message));
+        }
+
+        [Fact]
+        public void WebSocketClient_AcceptsAnyUrl()
+        {
+            Exception result = null;
+            WebSocketClient reader = null;
+            try
+            {
+                var webSocketClient = new WebSocketClient("fakeurl");
+                reader = webSocketClient;
+            }
+            catch (Exception ex)
+            {
+                result = ex;
+            }
+
+            reader.Dispose();
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task WebSocketClient_ConnectThrowsIfUrlIsBad()
+        {
+            Exception result = null;
+            WebSocketClient reader = null;
+            IDictionary<string, string> fakeHeaders = new Dictionary<string, string>();
+            fakeHeaders.Add("authorization", "totally");
+            fakeHeaders.Add("channelId", "mtv");
+            try
+            {
+                var webSocketClient = new WebSocketClient("fakeurl");
+                reader = webSocketClient;
+                await reader.ConnectAsync(fakeHeaders);
+            }
+            catch (Exception ex)
+            {
+                result = ex;
+            }
+
+            reader.Dispose();
+            Assert.IsType<UriFormatException>(result);
+        }
+
+        [Fact]
+        public async Task WebSocketClient_ConnectAsyncExThrowsIfUrlIsBad()
+        {
+            WebSocketClient reader = null;
+            using var webSocketClient = new WebSocketClient("fakeurl");
+            reader = webSocketClient;
+            await Assert.ThrowsAsync<UriFormatException>(async () => await reader.ConnectAsyncEx(null, CancellationToken.None));
+        }
+
+        // This extends the basic faux socket with a TaskCompletionSource that can be used to block methods to add some synchronization to tests.
+        private class FauxSocketTaskCompletionSource : FauxSock
+        {
+            public TaskCompletionSource<string> TaskCompletionSource { get; } = new TaskCompletionSource<string>();
+
+            public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+            {
+                // indicate to the test that receive has been called - to we should now be connected
+                TaskCompletionSource.SetResult("ReceiveAsync");
+
+                // delay so we don't thrash, the header we return with End=false will cause an infinite receive loop
+                await Task.Delay(1000);
+
+                // send a valid header so we don't immediate get a deserialization exception that triggers disconnect 
+                var header = new Header() { Type = PayloadTypes.Stream, Id = Guid.NewGuid(), PayloadLength = 0, End = false };
+                var count = HeaderSerializer.Serialize(header, buffer.Array, buffer.Offset);
+                return new WebSocketReceiveResult(count, WebSocketMessageType.Binary, true);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Streaming.Tests/WebSocketTransportTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/WebSocketTransportTests.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 
-using System;
-using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Streaming.Payloads;
+using Microsoft.Bot.Streaming.Tests.Utilities;
 using Microsoft.Bot.Streaming.Transport.WebSockets;
-using Microsoft.Extensions.Logging;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Bot.Streaming.UnitTests
@@ -19,171 +13,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
     public class WebSocketTransportTests
     {
         [Fact]
-        public async Task WebSocketServer_Connects()
-        {
-            // Arrange
-            var requestHandlerMock = new Mock<RequestHandler>();
-            requestHandlerMock.Setup(
-                rh => rh.ProcessRequestAsync(It.IsAny<ReceiveRequest>(), It.IsAny<ILogger<RequestHandler>>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new StreamingResponse { StatusCode = 200 });
-
-            // TaskCompletionSource will complete when the first receive is executed and this must happen AFTER the IsConnected state is set
-            var sock = new FauxSocketTaskCompletionSource();
-
-            // Set the faux-socket state because otherwise the background task might check it and disconnected before this test completes
-            sock.RealState = WebSocketState.Open;
-
-            var writer = new WebSocketServer(sock, requestHandlerMock.Object);
-
-            // Act
-
-            var task = writer.StartAsync();
-
-            // wait for a socket receive to actually happen to eliminate a race
-            await sock.TaskCompletionSource.Task;
-
-            // now check the connected state
-            bool isConnectedAfterStart = writer.IsConnected;
-
-            // we should be able to safely wait for the Start to complete now
-            await task;
-
-            // disconnect will stop the receive loop
-            writer.Disconnect();
-
-            // now check the connected state
-            bool isConnectedAfterDisconnect = writer.IsConnected;
-
-            // Assert
-            Assert.True(isConnectedAfterStart);
-            Assert.False(isConnectedAfterDisconnect);
-        }
-
-        [Fact]
-        public void WebSocketServer_ctor_With_No_Socket()
-        {
-            var requestHandlerMock = new Mock<RequestHandler>();
-
-            Assert.Throws<ArgumentNullException>(() => new WebSocketServer(null, requestHandlerMock.Object));
-        }
-
-        [Fact]
-        public void WebSocketServer_ctor_With_No_RequestHandler()
-        {
-            var requestHandlerMock = new Mock<RequestHandler>();
-            var socketMock = new Mock<WebSocket>();
-
-            Assert.Throws<ArgumentNullException>(() => new WebSocketServer(socketMock.Object, null));
-        }
-
-        [Fact]
-        public async void WebSocketServer_SendAsync_With_No_Message()
-        {
-            var socketMock = new Mock<WebSocket>();
-            var requestHandlerMock = new Mock<RequestHandler>();
-            var server = new WebSocketServer(socketMock.Object, requestHandlerMock.Object);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => server.SendAsync(null));
-        }
-
-        [Fact]
-        public async void WebSocketServer_SendAsync_With_No_Connected_Client()
-        {
-            var socketMock = new Mock<WebSocket>();
-            var requestHandlerMock = new Mock<RequestHandler>();
-            var server = new WebSocketServer(socketMock.Object, requestHandlerMock.Object);
-            var message = new StreamingRequest();
-
-            await Assert.ThrowsAsync<InvalidOperationException>(() => server.SendAsync(message));
-        }
-
-        [Fact]
-        public async Task WebSocketClient_ThrowsOnEmptyUrl()
-        {
-            Exception result = null;
-
-            try
-            {
-                var reader = new WebSocketClient(string.Empty);
-            }
-            catch (Exception ex)
-            {
-                result = ex;
-            }
-
-            Assert.IsType<ArgumentNullException>(result);
-        }
-
-        [Fact]
-        public async void WebSocketClient_SendAsync_With_No_Message()
-        {
-            var client = new WebSocketClient("url");
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => client.SendAsync(null));
-        }
-
-        [Fact]
-        public async void WebSocketClient_SendAsync_With_No_Connected_Client()
-        {
-            var client = new WebSocketClient("url");
-            var message = new StreamingRequest();
-
-            await Assert.ThrowsAsync<InvalidOperationException>(() => client.SendAsync(message));
-        }
-
-        [Fact]
-        public async Task WebSocketClient_AcceptsAnyUrl()
-        {
-            Exception result = null;
-            WebSocketClient reader = null;
-            try
-            {
-                var webSocketClient = new WebSocketClient("fakeurl");
-                reader = webSocketClient;
-            }
-            catch (Exception ex)
-            {
-                result = ex;
-            }
-
-            reader.Dispose();
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public async Task WebSocketClient_ConnectThrowsIfUrlIsBad()
-        {
-            Exception result = null;
-            WebSocketClient reader = null;
-            IDictionary<string, string> fakeHeaders = new Dictionary<string, string>();
-            fakeHeaders.Add("authorization", "totally");
-            fakeHeaders.Add("channelId", "mtv");
-            try
-            {
-                var webSocketClient = new WebSocketClient("fakeurl");
-                reader = webSocketClient;
-                await reader.ConnectAsync(fakeHeaders);
-            }
-            catch (Exception ex)
-            {
-                result = ex;
-            }
-
-            reader.Dispose();
-            Assert.IsType<UriFormatException>(result);
-        }
-
-        [Fact]
-        public async Task WebSocketClient_ConnectAsyncExThrowsIfUrlIsBad()
-        {
-            WebSocketClient reader = null;
-            using var webSocketClient = new WebSocketClient("fakeurl");
-            reader = webSocketClient;
-            await Assert.ThrowsAsync<UriFormatException>(async () => await reader.ConnectAsyncEx(null, CancellationToken.None));
-        }
-
-        [Fact]
-        public async Task WebSocketTransport_Connects()
+        public void WebSocketTransport_Connects()
         {
             var sock = new FauxSock();
             sock.RealState = WebSocketState.Open;
@@ -196,7 +26,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async Task WebSocketTransport_SetsState()
+        public void WebSocketTransport_SetsState()
         {
             var sock = new FauxSock();
             sock.RealState = WebSocketState.Open;
@@ -239,81 +69,6 @@ namespace Microsoft.Bot.Streaming.UnitTests
 
             // Assert
             Assert.Equal(message.Length, received);
-        }
-
-        private class FauxSock : WebSocket
-        {
-            public ArraySegment<byte> SentArray { get; set; }
-
-            public ArraySegment<byte> ReceivedArray { get; set; }
-
-            public WebSocketState RealState { get; set; }
-
-            public override WebSocketCloseStatus? CloseStatus => throw new NotImplementedException();
-
-            public override string CloseStatusDescription => throw new NotImplementedException();
-
-            public override WebSocketState State { get => RealState; }
-
-            public override string SubProtocol => throw new NotImplementedException();
-
-            public override void Abort()
-            {
-                throw new NotImplementedException();
-            }
-
-            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-            {
-                RealState = WebSocketState.Closed;
-
-                return Task.CompletedTask;
-            }
-
-            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void Dispose()
-            {
-                RealState = WebSocketState.Closed;
-
-                return;
-            }
-
-            public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
-            {
-                ReceivedArray = buffer;
-
-                return new WebSocketReceiveResult(buffer.Count, WebSocketMessageType.Close, true);
-            }
-
-            public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
-            {
-                SentArray = buffer;
-
-                return Task.CompletedTask;
-            }
-        }
-
-        // This extends the basic faux socket with a TaskCompletionSource that can be used to block methods to add some synchronization to tests.
-        private class FauxSocketTaskCompletionSource : FauxSock
-        {
-            public TaskCompletionSource<string> TaskCompletionSource { get; } = new TaskCompletionSource<string>();
-
-            public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
-            {
-                // indicate to the test that receive has been called - to we should now be connected
-                TaskCompletionSource.SetResult("ReceiveAsync");
-
-                // delay so we don't thrash, the header we return with End=false will cause an infinite receive loop
-                await Task.Delay(1000);
-
-                // send a valid header so we don't immediate get a deserialization exception that triggers disconnect 
-                var header = new Header() { Type = PayloadTypes.Stream, Id = Guid.NewGuid(), PayloadLength = 0, End = false };
-                var count = HeaderSerializer.Serialize(header, buffer.Array, buffer.Offset);
-                return new WebSocketReceiveResult(count, WebSocketMessageType.Binary, true);
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #6624

## Description
This PR ports the changes from [PR#4461](https://github.com/microsoft/botbuilder-js/pull/4461) to reject all pending requests when the websocket is disconnected. 

## Specific Changes
  - Added new `RejectAllResponses` method in **_RequestManager_** class.
  - Added call to `RejectAllResponses` in _OnConnectionDisconnected_ of **_WebSocketClient_**.
  - Added a unit test to cover the new method in **_RequestManagerTests_**.
  - Refactored **_WebSocketTransportTests_** to follow the implementation in JS:
     - Move _WebSocketClient_ and _WebSocketServer_ tests to the new class **_WebSocketClientServerTests_**. 
     - Move the **_FauxSock_** class to the `Utilities` folder for reuse by the test classes.

## Testing
These images show the pending requests being rejected after the fix and the new unit tests passing.
![image](https://user-images.githubusercontent.com/44245136/235201480-263bc8da-8525-4a38-8f85-fbbb126874e0.png)

![image](https://user-images.githubusercontent.com/44245136/235201547-6527fdfa-314f-4c53-ac78-9abac1bbcf90.png)

