### PR TITLE
[#6628] port [#4449] CloudAdapter always builds Connector with MicrosoftAppCredentials (never CertificateAppCredentials) -- certificate auth flow broken

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Rest;
+
+namespace Microsoft.Bot.Connector.Authentication
+{
+    /// <summary>
+    /// A Managed Identity implementation of the <see cref="ServiceClientCredentialsFactory"/> interface.
+    /// </summary>
+    public class CertificateServiceClientCredentialsFactory : ServiceClientCredentialsFactory
+    {
+        private readonly X509Certificate2 _certificate;
+        private readonly string _appId;
+        private readonly string _tenantId;
+        private readonly HttpClient _httpClient;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CertificateServiceClientCredentialsFactory"/> class.
+        /// </summary>
+        /// <param name="certificate">The certificate to use for authentication.</param>
+        /// <param name="appId">Microsoft application Id related to the certificate.</param>
+        /// <param name="tenantId">The oauth token tenant.</param>
+        /// <param name="httpClient">A custom httpClient to use.</param>
+        /// <param name="logger">A logger instance to use.</param>
+        public CertificateServiceClientCredentialsFactory(X509Certificate2 certificate, string appId, string tenantId = null, HttpClient httpClient = null, ILogger logger = null)
+            : base()
+        {
+            if (certificate == null)
+            {
+                throw new ArgumentNullException(nameof(certificate));
+            }
+
+            if (string.IsNullOrWhiteSpace(appId))
+            {
+                throw new ArgumentNullException(nameof(appId));
+            }
+
+            _certificate = certificate;
+            _appId = appId;
+            _tenantId = tenantId;
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public override Task<bool> IsValidAppIdAsync(string appId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(appId == _appId);
+        }
+
+        /// <inheritdoc />
+        public override Task<bool> IsAuthenticationDisabledAsync(CancellationToken cancellationToken)
+        {
+            // Auth is always enabled for Certificate.
+            return Task.FromResult(false);
+        }
+
+        /// <inheritdoc />
+        public override Task<ServiceClientCredentials> CreateCredentialsAsync(
+            string appId, string audience, string loginEndpoint, bool validateAuthority, CancellationToken cancellationToken)
+        {
+            if (appId != _appId)
+            {
+                throw new InvalidOperationException("Invalid Managed ID.");
+            }
+
+            return Task.FromResult<ServiceClientCredentials>(
+                new CertificateAppCredentials(_certificate, _appId, _tenantId, _httpClient, _logger));
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Connector.Authentication
                 throw new ArgumentNullException(nameof(appId));
             }
 
-           _certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
+            _certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
             _appId = appId;
             _tenantId = tenantId;
             _httpClient = httpClient;

--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateServiceClientCredentialsFactory.cs
@@ -33,17 +33,12 @@ namespace Microsoft.Bot.Connector.Authentication
         public CertificateServiceClientCredentialsFactory(X509Certificate2 certificate, string appId, string tenantId = null, HttpClient httpClient = null, ILogger logger = null)
             : base()
         {
-            if (certificate == null)
-            {
-                throw new ArgumentNullException(nameof(certificate));
-            }
-
             if (string.IsNullOrWhiteSpace(appId))
             {
                 throw new ArgumentNullException(nameof(appId));
             }
 
-            _certificate = certificate;
+           _certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
             _appId = appId;
             _tenantId = tenantId;
             _httpClient = httpClient;

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Bot.Connector.Tests.Authentication
+{
+    public class CertificateServiceClientCredentialsFactoryTests
+    {
+        private const string TestAppId = nameof(TestAppId);
+        private const string TestTenantId = nameof(TestTenantId);
+        private const string TestAudience = nameof(TestAudience);
+        private readonly Mock<ILogger> logger = new Mock<ILogger>();
+        private readonly Mock<X509Certificate2> certificate = new Mock<X509Certificate2>();
+
+        [Fact]
+        public void ConstructorTests()
+        {
+            _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
+            _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, tenantId: TestTenantId);
+            _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, logger: logger.Object);
+            _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, httpClient: new HttpClient());
+        }
+
+        [Fact]
+        public void CannotCreateCredentialsFactoryWithoutCertificate()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CertificateServiceClientCredentialsFactory(null, TestAppId));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void CannotCreateCredentialsFactoryWithoutAppId(string appId)
+        {
+            Assert.Throws<ArgumentNullException>(() => new CertificateServiceClientCredentialsFactory(certificate.Object, appId));
+        }
+
+        [Fact]
+        public void IsValidAppIdTest()
+        {
+            var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
+
+            Assert.True(factory.IsValidAppIdAsync(TestAppId, CancellationToken.None).GetAwaiter().GetResult());
+            Assert.False(factory.IsValidAppIdAsync("InvalidAppId", CancellationToken.None).GetAwaiter().GetResult());
+        }
+
+        [Fact]
+        public void IsAuthenticationDisabledTest()
+        {
+            var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
+
+            Assert.False(factory.IsAuthenticationDisabledAsync(CancellationToken.None).GetAwaiter().GetResult());
+        }
+
+        [Fact]
+        public async void CanCreateCredentials()
+        {
+            var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
+
+            var credentials = await factory.CreateCredentialsAsync(
+                TestAppId, TestAudience, "https://login.microsoftonline.com", true, CancellationToken.None);
+
+            Assert.NotNull(credentials);
+            Assert.IsType<CertificateAppCredentials>(credentials);
+        }
+
+        [Fact]
+        public void CannotCreateCredentialsWithInvalidAppId()
+        {
+            var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
+
+            Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateCredentialsAsync(
+                    "InvalidAppId", TestAudience, "https://login.microsoftonline.com", true, CancellationToken.None));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #6628

## Description
This PR add the `CertificateServiceClientCredentialsFactory` class to allow bot authentication with a certificate.

> Note: to provide a certificate, add the `CertificateServiceClientCredentialsFactory` class to the bot's service collection in the `Setup.cs` file.
```csharp
// Setup.cs file.
// Note: add `Configuration["MicrosoftAppTenantId"]` to the `tenantId` parameter when using `SingleTenant`.

services.AddSingleton<ServiceClientCredentialsFactory>((e) => new CertificateServiceClientCredentialsFactory(certificate, Configuration["MicrosoftAppId"], Configuration["MicrosoftAppTenantId"]));
```

## Specific Changes
- Added `CertificateServiceClientCredentialsFactory` class to instantiate and use the `CertificateAppCredentials`.
- Added `CertificateServiceClientCredentialsFactoryTests` class with all the unit tests for the methods.

## Testing
The following image shows the changes working as expected.
![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/3d3e2026-4987-4b69-95f8-cc92d22f5e5c)
