### PR TITLE
Support Bot new invoke type: config

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -92,6 +92,12 @@ namespace Microsoft.Bot.Builder.Teams
                         case "tab/submit":
                             return CreateInvokeResponse(await OnTeamsTabSubmitAsync(turnContext, SafeCast<TabSubmit>(turnContext.Activity.Value), cancellationToken).ConfigureAwait(false));
 
+                        case "config/fetch":
+                            return CreateInvokeResponse(await OnTeamsConfigFetchAsync(turnContext, turnContext.Activity.Value as JObject, cancellationToken).ConfigureAwait(false));
+
+                        case "config/submit":
+                            return CreateInvokeResponse(await OnTeamsConfigSubmitAsync(turnContext, turnContext.Activity.Value as JObject, cancellationToken).ConfigureAwait(false));
+
                         default:
                             return await base.OnInvokeActivityAsync(turnContext, cancellationToken).ConfigureAwait(false);
                     }
@@ -427,6 +433,32 @@ namespace Microsoft.Bot.Builder.Teams
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A Tab Response for the request.</returns>
         protected virtual Task<TabResponse> OnTeamsTabSubmitAsync(ITurnContext<IInvokeActivity> turnContext, TabSubmit tabSubmit, CancellationToken cancellationToken)
+        {
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
+        }
+
+        /// <summary>
+        /// Override this in a derived class to provide logic for when a config is fetched.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="configData">The config fetch invoke request value payload.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A Config Response for the request.</returns>
+        protected virtual Task<InvokeResponseBase> OnTeamsConfigFetchAsync(ITurnContext<IInvokeActivity> turnContext, JObject configData, CancellationToken cancellationToken)
+        {
+            throw new InvokeResponseException(HttpStatusCode.NotImplemented);
+        }
+
+        /// <summary>
+        /// Override this in a derived class to provide logic for when a config is submitted.
+        /// </summary>
+        /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+        /// <param name="configData">The config fetch invoke request value payload.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A Config Response for the request.</returns>
+        protected virtual Task<InvokeResponseBase> OnTeamsConfigSubmitAsync(ITurnContext<IInvokeActivity> turnContext, JObject configData, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsActivityHandler.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A Config Response for the request.</returns>
-        protected virtual Task<InvokeResponseBase> OnTeamsConfigFetchAsync(ITurnContext<IInvokeActivity> turnContext, JObject configData, CancellationToken cancellationToken)
+        protected virtual Task<ConfigResponseBase> OnTeamsConfigFetchAsync(ITurnContext<IInvokeActivity> turnContext, JObject configData, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
@@ -458,7 +458,7 @@ namespace Microsoft.Bot.Builder.Teams
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A Config Response for the request.</returns>
-        protected virtual Task<InvokeResponseBase> OnTeamsConfigSubmitAsync(ITurnContext<IInvokeActivity> turnContext, JObject configData, CancellationToken cancellationToken)
+        protected virtual Task<ConfigResponseBase> OnTeamsConfigSubmitAsync(ITurnContext<IInvokeActivity> turnContext, JObject configData, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }

--- a/libraries/Microsoft.Bot.Schema/Teams/BotConfigAuth.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/BotConfigAuth.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specifies bot config auth, including type and suggestedActions.
+    /// </summary>
+    public partial class BotConfigAuth
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BotConfigAuth"/> class.
+        /// </summary>
+        public BotConfigAuth()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets type of bot config auth.
+        /// </summary>
+        /// <value>
+        /// The type of bot config auth.
+        /// </value>
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; } = "auth";
+
+        /// <summary>
+        /// Gets or sets suggested actions. 
+        /// </summary>
+        /// <value>
+        /// The suggested actions of bot config auth.
+        /// </value>
+        [JsonProperty(PropertyName = "suggestedActions")]
+        public SuggestedActions SuggestedActions { get; set; }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/ConfigAuthResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConfigAuthResponse.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Envelope for Config Auth Response.
+    /// </summary>
+    public partial class ConfigAuthResponse : ConfigResponse<BotConfigAuth>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigAuthResponse"/> class.
+        /// </summary>
+        public ConfigAuthResponse()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/ConfigResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConfigResponse.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Envelope for Config Response Payload.
+    /// </summary>
+    /// <typeparam name="T">The first generic type parameter.</typeparam>.
+    public partial class ConfigResponse<T> : InvokeResponseBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigResponse{T}"/> class.
+        /// </summary>
+        public ConfigResponse()
+            : base("config")
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Gets or sets the response to the config message.
+        /// Possible values for the config type include: 'auth'or 'task'.
+        /// </summary>
+        /// <value>
+        /// Response to a config request.
+        /// </value>
+        [JsonProperty(PropertyName = "config")]
+        public T Config { get; set; }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/ConfigResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConfigResponse.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Bot.Schema.Teams
     /// Envelope for Config Response Payload.
     /// </summary>
     /// <typeparam name="T">The first generic type parameter.</typeparam>.
-    public partial class ConfigResponse<T> : InvokeResponseBase
+    public partial class ConfigResponse<T> : ConfigResponseBase
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigResponse{T}"/> class.
@@ -29,6 +29,13 @@ namespace Microsoft.Bot.Schema.Teams
         /// </value>
         [JsonProperty(PropertyName = "config")]
         public T Config { get; set; }
+
+        /// <summary>
+        /// Gets or sets response cache Info.
+        /// </summary>
+        /// <value> Value of cache info. </value>
+        [JsonProperty(PropertyName = "cacheInfo")]
+        public CacheInfo CacheInfo { get; set; }
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults.

--- a/libraries/Microsoft.Bot.Schema/Teams/ConfigResponseBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConfigResponseBase.cs
@@ -8,20 +8,20 @@ namespace Microsoft.Bot.Schema.Teams
     /// <summary>
     /// Specifies Invoke response base including response type.
     /// </summary>
-    public partial class InvokeResponseBase
+    public partial class ConfigResponseBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="InvokeResponseBase"/> class.
+        /// Initializes a new instance of the <see cref="ConfigResponseBase"/> class.
         /// </summary>
-        protected InvokeResponseBase()
+        protected ConfigResponseBase()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InvokeResponseBase"/> class.
+        /// Initializes a new instance of the <see cref="ConfigResponseBase"/> class.
         /// </summary>
         /// <param name="responseType"> response type for invoke.</param>
-        protected InvokeResponseBase(string responseType)
+        protected ConfigResponseBase(string responseType)
         {
             ResponseType = responseType;
         }
@@ -32,12 +32,5 @@ namespace Microsoft.Bot.Schema.Teams
         /// <value> Invoke request response type.</value>
         [JsonProperty("responseType")]
         public string ResponseType { get; set; }
-
-        /// <summary>
-        /// Gets or sets response cache Info.
-        /// </summary>
-        /// <value> Value of cache info. </value>
-        [JsonProperty(PropertyName = "cacheInfo")]
-        public CacheInfo CacheInfo { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/Teams/ConfigTaskResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/ConfigTaskResponse.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Envelope for Config Task Response.
+    /// </summary>
+    public partial class ConfigTaskResponse : ConfigResponse<TaskModuleResponseBase>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigTaskResponse"/> class.
+        /// </summary>
+        public ConfigTaskResponse()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults.
+        /// </summary>
+        partial void CustomInit();
+    }
+}

--- a/libraries/Microsoft.Bot.Schema/Teams/InvokeResponseBase.cs
+++ b/libraries/Microsoft.Bot.Schema/Teams/InvokeResponseBase.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Schema.Teams
+{
+    /// <summary>
+    /// Specifies Invoke response base including response type.
+    /// </summary>
+    public partial class InvokeResponseBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeResponseBase"/> class.
+        /// </summary>
+        protected InvokeResponseBase()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeResponseBase"/> class.
+        /// </summary>
+        /// <param name="responseType"> response type for invoke.</param>
+        protected InvokeResponseBase(string responseType)
+        {
+            ResponseType = responseType;
+        }
+
+        /// <summary>
+        /// Gets or sets response type invoke request.
+        /// </summary>
+        /// <value> Invoke request response type.</value>
+        [JsonProperty("responseType")]
+        public string ResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets response cache Info.
+        /// </summary>
+        /// <value> Value of cache info. </value>
+        [JsonProperty(PropertyName = "cacheInfo")]
+        public CacheInfo CacheInfo { get; set; }
+    }
+}

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerNotImplementedTests.cs
@@ -485,6 +485,66 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         }
 
         [Fact]
+        public async Task TestConfigFetch()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/fetch",
+                Value = JObject.Parse(@"{""data"":{""key"":""value"",""type"":""config / fetch""},""context"":{""theme"":""default""}}"),
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [Fact]
+        public async Task TestConfigSubmit()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/submit",
+                Value = JObject.Parse(@"{""data"":{""key"":""value"",""type"":""config / submit""},""context"":{""theme"":""default""}}"),
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(501, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [Fact]
         public async Task TestFileConsentAcceptImplemented()
         {
             // Arrange

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -1053,6 +1053,72 @@ namespace Microsoft.Bot.Builder.Teams.Tests
         }
 
         [Fact]
+        public async Task TestConfigFetch()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/fetch",
+                Value = JObject.Parse(@"{""data"":{""key"":""value"",""type"":""config / fetch""},""context"":{""theme"":""default""}}"),
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            //Assert.Equal(2, bot.Record.Count);
+            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+            Assert.Equal("OnTeamsConfigFetchAsync", bot.Record[1]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [Fact]
+        public async Task TestConfigSubmit()
+        {
+            // Arrange
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "config/submit",
+                Value = JObject.Parse(@"{""data"":{""key"":""value"",""type"":""config / submit""},""context"":{""theme"":""default""}}"),
+            };
+
+            Activity[] activitiesToSend = null;
+            void CaptureSend(Activity[] arg)
+            {
+                activitiesToSend = arg;
+            }
+
+            var turnContext = new TurnContext(new SimpleAdapter(CaptureSend), activity);
+
+            // Act
+            var bot = new TestActivityHandler();
+            await ((IBot)bot).OnTurnAsync(turnContext);
+
+            // Assert
+            //Assert.Equal(2, bot.Record.Count);
+            Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
+            Assert.Equal("OnTeamsConfigSubmitAsync", bot.Record[1]);
+            Assert.NotNull(activitiesToSend);
+            Assert.Single(activitiesToSend);
+            Assert.IsType<InvokeResponse>(activitiesToSend[0].Value);
+            Assert.Equal(200, ((InvokeResponse)activitiesToSend[0].Value).Status);
+        }
+
+        [Fact]
         public async Task TestSigninVerifyState()
         {
             // Arrange
@@ -1607,6 +1673,20 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             {
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(new TabResponse());
+            }
+
+            protected override Task<InvokeResponseBase> OnTeamsConfigFetchAsync(ITurnContext<IInvokeActivity> turnContext, JObject configRequest, CancellationToken cancellationToken)
+            {
+                InvokeResponseBase configResponse = new ConfigTaskResponse();
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return Task.FromResult(configResponse);
+            }
+
+            protected override Task<InvokeResponseBase> OnTeamsConfigSubmitAsync(ITurnContext<IInvokeActivity> turnContext, JObject configRequest, CancellationToken cancellationToken)
+            {
+                InvokeResponseBase configResponse = new ConfigTaskResponse();
+                Record.Add(MethodBase.GetCurrentMethod().Name);
+                return Task.FromResult(configResponse);
             }
 
             protected override Task OnEventActivityAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityHandlerTests.cs
@@ -1076,7 +1076,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             await ((IBot)bot).OnTurnAsync(turnContext);
 
             // Assert
-            //Assert.Equal(2, bot.Record.Count);
+            Assert.Equal(2, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
             Assert.Equal("OnTeamsConfigFetchAsync", bot.Record[1]);
             Assert.NotNull(activitiesToSend);
@@ -1109,7 +1109,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             await ((IBot)bot).OnTurnAsync(turnContext);
 
             // Assert
-            //Assert.Equal(2, bot.Record.Count);
+            Assert.Equal(2, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
             Assert.Equal("OnTeamsConfigSubmitAsync", bot.Record[1]);
             Assert.NotNull(activitiesToSend);
@@ -1675,16 +1675,16 @@ namespace Microsoft.Bot.Builder.Teams.Tests
                 return Task.FromResult(new TabResponse());
             }
 
-            protected override Task<InvokeResponseBase> OnTeamsConfigFetchAsync(ITurnContext<IInvokeActivity> turnContext, JObject configRequest, CancellationToken cancellationToken)
+            protected override Task<ConfigResponseBase> OnTeamsConfigFetchAsync(ITurnContext<IInvokeActivity> turnContext, JObject configRequest, CancellationToken cancellationToken)
             {
-                InvokeResponseBase configResponse = new ConfigTaskResponse();
+                ConfigResponseBase configResponse = new ConfigTaskResponse();
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(configResponse);
             }
 
-            protected override Task<InvokeResponseBase> OnTeamsConfigSubmitAsync(ITurnContext<IInvokeActivity> turnContext, JObject configRequest, CancellationToken cancellationToken)
+            protected override Task<ConfigResponseBase> OnTeamsConfigSubmitAsync(ITurnContext<IInvokeActivity> turnContext, JObject configRequest, CancellationToken cancellationToken)
             {
-                InvokeResponseBase configResponse = new ConfigTaskResponse();
+                ConfigResponseBase configResponse = new ConfigTaskResponse();
                 Record.Add(MethodBase.GetCurrentMethod().Name);
                 return Task.FromResult(configResponse);
             }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/BotConfigAuthTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/BotConfigAuthTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class BotConfigAuthTests
+    {
+        [Fact]
+        public void BotConfigAuthInitsWithNoArgs()
+        {
+            var botConfigAuthResponse = new BotConfigAuth();
+
+            Assert.NotNull(botConfigAuthResponse);
+            Assert.IsType<BotConfigAuth>(botConfigAuthResponse);
+            Assert.Equal("auth", botConfigAuthResponse.Type);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/ConfigAuthResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/ConfigAuthResponseTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class ConfigAuthResponseTests
+    {
+        [Fact]
+        public void ConfigAuthResponseInitWithNoArgs()
+        {
+            var configAuthResponse = new ConfigAuthResponse();
+
+            Assert.NotNull(configAuthResponse);
+            Assert.IsType<ConfigAuthResponse>(configAuthResponse);
+            Assert.Equal("config", configAuthResponse.ResponseType);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/ConfigResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/ConfigResponseTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class ConfigResponseTests
+    {
+        [Fact]
+        public void ConfigResponseInitsWithNoArgs()
+        {
+            var configResponse = new ConfigResponse<BotConfigAuth>();
+
+            Assert.NotNull(configResponse);
+            Assert.IsType<ConfigResponse<BotConfigAuth>>(configResponse);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/ConfigTaskResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/ConfigTaskResponseTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Schema.Teams;
+using Xunit;
+
+namespace Microsoft.Bot.Schema.Tests.Teams
+{
+    public class ConfigTaskResponseTests
+    {
+        [Fact]
+        public void ConfigTaskResponseInitWithNoArgs()
+        {
+            var configTaskResponse = new ConfigTaskResponse();
+
+            Assert.NotNull(configTaskResponse);
+            Assert.IsType<ConfigTaskResponse>(configTaskResponse);
+            Assert.Equal("config", configTaskResponse.ResponseType);
+        }
+    }
+}

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleContinueResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleContinueResponseTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.NotNull(continueResponse);
             Assert.IsType<TaskModuleContinueResponse>(continueResponse);
             Assert.Equal(value, continueResponse.Value);
+            Assert.Equal("continue", continueResponse.Type);
         }
         
         [Fact]
@@ -27,6 +28,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             Assert.NotNull(continueResponse);
             Assert.IsType<TaskModuleContinueResponse>(continueResponse);
+            Assert.Equal("continue", continueResponse.Type);
         }
     }
 }

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleMessageResponseTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/TaskModuleMessageResponseTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.NotNull(messageResponse);
             Assert.IsType<TaskModuleMessageResponse>(messageResponse);
             Assert.Equal(value, messageResponse.Value);
+            Assert.Equal("message", messageResponse.Type);
         }
         
         [Fact]
@@ -27,6 +28,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
 
             Assert.NotNull(messageResponse);
             Assert.IsType<TaskModuleMessageResponse>(messageResponse);
+            Assert.Equal("message", messageResponse.Type);
         }
     }
 }


### PR DESCRIPTION
Fixes #6634

## Description
Support new bot invoke type: config.

## Specific Changes
- Support new config invoke requests, including config/submit and config/fetch.
- Support related bot schema for Bot config responses.

## Testing
E2E manual tests against local changes for various config requests and responses.
Unit Tests.
