### PR TITLE
Allow sending GET requests with a body

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -289,6 +289,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                     case HttpMethod.POST:
                     case HttpMethod.PATCH:
                     case HttpMethod.PUT:
+                    case HttpMethod.GET:
                         if (instanceBody == null)
                         {
                             response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -314,9 +315,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                         }
 
                         break;
-
-                    case HttpMethod.DELETE:
-                    case HttpMethod.GET:
+                    case HttpMethod.DELETE:                 
                         response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
                         break;
                 }


### PR DESCRIPTION
#minor

## Description
This PR allows sending GET requests by adding a body to the request's content.

Composer related issue: [#9158](https://github.com/microsoft/BotFramework-Composer/issues/9158).

## Specific Changes
  - Modified the switch clause to move the GET request case, to allow the body to be added to the request content.
 
## Testing
The following image shows the GET request sent with a body in the content.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/47e1d515-1819-4473-9f2a-0c787522a7e1)