### PR TITLE
[#6346] Add Azure Storage (BlobStorage.cs) using a managed identity

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using Azure;
+using Azure.Core;
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -88,6 +89,45 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
             _checkForContainerExistence = 1;
 
             _containerClient = new BlobContainerClient(dataConnectionString, containerName);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlobsStorage"/> class.
+        /// </summary>
+        /// <param name="blobContainerUri">Azure blob storage container Uri.</param>
+        /// <param name="tokenCredential">The token credential to authenticate to the Azure storage.</param>
+        /// <param name="storageTransferOptions">Used for providing options for parallel transfers <see cref="StorageTransferOptions"/>.</param>
+        /// <param name="options">Client options that define the transport pipeline policies for authentication, retries, etc., that are applied to every request.</param>
+        /// <param name="jsonSerializer">If passing in a custom JsonSerializer, we recommend the following settings:
+        /// <para>jsonSerializer.TypeNameHandling = TypeNameHandling.None.</para>
+        /// <para>jsonSerializer.NullValueHandling = NullValueHandling.Include.</para>
+        /// <para>jsonSerializer.ContractResolver = new DefaultContractResolver().</para>
+        /// <para>jsonSerializer.SerializationBinder = new AllowedTypesSerializationBinder().</para>
+        /// </param>
+        public BlobsStorage(Uri blobContainerUri, TokenCredential tokenCredential, StorageTransferOptions storageTransferOptions, BlobClientOptions options = default, JsonSerializer jsonSerializer = null)
+        {
+            if (blobContainerUri == null)
+            {
+                throw new ArgumentNullException(nameof(blobContainerUri));
+            }
+
+            if (tokenCredential == null)
+            {
+                throw new ArgumentNullException(nameof(tokenCredential));
+            }
+
+            _storageTransferOptions = storageTransferOptions;
+
+            _jsonSerializer = jsonSerializer ?? JsonSerializer.Create(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All, // lgtm [cs/unsafe-type-name-handling]
+                MaxDepth = null,
+            });
+
+            // Triggers a check for the existence of the container
+            _checkForContainerExistence = 1;
+
+            _containerClient = new BlobContainerClient(blobContainerUri, tokenCredential, options);
         }
 
         /// <summary>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using Azure;
+using Azure.Core;
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -42,6 +43,28 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             // No containerName. Should throw.
             Assert.Throws<ArgumentNullException>(() => new BlobsStorage(ConnectionString, null));
             Assert.Throws<ArgumentNullException>(() => new BlobsStorage(ConnectionString, string.Empty));
+        }
+
+        [Fact]
+        public void ConstructorWithTokenCredentialValidation()
+        {
+            var mockTokenCredential = new Moq.Mock<TokenCredential>();
+            var storageTransferOptions = new StorageTransferOptions();
+            var uri = new Uri("https://uritest.com");
+
+            // Should work.
+            _ = new BlobsStorage(
+                uri,
+                mockTokenCredential.Object,
+                storageTransferOptions,
+                new BlobClientOptions(),
+                JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }));
+
+            // No blobContainerUri. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsStorage(null, mockTokenCredential.Object, storageTransferOptions));
+
+            // No tokenCredential. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsStorage(uri, null, storageTransferOptions));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6346

## Description
This PR enables MSI authentication for Azure Blob Storage.

## Specific Changes
  - Added a new constructor with the necessary parameters for creating the blob storage client using a _tokenCredential_.

## Testing
The following image shows a bot saving data in the blob storage after using the _tokenCredential_ to authenticate.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/e93960de-1f76-4460-850e-5bd8037cf687)


The following image shows the new unit test passing.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/e5d4c759-86d5-47f3-9fc6-63f8544ab63a)
