### PR TITLE
[#6644] Remove BotFrameworkAdapter Obsolete annotation

### DIFF
--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Bot.Builder
 {
     /// <summary>
-    /// A bot adapter that can connect a bot to a service endpoint. 
+    /// A bot adapter that can connect a bot to a service endpoint.
     /// </summary>
     /// <remarks>BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
     /// The bot adapter encapsulates authentication processes and sends

--- a/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
+++ b/libraries/Microsoft.Bot.Builder/BotFrameworkAdapter.cs
@@ -28,9 +28,10 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.Bot.Builder
 {
     /// <summary>
-    /// A bot adapter that can connect a bot to a service endpoint.
+    /// A bot adapter that can connect a bot to a service endpoint. 
     /// </summary>
-    /// <remarks>The bot adapter encapsulates authentication processes and sends
+    /// <remarks>BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
+    /// The bot adapter encapsulates authentication processes and sends
     /// activities to and receives activities from the Bot Connector Service. When your
     /// bot receives an activity, the adapter creates a context object, passes it to your
     /// bot's application logic, and sends responses back to the user's channel.
@@ -45,7 +46,6 @@ namespace Microsoft.Bot.Builder
     /// <seealso cref="IActivity"/>
     /// <seealso cref="IBot"/>
     /// <seealso cref="IMiddleware"/>h
-    [Obsolete("Use `CloudAdapter` instead.", false)]
     public class BotFrameworkAdapter : BotAdapter, IAdapterIntegration, IExtendedUserTokenProvider, IConnectorClientBuilder
     {
         private static readonly HttpClient DefaultHttpClient = new HttpClient();

--- a/libraries/Microsoft.Bot.Builder/Integration/IAdapterIntegration.cs
+++ b/libraries/Microsoft.Bot.Builder/Integration/IAdapterIntegration.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Bot.Builder.Integration
     /// <summary>
     /// An interface that defines the contract between web service integration pieces and the bot adapter.
     /// </summary>
-    [Obsolete("Use `CloudAdapter` instead to process incoming messages.", false)]
+    /// <remarks>
+    /// BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
+    /// </remarks>
     public interface IAdapterIntegration
     {
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
+++ b/libraries/Microsoft.Bot.Builder/Streaming/BotFrameworkHttpAdapterBase.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Bot.Builder.Streaming
     /// <summary>
     /// An HTTP adapter base class.
     /// </summary>
-    [Obsolete("Use `CloudAdapter` instead.", false)]
+    /// <remarks>
+    /// BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
+    /// </remarks>
     public class BotFrameworkHttpAdapterBase : BotFrameworkAdapter, IStreamingActivityProcessor, IDisposable
     {
         private bool _disposedValue;

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
     /// <summary>
     /// A Bot Builder Adapter implementation used to handled bot Framework HTTP requests.
     /// </summary>
-    [Obsolete("Use `CloudAdapter` instead.", false)]
+    /// <remarks>
+    /// BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
+    /// </remarks>
     public class BotFrameworkHttpAdapter : BotFrameworkHttpAdapterBase, IBotFrameworkHttpAdapter
     {
         private const string AuthHeaderName = "authorization";

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandler.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     /// <summary>
     /// A handler to process incoming http requests via using an adapter.
     /// </summary>
-    [Obsolete("Use `CloudAdapter` instead to process incoming messages.", false)]
+    /// <remarks>
+    /// BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
+    /// </remarks>
     public class BotMessageHandler : BotMessageHandlerBase
     {
         /// <summary>

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotMessageHandlerBase.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Handlers
     /// <summary>
     /// Abstract base class for a bot message handler.
     /// </summary>
-    [Obsolete("Use `CloudAdapter` instead to process incoming messages.", false)]
+    /// <remarks>
+    /// BotFrameworkAdapter is still supported but the recommended adapter is `CloudAdapter`.
+    /// </remarks>
     public abstract class BotMessageHandlerBase
     {
         /// <summary>


### PR DESCRIPTION
Fixes #6644

## Description
This PR removes the _**Obsolete**_ tags from the _BotFrameworkAdapter_ class and its related classes.

## Specific Changes
Removed tags and added the suggestion of the use of _CloudAdapter_ in the following classes:
    - BotMessageHandler 
    - BotFrameworkHttpAdapter
    - BotMessageHandlerBase
    - IAdapterIntegration
    - BotFrameworkHttpAdapterBase
    - BotFrameworkAdapter
