### PR TITLE
fix: cleanup streaming high-perf logs

### DIFF
--- a/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Application/StreamingTransportClient.cs
@@ -304,16 +304,16 @@ namespace Microsoft.Bot.Connector.Streaming.Application
                 LogLevel.Information, new EventId(1, nameof(ClientStarted)), "Streaming transport client connected to {string}.");
 
             private static readonly Action<ILogger, string, Exception> _clientCompleted = LoggerMessage.Define<string>(
-                LogLevel.Information, new EventId(2, nameof(ClientKeepAliveSucceed)), "Streaming transport client connection to {string} closed.");
+                LogLevel.Information, new EventId(2, nameof(ClientCompleted)), "Streaming transport client connection to {string} closed.");
 
             private static readonly Action<ILogger, string, Exception> _clientKeepAliveSucceed = LoggerMessage.Define<string>(
-                LogLevel.Debug, new EventId(3, nameof(ClientStarted)), "Streaming transport client heartbeat to {string} succeeded.");
+                LogLevel.Debug, new EventId(3, nameof(ClientKeepAliveSucceed)), "Streaming transport client heartbeat to {string} succeeded.");
 
             private static readonly Action<ILogger, string, int, Exception> _clientKeepAliveFail = LoggerMessage.Define<string, int>(
                 LogLevel.Error, new EventId(4, nameof(ClientKeepAliveFail)), "Streaming transport client heartbeat to {string} failed with status code {int}.");
 
             private static readonly Action<ILogger, string, Exception> _clientTransportApplicationCompleted = LoggerMessage.Define<string>(
-                LogLevel.Debug, new EventId(5, nameof(ClientTransportApplicationCompleted)), "Streaming transport client heartbeat to {string} completed transport and application tasks.");
+                LogLevel.Debug, new EventId(5, nameof(ClientTransportApplicationCompleted)), "Streaming transport client to {string} completed transport and application tasks.");
 
             public static void ClientStarted(ILogger logger, string url) => _clientStarted(logger, url ?? string.Empty, null);
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
@@ -504,10 +504,10 @@ namespace Microsoft.Bot.Connector.Streaming.Session
         private class Log
         {
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _orphanedStream =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(1, nameof(OrphanedStream)), "Stream has no associated payload. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(1, nameof(OrphanedStream)), "Stream has no associated payload. Header: ID {Guid} Type: {char} Payload length: {int} End: {bool}");
 
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _payloadReceived =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(2, nameof(PayloadReceived)), "Payload received in session. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}..");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(2, nameof(PayloadReceived)), "Payload received in session. Header: ID {Guid} Type: {char} Payload length: {int} End: {bool}");
 
             public static void OrphanedStream(ILogger logger, Header header) => _orphanedStream(logger, header.Id, header.Type, header.PayloadLength, header.End, null);
 

--- a/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Transport/TransportHandler.cs
@@ -341,16 +341,16 @@ namespace Microsoft.Bot.Connector.Streaming.Transport
         private static class Log
         {
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _payloadReceived =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(1, nameof(PayloadReceived)), "Payload received. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(1, nameof(PayloadReceived)), "Payload received. Header: ID {Guid} Type: {char} Payload length: {int} End: {bool}");
 
             private static readonly Action<ILogger, Exception> _readFrameFailed =
                 LoggerMessage.Define(LogLevel.Error, new EventId(2, nameof(ReadFrameFailed)), "Failed to read frame from transport.");
 
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _payloadSending =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(3, nameof(SendingPayload)), "Sending Payload. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Debug, new EventId(3, nameof(SendingPayload)), "Sending Payload. Header: ID {Guid} Type: {char} Payload length: {int} End: {bool}");
 
             private static readonly Action<ILogger, Guid, char, int, bool, Exception> _semaphoreTimeOut =
-                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(4, nameof(SemaphoreTimeOut)), "Timed out trying to acquire write semaphore. Header: ID {Guid} Type {char} Payload length:{int}. End :{bool}.");
+                LoggerMessage.Define<Guid, char, int, bool>(LogLevel.Error, new EventId(4, nameof(SemaphoreTimeOut)), "Timed out trying to acquire write semaphore. Header: ID {Guid} Type: {char} Payload length: {int} End: {bool}");
 
             private static readonly Action<ILogger, Exception> _listenError =
                 LoggerMessage.Define(LogLevel.Error, new EventId(5, nameof(ListenError)), "TransportHandler encountered an error and will stop listening.");

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/CloudAdapter.cs
@@ -166,10 +166,10 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     {
                         // Start receiving activities on the named pipe
                         _streamingConnections.TryAdd(connectionId, streamingActivityProcessor);
-                        Log.WebSocketConnectionStarted(Logger);
+                        Log.NamedPipeConnectionStarted(Logger);
                         await streamingActivityProcessor.ListenAsync(CancellationToken.None).ConfigureAwait(false);
                         _streamingConnections.TryRemove(connectionId, out _);
-                        Log.WebSocketConnectionCompleted(Logger);
+                        Log.NamedPipeConnectionCompleted(Logger);
                         Logger.LogWarning("Named pipe got disconnected. Reconnecting.");
                     }
                 }
@@ -365,11 +365,21 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
 
         private class Log
         {
+            private static readonly Action<ILogger, Exception> _namedPipeConnectionStarted =
+                LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(NamedPipeConnectionStarted)), "NamedPipe connection started.");
+
+            private static readonly Action<ILogger, Exception> _namedConnectionCompleted =
+                LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(NamedPipeConnectionCompleted)), "NamedPipe connection completed.");
+
             private static readonly Action<ILogger, Exception> _webSocketConnectionStarted =
                 LoggerMessage.Define(LogLevel.Information, new EventId(1, nameof(WebSocketConnectionStarted)), "WebSocket connection started.");
 
             private static readonly Action<ILogger, Exception> _webSocketConnectionCompleted =
                 LoggerMessage.Define(LogLevel.Information, new EventId(2, nameof(WebSocketConnectionCompleted)), "WebSocket connection completed.");
+
+            public static void NamedPipeConnectionStarted(ILogger logger) => _namedPipeConnectionStarted(logger, null);
+
+            public static void NamedPipeConnectionCompleted(ILogger logger) => _namedConnectionCompleted(logger, null);
 
             public static void WebSocketConnectionStarted(ILogger logger) => _webSocketConnectionStarted(logger, null);
 


### PR DESCRIPTION
Fixes #6649

## Specific Changes
- Fixes the high performance logging in the **StreamingTransportClient** from using the wrong `EventId.Name`
  - Specifically `_clientCompleted` and `_clientKeepAliveSucceed`
- Adds `NamedPipeConnectionStarted` and `NamedPipeConnectionCompleted` for use in **CloudAdapter.ConnectNamedPipeAsync()** instead of using the incorrect `WebSocketConnectionStarted` and `WebSocketConnectionCompleted`.
- Minor cleanup in logs for **StreamingSession** and **TransportHandler**

