### PR TITLE
Use LRUCache in ExpressionParser for efficient memory usage

### DIFF
--- a/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
+++ b/libraries/AdaptiveExpressions/parser/ExpressionParser.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
@@ -11,7 +10,6 @@ using System.Text.RegularExpressions;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using Antlr4.Runtime.Tree;
-using Newtonsoft.Json.Linq;
 
 namespace AdaptiveExpressions
 {
@@ -20,7 +18,7 @@ namespace AdaptiveExpressions
     /// </summary>
     public class ExpressionParser : IExpressionParser
     {
-        private static ConcurrentDictionary<string, IParseTree> expressionDict = new ConcurrentDictionary<string, IParseTree>();
+        private static LRUCache<string, IParseTree> expressionDict = new LRUCache<string, IParseTree>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExpressionParser"/> class.
@@ -64,7 +62,7 @@ namespace AdaptiveExpressions
         /// <returns>A ParseTree.</returns>
         protected static IParseTree AntlrParse(string expression)
         {
-            if (expressionDict.TryGetValue(expression, out var expressionParseTree))
+            if (expressionDict.TryGet(expression, out var expressionParseTree))
             {
                 return expressionParseTree;
             }
@@ -78,7 +76,7 @@ namespace AdaptiveExpressions
             parser.AddErrorListener(ParserErrorListener.Instance);
             parser.BuildParseTree = true;
             var expressionContext = parser.file()?.expression();
-            expressionDict.TryAdd(expression, expressionContext);
+            expressionDict.Set(expression, expressionContext);
             return expressionContext;
         }
 


### PR DESCRIPTION
Fixes #6656

## Description
This PR addresses a memory leak issue in the `ExpressionParser` class. Previously, the `ExpressionParser` class used a `ConcurrentDictionary` to cache parsed expressions, which could lead to excessive memory usage over time. This PR changes the `ExpressionParser` class to use an `LRUCache` instead, which has a maximum capacity and uses a least-recently-used policy to evict entries from the cache when the maximum capacity is reached. This change should help to mitigate the memory leak issue.

## Specific Changes
- Changed the `ExpressionParser` class to use an `LRUCache` instead of a `ConcurrentDictionary` for caching parsed expressions.

## Testing
This change was tested using a console application that demonstrates the memory leak issue in `ExpressionParser`:
https://github.com/jamesemann/expression-parser-leak

Before:
<img src="https://github.com/microsoft/botbuilder-dotnet/assets/38049078/fbf21e6f-e806-4c68-ad43-885115cc494c" width="500"/>

After:
<img src="https://github.com/microsoft/botbuilder-dotnet/assets/38049078/be2fa347-9516-4e74-9743-ed5e89052a3c" width="500"/>
