### PR TITLE
Add WithAuthority to MSAL client application builder

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Bot.Connector.Authentication
         private Identity.Client.IConfidentialClientApplication CreateClientApplication(X509Certificate2 clientCertificate, string appId, HttpClient customHttpClient = null)
         {
             var clientBuilder = Identity.Client.ConfidentialClientApplicationBuilder.Create(appId)
+               .WithAuthority(new Uri(OAuthEndpoint), ValidateAuthority)
                .WithCertificate(clientCertificate);
 
             if (customHttpClient != null)

--- a/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MicrosoftAppCredentials.cs
@@ -172,6 +172,7 @@ namespace Microsoft.Bot.Connector.Authentication
         private Identity.Client.IConfidentialClientApplication CreateClientApplication(string appId, string password, HttpClient customHttpClient = null)
         {
             var clientBuilder = Identity.Client.ConfidentialClientApplicationBuilder.Create(appId)
+               .WithAuthority(new Uri(OAuthEndpoint), ValidateAuthority)
                .WithClientSecret(password);
 
             if (customHttpClient != null)

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -68,13 +68,17 @@ namespace Microsoft.Bot.Connector.Authentication
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2234:Pass system uri objects instead of strings", Justification = "Using string overload for legacy compatibility.")]
         public MsalAppCredentials(string appId, string appPassword, string authority = null, string scope = null, bool validateAuthority = true, ILogger logger = null)
             : this(
-                  clientApplication: ConfidentialClientApplicationBuilder.Create(appId).WithClientSecret(appPassword).Build(),
+                  clientApplication: null,
                   appId: appId,
                   authority: authority,
                   scope: scope,
                   validateAuthority: validateAuthority,
                   logger: logger)
         {
+            _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
+                .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
+                .WithClientSecret(appPassword)
+                .Build();
         }
 
         /// <summary>
@@ -89,13 +93,17 @@ namespace Microsoft.Bot.Connector.Authentication
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2234:Pass system uri objects instead of strings", Justification = "Using string overload for legacy compatibility.")]
         public MsalAppCredentials(string appId, X509Certificate2 certificate, string authority = null, string scope = null, bool validateAuthority = true, ILogger logger = null)
             : this(
-                  clientApplication: ConfidentialClientApplicationBuilder.Create(appId).WithCertificate(certificate).Build(),
+                  clientApplication: null,
                   appId: appId,
                   authority: authority,
                   scope: scope,
                   validateAuthority: validateAuthority,
                   logger: logger)
         {
+            _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
+                .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
+                .WithCertificate(certificate)
+                .Build();
         }
 
         async Task<AuthenticatorResult> IAuthenticator.GetTokenAsync(bool forceRefresh)
@@ -168,7 +176,7 @@ namespace Microsoft.Bot.Connector.Authentication
 
                     // This means we acquired a valid token successfully. We can make our retry policy null.
                     return new AuthenticatorResult()
-                    { 
+                    {
                         AccessToken = msalResult.AccessToken,
                         ExpiresOn = msalResult.ExpiresOn
                     };


### PR DESCRIPTION
#minor

## Description
This PR fixes an issue in MSAL where the `Authority` for Government, Office 365 GCC High and DoD was not set in the MSAL credentials' application level.

## Specific Changes
  - Added `WithAuthority` to Certificate, Microsoft and Msal app credentials when creating the client application builder.

## Testing
The following images show the tests passing successfully and the Echo bot working in Public Cloud.
![image](https://github.com/microsoft/botbuilder-dotnet/assets/62260472/e0a9d149-8ab1-4a89-a127-d3080f3b23a2)
![image](https://github.com/microsoft/botbuilder-dotnet/assets/62260472/33c26e3d-5129-4f88-906a-9c42927491b7)
