### PR TITLE
Updated stray Microsoft.Rest.ClientRuntime dependency

### DIFF
--- a/tests/Microsoft.Bot.Builder.TestBot.WebApi/packages.config
+++ b/tests/Microsoft.Bot.Builder.TestBot.WebApi/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net461" />
   <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net461" />
   <package id="Microsoft.Net.Compilers" version="2.6.1" targetFramework="net462" developmentDependency="true" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.13" targetFramework="net461" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.24" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net461" />


### PR DESCRIPTION
#minor

It doesn't appear this is even used, but is triggering alerts.