### PR TITLE
#6673 - Fix of SNI auth not working in Cert based authentication

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/CertificateAppCredentials.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Bot.Connector.Authentication
             return new Lazy<IAuthenticator>(
                 () =>
                 {
-                    var clientApplication = CreateClientApplication(clientCertificate, MicrosoftAppId, CustomHttpClient);
+                    var clientApplication = CreateClientApplication(clientCertificate, MicrosoftAppId, sendX5c, CustomHttpClient);
                     return new MsalAppCredentials(
                         clientApplication,
                         MicrosoftAppId,
@@ -151,11 +151,11 @@ namespace Microsoft.Bot.Connector.Authentication
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
-        private Identity.Client.IConfidentialClientApplication CreateClientApplication(X509Certificate2 clientCertificate, string appId, HttpClient customHttpClient = null)
+        private Identity.Client.IConfidentialClientApplication CreateClientApplication(X509Certificate2 clientCertificate, string appId, bool sendX5c, HttpClient customHttpClient = null)
         {
             var clientBuilder = Identity.Client.ConfidentialClientApplicationBuilder.Create(appId)
                .WithAuthority(new Uri(OAuthEndpoint), ValidateAuthority)
-               .WithCertificate(clientCertificate);
+               .WithCertificate(clientCertificate, sendX5c);
 
             if (customHttpClient != null)
             {


### PR DESCRIPTION
Fixes #6673

## Description
After upgrade from ADAL to MSAL auth library, sendX5C flag was not set and it breaks SN+I authentication with AAD app registrations.

## Specific Changes
Added sendX5C flag to ConfidentialClientApplicationBuilder.WithCertificate() method.

## Testing
Tested locally and also on our repo by implementing this fix on an inherited class.