### PR TITLE
Resolve concurrency issues in InterfaceConverter's ReadJson method

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Converters/InterfaceConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Bot.Builder.Dialogs.Debugging;
 using Microsoft.Bot.Builder.Dialogs.Declarative.Debugging;
@@ -22,9 +23,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Converters
         private readonly ResourceExplorer resourceExplorer;
         private readonly List<IJsonLoadObserver> observers = new List<IJsonLoadObserver>();
         private readonly SourceContext sourceContext;
-        private readonly Dictionary<string, T> cachedRefDialogs = new Dictionary<string, T>();
-        private readonly Dictionary<string, T> cachedTypes = new Dictionary<string, T>();
-        private readonly Dictionary<JToken, SourceRange> rangeReferences = new Dictionary<JToken, SourceRange>(JToken.EqualityComparer);
+        private readonly IDictionary<string, T> cachedRefDialogs = new ConcurrentDictionary<string, T>();
+        private readonly IDictionary<string, T> cachedTypes = new ConcurrentDictionary<string, T>();
+        private readonly IDictionary<JToken, SourceRange> rangeReferences = new ConcurrentDictionary<JToken, SourceRange>(JToken.EqualityComparer);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InterfaceConverter{T}"/> class.


### PR DESCRIPTION
#minor
Closes IcM: https://portal.microsofticm.com/imp/v3/incidents/details/403753372/home

## Description
This PR addresses concurrency issues observed in the `InterfaceConverter`'s `ReadJson` method. The changes ensure thread-safe operations when deserializing JSON concurrently.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Replaced `Dictionary<string, T>` type declarations with `ConcurrentDictionary<string, T>` for rangeReferences, cachedRefDialogs and cachedTypes.
