### PR TITLE
Support SN+I authentication with AAD

### DIFF
--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, tenantId: TestTenantId);
             _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, logger: logger.Object);
             _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, httpClient: new HttpClient());
+            _ = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId, httpClient: new HttpClient(), sendX5c: true);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6679

## Description
Support SN+I authentication with AAD for CertificateServiceClientCredentialsFactory. Fix of throttling issue caused by fetching a token from AAD for each request.

## Specific Changes
  - Added support for sendX5c flag in CertificateServiceClientCredentialsFactory.
  - Reused CertificateAppCredentials to fix throttling issue with AAD.

## Testing
Unit test added.