### PR TITLE
fix: [#6683] Timeout issue when using DLASE

### DIFF
--- a/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/Session/StreamingSession.cs
@@ -195,6 +195,11 @@ namespace Microsoft.Bot.Connector.Streaming.Session
 
             Log.PayloadReceived(_logger, header);
 
+            if (response.StatusCode == (int)HttpStatusCode.Accepted)
+            {
+                return;
+            }
+
             lock (_receiveSync)
             {
                 if (!response.Streams.Any())

--- a/libraries/Microsoft.Bot.Streaming/ProtocolAdapter.cs
+++ b/libraries/Microsoft.Bot.Streaming/ProtocolAdapter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,6 +76,11 @@ namespace Microsoft.Bot.Streaming
 
         private async Task OnReceiveResponseAsync(Guid id, ReceiveResponse response)
         {
+            if (response.StatusCode == (int)HttpStatusCode.Accepted)
+            {
+                return;
+            }
+
             // we received the response to something, signal it
             await _requestManager.SignalResponseAsync(id, response).ConfigureAwait(false);
         }


### PR DESCRIPTION
Fixes #6683

## Description
This PR fixes an issue where, while using _DLASE_, the bot threw a timeout issue while streaming, due to not generating a response in the initial request.
Therefore, if the streaming process in the initial request takes longer than 15 seconds to finalize and generate a response, the bot will throw a timeout issue.
Sending a response (`HTTP 202 (Accepted)`) before starting to process all streaming requests addressed the issue and will not generate a timeout issue.

## Specific Changes
  - Add `SendResponseAsync` call to the `StreamingSession` class to send an HTTP 202 (Accepted) response before starting processing all streaming information.
  - Add `Accepted` StatusCode condition to `ProtocolAdapter` for Streaming and `StreamingSession` for Connector.Streaming. This allows to detect when the Accepted response is taking place and can proceed to ignore the response and let the actual OK response to be used after streaming.

## Testing
The following image shows the timeout issue before and after the fix.
> **Note**: consistently was timing out around 25 to 35 activities, with the fix, it is no longer the case.

![imagen](https://github.com/southworks/botbuilder-dotnet/assets/62260472/48c36ef3-3bf9-40f0-9ab0-7a0f2cbce65a)
