### PR TITLE
[SharePointActivityHandler]: fix responseType serialization

### DIFF
--- a/libraries/Microsoft.Bot.Schema/SharePoint/BaseHandleActionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/SharePoint/BaseHandleActionResponse.cs
@@ -34,14 +34,23 @@ namespace Microsoft.Bot.Schema.SharePoint
     /// <summary>
     /// Response returned when handling a client-side action on an Adaptive Card Extension.
     /// </summary>
-    public abstract class BaseHandleActionResponse
+    public class BaseHandleActionResponse
     {
         /// <summary>
         /// Gets the response type.
         /// </summary>
         /// <value>Response type.</value>
         [JsonProperty(PropertyName = "responseType")]
-        public abstract ViewResponseType ResponseType { get; }
+        private readonly ViewResponseType responseType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseHandleActionResponse"/> class.
+        /// </summary>
+        /// <param name="responseType">Response type.</param>
+        protected BaseHandleActionResponse(ViewResponseType responseType)
+        {
+            this.responseType = responseType;
+        }
 
         /// <summary>
         /// Gets or sets render arguments.

--- a/libraries/Microsoft.Bot.Schema/SharePoint/CardViewHandleActionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/SharePoint/CardViewHandleActionResponse.cs
@@ -14,11 +14,13 @@ namespace Microsoft.Bot.Schema.SharePoint
     public class CardViewHandleActionResponse : BaseHandleActionResponse
     {
         /// <summary>
-        /// Gets the response type.
+        /// Initializes a new instance of the <see cref="CardViewHandleActionResponse"/> class.
         /// </summary>
-        /// <value>Card.</value>
-        [JsonProperty(PropertyName = "responseType")]
-        public override ViewResponseType ResponseType => ViewResponseType.Card;
+        public CardViewHandleActionResponse()
+        : base(ViewResponseType.Card)
+        {
+            // Do nothing
+        }
 
         /// <summary>
         /// Gets or sets card view render arguments.

--- a/libraries/Microsoft.Bot.Schema/SharePoint/NoOpHandleActionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/SharePoint/NoOpHandleActionResponse.cs
@@ -14,11 +14,13 @@ namespace Microsoft.Bot.Schema.SharePoint
     public class NoOpHandleActionResponse : BaseHandleActionResponse
     {
         /// <summary>
-        /// Gets the response type.
+        /// Initializes a new instance of the <see cref="NoOpHandleActionResponse"/> class.
         /// </summary>
-        /// <value>Card.</value>
-        [JsonProperty(PropertyName = "responseType")]
-        public override ViewResponseType ResponseType => ViewResponseType.NoOp;
+        public NoOpHandleActionResponse() 
+            : base(ViewResponseType.NoOp)
+        {
+            // Do nothing
+        }
 
         /// <summary>
         /// Gets or sets card view render arguments.

--- a/libraries/Microsoft.Bot.Schema/SharePoint/QuickViewHandleActionResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/SharePoint/QuickViewHandleActionResponse.cs
@@ -14,11 +14,13 @@ namespace Microsoft.Bot.Schema.SharePoint
     public class QuickViewHandleActionResponse : BaseHandleActionResponse
     {
         /// <summary>
-        /// Gets the response type.
+        /// Initializes a new instance of the <see cref="QuickViewHandleActionResponse"/> class.
         /// </summary>
-        /// <value>Card.</value>
-        [JsonProperty(PropertyName = "responseType")]
-        public override ViewResponseType ResponseType => ViewResponseType.QuickView;
+        public QuickViewHandleActionResponse() 
+            : base(ViewResponseType.QuickView)
+        {
+            // Do nothing
+        }
 
         /// <summary>
         /// Gets or sets card view render arguments.


### PR DESCRIPTION
Fixes #6613 

## Description
The PR fixes serialization of `responseType` property for the `HandleActionResponse`.

## Specific Changes
Newtonsoft does not serialize inherited property without a setter. So the property has been changed to private readonly field with initialization from child classes using constructor's parameter.

## Testing
Full flow test using locally served bot and SharePoint Online
![image](https://github.com/microsoft/botbuilder-dotnet/assets/17036219/97da5be3-99f8-4425-956c-ee4c20b46eb3)
