### PR TITLE
Enable MSAL settings to save access token in cache

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -82,7 +82,6 @@ namespace Microsoft.Bot.Connector.Authentication
             _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
                 .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
                 .WithClientSecret(appPassword)
-                .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                 .Build();
         }
 
@@ -107,7 +106,6 @@ namespace Microsoft.Bot.Connector.Authentication
         {
             _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
                 .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
-                .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                 .WithCertificate(certificate)
                 .Build();
         }
@@ -136,7 +134,6 @@ namespace Microsoft.Bot.Connector.Authentication
             _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
                 .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
                 .WithCertificate(certificate, sendX5c)
-                .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                 .Build();
         }
 

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _scope = scope;
             _authority = authority;
             _validateAuthority = validateAuthority;
-            if (_clientApplication != null)
+            if (_clientApplication?.AppTokenCache != null)
             {
                 _clientApplication.AppTokenCache.SetCacheOptions(CacheOptions.EnableSharedCacheOptions);
             }

--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalAppCredentials.cs
@@ -54,6 +54,10 @@ namespace Microsoft.Bot.Connector.Authentication
             _scope = scope;
             _authority = authority;
             _validateAuthority = validateAuthority;
+            if (_clientApplication != null)
+            {
+                _clientApplication.AppTokenCache.SetCacheOptions(CacheOptions.EnableSharedCacheOptions);
+            }
         }
 
         /// <summary>
@@ -78,6 +82,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
                 .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
                 .WithClientSecret(appPassword)
+                .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                 .Build();
         }
 
@@ -102,6 +107,7 @@ namespace Microsoft.Bot.Connector.Authentication
         {
             _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
                 .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
+                .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                 .WithCertificate(certificate)
                 .Build();
         }
@@ -130,6 +136,7 @@ namespace Microsoft.Bot.Connector.Authentication
             _clientApplication = ConfidentialClientApplicationBuilder.Create(appId)
                 .WithAuthority(authority ?? OAuthEndpoint, validateAuthority)
                 .WithCertificate(certificate, sendX5c)
+                .WithCacheOptions(CacheOptions.EnableSharedCacheOptions)
                 .Build();
         }
 


### PR DESCRIPTION
#minor

## Description
This PR adds the necessary MSAL settings to manage the cached access token value and not request a new value on each request.

## Specific Changes
  - Added _**SetCacheOptions**_ to the _AppTokenCache_ of the _ClientApplication_ in _MsalAppCredentials_ class.

## Testing
The following images show the interaction with the bot and the token values in every message.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/f99b430f-8c4f-4a78-a123-874dd0a4d2c6)
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/f13e0a08-b61f-43ac-a9d5-d45c762c420c)