### PR TITLE
Add error detection when EmitEventAsync fails in internal RunAsync

### DIFF
--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
@@ -1119,17 +1119,26 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         [Trait("TestCategory", "LanguageService")]
         public async void LanguageService_Test_NotSpecifiedQnAServiceType()
         {
+            AggregateException result = null;
             var mockHttp = new MockHttpMessageHandler();
             mockHttp.When(HttpMethod.Post, GetRequestUrl())
                 .Respond("application/json", GetResponse("LanguageService_ReturnsAnswer.json"));
 
             var rootDialog = CreateLanguageServiceActionDialog(mockHttp, true, ServiceType.QnAMaker);
 
-            await Assert.ThrowsAsync<HttpRequestException>(() => CreateFlow(rootDialog, nameof(LanguageServiceAction_MultiTurnDialogBase_WithNoAnswer))
-        .Send("What happens if I pass empty qnaServiceType with host of Language Service")
-        .StartTestAsync());
+            try
+            {
+                await CreateFlow(rootDialog, nameof(LanguageServiceAction_MultiTurnDialogBase_WithNoAnswer))
+                    .Send("What happens if I pass empty qnaServiceType with host of Language Service")
+                    .StartTestAsync();
+            }
+            catch (AggregateException ex)
+            {
+                result = ex;
+            }
 
-            //Assert.Throws<ArgumentOutOfRangeException>(() => new CustomQuestionAnswering(endpoint, qnaMakerOptions));
+            Assert.Equal(2, result.InnerExceptions.Count);
+            Assert.All(result.InnerExceptions, (e) => Assert.IsType<HttpRequestException>(e));
         }
 
         /// <summary>


### PR DESCRIPTION
#minor

## Description
This PR adds error detection when the internal `RunAsync` method fails using `AdaptiveDialogs`, otherwise, the original `Exception` gets lost.
> e.g.: original exception containing circular reference errors, it's captured by the `dialogContext.EmitEventAsync` to send the error as a message, then, it proceeds to fail, and the error thrown in the stack is the circular reference error, and the original exception gets lost.

## Specific Changes
- Added `try/catch` around the `EmitEventAsync` when used in the `InternalRunAsync` method. If there is an error, it will be captured and thrown as an `AggregateException` containing the original and new error.
- Added unit test to validate this behavior.
- Updated unit test failing with similar behavior.

## Testing
The following image shows the pipeline working and how the error is thrown.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/c0c270e0-9608-46cb-b318-54ce8a13d7d9)
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/7829b08b-3eca-45b6-b8ab-17fc120540e4)
