### PR TITLE
feat: Include HEAD method to http requests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Actions/HttpRequest.cs
@@ -126,7 +126,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
             /// <summary>
             /// Http DELETE.
             /// </summary>
-            DELETE
+            DELETE,
+
+            /// <summary>
+            /// Http HEAD.
+            /// </summary>
+            HEAD
         }
 
         /// <summary>
@@ -315,7 +320,8 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Actions
                         }
 
                         break;
-                    case HttpMethod.DELETE:                 
+                    case HttpMethod.DELETE:
+                    case HttpMethod.HEAD:
                         response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
                         break;
                 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.HttpRequest.schema
@@ -31,7 +31,8 @@
                 "POST",
                 "PATCH",
                 "PUT",
-                "DELETE"
+                "DELETE",
+                "HEAD"
             ],
             "examples": [
                 "GET",

--- a/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
+++ b/tests/Microsoft.Bot.Builder.TestBot.Json/testbot.schema
@@ -3607,7 +3607,8 @@
                         "POST",
                         "PATCH",
                         "PUT",
-                        "DELETE"
+                        "DELETE",
+                        "HEAD"
                     ],
                     "examples": [
                         "GET",
@@ -9216,7 +9217,8 @@
                         "POST",
                         "PATCH",
                         "PUT",
-                        "DELETE"
+                        "DELETE",
+                        "HEAD"
                     ],
                     "examples": [
                         "GET",

--- a/tests/tests.schema
+++ b/tests/tests.schema
@@ -3868,7 +3868,8 @@
             "POST",
             "PATCH",
             "PUT",
-            "DELETE"
+            "DELETE",
+            "HEAD"
           ],
           "examples": [
             "GET",


### PR DESCRIPTION
#minor

## Description
This PR adds the HEAD method in the HttpRequest class and adds the method in every schema

## Specific Changes

  - Added **HEAD** method to the HttpRequest method list.
  - Added **HEAD** method to schemas of testing and HttpRequest.

## Testing
The following image shows the _dialogs_ unit tests passing after the changes.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/0869c4c0-4163-4cf7-b917-c19ce1acf95d)
