### PR TITLE
port: [#4587] Add blob content type header

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -277,8 +277,10 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
 
                     await streamWriter.FlushAsync().ConfigureAwait(false);
                     memoryStream.Seek(0, SeekOrigin.Begin);
+                    var blobHttpHeaders = new BlobHttpHeaders();
+                    blobHttpHeaders.ContentType = "application/json";
 
-                    await blobReference.UploadAsync(memoryStream, conditions: accessCondition, transferOptions: _storageTransferOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    await blobReference.UploadAsync(memoryStream, conditions: accessCondition, transferOptions: _storageTransferOptions, cancellationToken: cancellationToken, httpHeaders: blobHttpHeaders).ConfigureAwait(false);
                 }
                 catch (RequestFailedException ex)
                 when (ex.Status == (int)HttpStatusCode.BadRequest


### PR DESCRIPTION
#minor

## Description
This PR ports from Javascript the header **_blobContentType_** in the BlobStorage writing, setting the value as _application/json_ to the uploaded blobs.

## Specific Changes
  - Added **_blobContentType_** as _application/json_ to the httpHeaders of the blobs to upload.

## Testing
The following image shows the reading of the **_blobContentType_** value as application/json.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/52c538f7-fa5a-4d7d-91f5-bbd3b195c1a6)