### PR TITLE
fix: [#6697] Typing middleware not working as expected in teams as well as web chat channel

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -66,19 +66,13 @@ namespace Microsoft.Bot.Builder
                 var containsMessage = activities.Any(e => e.Type == ActivityTypes.Message);
                 if (containsMessage)
                 {
-                    await FinishTypingTaskAsync(ctx).ConfigureAwait(false);
+                    await ProcessTypingAsync(ctx).ConfigureAwait(false);
                 }
 
                 return await nextSend().ConfigureAwait(false);
             });
 
-            // Start a timer to periodically send the typing activity (bots running as skills should not send typing activity)
-            if (!IsSkillBot(turnContext) && turnContext.Activity.Type == ActivityTypes.Message)
-            {
-                // Override the typing background task.
-                await FinishTypingTaskAsync(turnContext).ConfigureAwait(false);
-                StartTypingTask(turnContext);
-            }
+            await ProcessTypingAsync(turnContext).ConfigureAwait(false);
 
             await next(cancellationToken).ConfigureAwait(false);
 
@@ -176,6 +170,20 @@ namespace Microsoft.Bot.Builder
             }
 
             _tasks.TryRemove(turnContext.Activity.Conversation.Id, out _);
+        }
+
+        /// <summary>
+        /// Start a timer to periodically send the typing activity (bots running as skills should not send typing activity).
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        private async Task ProcessTypingAsync(ITurnContext turnContext)
+        {
+            if (!IsSkillBot(turnContext) && turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                // Override the typing background task.
+                await FinishTypingTaskAsync(turnContext).ConfigureAwait(false);
+                StartTypingTask(turnContext);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #6697

## Description
This PR allows showing the typing indicator before every message bot.

## Specific Changes
  - Added _**ProcessTypingAsync**_ method in _ShowTypingMiddleware_ class.
  - Added _StartTyping_ process to every activity iteration in the _OnSendActivities_ method execution.
 
## Testing
The following image shows the typing indicator being displayed between the different messages sent by the bot.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/4b6ae68a-f16b-4e8b-9ade-cafb3ee6624b)
