### PR TITLE
Manually adding zh-CN and zh-TW to LanguagePolicy

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguagePolicy.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguagePolicy.cs
@@ -77,9 +77,16 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
             // Locales like zh-CN, zh-TW, etc... are deprecated locales returned by CultureInfo.
             // However, many still supply the old value when setting up WebChat.  Since we
             // really just need the progression to check for LG/LU files, we are manually adding
-            // them so that these files are found.
-            policy.Add("zh-cn", new string[] { "zh-cn", "zh" });
-            policy.Add("zh-tw", new string[] { "zh-tw", "zh" });
+            // them so that these files are found.  This is OS version specific.
+            if (!policy.ContainsKey("zh-cn"))
+            {
+                policy.Add("zh-cn", new string[] { "zh-cn", "zh" });
+            }
+
+            if (!policy.ContainsKey("zh-tw"))
+            {
+                policy.Add("zh-tw", new string[] { "zh-tw", "zh" });
+            }
 
             return policy;
         }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguagePolicy.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguagePolicy.cs
@@ -74,6 +74,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive
                 policy.Add(language, fallback.ToArray());
             }
 
+            // Locales like zh-CN, zh-TW, etc... are deprecated locales returned by CultureInfo.
+            // However, many still supply the old value when setting up WebChat.  Since we
+            // really just need the progression to check for LG/LU files, we are manually adding
+            // them so that these files are found.
+            policy.Add("zh-cn", new string[] { "zh-cn", "zh" });
+            policy.Add("zh-tw", new string[] { "zh-tw", "zh" });
+
             return policy;
         }
     }


### PR DESCRIPTION
#minor

From IcM where the older zh-CN locale was specified in WebChat, and CultureInfo.GetCultures only has the newer (and standard) zh-hans-* and zh-hants-*.