### PR TITLE
Support Sso for SharePoint bot ACEs

### DIFF
--- a/libraries/Microsoft.Bot.Builder/SharePoint/SharePointSSOTokenExchangeMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SharePoint/SharePointSSOTokenExchangeMiddleware.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Schema.SharePoint;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Bot.Builder.SharePoint
+{
+    /// <summary>
+    /// If the activity name is cardExtension/token, this middleware will attempt to
+    /// exchange the token, and deduplicate the incoming call, ensuring only one
+    /// exchange request is processed.
+    /// </summary>
+    /// <remarks>
+    /// If a user is signed into multiple devices, the Bot could receive a
+    /// "signin/tokenExchange" from each client. Each token exchange request for a
+    /// specific user login will have an identical Activity.Value.Id.
+    /// 
+    /// Only one of these token exchange requests should be processed by the bot.
+    /// The others return <see cref="System.Net.HttpStatusCode.PreconditionFailed"/>.
+    /// For a distributed bot in production, this requires a distributed storage
+    /// ensuring only one token exchange is processed. This middleware supports
+    /// CosmosDb storage found in Microsoft.Bot.Builder.Azure, or MemoryStorage for
+    /// local development. IStorage's ETag implementation for token exchange activity
+    /// deduplication.
+    /// </remarks>
+    public class SharePointSSOTokenExchangeMiddleware
+    {
+        private readonly IStorage _storage;
+        private readonly string _oAuthConnectionName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SharePointSSOTokenExchangeMiddleware"/> class.
+        /// </summary>
+        /// <param name="storage">The <see cref="IStorage"/> to use for deduplication.</param>
+        /// <param name="connectionName">The connection name to use for the single
+        /// sign on token exchange.</param>
+        public SharePointSSOTokenExchangeMiddleware(IStorage storage, string connectionName)
+        {
+            if (storage == null)
+            {
+                // TODO: ADD THIS BACK IN
+                // throw new ArgumentNullException(nameof(storage));
+            }
+
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentNullException(nameof(connectionName));
+            }
+
+            _oAuthConnectionName = connectionName;
+            _storage = storage;
+        }
+
+        /// <summary>
+        /// Handles a turn.
+        /// </summary>
+        /// <param name="turnContext">turn context.</param>
+        /// <param name="cancellationToken">cancellation token.</param>
+        /// <returns>Task.</returns>
+        public async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            if (string.Equals(Channels.M365, turnContext.Activity.ChannelId, StringComparison.OrdinalIgnoreCase) 
+                && string.Equals(SignInConstants.SharePointTokenExchange, turnContext.Activity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                // If the TokenExchange is NOT successful, the response will have already been sent by ExchangedTokenAsync
+                if (!await this.ExchangedTokenAsync(turnContext, cancellationToken).ConfigureAwait(false))
+                {
+                    return;
+                }
+
+                // Only one token exchange should proceed from here. Deduplication is performed second because in the case
+                // of failure due to consent required, every caller needs to receive the 
+                if (!await DeduplicatedTokenExchangeIdAsync(turnContext, cancellationToken).ConfigureAwait(false))
+                {
+                    // If the token is not exchangeable, do not process this activity further.
+                    return;
+                }
+            }
+
+            return;
+        }
+
+        private async Task<bool> DeduplicatedTokenExchangeIdAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            // Create a StoreItem with Etag of the unique 'signin/tokenExchange' request
+            var storeItem = new TokenStoreItem
+            {
+                ETag = (turnContext.Activity.Value as JObject).Value<string>("id")
+            };
+
+            var storeItems = new Dictionary<string, object> { { TokenStoreItem.GetStorageKey(turnContext), storeItem } };
+            try
+            {
+                // Writing the IStoreItem with ETag of unique id will succeed only once
+                await _storage.WriteAsync(storeItems, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+
+                // Memory storage throws a generic exception with a Message of 'Etag conflict. [other error info]'
+                // CosmosDbPartitionedStorage throws: ex.Message.Contains("pre-condition is not met")
+                when (ex.Message.StartsWith("Etag conflict", StringComparison.OrdinalIgnoreCase) || ex.Message.Contains("pre-condition is not met"))
+            {
+                // Do NOT proceed processing this message, some other thread or machine already has processed it.
+
+                // Send 200 invoke response.
+                await SendInvokeResponseAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return false;
+            }
+
+            return true;
+        }
+
+        private async Task SendInvokeResponseAsync(ITurnContext turnContext, object body = null, HttpStatusCode httpStatusCode = HttpStatusCode.OK, CancellationToken cancellationToken = default)
+        {
+            await turnContext.SendActivityAsync(
+                new Activity
+                {
+                    Type = ActivityTypesEx.InvokeResponse,
+                    Value = new InvokeResponse
+                    {
+                        Status = (int)httpStatusCode,
+                        Body = body,
+                    },
+                }, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<bool> ExchangedTokenAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            TokenResponse tokenExchangeResponse = null;
+
+            AceRequest aceRequest = SharePointActivityHandler.SafeCast<AceRequest>(turnContext.Activity.Value);
+
+            try
+            {
+                var userTokenClient = turnContext.TurnState.Get<UserTokenClient>();
+                if (userTokenClient != null)
+                {
+                    tokenExchangeResponse = await userTokenClient.ExchangeTokenAsync(
+                        turnContext.Activity.From.Id,
+                        _oAuthConnectionName,
+                        turnContext.Activity.ChannelId,
+                        new TokenExchangeRequest { Token = aceRequest.Data as string },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                else if (turnContext.Adapter is IExtendedUserTokenProvider adapter)
+                {
+                    tokenExchangeResponse = await adapter.ExchangeTokenAsync(
+                        turnContext,
+                        _oAuthConnectionName,
+                        turnContext.Activity.From.Id,
+                        new TokenExchangeRequest { Token = aceRequest.Data as string },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    throw new NotSupportedException("Token Exchange is not supported by the current adapter.");
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types (ignoring, see comment below)
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // Ignore Exceptions
+                // If token exchange failed for any reason, tokenExchangeResponse above stays null,
+                // and hence we send back a failure invoke response to the caller.
+            }
+
+            if (string.IsNullOrEmpty(tokenExchangeResponse?.Token))
+            {
+                // The token could not be exchanged (which could be due to a consent requirement)
+                // Notify the sender that PreconditionFailed so they can respond accordingly.
+
+                var invokeResponse = new TokenExchangeInvokeResponse
+                {
+                    Id = "FAKE ID", // tokenExchangeRequest.Id,
+                    ConnectionName = _oAuthConnectionName,
+                    FailureDetail = "The bot is unable to exchange token. Proceed with regular login.",
+                };
+
+                await SendInvokeResponseAsync(turnContext, invokeResponse, HttpStatusCode.PreconditionFailed, cancellationToken).ConfigureAwait(false);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private class TokenStoreItem : IStoreItem
+        {
+            public string ETag { get; set; }
+
+            public static string GetStorageKey(ITurnContext turnContext)
+            {
+                var activity = turnContext.Activity;
+                var channelId = activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
+                var conversationId = activity.Conversation?.Id ?? throw new InvalidOperationException("invalid activity-missing Conversation.Id");
+
+                var value = activity.Value as JObject;
+                if (value == null || !value.ContainsKey("id"))
+                {
+                    throw new InvalidOperationException("Invalid signin/tokenExchange. Missing activity.Value.Id.");
+                }
+
+                return $"{channelId}/{conversationId}/{value.Value<string>("id")}";
+            }
+        }
+    }
+}

--- a/libraries/Microsoft.Bot.Builder/SharePoint/SharePointSSOTokenExchangeMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/SharePoint/SharePointSSOTokenExchangeMiddleware.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Bot.Builder.SharePoint
         {
             if (storage == null)
             {
-                // TODO: ADD THIS BACK IN
-                // throw new ArgumentNullException(nameof(storage));
+                throw new ArgumentNullException(nameof(storage));
             }
 
             if (string.IsNullOrEmpty(connectionName))

--- a/libraries/Microsoft.Bot.Connector/Channels.cs
+++ b/libraries/Microsoft.Bot.Connector/Channels.cs
@@ -144,5 +144,10 @@ namespace Microsoft.Bot.Connector
         /// Outlook channel.
         /// </summary>
         public const string Outlook = "outlook";
+
+        /// <summary>
+        /// M365 channel.
+        /// </summary>
+        public const string M365 = "m365extensions";
     }
 }

--- a/libraries/Microsoft.Bot.Schema/SharePoint/QuickViewResponse.cs
+++ b/libraries/Microsoft.Bot.Schema/SharePoint/QuickViewResponse.cs
@@ -67,5 +67,23 @@ namespace Microsoft.Bot.Schema.SharePoint
         /// <value>This value is the focus parameters of the quick view response.</value>
         [JsonProperty(PropertyName = "focusParameters")]
         public FocusParameters FocusParameters { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a value indicating whether the client to trigger a single sign on flow.
+        /// </summary>
+        /// <value>
+        /// True if single sign on flow should be started.
+        /// </value>
+        [JsonProperty(PropertyName = "requiresSso")]
+        public bool RequiresSso { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a value which tells the client what view to load after SSO is complete.
+        /// </summary>
+        /// <value>
+        /// ViewId to load from client after the SSO flow completes.
+        /// </value>
+        [JsonProperty(PropertyName = "postSsoViewId")]
+        public string PostSsoViewId { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Schema/SignInConstants.cs
+++ b/libraries/Microsoft.Bot.Schema/SignInConstants.cs
@@ -28,5 +28,10 @@ namespace Microsoft.Bot.Schema
         /// The EventActivity name when a token is sent to the bot.
         /// </summary>
         public const string TokenResponseEventName = "tokens/response";
+
+        /// <summary>
+        /// The invoke operation used to exchange a sharepoint token for SSO.
+        /// </summary>
+        public const string SharePointTokenExchange = "cardExtension/token";
     }
 }


### PR DESCRIPTION
Fixes
This change allows SharePoint Bot Driven Aces to use SSO.

## Description
Currently a bot driven ace in SharePoint can only use the magic code flow.  This flow is not ideal as it requires a user to copy and paste a code from a different window or at a minimum we get flicker of the window being shown.  This change allows us to use the SSO flow so that not authentication prompts are shown.

#minor
## Specific Changes
Adds a new cardExtension/token activity for doing a token exchange.

  - 
  -
  -

## Testing
Used a debug string in SharePoint and copied the bot builder bits locally to produce a bot running on ngrok.