### PR TITLE
[#6741] Update functional test pipelines to .NET8

### DIFF
--- a/build/yaml/botbuilder-dotnet-functional-test-linux.yml
+++ b/build/yaml/botbuilder-dotnet-functional-test-linux.yml
@@ -87,7 +87,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '-r linux-x64 --configuration $(BuildConfiguration) --output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot -p:TreatWarningsAsErrors=false -p:RestoreUseSkipNonexistentTargets=false'
+    arguments: '-r linux-x64 --configuration $(BuildConfiguration) --self-contained --output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\publishedbot -p:TreatWarningsAsErrors=false -p:RestoreUseSkipNonexistentTargets=false'
     zipAfterPublish: false
     modifyOutputPath: false
 

--- a/build/yaml/functional-test-setup-steps.yml
+++ b/build/yaml/functional-test-setup-steps.yml
@@ -8,7 +8,7 @@ steps:
     command: publish
     publishWebProjects: false
     projects: '$(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\Microsoft.Bot.Builder.TestBot.csproj'
-    arguments: '-r linux-x64 --output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --configuration $(TestConfiguration) --framework net6.0'
+    arguments: '-r linux-x64 --output $(System.DefaultWorkingDirectory)\tests\Microsoft.Bot.Builder.TestBot\PublishedBot --configuration $(TestConfiguration) --framework net8.0'
 
 - task: CopyFiles@2
   displayName: 'Copy root Directory.Build.props to staging'


### PR DESCRIPTION
Addresses #6741
#minor

## Description
This PR updates the Functional Test yamls to target .NET 8 instead of .NET 6.

> Note: The adapters' functional test pipelines didn't require updating, but we tested them with the bots targeting .NET 8.

## Specific Changes
- Updated  `functional-test-setup-steps.yml` to target the net8.0 framework.
- Updated `botbuilder-dotnet-functional-test-linux.yml` to add  the self-contained flag to the publish command, as starting .NET 8 this is no longer the default behavior ([documentation](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/runtimespecific-app-default)).

## Testing
These images show the Functional Test pipelines working after the changes.
![image](https://github.com/microsoft/botbuilder-dotnet/assets/44245136/1d735537-ee3d-4f06-bf85-cb5580af1265)

![image](https://github.com/microsoft/botbuilder-dotnet/assets/44245136/fbc03329-be6a-48f8-94ef-5d897f231971)
