### PR TITLE
fix: [#6752] The ShowTypingMiddleware throws System.ObjectDisposedException when an exception occurs in the bot

### DIFF
--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -165,8 +165,11 @@ namespace Microsoft.Bot.Builder
             cts?.Dispose();
             if (typingTask != null)
             {
-                await typingTask.ConfigureAwait(false);
-                typingTask.Dispose();
+                if (!typingTask.IsFaulted)
+                {
+                    await typingTask.ConfigureAwait(false);
+                    typingTask.Dispose();
+                }
             }
 
             _tasks.TryRemove(turnContext.Activity.Conversation.Id, out _);

--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -163,13 +163,10 @@ namespace Microsoft.Bot.Builder
             var (typingTask, cts) = item;
             cts?.Cancel();
             cts?.Dispose();
-            if (typingTask != null)
+            if (typingTask != null && !typingTask.IsFaulted)
             {
-                if (!typingTask.IsFaulted)
-                {
-                    await typingTask.ConfigureAwait(false);
-                    typingTask.Dispose();
-                }
+                await typingTask.ConfigureAwait(false);
+                typingTask.Dispose();              
             }
 
             _tasks.TryRemove(turnContext.Activity.Conversation.Id, out _);

--- a/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
+++ b/libraries/Microsoft.Bot.Builder/ShowTypingMiddleware.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Builder
             if (typingTask != null && !typingTask.IsFaulted)
             {
                 await typingTask.ConfigureAwait(false);
-                typingTask.Dispose();              
+                typingTask.Dispose();
             }
 
             _tasks.TryRemove(turnContext.Activity.Conversation.Id, out _);


### PR DESCRIPTION
#minor
Fixes # 6752

## Description
This PR fixes the Dispose error avoiding the dispose of faulted tasks.

## Specific Changes
  - Added _**if**_ condition to dispose tasks that are not faulted.

## Testing
The following image shows the bot responding correctly to other requests after an error has occurred.
![image](https://github.com/microsoft/botbuilder-dotnet/assets/122501764/38bf1410-eebf-45ef-993a-04445e5f7b4b)