### PR TITLE
Update TimeoutException message

### DIFF
--- a/libraries/Microsoft.Bot.Connector.Streaming/TaskExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector.Streaming/TaskExtensions.cs
@@ -6,14 +6,14 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Bot.Connector.Streaming
-{ 
+{
     internal static class TaskExtensions
     {
-        private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
         public static async Task<T> DefaultTimeOutAsync<T>(this Task<T> task)
         {
-            return await task.TimeoutAfterAsync<T>(_defaultTimeout).ConfigureAwait(false);
+            return await task.TimeoutAfterAsync<T>(DefaultTimeout).ConfigureAwait(false);
         }
 
         public static async Task<T> TimeoutAfterAsync<T>(this Task<T> task, TimeSpan timeout)
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Connector.Streaming
 
         public static async Task DefaultTimeOutAsync(this Task task)
         {
-            await task.TimeoutAfterAsync(_defaultTimeout).ConfigureAwait(false);
+            await task.TimeoutAfterAsync(DefaultTimeout).ConfigureAwait(false);
         }
 
         public static async Task TimeoutAfterAsync(this Task task, TimeSpan timeout)


### PR DESCRIPTION
#minor

## Description
This PR detects when a timeout happens while streaming, it will throw a new `OperationCanceledException` explaining why the timeout happened.

## Specific Changes
  - Adds 2 messages when timing out, when the streaming connection got disconnected, and just when the request didn't receive a response in the defined time frame.

## Testing
The following image shows the bot capturing the new `TimeoutException` message.
![image](https://github.com/southworks/botbuilder-dotnet/assets/62260472/b4040b81-4c28-499f-8255-be4eddf05d5a)
