### PR TITLE
Add counter to onError trigger to break possible loops

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.schema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.schema
@@ -3,5 +3,16 @@
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
     "title": "On error",
     "description": "Action to perform when an 'Error' dialog event occurs.",
-    "type": "object"
+    "type": "object",
+    "properties": {
+        "executionLimit": {
+            "$ref": "schema:#/definitions/numberExpression",
+            "title": "Execution limit",
+            "description": "Number of executions allowed for this trigger. Used to break loops in case of errors inside the trigger.",
+            "examples": [
+                3,
+                "=f(x)"
+            ]
+        }
+    }
 }

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/TriggerConditions/Microsoft.OnError.uischema
@@ -3,7 +3,8 @@
     "form": {
         "order": [
             "condition",
-            "*"
+            "*",
+            "executionLimit"
         ],
         "hidden": [
             "actions"

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         /// <summary>
         /// Gets or sets the number of executions allowed. Used to avoid infinite loops in case of error.
         /// </summary>
-        /// <value>.</value>
+        /// <value>The number of executions allowed for this trigger.</value>
         [JsonProperty("executionLimit")]
         public NumberExpression ExecutionLimit { get; set; } = new NumberExpression();
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
@@ -29,6 +31,26 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         public OnError(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
             : base(@event: AdaptiveEvents.Error, actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)
         {
+        }
+
+        /// <summary>
+        /// Gets or sets the number of executions allowed. Used to avoid infinit loops in case of error.
+        /// </summary>
+        /// <value>.</value>
+        [JsonProperty("executionLimit")]
+        public NumberExpression ExecutionLimit { get; set; } = new NumberExpression();
+
+        /// <summary>
+        /// Method called to execute the rule's actions.
+        /// </summary>
+        /// <param name="actionContext">Context.</param>
+        /// <returns>A <see cref="Task"/> with plan change list.</returns>
+        public override Task<List<ActionChangeList>> ExecuteAsync(ActionContext actionContext)
+        {
+            // 10 is the default number of executions we'll allow before breaking the loop.
+            var limit = ExecutionLimit.Value > 0 ? ExecutionLimit.Value : 10;
+            actionContext.State.SetValue(TurnPath.ExecutionLimit, limit);
+            return base.ExecuteAsync(actionContext);
         }
 
         /// <summary>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/TriggerConditions/OnError.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions
         }
 
         /// <summary>
-        /// Gets or sets the number of executions allowed. Used to avoid infinit loops in case of error.
+        /// Gets or sets the number of executions allowed. Used to avoid infinite loops in case of error.
         /// </summary>
         /// <value>.</value>
         [JsonProperty("executionLimit")]

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Bot.Builder.Dialogs
         public const string ActivityProcessed = "turn.activityProcessed";
 
         /// <summary>
-        /// Used to limit the execution of a trigger avoiding infinit loops in case of errors.
+        /// Used to limit the execution of a trigger avoiding infinite loops in case of errors.
         /// </summary>
         public const string ExecutionLimit = "turn.executionLimit";
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/Memory/TurnPath.cs
@@ -73,6 +73,11 @@ namespace Microsoft.Bot.Builder.Dialogs
         public const string ActivityProcessed = "turn.activityProcessed";
 
         /// <summary>
+        /// Used to limit the execution of a trigger avoiding infinit loops in case of errors.
+        /// </summary>
+        public const string ExecutionLimit = "turn.executionLimit";
+
+        /// <summary>
         /// The result from the last dialog that was called.
         /// </summary>
         /// <remarks>This property is deprecated, use TurnPath.LastResult instead.</remarks>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ConditionalsTests.cs
@@ -90,6 +90,18 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
         }
 
         [Fact]
+        public async Task ConditionalsTests_OnErrorLoop()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task ConditionalsTests_OnErrorLoopDefaultLimit()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
         public void OnConditionWithCondition()
         {
             AssertExpression(

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ConditionalsTests/ConditionalsTests_OnErrorLoop.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ConditionalsTests/ConditionalsTests_OnErrorLoop.test.dialog
@@ -1,0 +1,65 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "ErrorLoop",
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in BeginDialog."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in BeginDialog."
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in OnError."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in OnError."
+                    }
+                ],
+                "executionLimit": 3
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in BeginDialog."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Exception in OnError."
+        }
+    ]
+}

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ConditionalsTests/ConditionalsTests_OnErrorLoopDefaultLimit.test.dialog
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Tests/ConditionalsTests/ConditionalsTests_OnErrorLoopDefaultLimit.test.dialog
@@ -1,0 +1,92 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "ErrorLoop",
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in BeginDialog."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in BeginDialog."
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Throw Exception in OnError."
+                    },
+                    {
+                        "$kind": "Microsoft.ThrowException",
+                        "errorValue": "Exception in OnError."
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in BeginDialog."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Throw Exception in OnError."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Exception in OnError."
+        }
+    ]
+}


### PR DESCRIPTION
#minor

## Description
This PR adds a counter in the loop that executes the _onError_ trigger to detect and break possible infinite loops when there's an error inside the _onError_ handler.
It also includes a new property to the _onError_, to make the limit of executions configurable for the users (default value: 10).

## Specific Changes
- Added `ExecutionLimit` property to the _onError_ trigger and read it in the override of the _ExecuteAsync_ method.
- Updated _InternalRunAsync_ in `DialogExtensions` to evaluate the execution limit property and break the loop in case of detecting one.
- Added _ExecutionLimit_ property to `TurnPath` to be able to store the value in memory.
- Updated `Microsoft.OnError.schema` and  `Microsoft.OnError.uischema` to include the new property.
- Added 2 unit tests in `ConditionalTests` to cover the new functionality.

## Testing
These images show the scenarios we tested with the new implementation.
![image](https://github.com/southworks/botbuilder-dotnet/assets/44245136/c140bd3b-63d6-4d48-9603-5b93138bbc6d)