### PR TITLE
Logging UnauthorizedAccessException in BotFrameworkHttpAdapter

### DIFF
--- a/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.AspNet.Core/BotFrameworkHttpAdapter.cs
@@ -181,10 +181,12 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core
                     // write the response, potentially serializing the InvokeResponse
                     await HttpHelper.WriteResponseAsync(httpResponse, invokeResponse).ConfigureAwait(false);
                 }
-                catch (UnauthorizedAccessException)
+                catch (UnauthorizedAccessException ex)
                 {
                     // handle unauthorized here as this layer creates the http response
                     httpResponse.StatusCode = (int)HttpStatusCode.Unauthorized;
+
+                    Logger.LogError(ex.ToString());
                 }
             }
         }


### PR DESCRIPTION
#minor

Makes it easier to see auth errors due to misconfiguration.