### PR TITLE
fix: [#6758] Update to version 3 of the Azure Cosmos DB .NET SDK

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.40.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />


### PR DESCRIPTION
Fixes #6758

## Description
This PR updates the _**Microsoft.Azure.Cosmos**_ version from 3.32.2 to 3.40.0.

## Specific Changes
  - Updated _**Microsoft.Azure.Cosmos**_ to 3.40.0.

## Testing
The following image shows the BotBuilder Azure unit tests working after the update.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/d6075031-a60a-4270-93f8-e7fe391e3c38)