### PR TITLE
fix: [#6798] Not able to create instance of BlobsTranscriptStore using TokenCredential instead of connectionString and containerName

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Core;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Bot.Builder.Azure.Blobs;
@@ -50,6 +51,13 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 "containerName",
                 JsonSerializer.Create(new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All }));
 
+            var blobServiceUri = new Uri("https://storage.net/");
+
+            var mockCredential = new Mock<TokenCredential>();
+            mockCredential
+                .Setup(c => c.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AccessToken("fake-token", DateTimeOffset.UtcNow.AddHours(1)));
+
             // No dataConnectionString. Should throw.
             Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(null, "containerName"));
             Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(string.Empty, "containerName"));
@@ -57,6 +65,16 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             // No containerName. Should throw.
             Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(ConnectionString, null));
             Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(ConnectionString, string.Empty));
+
+            // No URI. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(blobServiceUri: null, mockCredential.Object, "containerName"));
+
+            // No tokenCredential. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(blobServiceUri, null, "containerName"));
+            
+            // No containerName. Should throw.
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(blobServiceUri, mockCredential.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new BlobsTranscriptStore(blobServiceUri, mockCredential.Object, string.Empty));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #6798

## Description
This PR allows the use of Token Credentials to authenticate and create an instance of _BlobsTranscriptStore_.

## Specific Changes
  - Added constructors in _BlobsTranscriptStore_ with _**blobServiceUri**_ and _**tokenCredentials**_ as parameters. 
  - Added constructor validations in unit tests.

## Testing
The following images show the bot working and saving transcripts using _BlobsTranscriptStore_ instantiated with token credentials.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/5510a375-c492-44ca-ab6e-7bfa08761dde)
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/d6218d06-56bf-4122-8439-e3926a190f18)