### PR TITLE
[#6825] Update Threading.Analyzers

### DIFF
--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/BotBuilderTemplatesVSIX.csproj
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/BotBuilderTemplatesVSIX.csproj
@@ -119,7 +119,7 @@
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
-    <Analyzer Include="packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+    <Analyzer Include="packages\Microsoft.VisualStudio.Threading.Analyzers.17.10.48\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
@@ -128,12 +128,12 @@
 powershell Compress-Archive -Path '$(SolutionDir)UncompressedProjectTemplates\*' -DestinationPath $(ProjectDir)ProjectTemplates\Bot` Framework.zip -Force
     </PreBuildEvent>
   </PropertyGroup>
-  <Import Project="packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
+  <Import Project="packages\Microsoft.VisualStudio.Threading.Analyzers.17.10.48\build\Microsoft.VisualStudio.Threading.Analyzers.targets" Condition="Exists('packages\Microsoft.VisualStudio.Threading.Analyzers.17.10.48\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudio.Threading.Analyzers.15.8.122\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.VisualStudio.Threading.Analyzers.17.10.48\build\Microsoft.VisualStudio.Threading.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudio.Threading.Analyzers.17.10.48\build\Microsoft.VisualStudio.Threading.Analyzers.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\build\Microsoft.VisualStudio.SDK.Analyzers.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.props'))" />
     <Error Condition="!Exists('packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.VSSDK.BuildTools.17.0.5232\build\Microsoft.VSSDK.BuildTools.targets'))" />

--- a/generators/vsix-vs-win/BotBuilderVSIX-V4/packages.config
+++ b/generators/vsix-vs-win/BotBuilderVSIX-V4/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.SDK.Analyzers" version="15.8.33" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.122" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading.Analyzers" version="17.10.48" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="17.0.5232" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/libraries/Directory.Build.props
+++ b/libraries/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestScript.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
                 userToken.Setup(adapter);
             }
 
-            async Task Inspect(DialogContextInspector inspector)
+            async Task InspectAsync(DialogContextInspector inspector)
             {
                 var di = new DialogInspector(Dialog, resourceExplorer);
                 var activity = new Activity();
@@ -235,7 +235,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Testing
 
             foreach (var testAction in Script)
             {
-                await testAction.ExecuteAsync(adapter, callback, Inspect).ConfigureAwait(false);
+                await testAction.ExecuteAsync(adapter, callback, InspectAsync).ConfigureAwait(false);
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs.Declarative/Resources/ResourceExplorer.cs
@@ -747,7 +747,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Resources
                     cancelReloadToken.Cancel();
                     cancelReloadToken = new CancellationTokenSource();
 
-                    Task.Delay(1000, cancelReloadToken.Token)
+                    _ = Task.Delay(1000, cancelReloadToken.Token)
                         .ContinueWith(
                             t =>
                             {


### PR DESCRIPTION
Addresses #6825
#minor

## Description
This PR updates the `Microsoft.VisualStudio.Threading.Analyzers` from `15.8.122` to `17.10.48`, and fixes the [VSTHRD200](https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/VSTHRD200.md) issue with internal methods.

## Specific Changes
  - Updated `Microsoft.VisualStudio.Threading.Analyzers` to latest version in BotBuilder and VSIX projects.
  - Updated some internal methods that required the `Async` suffix due to the `VSTHRD200` error alert.

## Testing
The following image shows the CI pipeline working, and an echo bot generated with VSIX templates.
![image](https://github.com/user-attachments/assets/35e5792e-bb34-4cc5-b0e9-6db3b2a1a474)
