### PR TITLE
[#6825] Replace deprecated FxCopAnalyzers with NetAnalyzers

### DIFF
--- a/libraries/Directory.Build.props
+++ b/libraries/Directory.Build.props
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/libraries/Microsoft.Bot.Builder/TokenResolver.cs
+++ b/libraries/Microsoft.Bot.Builder/TokenResolver.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder
 
                 if (!pollingParams.SentToken)
                 {
-                    pollingHelper.Logger.LogInformation("PollForTokenAsync completed without receiving a token", pollingHelper.Activity);
+                    pollingHelper.Logger.LogInformation("PollForTokenAsync completed without receiving a token");
                 }
 
                 stopwatch.Stop();
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Builder
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                pollingHelper.Logger.LogError(ex, "PollForTokenAsync threw an exception", connectionName);
+                pollingHelper.Logger.LogError(ex, "PollForTokenAsync threw an exception");
             }
         }
 
@@ -214,7 +214,7 @@ namespace Microsoft.Bot.Builder
                             pollingParams.ShouldEndPolling = true;
                             pollingParams.SentToken = true;
 
-                            Logger.LogInformation("PollForTokenAsync completed with a token", Activity);
+                            Logger.LogInformation("PollForTokenAsync completed with a token");
                         }
                     }
                 };


### PR DESCRIPTION
Addresses #6825
#minor

## Description
This PR replaces deprecated `Microsoft.CodeAnalysis.FxCopAnalyzers` with `Microsoft.CodeAnalysis.NetAnalyzers` as suggested in [this guide](https://learn.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2022).

## Specific Changes
  - Replaced  `Microsoft.CodeAnalysis.FxCopAnalyzers` with `Microsoft.CodeAnalysis.NetAnalyzers` latest version.
  - Updated `TokenResolver` logs due to [CA2017](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2017) issue.

## Testing
The following image shows the CI pipeline working.
![imagen](https://github.com/user-attachments/assets/be942741-c417-468a-bfbd-afb4579d2707)