### PR TITLE
fix: [#6825] Update xunit and fix compatibility issues in unit tests

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Testing/Microsoft.Bot.Builder.Testing.csproj
+++ b/libraries/Microsoft.Bot.Builder.Testing/Microsoft.Bot.Builder.Testing.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Bot.Builder.Dialogs\Microsoft.Bot.Builder.Dialogs.csproj" />

--- a/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
@@ -40,7 +40,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
+++ b/libraries/Microsoft.Bot.Streaming/Microsoft.Bot.Streaming.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <PackageId>Microsoft.Bot.Streaming</PackageId>
     <Description>Streaming library for the Bot Framework SDK</Description>
     <Summary>Streaming library for the Bot Framework SDK</Summary>
@@ -26,9 +26,20 @@
     <NoWarn>$(NoWarn);</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	  <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/libraries/Microsoft.Bot.Streaming/Payloads/RequestManager.cs
+++ b/libraries/Microsoft.Bot.Streaming/Payloads/RequestManager.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Streaming.Payloads
                 return null;
             }
 
-            if (cancellationToken == null)
+            if (cancellationToken == default)
             {
                 cancellationToken = CancellationToken.None;
             }

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookAdapterTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldSucceed()
+        public async Task ContinueConversationAsyncShouldSucceed()
         {
             var callbackInvoked = false;
             var facebookAdapter = new FacebookAdapter(new FacebookClientWrapper(_testOptions), _adapterOptions);
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldFailWithNullConversationReference()
+        public async Task ContinueConversationAsyncShouldFailWithNullConversationReference()
         {
             var facebookAdapter = new FacebookAdapter(new FacebookClientWrapper(_testOptions), _adapterOptions);
             Task BotsLogic(ITurnContext turnContext, CancellationToken cancellationToken)
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldFailWithNullLogic()
+        public async Task ContinueConversationAsyncShouldFailWithNullLogic()
         {
             var facebookAdapter = new FacebookAdapter(new FacebookClientWrapper(_testOptions), _adapterOptions);
             var conversationReference = new ConversationReference();
@@ -83,7 +83,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldSucceedWithCorrectData()
+        public async Task ProcessAsyncShouldSucceedWithCorrectData()
         {
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/Payload.json");
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldSucceedWithStandbyMessages()
+        public async Task ProcessAsyncShouldSucceedWithStandbyMessages()
         {
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/PayloadWithStandby.json");
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldSucceedWithReferralMessages()
+        public async Task ProcessAsyncShouldSucceedWithReferralMessages()
         {
             var payload = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/PayloadWithReferral.json");
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldVerifyWebhookOnHubModeSubscribe()
+        public async Task ProcessAsyncShouldVerifyWebhookOnHubModeSubscribe()
         {
             var testOptionsVerifyEnabled = new FacebookAdapterOptions()
             {
@@ -190,7 +190,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldSucceedWithActivityTypeMessage()
+        public async Task SendActivitiesAsyncShouldSucceedWithActivityTypeMessage()
         {
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -219,7 +219,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldSucceedWithActivityTypeMessageAndAttachments()
+        public async Task SendActivitiesAsyncShouldSucceedWithActivityTypeMessageAndAttachments()
         {
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -251,7 +251,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldSucceedAndNoActivityReturnedWithActivityTypeNotMessage()
+        public async Task SendActivitiesAsyncShouldSucceedAndNoActivityReturnedWithActivityTypeNotMessage()
         {
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -283,7 +283,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldPostToFacebookOnPassThreadControl()
+        public async Task SendActivitiesAsyncShouldPostToFacebookOnPassThreadControl()
         {
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -315,7 +315,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldPostToFacebookOnTakeThreadControl()
+        public async Task SendActivitiesAsyncShouldPostToFacebookOnTakeThreadControl()
         {
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);
@@ -347,7 +347,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldPostToFacebookOnRequestThreadControl()
+        public async Task SendActivitiesAsyncShouldPostToFacebookOnRequestThreadControl()
         {
             const string testResponse = "Test Response";
             var facebookClientWrapper = new Mock<FacebookClientWrapper>(_testOptions);

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/FacebookWrapperTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Newtonsoft.Json;
@@ -64,7 +65,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendMessageAsyncShouldThrowAnExceptionWithWrongPath()
+        public async Task SendMessageAsyncShouldThrowAnExceptionWithWrongPath()
         {
             var facebookMessageJson = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/FacebookMessages.json");
             var facebookMessage = JsonConvert.DeserializeObject<List<FacebookMessage>>(facebookMessageJson)[5];
@@ -77,7 +78,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendMessageAsyncShouldThrowAnExceptionWithNullPath()
+        public async Task SendMessageAsyncShouldThrowAnExceptionWithNullPath()
         {
             var facebookMessageJson = File.ReadAllText(Directory.GetCurrentDirectory() + @"/Files/FacebookMessages.json");
             var facebookMessage = JsonConvert.DeserializeObject<List<FacebookMessage>>(facebookMessageJson)[5];
@@ -90,7 +91,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void SendMessageAsyncShouldThrowAnExceptionWithNullPayload()
+        public async Task SendMessageAsyncShouldThrowAnExceptionWithNullPayload()
         {
             var facebookWrapper = new FacebookClientWrapper(_testOptions);
 
@@ -101,7 +102,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void VerifyWebhookAsyncShouldSendOkWhenVerified()
+        public async Task VerifyWebhookAsyncShouldSendOkWhenVerified()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -124,7 +125,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void VerifyWebhookAsyncShouldSendUnauthorizedWhenNotVerified()
+        public async Task VerifyWebhookAsyncShouldSendUnauthorizedWhenNotVerified()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -147,7 +148,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void VerifyWebhookAsyncShouldThrowExceptionWithNullRequest()
+        public async Task VerifyWebhookAsyncShouldThrowExceptionWithNullRequest()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
             var httpResponse = new Mock<HttpResponse>();
@@ -156,7 +157,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void VerifyWebhookAsyncShouldThrowExceptionWithNullResponse()
+        public async Task VerifyWebhookAsyncShouldThrowExceptionWithNullResponse()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -165,7 +166,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void PassThreadControlAsyncShouldThrowExceptionWithNullTargetAppId()
+        public async Task PassThreadControlAsyncShouldThrowExceptionWithNullTargetAppId()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
@@ -173,7 +174,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void PassThreadControlAsyncShouldThrowExceptionWithNullUserId()
+        public async Task PassThreadControlAsyncShouldThrowExceptionWithNullUserId()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
@@ -181,7 +182,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void RequestThreadControlAsyncShouldThrowExceptionWithNullUserId()
+        public async Task RequestThreadControlAsyncShouldThrowExceptionWithNullUserId()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
@@ -189,7 +190,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void TakeThreadControlAsyncShouldThrowExceptionWithNullUserId()
+        public async Task TakeThreadControlAsyncShouldThrowExceptionWithNullUserId()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
@@ -197,7 +198,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void PostToFacebookApiAsyncShouldThrowExceptionWithNullPostType()
+        public async Task PostToFacebookApiAsyncShouldThrowExceptionWithNullPostType()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 
@@ -205,7 +206,7 @@ namespace Microsoft.Bot.Builder.Adapters.Facebook.Tests
         }
 
         [Fact]
-        public async void PostToFacebookApiAsyncShouldThrowExceptionWithNullContent()
+        public async Task PostToFacebookApiAsyncShouldThrowExceptionWithNullContent()
         {
             var facebookClientWrapper = new FacebookClientWrapper(_testOptions);
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Facebook.Tests/Microsoft.Bot.Builder.Adapters.Facebook.Tests.csproj
@@ -18,7 +18,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/Microsoft.Bot.Builder.Adapters.Slack.Tests.csproj
@@ -20,7 +20,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Slack.Tests/SlackAdapterTests.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullHttpRequest()
+        public async Task ProcessAsyncShouldFailWithNullHttpRequest()
         {
             var slackApi = new Mock<SlackClientWrapper>(_testOptions);
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
@@ -421,7 +421,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullHttpResponse()
+        public async Task ProcessAsyncShouldFailWithNullHttpResponse()
         {
             var slackApi = new Mock<SlackClientWrapper>(_testOptions);
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
@@ -437,7 +437,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullBot()
+        public async Task ProcessAsyncShouldFailWithNullBot()
         {
             var slackApi = new Mock<SlackClientWrapper>(_testOptions);
             slackApi.Setup(x => x.TestAuthAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult("mockedUserId"));
@@ -543,7 +543,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             await slackAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, new Mock<IBot>().Object, default);
 
-            Assert.Equal(httpResponse.Object.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, httpResponse.Object.StatusCode);
         }
 
         [Fact]
@@ -559,7 +559,7 @@ namespace Microsoft.Bot.Builder.Adapters.Slack.Tests
 
             await slackAdapter.ProcessAsync(httpRequest.Object, httpResponse.Object, new Mock<IBot>().Object, default);
 
-            Assert.Equal(httpResponse.Object.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, httpResponse.Object.StatusCode);
         }
 
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/Microsoft.Bot.Builder.Adapters.Twilio.Tests.csproj
@@ -16,7 +16,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioAdapterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldSucceed()
+        public async Task SendActivitiesAsyncShouldSucceed()
         {
             var activity = new Mock<Activity>().SetupAllProperties();
             activity.Object.Type = "message";
@@ -46,13 +46,13 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             twilioApi.Setup(x => x.SendMessageAsync(It.IsAny<TwilioMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
 
             var twilioAdapter = new TwilioAdapter(twilioApi.Object, _adapterOptions);
-            var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default).ConfigureAwait(false);
+            var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default);
 
             Assert.True(resourceResponses[0].Id == resourceIdentifier);
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldSucceedAndNoActivityReturnedWithActivityTypeNotMessage()
+        public async Task SendActivitiesAsyncShouldSucceedAndNoActivityReturnedWithActivityTypeNotMessage()
         {
             var activity = new Mock<Activity>().SetupAllProperties();
             activity.Object.Type = ActivityTypes.Trace;
@@ -65,13 +65,13 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
             twilioApi.Setup(x => x.SendMessageAsync(It.IsAny<TwilioMessageOptions>(), default)).Returns(Task.FromResult(resourceIdentifier));
 
             var twilioAdapter = new TwilioAdapter(twilioApi.Object, _adapterOptions);
-            var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default).ConfigureAwait(false);
+            var resourceResponses = await twilioAdapter.SendActivitiesAsync(null, new Activity[] { activity.Object }, default);
 
             Assert.True(resourceResponses.Length == 0);
         }
 
         [Fact]
-        public async void ProcessAsyncShouldSucceedWithHttpBody()
+        public async Task ProcessAsyncShouldSucceedWithHttpBody()
         {
             var payload = File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/NoMediaPayload.txt"));
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload.ToString()));
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldSucceedWithNullHttpBody()
+        public async Task ProcessAsyncShouldSucceedWithNullHttpBody()
         {
             var payload = File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/NoMediaPayload.txt"));
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload.ToString()));
@@ -133,7 +133,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullHttpRequest()
+        public async Task ProcessAsyncShouldFailWithNullHttpRequest()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
             var httpResponse = new Mock<HttpResponse>();
@@ -146,7 +146,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullHttpResponse()
+        public async Task ProcessAsyncShouldFailWithNullHttpResponse()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -159,7 +159,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullBot()
+        public async Task ProcessAsyncShouldFailWithNullBot()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -172,7 +172,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void UpdateActivityAsyncShouldThrowNotSupportedException()
+        public async Task UpdateActivityAsyncShouldThrowNotSupportedException()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
             var activity = new Activity();
@@ -187,7 +187,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void DeleteActivityAsyncShouldThrowNotSupportedException()
+        public async Task DeleteActivityAsyncShouldThrowNotSupportedException()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
             var activity = new Activity();
@@ -203,7 +203,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldSucceed()
+        public async Task ContinueConversationAsyncShouldSucceed()
         {
             var callbackInvoked = false;
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
@@ -221,7 +221,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldFailWithNullConversationReference()
+        public async Task ContinueConversationAsyncShouldFailWithNullConversationReference()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
 
@@ -234,7 +234,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldFailWithNullLogic()
+        public async Task ContinueConversationAsyncShouldFailWithNullLogic()
         {
             var twilioAdapter = new TwilioAdapter(new Mock<TwilioClientWrapper>(_testOptions).Object, _adapterOptions);
             var conversationReference = new ConversationReference();
@@ -243,7 +243,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
         }
 
         [Fact]
-        public async void AdapterOptionsValidateFalseShouldNotCallValidateSignature()
+        public async Task AdapterOptionsValidateFalseShouldNotCallValidateSignature()
         {
             var payload = File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/NoMediaPayload.txt"));
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload.ToString()));

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Twilio.Tests/TwilioHelperTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             var activity = TwilioHelper.PayloadToActivity(dictionaryPayload);
 
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio.Tests
 
             var activity = TwilioHelper.PayloadToActivity(dictionaryPayload);
 
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
         }
 
         [Fact]

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/Microsoft.Bot.Builder.Adapters.Webex.Tests.csproj
@@ -14,7 +14,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexAdapterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldSucceed()
+        public async Task ContinueConversationAsyncShouldSucceed()
         {
             var callbackInvoked = false;
 
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldFailWithNullConversationReference()
+        public async Task ContinueConversationAsyncShouldFailWithNullConversationReference()
         {
             var webexAdapter = new WebexAdapter(new Mock<WebexClientWrapper>(_testOptions).Object, _adapterOptions);
 
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ContinueConversationAsyncShouldFailWithNullLogic()
+        public async Task ContinueConversationAsyncShouldFailWithNullLogic()
         {
             var webexAdapter = new WebexAdapter(new Mock<WebexClientWrapper>(_testOptions).Object, _adapterOptions);
             var conversationReference = new ConversationReference();
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncWithEvenTypeCreatedShouldSucceed()
+        public async Task ProcessAsyncWithEvenTypeCreatedShouldSucceed()
         {
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"\Files\Message.json")));
             var payload = File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/Payload.json"));
@@ -107,7 +107,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncWithEvenTypeUpdatedShouldSucceed()
+        public async Task ProcessAsyncWithEvenTypeUpdatedShouldSucceed()
         {
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
             webexApi.SetupAllProperties();
@@ -136,7 +136,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncWithAttachmentActionsShouldSucceed()
+        public async Task ProcessAsyncWithAttachmentActionsShouldSucceed()
         {
             var message = JsonConvert.DeserializeObject<Message>(File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/MessageWithInputs.json")));
             var payload = File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/PayloadAttachmentActions.json"));
@@ -167,7 +167,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullHttpRequest()
+        public async Task ProcessAsyncShouldFailWithNullHttpRequest()
         {
             var webexAdapter = new WebexAdapter(new Mock<WebexClientWrapper>(_testOptions).Object, _adapterOptions);
             var httpResponse = new Mock<HttpResponse>();
@@ -180,7 +180,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullHttpResponse()
+        public async Task ProcessAsyncShouldFailWithNullHttpResponse()
         {
             var webexAdapter = new WebexAdapter(new Mock<WebexClientWrapper>(_testOptions).Object, _adapterOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNullBot()
+        public async Task ProcessAsyncShouldFailWithNullBot()
         {
             var webexAdapter = new WebexAdapter(new Mock<WebexClientWrapper>(_testOptions).Object, _adapterOptions);
             var httpRequest = new Mock<HttpRequest>();
@@ -206,7 +206,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void ProcessAsyncShouldFailWithNonMatchingSignature()
+        public async Task ProcessAsyncShouldFailWithNonMatchingSignature()
         {
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
             webexApi.SetupAllProperties();
@@ -232,7 +232,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void UpdateActivityAsyncShouldThrowNotSupportedException()
+        public async Task UpdateActivityAsyncShouldThrowNotSupportedException()
         {
             var webexAdapter = new WebexAdapter(new Mock<WebexClientWrapper>(_testOptions).Object, _adapterOptions);
 
@@ -247,7 +247,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void SendActivitiesAsyncNotNullToPersonEmailShouldSucceed()
+        public async Task SendActivitiesAsyncNotNullToPersonEmailShouldSucceed()
         {
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
@@ -264,14 +264,14 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
 
-            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default).ConfigureAwait(false);
+            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default);
 
             // Assert the result
             Assert.True(resourceResponse[0].Id == expectedResponseId);
         }
 
         [Fact]
-        public async void SendActivitiesAsyncWithAttachmentShouldSucceed()
+        public async Task SendActivitiesAsyncWithAttachmentShouldSucceed()
         {
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
@@ -292,14 +292,14 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
 
-            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default).ConfigureAwait(false);
+            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default);
 
             // Assert the result
             Assert.True(resourceResponse[0].Id == expectedResponseId);
         }
 
         [Fact]
-        public async void SendActivitiesAsyncWithAttachmentActionsShouldSucceed()
+        public async Task SendActivitiesAsyncWithAttachmentActionsShouldSucceed()
         {
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
@@ -318,13 +318,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
 
-            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default).ConfigureAwait(false);
+            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default);
 
             Assert.True(resourceResponse[0].Id == expectedResponseId);
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldSucceedAndNoActivityReturnedWithActivityTypeNotMessage()
+        public async Task SendActivitiesAsyncShouldSucceedAndNoActivityReturnedWithActivityTypeNotMessage()
         {
             const string expectedResponseId = "Mocked Response Id";
             var webexApi = new Mock<WebexClientWrapper>(_testOptions);
@@ -339,13 +339,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
 
             var turnContext = new TurnContext(webexAdapter, activity.Object);
 
-            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default).ConfigureAwait(false);
+            var resourceResponse = await webexAdapter.SendActivitiesAsync(turnContext, new Activity[] { activity.Object }, default);
 
             Assert.True(resourceResponse.Length == 0);
         }
 
         [Fact]
-        public async void SendActivitiesAsyncShouldFailWithNullToPersonEmail()
+        public async Task SendActivitiesAsyncShouldFailWithNullToPersonEmail()
         {
             // Setup mocked Webex API client
             const string expectedResponseId = "Mocked Response Id";
@@ -367,7 +367,7 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void DeleteActivityAsyncWithActivityIdShouldSucceed()
+        public async Task DeleteActivityAsyncWithActivityIdShouldSucceed()
         {
             var deletedMessages = 0;
 

--- a/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
+++ b/tests/Adapters/Microsoft.Bot.Builder.Adapters.Webex.Tests/WebexHelperTests.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Bot.Builder.Adapters.Webex.Tests
         }
 
         [Fact]
-        public async void GetDecryptedMessageAsyncShouldReturnNullWithNullPayload()
+        public async Task GetDecryptedMessageAsyncShouldReturnNullWithNullPayload()
         {
             Assert.Null(await WebexHelper.GetDecryptedMessageAsync(null, null, new CancellationToken()));
         }
 
         [Fact]
-        public async void GetDecryptedMessageAsyncShouldSucceed()
+        public async Task GetDecryptedMessageAsyncShouldSucceed()
         {
             var testOptions = new WebexClientWrapperOptions("Test", new Uri("http://contoso.com"), "Test");
             var payload = JsonConvert.DeserializeObject<WebhookEventData>(File.ReadAllText(PathUtils.NormalizePath(Directory.GetCurrentDirectory() + @"/Files/Payload.json")));

--- a/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
+++ b/tests/AdaptiveExpressions.Tests/AdaptiveExpressions.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AdaptiveExpressions.Tests/LRUCacheTest.cs
+++ b/tests/AdaptiveExpressions.Tests/LRUCacheTest.cs
@@ -59,10 +59,10 @@ namespace AdaptiveExpressions.Tests
             Assert.False(cache.TryGet(9998, out var result));
 
             Assert.True(cache.TryGet(maxIdx - 1, out result));
-            Assert.Equal(result, fib9999);
+            Assert.Equal(fib9999, result);
 
             Assert.True(cache.TryGet(maxIdx, out result));
-            Assert.Equal(result, fib100000);
+            Assert.Equal(fib100000, result);
         }
 
         [Fact]
@@ -87,10 +87,10 @@ namespace AdaptiveExpressions.Tests
             Assert.False(cache.TryGet(1, out var result));
 
             Assert.True(cache.TryGet(maxIdx - 1, out result));
-            Assert.Equal(result, fib9999);
+            Assert.Equal(fib9999, result);
 
             Assert.True(cache.TryGet(maxIdx, out result));
-            Assert.Equal(result, fib100000);
+            Assert.Equal(fib100000, result);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace AdaptiveExpressions.Tests
                 tasks.Add(Task.Run(() => StoreElement(cache, numOfOps, i)));
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await Task.WhenAll(tasks);
 
             for (var i = numOfOps - numOfThreads; i < numOfOps; i++)
             {

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests/LRUCacheTest.cs
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests/LRUCacheTest.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests
             Assert.False(cache.TryGet(9998, out var result));
 
             Assert.True(cache.TryGet(maxIdx - 1, out result));
-            Assert.Equal(result, fib9999);
+            Assert.Equal(fib9999, result);
 
             Assert.True(cache.TryGet(maxIdx, out result));
-            Assert.Equal(result, fib100000);
+            Assert.Equal(fib100000, result);
         }
 
         [Fact]
@@ -87,10 +87,10 @@ namespace Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests
             Assert.False(cache.TryGet(1, out var result));
 
             Assert.True(cache.TryGet(maxIdx - 1, out result));
-            Assert.Equal(result, fib9999);
+            Assert.Equal(fib9999, result);
 
             Assert.True(cache.TryGet(maxIdx, out result));
-            Assert.Equal(result, fib100000);
+            Assert.Equal(fib100000, result);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests
                 tasks.Add(Task.Run(() => StoreElement(cache, numOfOps, i)));
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await Task.WhenAll(tasks);
 
             for (var i = numOfOps - numOfThreads; i < numOfOps; i++)
             {

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests.csproj
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests/Microsoft.Bot.AdaptiveExpressions.Core.AOT.Tests.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/LRUCacheTest.cs
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/LRUCacheTest.cs
@@ -59,10 +59,10 @@ namespace Microsoft.Bot.AdaptiveExpressions.Core.Tests
             Assert.False(cache.TryGet(9998, out var result));
 
             Assert.True(cache.TryGet(maxIdx - 1, out result));
-            Assert.Equal(result, fib9999);
+            Assert.Equal(fib9999, result);
 
             Assert.True(cache.TryGet(maxIdx, out result));
-            Assert.Equal(result, fib100000);
+            Assert.Equal(fib100000, result);
         }
 
         [Fact]
@@ -87,10 +87,10 @@ namespace Microsoft.Bot.AdaptiveExpressions.Core.Tests
             Assert.False(cache.TryGet(1, out var result));
 
             Assert.True(cache.TryGet(maxIdx - 1, out result));
-            Assert.Equal(result, fib9999);
+            Assert.Equal(fib9999, result);
 
             Assert.True(cache.TryGet(maxIdx, out result));
-            Assert.Equal(result, fib100000);
+            Assert.Equal(fib100000, result);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Microsoft.Bot.AdaptiveExpressions.Core.Tests
                 tasks.Add(Task.Run(() => StoreElement(cache, numOfOps, i)));
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            await Task.WhenAll(tasks);
 
             for (var i = numOfOps - numOfThreads; i < numOfOps; i++)
             {

--- a/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests.csproj
+++ b/tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests/Microsoft.Bot.AdaptiveExpressions.Core.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.11.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisOracleTests.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [Fact]
-        public void UserAgentContainsProductVersion()
+        public async Task UserAgentContainsProductVersionAsync()
         {
             var application = new LuisApplication
             {
@@ -328,7 +328,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             var turnContext = new TurnContext(adapter, activity);
 
-            var recognizerResult = recognizer.RecognizeAsync(turnContext, CancellationToken.None).Result;
+            var recognizerResult = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
             Assert.NotNull(recognizerResult);
 
             var userAgent = clientHandler.UserAgent;
@@ -397,7 +397,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "test", "testvalue" },
                 { "foo", "foovalue" },
             };
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties);
 
             // Assert
             Assert.NotNull(result);
@@ -445,7 +445,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var recognizer = new LuisRecognizer(opts, clientHandler);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, null).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, null);
 
             // Assert
             Assert.NotNull(result);
@@ -492,7 +492,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var recognizer = new LuisRecognizer(options, clientHandler);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, null).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, null);
 
             // Assert
             Assert.NotNull(result);
@@ -544,7 +544,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "test", "testvalue" },
                 { "foo", "foovalue" },
             };
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties);
 
             // Assert
             Assert.NotNull(result);
@@ -602,7 +602,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "boo", 2.11 },
             };
 
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics);
 
             // Assert
             Assert.NotNull(result);
@@ -655,7 +655,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var recognizer = new LuisRecognizer(opts, clientHandler);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -699,7 +699,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Act
             // Use a class the converts the Recognizer Result..
-            var result = await recognizer.RecognizeAsync<TelemetryConvertResult>(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync<TelemetryConvertResult>(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -754,7 +754,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "luis", 1.0001 },
             };
 
-            var result = await recognizer.RecognizeAsync<TelemetryConvertResult>(turnContext, additionalProperties, additionalMetrics, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync<TelemetryConvertResult>(turnContext, additionalProperties, additionalMetrics, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisRecognizerTests.cs
@@ -26,17 +26,17 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [Theory]
-        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
-        [InlineData(true, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
-        [InlineData(false, 42, true, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
-        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", true, false)]
-        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, true)]
-        [InlineData(null, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(true, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42.0, true, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", true, false)]
+        [InlineData(false, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, true)]
+        [InlineData(null, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
         [InlineData(false, null, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
-        [InlineData(false, 42, null, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
-        [InlineData(false, 42, false, null, false, false)]
-        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", null, false)]
-        [InlineData(false, 42, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, null)]
+        [InlineData(false, 42.0, null, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, false)]
+        [InlineData(false, 42.0, false, null, false, false)]
+        [InlineData(false, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", null, false)]
+        [InlineData(false, 42.0, false, "Fake2806-EC0A-472D-95B7-A7132D159E03", false, null)]
         [InlineData(null, null, null, null, null, null)]
         public async Task LuisPredictionOptionsAreUsedInTheRequest(bool? includeAllIntents, double? timezoneOffset, bool? spellCheck, string bingSpellCheckSubscriptionKey, bool? log, bool? staging)
         {
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
         [Theory]
         [InlineData(false, null, null, null, null, null)]
-        [InlineData(null, 55, null, null, null, null)]
+        [InlineData(null, 55.0, null, null, null, null)]
         [InlineData(null, null, false, null, null, null)]
         [InlineData(null, null, null, "Override-EC0A-472D-95B7-A7132D159E03", null, null)]
         [InlineData(null, null, null, null, true, null)]
@@ -142,7 +142,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
         [Theory]
         [InlineData(false, null, null, null, null, null)]
-        [InlineData(null, 55, null, null, null, null)]
+        [InlineData(null, 55.0, null, null, null, null)]
         [InlineData(null, null, false, null, null, null)]
         [InlineData(null, null, null, "Override-EC0A-472D-95B7-A7132D159E03", null, null)]
         [InlineData(null, null, null, null, true, null)]
@@ -155,7 +155,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var constructorOptions = new LuisPredictionOptions()
             {
                 IncludeAllIntents = true,
-                TimezoneOffset = 42,
+                TimezoneOffset = 42.0,
                 SpellCheck = true,
                 BingSpellCheckSubscriptionKey = "Fake2806-EC0A-472D-95B7-A7132D159E03",
                 Log = false,

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/LuisV3OracleTests.cs
@@ -280,7 +280,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
         }
 
         [Fact]
-        public void UserAgentContainsProductVersion()
+        public async Task UserAgentContainsProductVersionAsync()
         {
             var application = new LuisApplication
             {
@@ -305,7 +305,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             var turnContext = new TurnContext(adapter, activity);
 
-            var recognizerResult = recognizer.RecognizeAsync(turnContext, CancellationToken.None).Result;
+            var recognizerResult = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
             Assert.NotNull(recognizerResult);
 
             var userAgent = clientHandler.UserAgent;
@@ -369,7 +369,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "test", "testvalue" },
                 { "foo", "foovalue" },
             };
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties);
 
             // Assert
             Assert.NotNull(result);
@@ -416,7 +416,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var recognizer = new LuisRecognizer(options, clientHandler);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -464,7 +464,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var recognizer = new LuisRecognizer(options, clientHandler);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -516,7 +516,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "test", "testvalue" },
                 { "foo", "foovalue" },
             };
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties);
 
             // Assert
             Assert.NotNull(result);
@@ -574,7 +574,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "boo", 2.11 },
             };
 
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics);
 
             // Assert
             Assert.NotNull(result);
@@ -627,7 +627,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
             var recognizer = new LuisRecognizer(options, clientHandler);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -671,7 +671,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
 
             // Act
             // Use a class the converts the Recognizer Result..
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -726,7 +726,7 @@ namespace Microsoft.Bot.Builder.AI.Luis.Tests
                 { "luis", 1.0001 },
             };
 
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);

--- a/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.LUIS.Tests/Microsoft.Bot.Builder.AI.Luis.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorAdaptiveRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.Orchestrator.Tests/OrchestratorAdaptiveRecognizerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Bot.Builder.AI.Orchestrator.Tests
 
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
             var result = await recognizer.RecognizeAsync(dc, activity, default);
-            Assert.Equal(1, result.Intents.Count);
+            Assert.Single(result.Intents);
             Assert.True(result.Intents.ContainsKey("mockLabel"));
             Assert.Equal(0.9, result.Intents["mockLabel"].Score);
         }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
@@ -249,10 +249,10 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text, cancellationToken: ct);
             })
                 .Send("how do I clean the stove?")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:how do I clean the stove?")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
@@ -1114,10 +1114,11 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
         /// <summary>
         /// The LanguageService_Test_ScoreThresholdTooLarge_OutOfRange.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         [Trait("TestCategory", "AI")]
         [Trait("TestCategory", "LanguageService")]
-        public async void LanguageService_Test_NotSpecifiedQnAServiceType()
+        public async Task LanguageService_Test_NotSpecifiedQnAServiceType()
         {
             AggregateException result = null;
             var mockHttp = new MockHttpMessageHandler();
@@ -1771,7 +1772,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"));
 
             // Assert - Check Telemetry logged
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
@@ -1826,7 +1827,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var results = await qna.GetAnswersAsync(GetContext("what is the answer to my nonsense question?"));
 
             // Assert - Check Telemetry logged
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
@@ -1999,7 +2000,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics);
 
             // Assert - added properties were added.
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.KnowledgeBaseIdProperty));
@@ -2069,7 +2070,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             await qna.GetAnswersAsync(GetContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics);
 
             // Assert - added properties were added.
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/Microsoft.Bot.Builder.AI.QnA.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -382,10 +382,10 @@ namespace Microsoft.Bot.Builder.AI.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("how do I clean the stove?")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:how do I clean the stove?")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
@@ -1544,7 +1544,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"));
 
             // Assert - Check Telemetry logged
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
@@ -1598,7 +1598,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             var results = await qna.GetAnswersAsync(GetContext("what is the answer to my nonsense question?"));
 
             // Assert - Check Telemetry logged
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));
@@ -1768,7 +1768,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             var results = await qna.GetAnswersAsync(GetContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics);
 
             // Assert - added properties were added.
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey(QnATelemetryConstants.KnowledgeBaseIdProperty));
@@ -1837,7 +1837,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             await qna.GetAnswersAsync(GetContext("how do I clean the stove?"), null, telemetryProperties, telemetryMetrics);
 
             // Assert - added properties were added.
-            Assert.Equal(1, telemetryClient.Invocations.Count);
+            Assert.Single(telemetryClient.Invocations);
             Assert.Equal(3, telemetryClient.Invocations[0].Arguments.Count);
             Assert.Equal(telemetryClient.Invocations[0].Arguments[0], QnATelemetryConstants.QnaMsgEvent);
             Assert.True(((Dictionary<string, string>)telemetryClient.Invocations[0].Arguments[1]).ContainsKey("knowledgeBaseId"));

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/LuisV3OracleTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
                     Assert.NotNull(luisTraceInfo["luisModel"]);
 
                     var recognizerResult = luisTraceInfo["recognizerResult"].ToObject<RecognizerResult>();
-                    Assert.Equal(recognizerResult.Text, utterance);
+                    Assert.Equal(utterance, recognizerResult.Text);
                     Assert.NotNull(recognizerResult.Intents["SpecifyName"]);
                     Assert.Equal(luisTraceInfo["luisResult"]["query"], utterance);
                     Assert.Equal(luisTraceInfo["luisModel"]["ModelID"], AppId);
@@ -268,7 +268,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
         }
 
         [Fact]
-        public void UserAgentContainsProductVersion()
+        public async Task UserAgentContainsProductVersion()
         {
             var application = new LuisApplication
             {
@@ -293,7 +293,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
 
             var turnContext = new TurnContext(adapter, activity);
 
-            var recognizerResult = recognizer.RecognizeAsync(turnContext, CancellationToken.None).Result;
+            var recognizerResult = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
             Assert.NotNull(recognizerResult);
 
             var userAgent = clientHandler.UserAgent;
@@ -358,7 +358,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
                 { "test", "testvalue" },
                 { "foo", "foovalue" },
             };
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties);
 
             // Assert
             Assert.NotNull(result);
@@ -405,7 +405,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             var recognizer = new LuisRecognizer(luisApp, options);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext);
 
             // Assert
             Assert.NotNull(result);
@@ -452,7 +452,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             var recognizer = new LuisRecognizer(luisApp, options);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext);
 
             // Assert
             Assert.NotNull(result);
@@ -504,7 +504,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
                 { "test", "testvalue" },
                 { "foo", "foovalue" },
             };
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties);
 
             // Assert
             Assert.NotNull(result);
@@ -562,7 +562,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
                 { "boo", 2.11 },
             };
 
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics);
 
             // Assert
             Assert.NotNull(result);
@@ -615,7 +615,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
             var recognizer = new LuisRecognizer(luisApp, options);
 
             // Act
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -659,7 +659,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
 
             // Act
             // Use a class the converts the Recognizer Result..
-            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);
@@ -714,7 +714,7 @@ namespace Microsoft.Bot.Builder.AI.LuisV3.Tests
                 { "luis", 1.0001 },
             };
 
-            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics, CancellationToken.None).ConfigureAwait(false);
+            var result = await recognizer.RecognizeAsync(turnContext, additionalProperties, additionalMetrics, CancellationToken.None);
 
             // Assert
             Assert.NotNull(result);

--- a/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Ai.LUISV3.tests/Microsoft.Bot.Builder.AI.LuisV3.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.ApplicationInsights.Tests/Microsoft.Bot.Builder.ApplicationInsights.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureBlobStorageTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 It.IsAny<OperationContext>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
-            Assert.Equal(1, items.Count);            
+            Assert.Single(items);            
             Assert.True(items.ContainsKey(keys[0]));
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 It.IsAny<OperationContext>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
-            Assert.Equal(0, items.Count);
+            Assert.Empty(items);
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                 It.IsAny<OperationContext>(),
                 It.IsAny<CancellationToken>()),
                 Times.Once);
-            Assert.Equal(0, items.Count);
+            Assert.Empty(items);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/AzureQueueStorageTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
@@ -32,7 +33,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void QueueActivityAsync()
+        public async Task QueueActivityAsync()
         {
             var client = new Mock<QueueClient>();
             var response = new Mock<Response<SendReceipt>>();

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsStorageTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
 using Azure.Storage;
@@ -68,7 +69,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsyncValidation()
+        public async Task WriteAsyncValidation()
         {
             InitStorage();
 
@@ -77,7 +78,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsync()
+        public async Task WriteAsync()
         {
             InitStorage();
 
@@ -117,7 +118,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsyncWithAllowedTypesSerializationBinder()
+        public async Task WriteAsyncWithAllowedTypesSerializationBinder()
         {
             var serializationBinder = new AllowedTypesSerializationBinder(
                 new List<Type>
@@ -170,7 +171,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
         
         [Fact]
-        public async void WriteAsyncWithEmptyAllowedTypesSerializationBinder()
+        public async Task WriteAsyncWithEmptyAllowedTypesSerializationBinder()
         {
             var serializationBinder = new AllowedTypesSerializationBinder();
             var jsonSerializerSettings = new JsonSerializerSettings
@@ -215,11 +216,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
                     It.IsAny<StorageTransferOptions>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(0));
-            Assert.Equal(0, serializationBinder.AllowedTypes.Count);
+            Assert.Empty(serializationBinder.AllowedTypes);
         }
 
         [Fact]
-        public async void WriteAsyncHttpBadRequestFailure()
+        public async Task WriteAsyncHttpBadRequestFailure()
         {
             InitStorage();
 
@@ -240,7 +241,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteAsyncValidation()
+        public async Task DeleteAsyncValidation()
         {
             InitStorage();
 
@@ -249,7 +250,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteAsync()
+        public async Task DeleteAsync()
         {
             InitStorage();
 
@@ -261,7 +262,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncValidation()
+        public async Task ReadAsyncValidation()
         {
             InitStorage();
 
@@ -270,7 +271,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsync()
+        public async Task ReadAsync()
         {
             InitStorage();
 
@@ -291,7 +292,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
         
         [Fact]
-        public async void ReadAsyncWithAllowedTypesSerializationBinder()
+        public async Task ReadAsyncWithAllowedTypesSerializationBinder()
         {            
             var jsonSerializerSettings = new JsonSerializerSettings
             {
@@ -333,7 +334,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
         
         [Fact]
-        public async void ReadAsyncWithEmptyAllowedTypesSerializationBinder()
+        public async Task ReadAsyncWithEmptyAllowedTypesSerializationBinder()
         {            
             var jsonSerializerSettings = new JsonSerializerSettings
             {
@@ -364,7 +365,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncHttpPreconditionFailure()
+        public async Task ReadAsyncHttpPreconditionFailure()
         {
             InitStorage();
 
@@ -391,7 +392,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncHttpNotFoundFailure()
+        public async Task ReadAsyncHttpNotFoundFailure()
         {
             InitStorage();
 
@@ -413,7 +414,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void GetBlobNameValidation()
+        public async Task GetBlobNameValidation()
         {
             InitStorage();
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/BlobsTranscriptStoreTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void LogActivityAsync()
+        public async Task LogActivityAsync()
         {
             InitStorage();
 
@@ -88,7 +88,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void LogActivityAsyncMessageUpdate()
+        public async Task LogActivityAsyncMessageUpdate()
         {
             InitStorage();
 
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void LogActivityAsyncMessageUpdateNotFound()
+        public async Task LogActivityAsyncMessageUpdateNotFound()
         {
             InitStorage();
 
@@ -120,7 +120,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void LogActivityAsyncMessageDelete()
+        public async Task LogActivityAsyncMessageDelete()
         {
             InitStorage();
 
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void LogActivityAsyncContinuationToken()
+        public async Task LogActivityAsyncContinuationToken()
         {
             InitStorage();
 
@@ -160,7 +160,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void LogActivityAsyncHttpPreconditionFailure()
+        public async Task LogActivityAsyncHttpPreconditionFailure()
         {
             InitStorage();
             var precondition = true;
@@ -185,7 +185,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void GetTranscriptActivitiesAsyncValidation()
+        public async Task GetTranscriptActivitiesAsyncValidation()
         {
             InitStorage();
 
@@ -199,7 +199,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void GetTranscriptActivitiesAsync()
+        public async Task GetTranscriptActivitiesAsync()
         {
             InitStorage();
 
@@ -212,7 +212,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void GetTranscriptActivitiesAsyncContinuationToken()
+        public async Task GetTranscriptActivitiesAsyncContinuationToken()
         {
             InitStorage();
 
@@ -224,7 +224,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void GetTranscriptActivitiesAsyncFullPageSize()
+        public async Task GetTranscriptActivitiesAsyncFullPageSize()
         {
             const int pageSize = 20;
             InitStorage(20);
@@ -238,7 +238,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ListTranscriptsAsyncValidation()
+        public async Task ListTranscriptsAsyncValidation()
         {
             InitStorage();
 
@@ -248,7 +248,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ListTranscriptsAsync()
+        public async Task ListTranscriptsAsync()
         {
             InitStorage();
 
@@ -260,7 +260,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ListTranscriptsAsyncContinuationToken()
+        public async Task ListTranscriptsAsyncContinuationToken()
         {
             InitStorage();
 
@@ -272,7 +272,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ListTranscriptsAsyncFullPageSize()
+        public async Task ListTranscriptsAsyncFullPageSize()
         {
             const int pageSize = 20;
             InitStorage(pageSize);
@@ -285,7 +285,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteTranscriptAsyncValidation()
+        public async Task DeleteTranscriptAsyncValidation()
         {
             InitStorage();
 
@@ -299,7 +299,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteTranscriptAsync()
+        public async Task DeleteTranscriptAsync()
         {
             InitStorage();
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             var sanitizedKey = CosmosDbKeyEscape.EscapeKey(key, suffix, false);
 
             // Verify the suffix was added to the end of the key
-            Assert.Equal(sanitizedKey, $"{key}{suffix}");
+            Assert.Equal($"{key}{suffix}", sanitizedKey);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionedStorageTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDbPartitionedStorageTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Bot.Builder.Dialogs;
 using Moq;
@@ -103,7 +104,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
         
         [Fact]
-        public async void ReadAsyncValidation()
+        public async Task ReadAsyncValidation()
         {
             InitStorage();
 
@@ -116,7 +117,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsync()
+        public async Task ReadAsync()
         {
             InitStorage();
 
@@ -138,7 +139,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncWithAllowedTypesSerializationBinder()
+        public async Task ReadAsyncWithAllowedTypesSerializationBinder()
         {
             var jsonSerializerSettings = new JsonSerializerSettings
             {
@@ -176,7 +177,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncWithEmptyAllowedTypesSerializationBinder()
+        public async Task ReadAsyncWithEmptyAllowedTypesSerializationBinder()
         {
             var jsonSerializerSettings = new JsonSerializerSettings
             {
@@ -208,7 +209,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncPartitionKey()
+        public async Task ReadAsyncPartitionKey()
         {
             InitStorage("/_partitionKey");
 
@@ -230,7 +231,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncNotFound()
+        public async Task ReadAsyncNotFound()
         {
             InitStorage();
 
@@ -244,7 +245,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncFailure()
+        public async Task ReadAsyncFailure()
         {
             InitStorage();
 
@@ -256,7 +257,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void ReadAsyncCustomPartitionKeyFailure()
+        public async Task ReadAsyncCustomPartitionKeyFailure()
         {
             InitStorage("/customKey");
 
@@ -264,7 +265,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsyncValidation()
+        public async Task WriteAsyncValidation()
         {
             InitStorage();
 
@@ -276,7 +277,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsync()
+        public async Task WriteAsync()
         {
             InitStorage();
 
@@ -295,7 +296,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
         
         [Fact]
-        public async void WriteAsyncWithAllowedTypesSerializationBinder()
+        public async Task WriteAsyncWithAllowedTypesSerializationBinder()
         {            
             var serializationBinder = new AllowedTypesSerializationBinder(
                 new List<Type>
@@ -332,7 +333,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
         
         [Fact]
-        public async void WriteAsyncWithEmptyAllowedTypesSerializationBinder()
+        public async Task WriteAsyncWithEmptyAllowedTypesSerializationBinder()
         {            
             var serializationBinder = new AllowedTypesSerializationBinder();
             var jsonSerializerSettings = new JsonSerializerSettings
@@ -360,11 +361,11 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             await Assert.ThrowsAsync<InvalidOperationException>(() => _storage.WriteAsync(changes));
 
             _container.Verify(e => e.UpsertItemAsync(It.IsAny<CosmosDbPartitionedStorage.DocumentStoreItem>(), It.IsAny<PartitionKey>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(0));
-            Assert.Equal(0, serializationBinder.AllowedTypes.Count);
+            Assert.Empty(serializationBinder.AllowedTypes);
         }
 
         [Fact]
-        public async void WriteAsyncEmptyTagFailure()
+        public async Task WriteAsyncEmptyTagFailure()
         {
             InitStorage();
 
@@ -377,7 +378,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsyncFailure()
+        public async Task WriteAsyncFailure()
         {
             InitStorage();
 
@@ -391,7 +392,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsyncWithNestedFailure()
+        public async Task WriteAsyncWithNestedFailure()
         {
             InitStorage();
 
@@ -405,7 +406,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void WriteAsyncWithNestedDialogFailure()
+        public async Task WriteAsyncWithNestedDialogFailure()
         {
             InitStorage();
 
@@ -423,7 +424,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteAsyncValidation()
+        public async Task DeleteAsyncValidation()
         {
             InitStorage();
 
@@ -432,7 +433,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteAsync()
+        public async Task DeleteAsync()
         {
             InitStorage();
 
@@ -444,7 +445,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteAsyncNotFound()
+        public async Task DeleteAsyncNotFound()
         {
             InitStorage();
 
@@ -457,7 +458,7 @@ namespace Microsoft.Bot.Builder.Azure.Tests
         }
 
         [Fact]
-        public async void DeleteAsyncFailure()
+        public async Task DeleteAsyncFailure()
         {
             InitStorage();
 

--- a/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Assertions.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Assertions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Bot.Builder.Runtime.Tests
 
             IList<ServiceDescriptor> descriptors = searchOptions.Search(services).ToList();
 
-            Assert.Equal(expected: 1, actual: descriptors.Count);
+            Assert.Single(descriptors);
 
             ServiceDescriptor descriptor = descriptors[0];
             Assert.Equal(expected: lifetime, actual: descriptor.Lifetime);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/ActivityFactoryTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             // fallback to text activity
             var lgResult = templates.Evaluate("notSupport");
             var activity = ActivityFactory.FromObject(lgResult);
-            Assert.Equal(0, activity.Attachments.Count);
+            Assert.Empty(activity.Attachments);
             Assert.Equal("{\"lgType\":\"Acti\",\"key\":\"value\"}", activity.Text.Replace("\r\n", string.Empty).Replace("\n", string.Empty).Replace(" ", string.Empty));
         }
 
@@ -410,11 +410,11 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal("accepting", activity.InputHint);
             var semanticAction = activity.SemanticAction;
             Assert.Equal("actionId", semanticAction.Id);
-            Assert.Equal(1, semanticAction.Entities.Count);
+            Assert.Single(semanticAction.Entities);
             Assert.True(semanticAction.Entities.ContainsKey("key1"));
             Assert.Equal("entityType", semanticAction.Entities["key1"].Type);
 
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(AttachmentLayoutTypes.List, activity.AttachmentLayout);
             Assert.Equal(HeroCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<HeroCard>();
@@ -424,7 +424,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal("tapvalue", tap.Value);
             Assert.Equal("imBack", tap.Type);
             Assert.Equal("textContent", card.Text);
-            Assert.Equal(1, card.Buttons.Count);
+            Assert.Single(card.Buttons);
             Assert.Equal($"imBack", card.Buttons[0].Type);
             Assert.Equal($"titleContent", card.Buttons[0].Title);
             Assert.Equal($"textContent", card.Buttons[0].Value);
@@ -472,7 +472,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(HeroCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<HeroCard>();
             var tap = card.Tap;
@@ -482,7 +482,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.NotNull(card);
             Assert.Equal("titleContent", card.Title);
             Assert.Equal("textContent", card.Text);
-            Assert.Equal(1, card.Buttons.Count);
+            Assert.Single(card.Buttons);
             Assert.Equal($"imBack", card.Buttons[0].Type);
             Assert.Equal($"titleContent", card.Buttons[0].Title);
             Assert.Equal($"textContent", card.Buttons[0].Value);
@@ -513,7 +513,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal("application/vnd.microsoft.card.adaptive", activity.Attachments[0].ContentType);
             Assert.Equal("test", (string)((dynamic)activity.Attachments[0].Content).body[0].text);
         }
@@ -536,13 +536,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(HeroCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<HeroCard>();
             Assert.NotNull(card);
             Assert.Equal("titleContent", card.Title);
             Assert.Equal("textContent", card.Text);
-            Assert.Equal(1, card.Buttons.Count);
+            Assert.Single(card.Buttons);
             Assert.Equal($"imBack", card.Buttons[0].Type);
             Assert.Equal($"titleContent", card.Buttons[0].Title);
             Assert.Equal($"textContent", card.Buttons[0].Value);
@@ -553,7 +553,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(ThumbnailCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<ThumbnailCard>();
             Assert.NotNull(card);
@@ -574,7 +574,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(HeroCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<HeroCard>();
             Assert.NotNull(card);
@@ -595,7 +595,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal("cardaction", activity.Attachments[0].ContentType);
             var cardContent = (JObject)activity.Attachments[0].Content;
             Assert.NotNull(cardContent);
@@ -610,7 +610,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(AudioCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<AudioCard>();
             Assert.NotNull(card);
@@ -635,7 +635,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(VideoCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<VideoCard>();
             Assert.NotNull(card);
@@ -660,12 +660,12 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(SigninCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<SigninCard>();
             Assert.NotNull(card);
             Assert.Equal("This is some text describing the card, it's cool because it's cool", card.Text);
-            Assert.Equal(1, card.Buttons.Count);
+            Assert.Single(card.Buttons);
             Assert.Equal($"Sign in", card.Buttons[0].Title);
             Assert.Equal(ActionTypes.Signin, card.Buttons[0].Type);
             Assert.Equal($"https://login.microsoftonline.com/", card.Buttons[0].Value);
@@ -676,13 +676,13 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(OAuthCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<OAuthCard>();
             Assert.NotNull(card);
             Assert.Equal("This is some text describing the card, it's cool because it's cool", card.Text);
             Assert.Equal("MyConnection", card.ConnectionName);
-            Assert.Equal(1, card.Buttons.Count);
+            Assert.Single(card.Buttons);
             Assert.Equal($"Sign in", card.Buttons[0].Title);
             Assert.Equal(ActionTypes.Signin, card.Buttons[0].Type);
             Assert.Equal($"https://login.microsoftonline.com/", card.Buttons[0].Value);
@@ -693,7 +693,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal(ActivityTypes.Message, activity.Type);
             Assert.True(string.IsNullOrEmpty(activity.Text));
             Assert.True(string.IsNullOrEmpty(activity.Speak));
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(AnimationCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<AnimationCard>();
             Assert.NotNull(card);
@@ -737,7 +737,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
         private void AssertReceiptCardActivity(Activity activity)
         {
             Assert.Equal(ActivityTypes.Message, activity.Type);
-            Assert.Equal(1, activity.Attachments.Count);
+            Assert.Single(activity.Attachments);
             Assert.Equal(ReceiptCard.ContentType, activity.Attachments[0].ContentType);
             var card = ((JObject)activity.Attachments[0].Content).ToObject<ReceiptCard>();
             Assert.NotNull(card);
@@ -746,7 +746,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
             Assert.Equal("$ 90.95", card.Total);
             var buttons = card.Buttons;
 
-            Assert.Equal(1, buttons.Count);
+            Assert.Single(buttons);
             Assert.Equal(ActionTypes.OpenUrl, buttons[0].Type);
             Assert.Equal("More information", buttons[0].Title);
             Assert.Equal("https://account.windowsazure.com/content/6.10.1.38-.8225.160809-1618/aux-pre/images/offer-icon-freetrial.png", buttons[0].Image);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Templates.Tests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ChoiceOptionsSetTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/ChoiceOptionsSetTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var context = new TurnContext(new TestAdapter(), _activity);
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
 
-            var choiceFactory = await choiceOptions.BindAsync(dc).ConfigureAwait(false);
+            var choiceFactory = await choiceOptions.BindAsync(dc);
 
             Assert.Equal(choiceOptions, choiceFactory);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var context = new TurnContext(new TestAdapter(), _activity);
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
 
-            await Assert.ThrowsAsync<MissingMemberException>(async () => await choiceOptions.BindAsync(dc).ConfigureAwait(false));
+            await Assert.ThrowsAsync<MissingMemberException>(async () => await choiceOptions.BindAsync(dc));
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
             dc.Services.Add(mockLG.Object);
 
-            var choiceFactory = await choiceOptions.BindAsync(dc).ConfigureAwait(false);
+            var choiceFactory = await choiceOptions.BindAsync(dc);
 
             Assert.Equal(lgResult, choiceFactory);
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
             dc.Services.Add(mockLG.Object);
 
-            var choiceFactory = await choiceOptions.BindAsync(dc).ConfigureAwait(false);
+            var choiceFactory = await choiceOptions.BindAsync(dc);
 
             Assert.Equal(",", choiceFactory.InlineSeparator);
             Assert.Equal(", or", choiceFactory.InlineOrMore);
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
             dc.Services.Add(mockLG.Object);
 
-            Assert.Null(await choiceOptions.BindAsync(dc).ConfigureAwait(false));
+            Assert.Null(await choiceOptions.BindAsync(dc));
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
             dc.Services.Add(mockLG.Object);
 
-            Assert.Null(await choiceOptions.BindAsync(dc).ConfigureAwait(false));
+            Assert.Null(await choiceOptions.BindAsync(dc));
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var dc = new DialogContext(new DialogSet(), context, new DialogState());
             dc.Services.Add(mockLG.Object);
 
-            Assert.Null(await choiceOptions.BindAsync(dc).ConfigureAwait(false));
+            Assert.Null(await choiceOptions.BindAsync(dc));
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/DebugComposer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Tests
             var script = resourceExplorer.LoadType<TestScript>(testScript);
             script.Locale = locale;
             script.Configuration = builder.Build();
-            await script.ExecuteAsync(resourceExplorer: resourceExplorer).ConfigureAwait(false);
+            await script.ExecuteAsync(resourceExplorer: resourceExplorer);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
@@ -51,13 +51,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         });
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestAge()
-After:
-        public void TestAgeAsync()
-*/
         public async Task TestAgeAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestAgeAsync), "This is a test of one, 2, three years old");
@@ -74,13 +67,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestConfirmation()
-After:
-        public void TestConfirmationAsync()
-*/
         public async Task TestConfirmationAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestConfirmationAsync), "yes, please");
@@ -96,13 +82,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestCurrency()
-After:
-        public void TestCurrencyAsync()
-*/
         public async Task TestCurrencyAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestCurrencyAsync), "I would pay four dollars for that.");
@@ -118,13 +97,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestDateTime()
-After:
-        public void TestDateTimeAsync()
-*/
         public async Task TestDateTimeAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestDateTimeAsync), "Next thursday at 4pm.");
@@ -141,13 +113,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestDimension()
-After:
-        public void TestDimensionAsync()
-*/
         public async Task TestDimensionAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestDimensionAsync), "I think he's 5 foot ten");
@@ -163,13 +128,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestEmail()
-After:
-        public void TestEmailAsync()
-*/
         public async Task TestEmailAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestEmailAsync), "my email address is foo@att.uk.co");
@@ -184,13 +142,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestGuid()
-After:
-        public void TestGuidAsync()
-*/
         public async Task TestGuidAsync()
         {
             var guid = Guid.Empty;
@@ -206,13 +157,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestHashtag()
-After:
-        public void TestHashtagAsync()
-*/
         public async Task TestHashtagAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestHashtagAsync), $"I'm so cool #cool #groovy...");
@@ -227,13 +171,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestIp()
-After:
-        public void TestIpAsync()
-*/
         public async Task TestIpAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestIpAsync), $"My address is 1.2.3.4");
@@ -249,13 +186,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestMention()
-After:
-        public void TestMentionAsync()
-*/
         public async Task TestMentionAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestMentionAsync), $"Tell @joesmith I'm coming...");
@@ -347,13 +277,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestNumber()
-After:
-        public void TestNumberAsync()
-*/
         public async Task TestNumberAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestNumberAsync), "This is a test of one, 2, three");
@@ -368,13 +291,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestNumberRange()
-After:
-        public void TestNumberRangeAsync()
-*/
         public async Task TestNumberRangeAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestNumberRangeAsync), "there are 3 to 5 of them");
@@ -389,13 +305,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestOrdinal()
-After:
-        public void TestOrdinalAsync()
-*/
         public async Task TestOrdinalAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestOrdinalAsync), "First, second or third");
@@ -410,13 +319,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestPercentage()
-After:
-        public void TestPercentageAsync()
-*/
         public async Task TestPercentageAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestPercentageAsync), "The population hit 33.3%");
@@ -431,13 +333,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestPhoneNumber()
-After:
-        public void TestPhoneNumberAsync()
-*/
         public async Task TestPhoneNumberAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestPhoneNumberAsync), "Call 425-882-8080");
@@ -452,13 +347,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestTemperature()
-After:
-        public void TestTemperatureAsync()
-*/
         public async Task TestTemperatureAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestTemperatureAsync), "set the oven to 350 degrees");
@@ -473,13 +361,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestUrl()
-After:
-        public void TestUrlAsync()
-*/
         public async Task TestUrlAsync()
         {
             var dialogContext = GetDialogContext(nameof(TestUrlAsync), "go to http://about.me for more info");
@@ -494,13 +375,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestRegEx()
-After:
-        public void TestRegExAsync()
-*/
         public async Task TestRegExAsync()
         {
             // I would like {order} 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerRecognizerTests.cs
@@ -51,12 +51,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         });
 
         [Fact]
-        public void TestAge()
-        {
-            var dialogContext = GetDialogContext(nameof(TestAge), "This is a test of one, 2, three years old");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestAge()
+After:
+        public void TestAgeAsync()
+*/
+        public async Task TestAgeAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestAgeAsync), "This is a test of one, 2, three years old");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -67,12 +74,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestConfirmation()
-        {
-            var dialogContext = GetDialogContext(nameof(TestConfirmation), "yes, please");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestConfirmation()
+After:
+        public void TestConfirmationAsync()
+*/
+        public async Task TestConfirmationAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestConfirmationAsync), "yes, please");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -82,12 +96,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestCurrency()
-        {
-            var dialogContext = GetDialogContext(nameof(TestCurrency), "I would pay four dollars for that.");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestCurrency()
+After:
+        public void TestCurrencyAsync()
+*/
+        public async Task TestCurrencyAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestCurrencyAsync), "I would pay four dollars for that.");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -97,12 +118,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestDateTime()
-        {
-            var dialogContext = GetDialogContext(nameof(TestDateTime), "Next thursday at 4pm.");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestDateTime()
+After:
+        public void TestDateTimeAsync()
+*/
+        public async Task TestDateTimeAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestDateTimeAsync), "Next thursday at 4pm.");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -113,12 +141,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestDimension()
-        {
-            var dialogContext = GetDialogContext(nameof(TestDimension), "I think he's 5 foot ten");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestDimension()
+After:
+        public void TestDimensionAsync()
+*/
+        public async Task TestDimensionAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestDimensionAsync), "I think he's 5 foot ten");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -128,12 +163,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestEmail()
-        {
-            var dialogContext = GetDialogContext(nameof(TestEmail), "my email address is foo@att.uk.co");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestEmail()
+After:
+        public void TestEmailAsync()
+*/
+        public async Task TestEmailAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestEmailAsync), "my email address is foo@att.uk.co");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -142,13 +184,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestGuid()
+After:
+        public void TestGuidAsync()
+*/
+        public async Task TestGuidAsync()
         {
             var guid = Guid.Empty;
-            var dialogContext = GetDialogContext(nameof(TestGuid), $"my account number is {guid}...");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+            var dialogContext = GetDialogContext(nameof(TestGuidAsync), $"my account number is {guid}...");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
 
-            Assert.Equal(1, results.Intents.Count);
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -157,12 +206,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestHashtag()
-        {
-            var dialogContext = GetDialogContext(nameof(TestHashtag), $"I'm so cool #cool #groovy...");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestHashtag()
+After:
+        public void TestHashtagAsync()
+*/
+        public async Task TestHashtagAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestHashtagAsync), $"I'm so cool #cool #groovy...");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -171,12 +227,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestIp()
-        {
-            var dialogContext = GetDialogContext(nameof(TestIp), $"My address is 1.2.3.4");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestIp()
+After:
+        public void TestIpAsync()
+*/
+        public async Task TestIpAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestIpAsync), $"My address is 1.2.3.4");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -186,12 +249,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestMention()
-        {
-            var dialogContext = GetDialogContext(nameof(TestMention), $"Tell @joesmith I'm coming...");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestMention()
+After:
+        public void TestMentionAsync()
+*/
+        public async Task TestMentionAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestMentionAsync), $"Tell @joesmith I'm coming...");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -206,9 +276,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestChannelMentionEntityRecognizer()
+        public async Task TestChannelMentionEntityRecognizerAsync()
         {
-            var dialogContext = GetDialogContext(nameof(TestMention), $"joelee bobsm...");
+            var dialogContext = GetDialogContext(nameof(TestMentionAsync), $"joelee bobsm...");
             dialogContext.Context.Activity.Entities = new List<Entity>();
 
             dynamic mention = new JObject();
@@ -227,9 +297,9 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             mention.text = "bobsm";
             dialogContext.Context.Activity.Entities.Add(((JObject)mention).ToObject<Entity>());
 
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
 
-            Assert.Equal(1, results.Intents.Count);
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -273,16 +343,23 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             Assert.NotNull(result);
             Assert.Empty(result.Intents);
             Assert.Empty(result.Entities);
-            Assert.Equal(0, telemetryClient.Invocations.Count);
+            Assert.Empty(telemetryClient.Invocations);
         }
 
         [Fact]
-        public void TestNumber()
-        {
-            var dialogContext = GetDialogContext(nameof(TestNumber), "This is a test of one, 2, three");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestNumber()
+After:
+        public void TestNumberAsync()
+*/
+        public async Task TestNumberAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestNumberAsync), "This is a test of one, 2, three");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -291,12 +368,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestNumberRange()
-        {
-            var dialogContext = GetDialogContext(nameof(TestNumberRange), "there are 3 to 5 of them");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestNumberRange()
+After:
+        public void TestNumberRangeAsync()
+*/
+        public async Task TestNumberRangeAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestNumberRangeAsync), "there are 3 to 5 of them");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -305,12 +389,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestOrdinal()
-        {
-            var dialogContext = GetDialogContext(nameof(TestOrdinal), "First, second or third");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestOrdinal()
+After:
+        public void TestOrdinalAsync()
+*/
+        public async Task TestOrdinalAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestOrdinalAsync), "First, second or third");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -319,12 +410,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestPercentage()
-        {
-            var dialogContext = GetDialogContext(nameof(TestPercentage), "The population hit 33.3%");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestPercentage()
+After:
+        public void TestPercentageAsync()
+*/
+        public async Task TestPercentageAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestPercentageAsync), "The population hit 33.3%");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -333,12 +431,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestPhoneNumber()
-        {
-            var dialogContext = GetDialogContext(nameof(TestPhoneNumber), "Call 425-882-8080");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestPhoneNumber()
+After:
+        public void TestPhoneNumberAsync()
+*/
+        public async Task TestPhoneNumberAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestPhoneNumberAsync), "Call 425-882-8080");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -347,12 +452,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestTemperature()
-        {
-            var dialogContext = GetDialogContext(nameof(TestTemperature), "set the oven to 350 degrees");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestTemperature()
+After:
+        public void TestTemperatureAsync()
+*/
+        public async Task TestTemperatureAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestTemperatureAsync), "set the oven to 350 degrees");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -361,12 +473,19 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-        public void TestUrl()
-        {
-            var dialogContext = GetDialogContext(nameof(TestUrl), "go to http://about.me for more info");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
 
-            Assert.Equal(1, results.Intents.Count);
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
+        public void TestUrl()
+After:
+        public void TestUrlAsync()
+*/
+        public async Task TestUrlAsync()
+        {
+            var dialogContext = GetDialogContext(nameof(TestUrlAsync), "go to http://about.me for more info");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
+
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -375,13 +494,20 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestRegEx()
+After:
+        public void TestRegExAsync()
+*/
+        public async Task TestRegExAsync()
         {
             // I would like {order} 
-            var dialogContext = GetDialogContext(nameof(TestRegEx), "I would like a red or Blue cat");
-            var results = recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity).Result;
+            var dialogContext = GetDialogContext(nameof(TestRegExAsync), "I would like a red or Blue cat");
+            var results = await recognizers.Value.RecognizeAsync(dialogContext, dialogContext.Context.Activity);
 
-            Assert.Equal(1, results.Intents.Count);
+            Assert.Single(results.Intents);
             Assert.Equal("None", results.Intents.Single().Key);
 
             dynamic entities = results.Entities;
@@ -410,7 +536,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
             Assert.NotNull(result);
             Assert.Empty(result.Intents);
             Assert.Empty(result.Entities);
-            Assert.Equal(0, telemetryClient.Invocations.Count);
+            Assert.Empty(telemetryClient.Invocations);
         }
 
         private DialogContext GetDialogContext(string testName, string text, string locale = "en-us")

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Adapters;
 using Newtonsoft.Json;
 using Xunit;
@@ -41,40 +42,61 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         });
 
         [Fact]
-        public void TestAge()
+        public async Task TestAgeAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestAge), "This is a test of one, 2, three years old");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestAgeAsync), "This is a test of one, 2, three years old");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(6, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "age").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestConfirmation()
+After:
+        public void TestConfirmationAsync()
+*/
+        public async Task TestConfirmationAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestConfirmation), "yes, please");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestConfirmationAsync), "yes, please");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(2, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "boolean").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestCurrency()
+After:
+        public void TestCurrencyAsync()
+*/
+        public async Task TestCurrencyAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestCurrency), "I would pay four dollars for that.");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestCurrencyAsync), "I would pay four dollars for that.");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(3, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "currency").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestDateTime()
+After:
+        public void TestDateTimeAsync()
+*/
+        public async Task TestDateTimeAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestDateTime), "Next thursday at 4pm.");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestDateTimeAsync), "Next thursday at 4pm.");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(4, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "datetimeV2.datetime").ToList());
@@ -83,142 +105,240 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestDimension()
+After:
+        public void TestDimensionAsync()
+*/
+        public async Task TestDimensionAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestDimension), "I think he's 5 foot ten");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestDimensionAsync), "I think he's 5 foot ten");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(4, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "dimension").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestEmail()
+After:
+        public void TestEmailAsync()
+*/
+        public async Task TestEmailAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestEmail), "my email address is foo@att.uk.co");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestEmailAsync), "my email address is foo@att.uk.co");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(2, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "email").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestGuid()
+After:
+        public void TestGuidAsync()
+*/
+        public async Task TestGuidAsync()
         {
             var guid = Guid.Empty;
-            var turnContext = GetTurnContext(nameof(TestGuid), $"my account number is {guid}...");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestGuidAsync), $"my account number is {guid}...");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(7, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "guid").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestHashtag()
+After:
+        public void TestHashtagAsync()
+*/
+        public async Task TestHashtagAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestHashtag), $"I'm so cool #cool #groovy...");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestHashtagAsync), $"I'm so cool #cool #groovy...");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(3, results.Count);
             Assert.Equal(2, results.Where(entity => entity.Type == "hashtag").Count());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestIp()
+After:
+        public void TestIpAsync()
+*/
+        public async Task TestIpAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestIp), $"My address is 1.2.3.4");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestIpAsync), $"My address is 1.2.3.4");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(6, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "ip").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestMention()
+After:
+        public void TestMentionAsync()
+*/
+        public async Task TestMentionAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestMention), $"Tell @joesmith I'm coming...");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestMentionAsync), $"Tell @joesmith I'm coming...");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(2, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "mention").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestNumber()
+After:
+        public void TestNumberAsync()
+*/
+        public async Task TestNumberAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestNumber), "This is a test of one, 2, three");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestNumberAsync), "This is a test of one, 2, three");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(4, results.Count);
             Assert.Equal(3, results.Where(entity => entity.Type == "number").Count());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestNumberRange()
+After:
+        public void TestNumberRangeAsync()
+*/
+        public async Task TestNumberRangeAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestNumberRange), "there are 3 to 5 of them");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestNumberRangeAsync), "there are 3 to 5 of them");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(4, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "numberrange").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestOrdinal()
+After:
+        public void TestOrdinalAsync()
+*/
+        public async Task TestOrdinalAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestOrdinal), "First, second or third");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestOrdinalAsync), "First, second or third");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(4, results.Count);
             Assert.Equal(3, results.Where(entity => entity.Type == "ordinal").Count());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestPercentage()
+After:
+        public void TestPercentageAsync()
+*/
+        public async Task TestPercentageAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestPercentage), "The population hit 33.3%");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestPercentageAsync), "The population hit 33.3%");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(3, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "percentage").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestPhoneNumber()
+After:
+        public void TestPhoneNumberAsync()
+*/
+        public async Task TestPhoneNumberAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestPhoneNumber), "Call 425-882-8080");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestPhoneNumberAsync), "Call 425-882-8080");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(5, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "phonenumber").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestTemperature()
+After:
+        public void TestTemperatureAsync()
+*/
+        public async Task TestTemperatureAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestTemperature), "set the oven to 350 degrees");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestTemperatureAsync), "set the oven to 350 degrees");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(3, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "temperature").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestUrl()
+After:
+        public void TestUrlAsync()
+*/
+        public async Task TestUrlAsync()
         {
-            var turnContext = GetTurnContext(nameof(TestUrl), "go to http://about.me for more info");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestUrlAsync), "go to http://about.me for more info");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(2, results.Count);
             Assert.Single(results.Where(entity => entity.Type == "url").ToList());
         }
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
+Before:
         public void TestRegEx()
+After:
+        public void TestRegExAsync()
+*/
+        public async Task TestRegExAsync()
         {
             // I would like {order} 
-            var turnContext = GetTurnContext(nameof(TestRegEx), "I would like a red or Blue cat");
-            var results = recognizers.Value.RecognizeEntitiesAsync(turnContext).Result;
+            var turnContext = GetTurnContext(nameof(TestRegExAsync), "I would like a red or Blue cat");
+            var results = await recognizers.Value.RecognizeEntitiesAsync(turnContext);
 
             Assert.Equal(3, results.Count);
             Assert.Equal(2, results.Where(entity => entity.Type == "color").Count());

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/EntityRecognizerTests.cs
@@ -52,13 +52,6 @@ namespace Microsoft.Bot.Builder.Dialogs.Adaptive.Recognizers.Tests
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestConfirmation()
-After:
-        public void TestConfirmationAsync()
-*/
         public async Task TestConfirmationAsync()
         {
             var turnContext = GetTurnContext(nameof(TestConfirmationAsync), "yes, please");
@@ -69,13 +62,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestCurrency()
-After:
-        public void TestCurrencyAsync()
-*/
         public async Task TestCurrencyAsync()
         {
             var turnContext = GetTurnContext(nameof(TestCurrencyAsync), "I would pay four dollars for that.");
@@ -86,13 +72,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestDateTime()
-After:
-        public void TestDateTimeAsync()
-*/
         public async Task TestDateTimeAsync()
         {
             var turnContext = GetTurnContext(nameof(TestDateTimeAsync), "Next thursday at 4pm.");
@@ -105,13 +84,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestDimension()
-After:
-        public void TestDimensionAsync()
-*/
         public async Task TestDimensionAsync()
         {
             var turnContext = GetTurnContext(nameof(TestDimensionAsync), "I think he's 5 foot ten");
@@ -122,13 +94,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestEmail()
-After:
-        public void TestEmailAsync()
-*/
         public async Task TestEmailAsync()
         {
             var turnContext = GetTurnContext(nameof(TestEmailAsync), "my email address is foo@att.uk.co");
@@ -139,13 +104,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestGuid()
-After:
-        public void TestGuidAsync()
-*/
         public async Task TestGuidAsync()
         {
             var guid = Guid.Empty;
@@ -157,13 +115,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestHashtag()
-After:
-        public void TestHashtagAsync()
-*/
         public async Task TestHashtagAsync()
         {
             var turnContext = GetTurnContext(nameof(TestHashtagAsync), $"I'm so cool #cool #groovy...");
@@ -174,13 +125,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestIp()
-After:
-        public void TestIpAsync()
-*/
         public async Task TestIpAsync()
         {
             var turnContext = GetTurnContext(nameof(TestIpAsync), $"My address is 1.2.3.4");
@@ -191,13 +135,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestMention()
-After:
-        public void TestMentionAsync()
-*/
         public async Task TestMentionAsync()
         {
             var turnContext = GetTurnContext(nameof(TestMentionAsync), $"Tell @joesmith I'm coming...");
@@ -208,13 +145,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestNumber()
-After:
-        public void TestNumberAsync()
-*/
         public async Task TestNumberAsync()
         {
             var turnContext = GetTurnContext(nameof(TestNumberAsync), "This is a test of one, 2, three");
@@ -225,13 +155,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestNumberRange()
-After:
-        public void TestNumberRangeAsync()
-*/
         public async Task TestNumberRangeAsync()
         {
             var turnContext = GetTurnContext(nameof(TestNumberRangeAsync), "there are 3 to 5 of them");
@@ -242,13 +165,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestOrdinal()
-After:
-        public void TestOrdinalAsync()
-*/
         public async Task TestOrdinalAsync()
         {
             var turnContext = GetTurnContext(nameof(TestOrdinalAsync), "First, second or third");
@@ -259,13 +175,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestPercentage()
-After:
-        public void TestPercentageAsync()
-*/
         public async Task TestPercentageAsync()
         {
             var turnContext = GetTurnContext(nameof(TestPercentageAsync), "The population hit 33.3%");
@@ -276,13 +185,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestPhoneNumber()
-After:
-        public void TestPhoneNumberAsync()
-*/
         public async Task TestPhoneNumberAsync()
         {
             var turnContext = GetTurnContext(nameof(TestPhoneNumberAsync), "Call 425-882-8080");
@@ -293,13 +195,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestTemperature()
-After:
-        public void TestTemperatureAsync()
-*/
         public async Task TestTemperatureAsync()
         {
             var turnContext = GetTurnContext(nameof(TestTemperatureAsync), "set the oven to 350 degrees");
@@ -310,13 +205,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestUrl()
-After:
-        public void TestUrlAsync()
-*/
         public async Task TestUrlAsync()
         {
             var turnContext = GetTurnContext(nameof(TestUrlAsync), "go to http://about.me for more info");
@@ -327,13 +215,6 @@ After:
         }
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Builder.Dialogs.Adaptive.Tests (net8.0)'
-Before:
-        public void TestRegEx()
-After:
-        public void TestRegExAsync()
-*/
         public async Task TestRegExAsync()
         {
             // I would like {order} 

--- a/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebuggerSourceMapTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/DebuggerSourceMapTests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
             };
 
             var breakpoints = sourceMap.SetBreakpoints(breakpointList);
-            Assert.Equal(1, breakpoints.Count);
+            Assert.Single(breakpoints);
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Debugging.Tests/TraceTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 
                 await new TestFlow((TestAdapter)adapter, async (turnContext, cancellationToken) =>
                 {
-                    await dialogManager.OnTurnAsync(turnContext, cancellationToken).ConfigureAwait(false);
+                    await dialogManager.OnTurnAsync(turnContext, cancellationToken);
                 })
                 .Send("one")
                 .AssertReply("hello")
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
             });
 
             var tokens = sorted.Select(JToken.FromObject).Select(TraceOracle.Normalize).ToArray();
-            await TraceOracle.ValidateAsync(pathJson, tokens, _output).ConfigureAwait(false);
+            await TraceOracle.ValidateAsync(pathJson, tokens, _output);
         }
 
         internal static DialogDebugAdapter MakeDebugger(IDebugTransport transport)
@@ -129,7 +129,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Debugging.Tests
 
             async Task<JToken> IDebugTransport.ReadAsync(CancellationToken cancellationToken)
             {
-                await _count.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _count.WaitAsync(cancellationToken);
                 lock (_gate)
                 {
                     return _queue.Dequeue();

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Declarative.Tests/ResourceTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 // new file
                 File.WriteAllText(testDialogFile, "{}");
 
-                await Task.WhenAny(changeFired.Task, Task.Delay(5000)).ConfigureAwait(false);
+                await Task.WhenAny(changeFired.Task, Task.Delay(5000));
 
                 AssertResourceFound(explorer, testId);
             }
@@ -215,7 +215,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 contents = "{'foo':123 }";
                 File.WriteAllText(testDialogFile, contents);
 
-                await Task.WhenAny(changeFired.Task, Task.Delay(5000)).ConfigureAwait(false);
+                await Task.WhenAny(changeFired.Task, Task.Delay(5000));
 
                 AssertResourceFound(explorer, testId);
 
@@ -252,7 +252,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 // changed file
                 File.Delete(testDialogFile);
 
-                await Task.WhenAny(changeFired.Task, Task.Delay(5000)).ConfigureAwait(false);
+                await Task.WhenAny(changeFired.Task, Task.Delay(5000));
 
                 AssertResourceNull(explorer, testId);
             }
@@ -274,7 +274,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var resource = explorer.GetResource(resourceId);
 
                 // Read token range using resource explorer
-                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext).ConfigureAwait(false);
+                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext);
 
                 // Verify correct range
                 var expectedRange = new SourceRange
@@ -307,7 +307,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
                 var resource = explorer.GetResource(resourceId);
 
                 // Read token range using resource explorer
-                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext, true).ConfigureAwait(false);
+                var (jToken, range) = await explorer.ReadTokenRangeAsync(resource, sourceContext, true);
 
                 // Verify correct range
                 var expectedRange = new SourceRange
@@ -339,7 +339,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 // Load file using resource explorer
                 var resource = explorer.GetResource(resourceId);
-                var dialog = await explorer.LoadTypeAsync<Dialog>(resource).ConfigureAwait(false);
+                var dialog = await explorer.LoadTypeAsync<Dialog>(resource);
 
                 // Verify correct range
                 var expectedRange = new SourceRange
@@ -371,7 +371,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 // Load file using resource explorer
                 var resource = explorer.GetResource(resourceId);
-                var dialog = await explorer.LoadTypeAsync<Dialog>(resource).ConfigureAwait(false);
+                var dialog = await explorer.LoadTypeAsync<Dialog>(resource);
 
                 // Verify correct range
                 var expectedRange = new SourceRange
@@ -400,7 +400,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Declarative.Tests
 
                 // Load file using resource explorer
                 var resource = explorer.GetResource(resourceId);
-                var dialog = await explorer.LoadTypeAsync<AdaptiveDialog>(resource).ConfigureAwait(false);
+                var dialog = await explorer.LoadTypeAsync<AdaptiveDialog>(resource);
 
                 // Verify that the correct id was assigned
                 Assert.Equal(resourceId, dialog.Id);

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/Microsoft.Bot.Builder.Dialogs.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
+++ b/tests/Microsoft.Bot.Builder.Dialogs.Tests/OAuthPromptTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Bot.Builder.Dialogs.Tests
                     var tokenResult = await dc.PromptAsync("OAuthPrompt", new PromptOptions(), cancellationToken: cancellationToken);
                     if (tokenResult.Result is TokenResponse)
                     {
-                        throw new XunitException();
+                        throw new XunitException("MagicCode detected in prompting.");
                     }
                 }
             };

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/Microsoft.Bot.Builder.LanguageGeneration.Tests.csproj
@@ -403,7 +403,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateDiagnosticTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("EmptyLGFile.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Warning, diagnostics[0].Severity);
             Assert.Contains(TemplateErrors.NoTemplate, diagnostics[0].Message);
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("EmptyTemplate.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Warning, diagnostics[0].Severity);
             Assert.Contains(TemplateErrors.NoTemplateBody("template"), diagnostics[0].Message);
         }
@@ -123,17 +123,17 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("MultiLineExprError.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
 
             diagnostics = Templates.ParseResource(new LGResource(string.Empty, string.Empty, "#Demo2\r\n- ${createArray(1,\r\n, 2,3)")).Diagnostics;
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
 
             diagnostics = Templates.ParseResource(new LGResource(string.Empty, string.Empty, "#Demo4\r\n- ${createArray(1,\r\n2,3)\r\n> this is a comment")).Diagnostics;
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
         }
@@ -171,7 +171,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("InvalidLGFileImportPath.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains("Could not find file", diagnostics[0].Message);
         }
@@ -181,7 +181,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("InvalidImportFormat.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Equal(TemplateErrors.ImportFormatError, diagnostics[0].Message);
         }
@@ -203,7 +203,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("MultiLineVariation.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains(TemplateErrors.NoEndingInMultiline, diagnostics[0].Message);
         }
@@ -213,7 +213,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         {
             var diagnostics = GetDiagnostics("MultiLineTemplate.lg");
 
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticSeverity.Error, diagnostics[0].Severity);
             Assert.Contains(TemplateErrors.NoEndingInMultiline, diagnostics[0].Message);
         }
@@ -311,7 +311,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void AddTextWithWrongId()
         {
             var diagnostics = Templates.ParseResource(new LGResource("a.lg", "a.lg", "[import](xx.lg) \r\n # t \n - hi")).Diagnostics;
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Contains("Could not find file", diagnostics[0].Message);
         }
 
@@ -382,7 +382,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestExpressionFormatError()
         {
             var diagnostics = GetDiagnostics("ExpressionFormatError.lg");
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.Contains("Close } is missing in Expression", diagnostics[0].Message);
         }
 
@@ -390,7 +390,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestLoopReference()
         {
             var diagnostics = GetDiagnostics("CycleRef1.lg");
-            Assert.Equal(1, diagnostics.Count);
+            Assert.Single(diagnostics);
             Assert.StartsWith(TemplateErrors.LoopDetected, diagnostics[0].Message);
         }
 

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplatesTest.cs
@@ -708,19 +708,19 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
                 "You have 2 alarms, 7 am of tomorrow and 8 pm of tomorrow"
             };
 
-            Assert.Equal(1, evaled.Count);
+            Assert.Single(evaled);
             Assert.Contains(evaled[0], evalOptions);
 
             evaled = templates.ExpandTemplate("T2");
-            Assert.Equal(1, evaled.Count);
+            Assert.Single(evaled);
             Assert.True(evaled[0].ToString() == "3" || evaled[0].ToString() == "5");
 
             evaled = templates.ExpandTemplate("T3");
-            Assert.Equal(1, evaled.Count);
+            Assert.Single(evaled);
             Assert.True(evaled[0].ToString() == "3" || evaled[0].ToString() == "5");
 
             evaled = templates.ExpandTemplate("T4");
-            Assert.Equal(1, evaled.Count);
+            Assert.Single(evaled);
             Assert.True(evaled[0].ToString() == "ey" || evaled[0].ToString() == "el");
         }
 
@@ -932,8 +932,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             var templates = Templates.ParseFile(GetExampleFilePath("CrudInit.lg"));
 
             Assert.Equal(2, templates.Count);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             Assert.Equal("template1", templates[0].Name);
             Assert.Equal(3, templates[0].SourceRange.Range.Start.Line);
             Assert.Equal(8, templates[0].SourceRange.Range.End.Line);
@@ -944,8 +944,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // Add a template
             templates.AddTemplate("newtemplate", new List<string> { "age", "name" }, "- hi ");
             Assert.Equal(3, templates.Count);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             var newTemplate = templates[2];
             Assert.Equal("newtemplate", newTemplate.Name);
             Assert.Equal(2, newTemplate.Parameters.Count);
@@ -958,7 +958,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // add another template
             templates.AddTemplate("newtemplate2", null, "- hi2 ");
             Assert.Equal(4, templates.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
             newTemplate = templates[3];
             Assert.Equal("newtemplate2", newTemplate.Name);
             Assert.Empty(newTemplate.Parameters);
@@ -969,8 +969,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // update a middle template
             templates.UpdateTemplate("newtemplate", "newtemplateName", new List<string> { "newage", "newname" }, "- new hi\r\n#hi");
             Assert.Equal(4, templates.Count);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             newTemplate = templates[2];
             Assert.Equal("newtemplateName", newTemplate.Name);
             Assert.Equal(2, newTemplate.Parameters.Count);
@@ -985,8 +985,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // update the tailing template
             templates.UpdateTemplate("newtemplate2", "newtemplateName2", new List<string> { "newage2", "newname2" }, "- new hi\r\n#hi2\r\n");
             Assert.Equal(4, templates.Count);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             newTemplate = templates[3];
             Assert.Equal("newtemplateName2", newTemplate.Name);
             Assert.Equal(2, newTemplate.Parameters.Count);
@@ -997,14 +997,14 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // delete a middle template
             templates.DeleteTemplate("newtemplateName");
             Assert.Equal(3, templates.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
             Assert.Equal(14, templates[2].SourceRange.Range.Start.Line);
             Assert.Equal(16, templates[2].SourceRange.Range.End.Line);
 
             // delete the tailing template
             templates.DeleteTemplate("newtemplateName2");
             Assert.Equal(2, templates.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
             Assert.Equal(9, templates[1].SourceRange.Range.Start.Line);
             Assert.Equal(12, templates[1].SourceRange.Range.End.Line);
         }
@@ -1017,8 +1017,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // Add a template
             templates.AddTemplate("newtemplate", new List<string> { "age", "name" }, "- hi ");
             Assert.Equal(3, templates.Count);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             var newTemplate = templates[2];
             Assert.Equal("newtemplate", newTemplate.Name);
             Assert.Equal(2, newTemplate.Parameters.Count);
@@ -1031,7 +1031,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // add another template
             templates.AddTemplate("newtemplate2", null, "- hi2 ");
             Assert.Equal(4, templates.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
             newTemplate = templates[3];
             Assert.Equal("newtemplate2", newTemplate.Name);
             Assert.Empty(newTemplate.Parameters);
@@ -1052,8 +1052,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // Delete template
             templates.DeleteTemplate("template1");
             Assert.Single(templates);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             Assert.Equal("template2", templates[0].Name);
             Assert.Equal(3, templates[0].SourceRange.Range.Start.Line);
             Assert.Equal(6, templates[0].SourceRange.Range.End.Line);
@@ -1061,8 +1061,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // Delete a template that does not exist
             templates.DeleteTemplate("xxx");
             Assert.Single(templates);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Empty(templates.Diagnostics);
             Assert.Equal("template2", templates[0].Name);
             Assert.Equal(3, templates[0].SourceRange.Range.Start.Line);
             Assert.Equal(6, templates[0].SourceRange.Range.End.Line);
@@ -1070,8 +1070,8 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
             // Delete all template
             templates.DeleteTemplate("template2");
             Assert.Empty(templates);
-            Assert.Equal(0, templates.Imports.Count);
-            Assert.Equal(1, templates.Diagnostics.Count);
+            Assert.Empty(templates.Imports);
+            Assert.Single(templates.Diagnostics);
             Assert.Equal(DiagnosticSeverity.Warning, templates.Diagnostics[0].Severity);
             Assert.Equal(TemplateErrors.NoTemplate, templates.Diagnostics[0].Message);
         }
@@ -1083,7 +1083,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             // add error template name (error in template)
             templates.AddTemplate("newtemplate#$%", new List<string> { "age", "name" }, "- hi ");
-            Assert.Equal(1, templates.Diagnostics.Count);
+            Assert.Single(templates.Diagnostics);
             var diagnostic = templates.Diagnostics[0];
             Assert.Equal(TemplateErrors.InvalidTemplateName("newtemplate#$%"), diagnostic.Message);
             Assert.Equal(14, diagnostic.Range.Start.Line);
@@ -1091,15 +1091,15 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             // replace the error template with right template
             templates.UpdateTemplate("newtemplate#$%", "newtemplateName", null, "- new hi");
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
 
             // reference the other exist template
             templates.UpdateTemplate("newtemplateName", "newtemplateName", null, "- ${template1()}");
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
 
             // wrong reference, throw by static checker
             templates.UpdateTemplate("newtemplateName", "newtemplateName", null, "- ${NoTemplate()}");
-            Assert.Equal(1, templates.Diagnostics.Count);
+            Assert.Single(templates.Diagnostics);
             diagnostic = templates.Diagnostics[0];
             Assert.Contains("it's not a built-in function or a custom function", diagnostic.Message);
             Assert.Equal(15, diagnostic.Range.Start.Line);
@@ -1107,7 +1107,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
 
             // delete the error template
             templates.DeleteTemplate("newtemplateName");
-            Assert.Equal(0, templates.Diagnostics.Count);
+            Assert.Empty(templates.Diagnostics);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TemplateManager/Microsoft.Bot.Builder.TemplateManager.Tests.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Bots/DialogAndWelcomeBotTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Bots/DialogAndWelcomeBotTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Bots
 
             // Assert
             var m = (IMessageActivity)reply;
-            Assert.Equal(1, m.Attachments.Count);
+            Assert.Single(m.Attachments);
             Assert.Equal("application/vnd.microsoft.card.adaptive", m.Attachments.FirstOrDefault()?.ContentType);
         }
     }

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Bots/DialogBotTests.cs
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Bots/DialogBotTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.BotBuilderSamples.Tests.Bots
             await testFlow.Send("Hi").StartTestAsync();
 
             // Assert that SaveChangesAsyncWasCalled
-            Assert.True(false, "TODO");
+            Assert.Fail("TODO");
         }
     }
 }

--- a/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.TestBot.Tests/Microsoft.Bot.Builder.TestBot.Tests.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Testing.Tests/Microsoft.Bot.Builder.Testing.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/EventFactoryTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Bot.Builder.Tests
             Assert.Null(transcript.Activities[0].Conversation);
 
             var handoffEvent = EventFactory.CreateHandoffInitiation(context, new { Skill = "any" }, transcript);
-            Assert.Equal(handoffEvent.Name, HandoffEventNames.InitiateHandoff);
+            Assert.Equal(HandoffEventNames.InitiateHandoff, handoffEvent.Name);
             var skill = (handoffEvent.Value as JObject)?.Value<string>("Skill");
             Assert.Equal("any", skill);
             Assert.Equal(handoffEvent.From.Id, fromID);
@@ -66,7 +66,7 @@ namespace Microsoft.Bot.Builder.Tests
             var state = "failed";
             var message = "timed out";
             var handoffEvent = EventFactory.CreateHandoffStatus(new ConversationAccount(), state, message);
-            Assert.Equal(handoffEvent.Name, HandoffEventNames.HandoffStatus);
+            Assert.Equal(HandoffEventNames.HandoffStatus, handoffEvent.Name);
 
             var stateFormEvent = (handoffEvent.Value as JObject)?.Value<string>("state");
             Assert.Equal(stateFormEvent, state);

--- a/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MessageFactoryTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Text(null);
             
             Assert.Null(message.Text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Text(messageText);
 
             Assert.Equal(message.Text, messageText);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
         }
 
         [Fact]
@@ -57,8 +57,8 @@ namespace Microsoft.Bot.Builder.Tests
 
             Assert.Equal(message.Text, messageText);
             Assert.Equal(message.Speak, ssml);
-            Assert.Equal(message.InputHint, InputHints.AcceptingInput);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(InputHints.AcceptingInput, message.InputHint);
+            Assert.Equal(ActivityTypes.Message, message.Type);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.SuggestedActions(textActions, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.NotNull(message.SuggestedActions);
@@ -97,7 +97,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.SuggestedActions(textActions, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.NotNull(message.SuggestedActions);
@@ -135,7 +135,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.SuggestedActions(cardActions, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.NotNull(message.SuggestedActions);
@@ -180,7 +180,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.SuggestedActions(cardActions, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.NotNull(message.SuggestedActions);
@@ -213,7 +213,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Attachment(attachment, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.True(message.Attachments.Count == 1, "Incorrect Attachment Count");
@@ -286,7 +286,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Carousel(multipleAttachments, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.True(message.AttachmentLayout == AttachmentLayoutTypes.Carousel);
@@ -320,7 +320,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Carousel(multipleAttachments, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.True(message.AttachmentLayout == AttachmentLayoutTypes.Carousel);
@@ -352,7 +352,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Attachment(multipleAttachments, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.True(message.AttachmentLayout == AttachmentLayoutTypes.List);
@@ -386,7 +386,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.Attachment(multipleAttachments, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.True(message.AttachmentLayout == AttachmentLayoutTypes.List);
@@ -407,7 +407,7 @@ namespace Microsoft.Bot.Builder.Tests
             var message = MessageFactory.ContentUrl(uri, contentType, name, text, ssml, inputHint);
 
             Assert.Equal(message.Text, text);
-            Assert.Equal(message.Type, ActivityTypes.Message);
+            Assert.Equal(ActivityTypes.Message, message.Type);
             Assert.Equal(message.InputHint, inputHint);
             Assert.Equal(message.Speak, ssml);
             Assert.True(message.Attachments.Count == 1);

--- a/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
+++ b/tests/Microsoft.Bot.Builder.Tests/Microsoft.Bot.Builder.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" targetFramework="net46" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Builder.Tests/Skills/CloudSkillHandlerTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Skills/CloudSkillHandlerTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         }
 
         [Fact]
-        public async void TestUpdateActivityAsync()
+        public async Task TestUpdateActivityAsync()
         {
             // Arrange
             var mockObjects = new CloudSkillHandlerTestMocks();
@@ -163,7 +163,7 @@ namespace Microsoft.Bot.Builder.Tests.Skills
         }
 
         [Fact]
-        public async void TestGetConversationMemberAsync()
+        public async Task TestGetConversationMemberAsync()
         {
             // Arrange
             var mockObjects = new CloudSkillHandlerTestMocks();            

--- a/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityExtensionsTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsActivityExtensionsTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Bot.Builder.Teams.Tests
             var onBehalfOfList = activity.TeamsGetTeamOnBehalfOf();
 
             // Assert
-            Assert.Equal(1, onBehalfOfList.Count);
+            Assert.Single(onBehalfOfList);
             Assert.Equal("TestOnBehalfOf", onBehalfOfList[0].DisplayName);
         }
     }

--- a/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TelemetryMiddlewareTests.cs
@@ -56,10 +56,10 @@ namespace Microsoft.Bot.Builder.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
@@ -138,10 +138,10 @@ namespace Microsoft.Bot.Builder.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
@@ -306,10 +306,10 @@ namespace Microsoft.Bot.Builder.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
@@ -379,10 +379,10 @@ namespace Microsoft.Bot.Builder.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 
@@ -579,7 +579,7 @@ namespace Microsoft.Bot.Builder.Tests
                 .StartTestAsync();
 
             // Assert
-            Assert.Equal(1, mockTelemetryClient.Invocations.Count);
+            Assert.Single(mockTelemetryClient.Invocations);
             Assert.Equal("BotMessageReceived", mockTelemetryClient.Invocations[0].Arguments[0]); // Check initial message
             Assert.True(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).Count == 8);
             Assert.True(((Dictionary<string, string>)mockTelemetryClient.Invocations[0].Arguments[1]).ContainsKey("type"));

--- a/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/Transcript_MiddlewareTests.cs
@@ -128,10 +128,10 @@ namespace Microsoft.Bot.Builder.Tests
                 await context.SendActivityAsync("echo:" + context.Activity.Text);
             })
                 .Send("foo")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:foo")
                 .Send("bar")
-                    .AssertReply((activity) => Assert.Equal(activity.Type, ActivityTypes.Typing))
+                    .AssertReply((activity) => Assert.Equal(ActivityTypes.Typing, activity.Type))
                     .AssertReply("echo:bar")
                 .StartTestAsync();
 

--- a/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
+++ b/tests/Microsoft.Bot.Configuration.Tests/Microsoft.Bot.Configuration.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Application/LegacyStreamingConnectionTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Application/LegacyStreamingConnectionTests.cs
@@ -77,14 +77,14 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Application
         }
 
         [Fact]
-        public void CanSendStreamingRequest()
+        public async Task CanSendStreamingRequestAsync()
         {
             var socket = new TestWebSocket();
             var requestHandler = new TestRequestHandler();
 
             using (var sut = new TestLegacyStreamingConnection(socket, NullLogger.Instance))
             {
-                sut.ListenAsync(requestHandler).Wait();
+                await sut.ListenAsync(requestHandler);
 
                 var request = new StreamingRequest
                 {
@@ -96,7 +96,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Application
                     }
                 };
 
-                var response = sut.SendStreamingRequestAsync(request).Result;
+                var response = await sut.SendStreamingRequestAsync(request);
 
                 Assert.Equal(request.Streams.Count, response.Streams.Count);
                 Assert.Equal(request.Streams[0].Id, response.Streams[0].Id);

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/ApplicationToApplicationIntegrationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/ApplicationToApplicationIntegrationTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     .Setup(r => r.ProcessRequestAsync(It.IsAny<ReceiveRequest>(), null, null, CancellationToken.None))
                     .ReturnsAsync(() => new StreamingResponse() { StatusCode = 200 });
 
-                var socket = await webSocketFeature.AcceptAsync().ConfigureAwait(false);
+                var socket = await webSocketFeature.AcceptAsync();
                 var connection = new WebSocketStreamingConnection(socket, logger);
 
                 var serverTask = Task.Run(() => connection.ListenAsync(botRequestHandler.Object));
@@ -60,7 +60,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 const string botToClientPayload = "Hello human, I'm Bender!";
                 var request = StreamingRequest.CreatePost(path, new StringContent(botToClientPayload));
 
-                var responseFromClient = await connection.SendStreamingRequestAsync(request).ConfigureAwait(false);
+                var responseFromClient = await connection.SendStreamingRequestAsync(request);
 
                 Assert.Equal(200, responseFromClient.StatusCode);
 
@@ -68,14 +68,14 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 var clientRequest = StreamingRequest.CreatePost(path, new StringContent(clientToBotPayload));
 
                 // Send request bot channel (client) -> (server) 
-                var clientToBotResult = await client.SendAsync(clientRequest).ConfigureAwait(false);
+                var clientToBotResult = await client.SendAsync(clientRequest);
 
                 Assert.Equal(200, clientToBotResult.StatusCode);
 
-                await client.DisconnectAsync().ConfigureAwait(false);
+                await client.DisconnectAsync();
 
-                await clientTask.ConfigureAwait(false);
-                await serverTask.ConfigureAwait(false);
+                await clientTask;
+                await serverTask;
             }
         }
 
@@ -95,7 +95,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                     .Setup(r => r.ProcessRequestAsync(It.IsAny<ReceiveRequest>(), null, null, CancellationToken.None))
                     .ReturnsAsync(() => new StreamingResponse() { StatusCode = 200 });
 
-                var socket = await webSocketFeature.AcceptAsync().ConfigureAwait(false);
+                var socket = await webSocketFeature.AcceptAsync();
                 var connection = new WebSocketStreamingConnection(socket, logger);
                 var serverTask = connection.ListenAsync(botRequestHandler.Object, cts.Token);
 
@@ -115,7 +115,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 const string botToClientPayload = "Hello human, I'm Bender!";
                 var request = StreamingRequest.CreatePost(path, new StringContent(botToClientPayload));
 
-                var responseFromClient = await connection.SendStreamingRequestAsync(request).ConfigureAwait(false);
+                var responseFromClient = await connection.SendStreamingRequestAsync(request);
 
                 Assert.Equal(200, responseFromClient.StatusCode);
 
@@ -123,11 +123,11 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 var clientRequest = StreamingRequest.CreatePost(path, new StringContent(clientToBotPayload));
 
                 // Send request bot channel (client) -> (server) 
-                var clientToBotResult = await client.SendAsync(clientRequest).ConfigureAwait(false);
+                var clientToBotResult = await client.SendAsync(clientRequest);
 
                 Assert.Equal(200, clientToBotResult.StatusCode);
 
-                await Task.Delay(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(3));
 
                 Assert.True(client.IsConnected);
             }

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Integration/EndToEndMiniLoadTests.cs
@@ -309,7 +309,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
         [Theory]
         [InlineData(3, 50, 4, false, false)] // new client, new server
         [InlineData(3, 100, 32, false, false)] // new client, new server
-        public void ConcurrencyTest(int connectionCount, int messageCount, int threadCount, bool useLegacyClient, bool useLegacyServer)
+        public async Task ConcurrencyTestAsync(int connectionCount, int messageCount, int threadCount, bool useLegacyClient, bool useLegacyServer)
         {
             var logger = XUnitLogger.CreateLogger(_testOutput);
 
@@ -366,7 +366,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
                         Assert.NotNull(response);
 
                         Assert.Equal($"Echo: {activities.FirstOrDefault(a => a.Id == response.ReplyToId)?.Text}", response.Text);
-                        Assert.Equal(1, response.Attachments.Count);
+                        Assert.Single(response.Attachments);
 
                         return Task.FromResult(StreamingResponse.OK());
                     }
@@ -384,7 +384,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests.Integration
                     RunActivityStreamingTest(activities, bot, server, clientRequestHandler.Object, logger, useLegacyClient, messageCount, threadCount));
             }
 
-            Task.WhenAll(connections).Wait();
+            await Task.WhenAll(connections);
         }
 
         [Fact]

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Microsoft.Bot.Connector.Streaming.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
     <PackageReference Include="ReportGenerator" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Connector.Streaming.Tests/Transport/TransportHandlerTests.cs
+++ b/tests/Microsoft.Bot.Connector.Streaming.Tests/Transport/TransportHandlerTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
             {
                 transport.AdvanceTo(buffer.Start, buffer.End);
 
-                result = await transport.ReadAsync().ConfigureAwait(false);
+                result = await transport.ReadAsync();
 
                 Assert.False(result.IsCanceled);
 
@@ -188,7 +188,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
             {
                 transport.AdvanceTo(buffer.Start, buffer.End);
 
-                result = await transport.ReadAsync().ConfigureAwait(false);
+                result = await transport.ReadAsync();
 
                 Assert.False(result.IsCanceled);
 
@@ -243,7 +243,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
             {
                 transport.AdvanceTo(buffer.Start, buffer.End);
 
-                result = await transport.ReadAsync().ConfigureAwait(false);
+                result = await transport.ReadAsync();
 
                 Assert.False(result.IsCanceled);
 
@@ -302,7 +302,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
 
                 Assert.Equal(entry.Header.PayloadLength, entry.Payload.Length);
 
-                await output.WriteAsync(headerBuffer, CancellationToken.None).ConfigureAwait(false);
+                await output.WriteAsync(headerBuffer, CancellationToken.None);
 
                 if (cancelWithoutPayload)
                 {
@@ -312,7 +312,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
 
                 if (entry.Header.PayloadLength > 0)
                 {
-                    await output.WriteAsync(entry.Payload, CancellationToken.None).ConfigureAwait(false);
+                    await output.WriteAsync(entry.Payload, CancellationToken.None);
                 }
 
                 if (first && cancelAfterFirst)
@@ -325,12 +325,12 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
             if (completeWithException)
             {
                 await Task.Delay(TimeSpan.FromSeconds(1));
-                await output.CompleteAsync(new Exception()).ConfigureAwait(false);
+                await output.CompleteAsync(new Exception());
                 await Assert.ThrowsAsync<Exception>(async () => await transportTask);
             }
             else
             {
-                await output.CompleteAsync().ConfigureAwait(false);
+                await output.CompleteAsync();
                 
                 if (Debugger.IsAttached)
                 {
@@ -338,7 +338,7 @@ namespace Microsoft.Bot.Connector.Streaming.Tests
                 }
                 else
                 {
-                    var result = await Task.WhenAny(transportTask, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+                    var result = await Task.WhenAny(transportTask, Task.Delay(TimeSpan.FromSeconds(5)));
                     Assert.Equal(result, transportTask);
                 }
             }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/CertificateServiceClientCredentialsFactoryTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -49,24 +50,24 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void IsValidAppIdTest()
+        public async Task IsValidAppIdTest()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
-            Assert.True(factory.IsValidAppIdAsync(TestAppId, CancellationToken.None).GetAwaiter().GetResult());
-            Assert.False(factory.IsValidAppIdAsync("InvalidAppId", CancellationToken.None).GetAwaiter().GetResult());
+            Assert.True(await factory.IsValidAppIdAsync(TestAppId, CancellationToken.None));
+            Assert.False(await factory.IsValidAppIdAsync("InvalidAppId", CancellationToken.None));
         }
 
         [Fact]
-        public void IsAuthenticationDisabledTest()
+        public async Task IsAuthenticationDisabledTest()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
-            Assert.False(factory.IsAuthenticationDisabledAsync(CancellationToken.None).GetAwaiter().GetResult());
+            Assert.False(await factory.IsAuthenticationDisabledAsync(CancellationToken.None));
         }
 
         [Fact]
-        public async void CanCreatePublicCredentials()
+        public async Task CanCreatePublicCredentials()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
@@ -78,7 +79,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void CanCreateGovCredentials()
+        public async Task CanCreateGovCredentials()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
@@ -90,7 +91,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void CanCreatePrivateCredentials()
+        public async Task CanCreatePrivateCredentials()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
@@ -103,7 +104,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void ShouldCreateUniqueCredentialsByAudience()
+        public async Task ShouldCreateUniqueCredentialsByAudience()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
@@ -122,11 +123,11 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void CannotCreateCredentialsWithInvalidAppId()
+        public async Task CannotCreateCredentialsWithInvalidAppId()
         {
             var factory = new CertificateServiceClientCredentialsFactory(certificate.Object, TestAppId);
 
-            Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateCredentialsAsync(
+            await Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateCredentialsAsync(
                     "InvalidAppId", TestAudience, LoginEndpoint, true, CancellationToken.None));
         }
     }

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/EndorsementsRetrieverTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
 
             [Fact]
-            public async void NullAddressParameterShouldThrow()
+            public async Task NullAddressParameterShouldThrow()
             {
                 Func<Task> action = async () => await _endorsementsRetriever.GetConfigurationAsync(null, _mockDocumentRetriever.Object, CancellationToken.None);
 
@@ -58,7 +58,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
 
             [Fact]
-            public async void NullDocumentRetrieverParameterShouldThrow()
+            public async Task NullDocumentRetrieverParameterShouldThrow()
             {
                 Func<Task> action = async () => await _endorsementsRetriever.GetConfigurationAsync(FakeDocumentAddress, null, CancellationToken.None);
 
@@ -134,7 +134,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
 
             [Fact]
-            public async void ThrowsIfDocumentRetrieverThrows()
+            public async Task ThrowsIfDocumentRetrieverThrows()
             {
                 _mockDocumentRetriever.Setup(dr => dr.GetDocumentAsync(FakeDocumentAddress, It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new Exception(nameof(ThrowsIfDocumentRetrieverThrows)));
@@ -160,7 +160,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
 
             [Fact]
-            public async void NullAddressParameterShouldThrow()
+            public async Task NullAddressParameterShouldThrow()
             {
                 Func<Task> action = async () => await _endorsementsRetriever.GetDocumentAsync(null, CancellationToken.None);
 
@@ -168,7 +168,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
 
             [Fact]
-            public async void NonSuccessHttpStatusResponseForEndorsementsDocumentShouldThrow()
+            public async Task NonSuccessHttpStatusResponseForEndorsementsDocumentShouldThrow()
             {
                 _mockHttpMessageHandler.When(FakeDocumentAddress)
                     .Respond(HttpStatusCode.NotFound);
@@ -179,7 +179,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             }
 
             [Fact]
-            public async void NonSuccessHttpStatusResponseForWebKeySetDocumentShouldThrow()
+            public async Task NonSuccessHttpStatusResponseForWebKeySetDocumentShouldThrow()
             {
                 _mockHttpMessageHandler.When(FakeDocumentAddress)
                     .Respond(new StringContent($@"{{ ""{EndorsementsRetriever.JsonWebKeySetUri}"": ""{FakeKeysAddressUrl}"" }}"));

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/JwtTokenValidationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Connector_AuthHeader_CorrectAppIdAndServiceUrl_ShouldValidate()
+        //public async Task Connector_AuthHeader_CorrectAppIdAndServiceUrl_ShouldValidate()
         //{
         //    string header = $"Bearer {await new MicrosoftAppCredentials("", "").GetTokenAsync()}";
         //    var credentials = new SimpleCredentialProvider("", string.Empty);
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Connector_AuthHeader_BotAppIdDiffers_ShouldNotValidate()
+        //public async Task Connector_AuthHeader_BotAppIdDiffers_ShouldNotValidate()
         //{
         //    string header = $"Bearer {await new MicrosoftAppCredentials("", "").GetTokenAsync()}";
         //    var credentials = new SimpleCredentialProvider("00000000-0000-0000-0000-000000000000", string.Empty);
@@ -56,7 +56,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Connector_AuthHeader_BotWithNoCredentials_ShouldNotValidate()
+        //public async Task Connector_AuthHeader_BotWithNoCredentials_ShouldNotValidate()
         //{
         //    // token received and auth disabled
         //    string header = $"Bearer {await new MicrosoftAppCredentials("", "").GetTokenAsync()}";
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         //}
 
         [Fact]
-        public async void EmptyHeader_BotWithNoCredentials_ShouldThrow()
+        public async Task EmptyHeader_BotWithNoCredentials_ShouldThrow()
         {
             var header = string.Empty;
             var credentials = new SimpleCredentialProvider(string.Empty, string.Empty);
@@ -78,7 +78,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Emulator_MsaHeader_CorrectAppIdAndServiceUrl_ShouldValidate()
+        //public async Task Emulator_MsaHeader_CorrectAppIdAndServiceUrl_ShouldValidate()
         //{
         //    string header = $"Bearer {await new MicrosoftAppCredentials("", "").GetTokenAsync()}";
         //    var credentials = new SimpleCredentialProvider("", string.Empty);
@@ -89,7 +89,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Emulator_MsaHeader_BotAppIdDiffers_ShouldNotValidate()
+        //public async Task Emulator_MsaHeader_BotAppIdDiffers_ShouldNotValidate()
         //{
         //    string header = $"Bearer {await new MicrosoftAppCredentials("", "").GetTokenAsync()}";
         //    var credentials = new SimpleCredentialProvider("00000000-0000-0000-0000-000000000000", string.Empty);
@@ -100,8 +100,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         /// <summary>
         /// Tests with no authentication header and makes sure the service URL is not added to the trusted list.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async void Channel_AuthenticationDisabled_ShouldBeAnonymous()
+        public async Task Channel_AuthenticationDisabled_ShouldBeAnonymous()
         {
             var header = string.Empty;
             var credentials = new SimpleCredentialProvider();
@@ -119,8 +120,9 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         /// <summary>
         /// Test with emulator channel Id and and RelatesTo set so it can validate we get an anonymous skill claim back.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async void Channel_AuthenticationDisabledAndSkill_ShouldBeAnonymous()
+        public async Task Channel_AuthenticationDisabledAndSkill_ShouldBeAnonymous()
         {
             var header = string.Empty;
             var credentials = new SimpleCredentialProvider();
@@ -144,7 +146,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Emulator_AuthHeader_CorrectAppIdAndServiceUrl_WithGovChannelService_ShouldValidate()
+        //public async Task Emulator_AuthHeader_CorrectAppIdAndServiceUrl_WithGovChannelService_ShouldValidate()
         //{
         //    await JwtTokenValidation_ValidateAuthHeader_WithChannelService_Succeeds(
         //        "",         // emulator creds
@@ -154,7 +156,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Emulator_AuthHeader_CorrectAppIdAndServiceUrl_WithPrivateChannelService_ShouldValidate()
+        //public async Task Emulator_AuthHeader_CorrectAppIdAndServiceUrl_WithPrivateChannelService_ShouldValidate()
         //{
         //    await JwtTokenValidation_ValidateAuthHeader_WithChannelService_Succeeds(
         //        "",         // emulator creds
@@ -164,7 +166,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
         // Disabled after appid was deleted. Issue created to move tests to functional tests
         //[Fact]
-        //public async void Connector_AuthHeader_CorrectAppIdAndServiceUrl_WithGovChannelService_ShouldValidate()
+        //public async Task Connector_AuthHeader_CorrectAppIdAndServiceUrl_WithGovChannelService_ShouldValidate()
         //{
         //    await JwtTokenValidation_ValidateAuthHeader_WithChannelService_Succeeds(
         //        "",         // emulator creds
@@ -173,7 +175,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         //}
 
         [Fact]
-        public async void GovernmentChannelValidation_Succeeds()
+        public async Task GovernmentChannelValidation_Succeeds()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -188,7 +190,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_NoAuthentication_Fails()
+        public async Task GovernmentChannelValidation_NoAuthentication_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -205,7 +207,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_NoAudienceClaim_Fails()
+        public async Task GovernmentChannelValidation_NoAudienceClaim_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -221,7 +223,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_WrongAudienceClaim_Fails()
+        public async Task GovernmentChannelValidation_WrongAudienceClaim_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -238,7 +240,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_WrongAudienceClaimIssuer_Fails()
+        public async Task GovernmentChannelValidation_WrongAudienceClaimIssuer_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -255,7 +257,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_NoAudienceClaimValue_Fails()
+        public async Task GovernmentChannelValidation_NoAudienceClaimValue_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -272,7 +274,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_NoServiceClaimValue_Fails()
+        public async Task GovernmentChannelValidation_NoServiceClaimValue_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -289,7 +291,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void GovernmentChannelValidation_WrongServiceClaimValue_Fails()
+        public async Task GovernmentChannelValidation_WrongServiceClaimValue_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -306,7 +308,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_Succeeds()
+        public async Task EnterpriseChannelValidation_Succeeds()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -321,7 +323,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_NoAuthentication_Fails()
+        public async Task EnterpriseChannelValidation_NoAuthentication_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -338,7 +340,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_NoAudienceClaim_Fails()
+        public async Task EnterpriseChannelValidation_NoAudienceClaim_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -354,7 +356,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_WrongAudienceClaim_Fails()
+        public async Task EnterpriseChannelValidation_WrongAudienceClaim_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -371,7 +373,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_WrongAudienceClaimIssuer_Fails()
+        public async Task EnterpriseChannelValidation_WrongAudienceClaimIssuer_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -388,7 +390,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_NoAudienceClaimValue_Fails()
+        public async Task EnterpriseChannelValidation_NoAudienceClaimValue_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -405,7 +407,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_NoServiceClaimValue_Fails()
+        public async Task EnterpriseChannelValidation_NoServiceClaimValue_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";
@@ -422,7 +424,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public async void EnterpriseChannelValidation_WrongServiceClaimValue_Fails()
+        public async Task EnterpriseChannelValidation_WrongServiceClaimValue_Fails()
         {
             var appId = "1234567890";
             var serviceUrl = "https://webchat.botframework.com/";

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAuthenticatorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAuthenticatorTests.cs
@@ -20,13 +20,6 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         private readonly Func<string, string> audience = (id) => $"audience {id} ";
 
         [Fact]
-
-/* Unmerged change from project 'Microsoft.Bot.Connector.Tests (net6.0)'
-Before:
-        public void CanGetJwtToken()
-After:
-        public void Task CanGetJwtTokenAsync()
-*/
         public async Task CanGetJwtTokenAsync()
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAuthenticatorTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/ManagedIdentityAuthenticatorTests.cs
@@ -20,7 +20,14 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         private readonly Func<string, string> audience = (id) => $"audience {id} ";
 
         [Fact]
+
+/* Unmerged change from project 'Microsoft.Bot.Connector.Tests (net6.0)'
+Before:
         public void CanGetJwtToken()
+After:
+        public void Task CanGetJwtTokenAsync()
+*/
+        public async Task CanGetJwtTokenAsync()
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
             var expiresOn = DateTimeOffset.Now.ToUnixTimeSeconds() + 10000;
@@ -37,8 +44,8 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
                 .ReturnsAsync(response);
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
 
-            var sut = new ManagedIdentityAuthenticator(appId(nameof(CanGetJwtToken)), audience(nameof(CanGetJwtToken)), httpClient);
-            var token = sut.GetTokenAsync().GetAwaiter().GetResult();
+            var sut = new ManagedIdentityAuthenticator(appId(nameof(CanGetJwtTokenAsync)), audience(nameof(CanGetJwtTokenAsync)), httpClient);
+            var token = await sut.GetTokenAsync();
 
             Assert.Equal("at_secret", token.AccessToken);
             Assert.Equal(expiresOn, token.ExpiresOn.ToUnixTimeSeconds());
@@ -47,7 +54,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         [Theory]
         [InlineData(false, 1)]
         [InlineData(true, 2)]
-        public void CanGetJwtTokenWithForceRefresh(bool forceRefreshInput, int index)
+        public async Task CanGetJwtTokenWithForceRefresh(bool forceRefreshInput, int index)
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
             var expiresOn = DateTimeOffset.Now.ToUnixTimeSeconds() + 10000;
@@ -65,14 +72,14 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
 
             var sut = new ManagedIdentityAuthenticator(appId(nameof(CanGetJwtTokenWithForceRefresh)) + index, audience(nameof(CanGetJwtTokenWithForceRefresh)) + index, httpClient);
-            var token = sut.GetTokenAsync(forceRefreshInput).GetAwaiter().GetResult();
+            var token = await sut.GetTokenAsync(forceRefreshInput);
 
             Assert.Equal("at_secret", token.AccessToken);
             Assert.Equal(expiresOn, token.ExpiresOn.ToUnixTimeSeconds());
         }
 
         [Fact]
-        public void DefaultRetryOnException()
+        public async Task DefaultRetryOnException()
         {
             var maxRetries = 10;
             var callsToAcquireToken = 0;
@@ -101,7 +108,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
 
             try
             {
-                _ = sut.GetTokenAsync().GetAwaiter().GetResult();
+                _ = await sut.GetTokenAsync();
             }
             catch (AggregateException e)
             {
@@ -114,7 +121,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void CanRetryAndAcquireToken()
+        public async Task CanRetryAndAcquireToken()
         {
             var callsToAcquireToken = 0;
             var response = new HttpResponseMessage(HttpStatusCode.OK);
@@ -142,7 +149,7 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
 
             var sut = new ManagedIdentityAuthenticator(appId(nameof(CanRetryAndAcquireToken)), audience(nameof(CanRetryAndAcquireToken)), httpClient);
-            var token = sut.GetTokenAsync().GetAwaiter().GetResult();
+            var token = await sut.GetTokenAsync();
 
             Assert.Equal("at_secret", token.AccessToken);
             Assert.Equal(expiresOn, token.ExpiresOn.ToUnixTimeSeconds());

--- a/tests/Microsoft.Bot.Connector.Tests/Authentication/MsalServiceClientCredentialsFactoryTests.cs
+++ b/tests/Microsoft.Bot.Connector.Tests/Authentication/MsalServiceClientCredentialsFactoryTests.cs
@@ -45,54 +45,54 @@ namespace Microsoft.Bot.Connector.Tests.Authentication
         }
 
         [Fact]
-        public void ShouldThrowIfAppIdDoesNotMatch()
+        public async Task ShouldThrowIfAppIdDoesNotMatch()
         {
             configuration.Setup(x => x.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey).Value).Returns(TestAppId);
             var factory = new MsalServiceClientCredentialsFactory(configuration.Object, clientApplication.Object, logger.Object);
-            
-            Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateCredentialsAsync(
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => factory.CreateCredentialsAsync(
                     "InvalidAppId", TestAudience, LoginEndpoint, true, CancellationToken.None));
         }
 
         [Fact]
-        public void ShouldCreateCredentials()
+        public async Task ShouldCreateCredentials()
         {
             configuration.Setup(x => x.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey).Value).Returns(TestAppId);
             var factory = new MsalServiceClientCredentialsFactory(configuration.Object, clientApplication.Object, logger.Object);
-            var credentials = factory.CreateCredentialsAsync(TestAppId, TestAudience, LoginEndpoint, true, CancellationToken.None).GetAwaiter().GetResult();
+            var credentials = await factory.CreateCredentialsAsync(TestAppId, TestAudience, LoginEndpoint, true, CancellationToken.None);
 
             Assert.NotNull(credentials);
             Assert.IsType<MsalAppCredentials>(credentials);
         }
 
         [Fact]
-        public void ShouldCreateCredentialsForGoverment()
+        public async Task ShouldCreateCredentialsForGoverment()
         {
             configuration.Setup(x => x.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey).Value).Returns(TestAppId);
             var factory = new MsalServiceClientCredentialsFactory(configuration.Object, clientApplication.Object, logger.Object);
-            var credentials = factory.CreateCredentialsAsync(TestAppId, TestAudience, LoginEndpointGov, true, CancellationToken.None).GetAwaiter().GetResult();
+            var credentials = await factory.CreateCredentialsAsync(TestAppId, TestAudience, LoginEndpointGov, true, CancellationToken.None);
 
             Assert.NotNull(credentials);
             Assert.IsType<MsalAppCredentials>(credentials);
         }
 
         [Fact]
-        public void IsValidAppIdTest()
+        public async Task IsValidAppIdTest()
         {
             configuration.Setup(x => x.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey).Value).Returns(TestAppId);
             var factory = new MsalServiceClientCredentialsFactory(configuration.Object, clientApplication.Object, logger.Object);
 
-            Assert.True(factory.IsValidAppIdAsync(TestAppId, CancellationToken.None).GetAwaiter().GetResult());
-            Assert.False(factory.IsValidAppIdAsync("InvalidAppId", CancellationToken.None).GetAwaiter().GetResult());
+            Assert.True(await factory.IsValidAppIdAsync(TestAppId, CancellationToken.None));
+            Assert.False(await factory.IsValidAppIdAsync("InvalidAppId", CancellationToken.None));
         }
 
         [Fact]
-        public void IsAuthenticationDisabledTest()
+        public async Task IsAuthenticationDisabledTest()
         {
             configuration.Setup(x => x.GetSection(MicrosoftAppCredentials.MicrosoftAppIdKey).Value).Returns(string.Empty);
             var factory = new MsalServiceClientCredentialsFactory(configuration.Object, clientApplication.Object, logger.Object);
 
-            Assert.True(factory.IsAuthenticationDisabledAsync(CancellationToken.None).GetAwaiter().GetResult());
+            Assert.True(await factory.IsAuthenticationDisabledAsync(CancellationToken.None));
         }
     }
 }

--- a/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
+++ b/tests/Microsoft.Bot.Connector.Tests/Microsoft.Bot.Connector.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
+++ b/tests/Microsoft.Bot.Schema.Tests/Microsoft.Bot.Schema.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="xunit" Version="2.4.1" />
+      <PackageReference Include="xunit" Version="2.9.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardOpenUriTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardOpenUriTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(name, openUri.Name);
             Assert.Equal(id, openUri.Id);
             Assert.Equal(targets, openUri.Targets);
-            Assert.Equal(1, openUri.Targets.Count);
+            Assert.Single(openUri.Targets);
         }
         
         [Fact]

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardSectionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardSectionTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(images, section.Images);
             Assert.Equal(2, section.Images.Count);
             Assert.Equal(potentialAction, section.PotentialAction);
-            Assert.Equal(1, section.PotentialAction.Count);
+            Assert.Single(section.PotentialAction);
         }
         
         [Fact]

--- a/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardViewActionTests.cs
+++ b/tests/Microsoft.Bot.Schema.Tests/Teams/O365ConnectorCardViewActionTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Bot.Schema.Tests.Teams
             Assert.Equal(name, viewAction.Name);
             Assert.Equal(id, viewAction.Id);
             Assert.Equal(target, viewAction.Target);
-            Assert.Equal(1, viewAction.Target.Count);
+            Assert.Single(viewAction.Target);
         }
         
         [Fact]

--- a/tests/Microsoft.Bot.Streaming.Tests/ConcurrentStreamTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ConcurrentStreamTests.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void DoneProducing_Data_WillCauseZeroRead_And_End()
+        public async Task DoneProducing_Data_WillCauseZeroRead_And_End()
         {
             const int expectedReadCount = 100;
             var producerBuffer = new byte[100];

--- a/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
+++ b/tests/Microsoft.Bot.Streaming.Tests/Microsoft.Bot.Streaming.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NunitXml.TestLogger" Version="2.1.41" />
     <PackageReference Include="ReportGenerator" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void NamedPipeClient_SendAsync_With_No_Message()
+        public async Task NamedPipeClient_SendAsync_With_No_Message()
         {
             var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
             var pipe = new NamedPipeClient(pipeName);
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void NamedPipeClient_SendAsync_With_No_Connected_Client()
+        public async Task NamedPipeClient_SendAsync_With_No_Connected_Client()
         {
             var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
             var pipe = new NamedPipeClient(pipeName);
@@ -106,7 +106,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void NamedPipeServer_SendAsync_With_No_Message()
+        public async Task NamedPipeServer_SendAsync_With_No_Message()
         {
             var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
             var requestHandler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), pipeName);
@@ -116,7 +116,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void NamedPipeServer_SendAsync_With_No_Connected_Client()
+        public async Task NamedPipeServer_SendAsync_With_No_Connected_Client()
         {
             var pipeName = Guid.NewGuid().ToString().Substring(0, 18);
             var requestHandler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), pipeName);

--- a/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTransportTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/NamedPipeTransportTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public void CanWriteAndRead()
+        public async Task CanWriteAndReadAsync()
         {
             var tasks = new List<Task>();
 
@@ -68,7 +68,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                         _output.WriteLine("After Write");
                     }));
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks.ToArray());
             }
             finally
             {
@@ -79,7 +79,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void ReceiveAsync_With_Null_Stream()
+        public async Task ReceiveAsync_With_Null_Stream()
         {
             var pipe = new NamedPipeTransport(null);
             var result = await pipe.ReceiveAsync(new byte[0], 0, 0);
@@ -99,7 +99,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public void ActiveStream_IsConnected()
+        public async Task ActiveStream_IsConnectedAsync()
         {
             var pipeName = Guid.NewGuid().ToString();
             var readStream = new NamedPipeServerStream(pipeName, PipeDirection.In, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.WriteThrough | PipeOptions.Asynchronous);
@@ -127,7 +127,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                         _output.WriteLine("After ConnectAsync");
                     }));
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks.ToArray());
 
                 Assert.True(reader.IsConnected);
                 Assert.True(writer.IsConnected);
@@ -141,7 +141,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public void Dispose_DisconnectsStream()
+        public async Task Dispose_DisconnectsStreamAsync()
         {
             var pipeName = Guid.NewGuid().ToString();
             var readStream = new NamedPipeServerStream(pipeName, PipeDirection.In, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.WriteThrough | PipeOptions.Asynchronous);
@@ -169,7 +169,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                         _output.WriteLine("After ConnectAsync");
                     }));
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks.ToArray());
 
                 Assert.True(reader.IsConnected);
 
@@ -185,7 +185,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public void Close_DisconnectsStream()
+        public async Task Close_DisconnectsStreamAsync()
         {
             var pipeName = Guid.NewGuid().ToString();
             var readStream = new NamedPipeServerStream(pipeName, PipeDirection.In, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.WriteThrough | PipeOptions.Asynchronous);
@@ -213,7 +213,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                         _output.WriteLine("After ConnectAsync");
                     }));
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks.ToArray());
 
                 Assert.True(reader.IsConnected);
 
@@ -229,7 +229,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public void Read_ReturnsZeroLength_WhenClosedDuringRead()
+        public async Task Read_ReturnsZeroLength_WhenClosedDuringReadAsync()
         {
             var tasks = new List<Task>();
             var pipeName = Guid.NewGuid().ToString();
@@ -271,7 +271,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                         _output.WriteLine("After Close");
                     }));
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks.ToArray());
             }
             finally
             {
@@ -282,7 +282,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public void Write_ReturnsZeroLength_WhenClosedDuringWrite()
+        public async Task Write_ReturnsZeroLength_WhenClosedDuringWriteAsync()
         {
             var tasks = new List<Task>();
 
@@ -329,7 +329,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
                         Assert.Equal(0, length);
                     }));
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks.ToArray());
             }
             finally
             {

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadAssemblerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/PayloadAssemblerTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public async void PayloadAssemblerManager_OnReceiveRequest()
+        public async Task PayloadAssemblerManager_OnReceiveRequest()
         {
             var id = Guid.NewGuid();
             var streamManager = new StreamManager();
@@ -201,7 +201,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public async void PayloadAssemblerManager_OnReceiveResponse()
+        public async Task PayloadAssemblerManager_OnReceiveResponse()
         {
             var id = Guid.NewGuid();
             var streamManager = new StreamManager();
@@ -294,7 +294,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public async void ReceiveRequestAssembler_Close()
+        public async Task ReceiveRequestAssembler_Close()
         {
             var id = Guid.NewGuid();
             var header = new Header { Id = id, End = true };
@@ -372,7 +372,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public async void ReceiveResponseAssembler_Close()
+        public async Task ReceiveResponseAssembler_Close()
         {
             var id = Guid.NewGuid();
             var header = new Header { Id = id, End = true };

--- a/tests/Microsoft.Bot.Streaming.Tests/Payloads/RequestManagerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/Payloads/RequestManagerTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             await rm.SignalResponseAsync(g, null);
 
-            Assert.Null(tcs.Task.Result);
+            Assert.Null(await tcs.Task);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
             var resp = new ReceiveResponse();
             await rm.SignalResponseAsync(g, resp);
 
-            Assert.True(resp.Equals(tcs.Task.Result));
+            Assert.True(resp.Equals(await tcs.Task));
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public void RequestManager_GetResponse_ReturnsResponse()
+        public async Task RequestManager_GetResponse_ReturnsResponseAsync()
         {
             var d = new ConcurrentDictionary<Guid, TaskCompletionSource<ReceiveResponse>>();
             var g = Guid.NewGuid();
@@ -98,7 +98,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
 
             var resp = new ReceiveResponse();
 
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     var r = await rm.GetResponseAsync(g, CancellationToken.None);
@@ -117,13 +117,13 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public void RequestManager_GetResponse_ReturnsNullResponse()
+        public async Task RequestManager_GetResponse_ReturnsNullResponseAsync()
         {
             var d = new ConcurrentDictionary<Guid, TaskCompletionSource<ReceiveResponse>>();
             var g = Guid.NewGuid();
             var rm = new RequestManager(d);
 
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     var r = await rm.GetResponseAsync(g, CancellationToken.None);
@@ -142,13 +142,13 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public void RequestManager_GetResponse_ThrowsOnCancelledTask()
+        public async Task RequestManager_GetResponse_ThrowsOnCancelledTaskAsync()
         {
             var d = new ConcurrentDictionary<Guid, TaskCompletionSource<ReceiveResponse>>();
             var g = Guid.NewGuid();
             var rm = new RequestManager(d);
 
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     await Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -169,16 +169,16 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
         }
 
         [Fact]
-        public void RequestManager_GetResponse_ThrowsOnErrorTask()
+        public async Task RequestManager_GetResponse_ThrowsOnErrorTaskAsync()
         {
             var d = new ConcurrentDictionary<Guid, TaskCompletionSource<ReceiveResponse>>();
             var g = Guid.NewGuid();
             var rm = new RequestManager(d);
 
-            Task.WaitAll(
-                Task.Run(() =>
+            await Task.WhenAll(
+                Task.Run(async () =>
                 {
-                    Assert.ThrowsAsync<AggregateException>(async () =>
+                    await Assert.ThrowsAsync<AggregateException>(async () =>
                     {
                         var r = await rm.GetResponseAsync(g, CancellationToken.None);
                     });
@@ -191,7 +191,7 @@ namespace Microsoft.Bot.Streaming.UnitTests.Payloads
                         // Wait for a value.;
                     }
 
-                    value.SetException(new InvalidOperationException());
+                    value.SetException(new AggregateException(new InvalidOperationException()));
                 }));
         }
 

--- a/tests/Microsoft.Bot.Streaming.Tests/ProtocolAdapterTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ProtocolAdapterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Bot.Streaming.Payloads;
 using Microsoft.Bot.Streaming.PayloadTransport;
 using Moq;
@@ -13,7 +14,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
     {
         [Fact]
 
-        public async void SendRequestAsync_With_No_StreamingRequest_Should_Fail()
+        public async Task SendRequestAsync_With_No_StreamingRequest_Should_Fail()
         {
             var requestHandler = new Mock<RequestHandler>();
             var requestManager = new Mock<RequestManager>();

--- a/tests/Microsoft.Bot.Streaming.Tests/RequestTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/RequestTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             Assert.Single(r.Streams);
             Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
-            var s = await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false);
+            var s = await r.Streams[0].Content.ReadAsStringAsync();
             Assert.Equal("123", s);
         }
 
@@ -248,7 +248,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             Assert.Single(r.Streams);
             Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
-            var s = JsonConvert.DeserializeObject<Activity>(await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false));
+            var s = JsonConvert.DeserializeObject<Activity>(await r.Streams[0].Content.ReadAsStringAsync());
             Assert.Equal(a.Text, s.Text);
             Assert.Equal(a.Type, s.Type);
         }

--- a/tests/Microsoft.Bot.Streaming.Tests/ResponseTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/ResponseTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             Assert.Single(r.Streams);
             Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
-            var s = await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false);
+            var s = await r.Streams[0].Content.ReadAsStringAsync();
             Assert.Equal("123", s);
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
             Assert.Single(r.Streams);
             Assert.Equal(typeof(StringContent), r.Streams[0].Content.GetType());
 
-            var s = JsonConvert.DeserializeObject<Activity>(await r.Streams[0].Content.ReadAsStringAsync().ConfigureAwait(false));
+            var s = JsonConvert.DeserializeObject<Activity>(await r.Streams[0].Content.ReadAsStringAsync());
             Assert.Equal(a.Text, s.Text);
             Assert.Equal(a.Type, s.Type);
         }

--- a/tests/Microsoft.Bot.Streaming.Tests/StreamingRequestHandlerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/StreamingRequestHandlerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void RequestHandlerRespondsWith500OnError()
+        public async Task RequestHandlerRespondsWith500OnError()
         {
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
@@ -148,7 +148,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void DoesNotThrowExceptionIfReceiveRequestIsNull()
+        public async Task DoesNotThrowExceptionIfReceiveRequestIsNull()
         {
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
@@ -162,7 +162,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void DoesNotThrowExceptionIfReceiveRequestHasNoActivity()
+        public async Task DoesNotThrowExceptionIfReceiveRequestHasNoActivity()
         {
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
@@ -184,7 +184,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void RequestHandlerRemembersConversations()
+        public async Task RequestHandlerRemembersConversations()
         {
             // Arrange
             var adapter = new BotFrameworkHttpAdapter();
@@ -222,7 +222,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void RequestHandlerForgetsConversations()
+        public async Task RequestHandlerForgetsConversations()
         {
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
@@ -260,7 +260,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void RequestHandlerAssignsAServiceUrl()
+        public async Task RequestHandlerAssignsAServiceUrl()
         {
             // Arrange
             var handler = new StreamingRequestHandler(new MockBot(), new BotFrameworkHttpAdapter(), Guid.NewGuid().ToString());
@@ -299,7 +299,7 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
         }
 
         [Fact]
-        public async void ItGetsUserAgentInfo()
+        public async Task ItGetsUserAgentInfo()
         {
             // Arrange
             var expectation = new Regex("{\"userAgent\":\"Microsoft-BotFramework\\/[0-9.]+\\s.*BotBuilder\\/[0-9.]+\\s+\\(.*\\)\".*}");
@@ -328,11 +328,11 @@ namespace Microsoft.Bot.Builder.Streaming.Tests
             var response = await handler.ProcessRequestAsync(testRequest);
 
             // Assert
-            Assert.Matches(expectation, response.Streams[0].Content.ReadAsStringAsync().Result);
+            Assert.Matches(expectation, await response.Streams[0].Content.ReadAsStringAsync());
         }
 
         [Fact]
-        public async void CallStreamingRequestHandlerOverrides()
+        public async Task CallStreamingRequestHandlerOverrides()
         {
             var activity = new Activity()
             {

--- a/tests/Microsoft.Bot.Streaming.Tests/WebSocketClientServerTests.cs
+++ b/tests/Microsoft.Bot.Streaming.Tests/WebSocketClientServerTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void WebSocketServer_SendAsync_With_No_Message()
+        public async Task WebSocketServer_SendAsync_With_No_Message()
         {
             var socketMock = new Mock<WebSocket>();
             var requestHandlerMock = new Mock<RequestHandler>();
@@ -86,7 +86,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void WebSocketServer_SendAsync_With_No_Connected_Client()
+        public async Task WebSocketServer_SendAsync_With_No_Connected_Client()
         {
             var socketMock = new Mock<WebSocket>();
             var requestHandlerMock = new Mock<RequestHandler>();
@@ -114,7 +114,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void WebSocketClient_SendAsync_With_No_Message()
+        public async Task WebSocketClient_SendAsync_With_No_Message()
         {
             var client = new WebSocketClient("url");
 
@@ -122,7 +122,7 @@ namespace Microsoft.Bot.Streaming.UnitTests
         }
 
         [Fact]
-        public async void WebSocketClient_SendAsync_With_No_Connected_Client()
+        public async Task WebSocketClient_SendAsync_With_No_Connected_Client()
         {
             var client = new WebSocketClient("url");
             var message = new StreamingRequest();

--- a/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
+++ b/tests/Parsers/Microsoft.Bot.Builder.Parsers.LU.Tests/Microsoft.Bot.Builder.Parsers.LU.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>

--- a/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.ApplicationInsights.Core.Tests/Microsoft.Bot.ApplicationInsights.Core.Tests.csproj
@@ -21,7 +21,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/CloudAdapterTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
         }
 
         [Fact]
-        public void CanContinueConversationOverWebSocket()
+        public async Task CanContinueConversationOverWebSocketAsync()
         {
             // Arrange
             var continueConversationWaiter = new AutoResetEvent(false);
@@ -372,8 +372,8 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                 authResult.ClaimsIdentity, invalidActivity, (turn, cancellationToken) => Task.CompletedTask, CancellationToken.None);
 
             continueConversationWaiter.Set();
-            nullUrlProcessRequest.Wait();
-            processRequest.Wait();
+            await nullUrlProcessRequest;
+            await processRequest;
 
             // Assert
             Assert.True(processRequest.IsCompletedSuccessfully);

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/integration/Microsoft.Bot.Builder.Integration.AspNet.Core.Tests/ServiceCollectionExtensionsTests.cs
@@ -205,8 +205,7 @@ namespace Microsoft.Bot.Builder.Integration.AspNet.Core.Tests
                         string.Empty,
                         activity,
                         (turnContext, ct) => { return Task.CompletedTask; },
-                        default(CancellationToken))
-                        .Result;
+                        default(CancellationToken));
 
                     // Verify the mock middleware was actually invoked (the only indicator we have that it was added).
                     middlewareMock.Verify(


### PR DESCRIPTION
Addresses #6825
#minor

## Description
This PR updates _**xunit**_ package version from 2.4.1 to 2.9.0 and applies the respective changes to meet the new version requirements. 

## Specific Changes
  - Changed _async void_ methods to _async Task_.
  - Swapped assert equal parameters to leave the expected value in the correct argument position. 
  - Changed assert equal comparison of size collection 0 and 1 to _Empty_ and _Single_ methods.
  - Added async operators instead of the use of Wait, GetAwaiter, and Result methods.

## Testing
The following image shows the unit tests working in Net 6.0 and 8.0.
![image](https://github.com/user-attachments/assets/24d77ecb-9795-4155-b086-b4513a214ecf)