### PR TITLE
[#6825] Fix Microsoft.Bcl.AsyncInterfaces warnings

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/libraries/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -37,6 +37,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.40.0" />
+    <!-- Force Microsoft.Bcl.AsyncInterfaces to a newer version. Since Microsoft.Azure.Cosmos has 1.1.1 version, which causes MSB3277 warnings. -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
+++ b/libraries/integration/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi/Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi.csproj
@@ -57,7 +57,7 @@
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
+    <Reference Include="System.Diagnostics.DiagnosticSource" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Addresses #6825
#minor

## Description
This PR adds the `Microsoft.Bcl.AsyncInterfaces` package to `Microsoft.Bot.Builder.Azure` project, forcing 1.x version to 8.x, solving the [MSB3277](https://learn.microsoft.com/en-us/visualstudio/msbuild/errors/msb3277?view=vs-2022&f1url=%3FappId%3DDev17IDEF1%26l%3DEN-US%26k%3Dk(MSBuild.ResolveAssemblyReference.FoundConflicts)%26rd%3Dtrue) warnings.

## Specific Changes
  - Added `Microsoft.Bcl.AsyncInterfaces` to `Microsoft.Bot.Builder.Azure` project, forcing to use 8.x version instead of 1.x that caused the conflict.
  - Updated `System.Diagnostics.DiagnosticSource` in `Microsoft.Bot.Builder.Integration.ApplicationInsights.WebApi` project, solving [MSB3245](https://learn.microsoft.com/en-us/visualstudio/msbuild/errors/msb3245?view=vs-2022) warning.

## Testing
The following images show the CI pipeline, and the reduction of the warnings.
![image](https://github.com/user-attachments/assets/a3d60b63-9ba9-4f67-9576-67327f12a401)


