### PR TITLE
[#6825] Update Twilio package

### DIFF
--- a/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
+++ b/FunctionalTests/Microsoft.Bot.Builder.FunctionalTests/Microsoft.Bot.Builder.FunctionalTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="NAudio" Version="1.9.0" />
-    <PackageReference Include="Twilio" Version="5.37.2" />
+    <PackageReference Include="Twilio" Version="7.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/Microsoft.Bot.Builder.Adapters.Twilio.csproj
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/Microsoft.Bot.Builder.Adapters.Twilio.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Description>Library for connecting bots with Twilio SMS API.</Description>
     <Summary>This library implements C# classes for Twilio adapter.</Summary>
     <PackageTags>msbot-component;msbot-adapter</PackageTags>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <!-- The Twilio package isn't signed, so supress the warning. There seems to not be a way to supress this for ONLY Twilio. -->
     <NoWarn>$(NoWarn),CS8002</NoWarn>
   </PropertyGroup>
@@ -33,7 +33,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Twilio" Version="5.37.2" />
+    <PackageReference Include="Twilio" Version="7.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />
   </ItemGroup>

--- a/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
+++ b/libraries/Adapters/Microsoft.Bot.Builder.Adapters.Twilio/TwilioHelper.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Bot.Builder.Adapters.Twilio
                 return values;
             }
 
-            var pairs = query.Replace("+", "%20").Split('&');
+            var pairs = query.Replace("+", "%20", StringComparison.InvariantCulture).Split('&');
 
             foreach (var p in pairs)
             {


### PR DESCRIPTION
Addresses #6825
#minor

## Description
This PR updates the `Twilio` package from `5.37.2` to `7.2.2`, and fixes the [NU1701](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1701) issue.

## Specific Changes
  - Updated `Twilio` in TwilioAdapter and FunctionalTests projects.
  - Updated TwilioAdapter from netstandard2.0 to netstandard2.1.
  - Fixed StringComparison issue in TwilioAdapter.

## Testing
The following images show the CI and Functional Tests pipelines.
![image](https://github.com/user-attachments/assets/b2f3268e-d334-43de-9eb9-d94f485be5a9)
![image](https://github.com/user-attachments/assets/38629aec-2bda-46af-8d1e-6479e760fb1c)

