### PR TITLE
fix: Avoid SM02211 issue alert

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Queues/AzureQueueStorage.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bot.Builder.Azure.Queues
 
             _jsonSettings = jsonSerializerSettings ?? new JsonSerializerSettings
             {
-                TypeNameHandling = TypeNameHandling.None,
+                TypeNameHandling = TypeNameHandling.None, // CODEQL [cs/unsafe-type-name-handling] We use None to prevent any type information from being serialized, ensuring that no arbitrary types are deserialized, which mitigates security risks.
                 NullValueHandling = NullValueHandling.Ignore,
                 MaxDepth = null
             };
@@ -67,7 +67,7 @@ namespace Microsoft.Bot.Builder.Azure.Queues
             _queueClient = queueClient;
             _jsonSettings = jsonSerializerSettings ?? new JsonSerializerSettings
             {
-                TypeNameHandling = TypeNameHandling.None,
+                TypeNameHandling = TypeNameHandling.None, // CODEQL [cs/unsafe-type-name-handling] We use None to prevent any type information from being serialized, ensuring that no arbitrary types are deserialized, which mitigates security risks.
                 NullValueHandling = NullValueHandling.Ignore
             };
         }


### PR DESCRIPTION
#minor

## Description
This PR adds a comment to clarify the _**TypeNameHandling**_ alert thrown in _AzureQueueStorage_.

## Specific Changes
  - Added CodeQL comment to _JsonSerializerSettings_ instantiation in _AzureQueueStorage_ constructors.

## Testing
This PR doesn't require a testing proof.