### PR TITLE
[#6841] SkillDialog.InterceptOAuthCardsAsync doesn't support CloudAdapter

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.Dialogs/SkillDialog.cs
@@ -320,45 +320,43 @@ namespace Microsoft.Bot.Builder.Dialogs
         /// </remarks>
         private async Task<bool> InterceptOAuthCardsAsync(ITurnContext turnContext, Activity activity, string connectionName, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(connectionName) || !(turnContext.Adapter is IExtendedUserTokenProvider tokenExchangeProvider))
+            if (string.IsNullOrWhiteSpace(connectionName))
             {
                 // The adapter may choose not to support token exchange, in which case we fallback to showing an oauth card to the user.
                 return false;
             }
 
             var oauthCardAttachment = activity.Attachments?.FirstOrDefault(a => a?.ContentType == OAuthCard.ContentType);
-            if (oauthCardAttachment != null)
+            if (oauthCardAttachment == null)
             {
-                var oauthCard = ((JObject)oauthCardAttachment.Content).ToObject<OAuthCard>();
-                if (!string.IsNullOrWhiteSpace(oauthCard?.TokenExchangeResource?.Uri))
-                {
-                    try
-                    {
-                        var result = await tokenExchangeProvider.ExchangeTokenAsync(
-                            turnContext,
-                            connectionName,
-                            turnContext.Activity.From.Id,
-                            new TokenExchangeRequest(oauthCard.TokenExchangeResource.Uri),
-                            cancellationToken).ConfigureAwait(false);
-
-                        if (!string.IsNullOrWhiteSpace(result?.Token))
-                        {
-                            // If token above is null, then SSO has failed and hence we return false.
-                            // If not, send an invoke to the skill with the token. 
-                            return await SendTokenExchangeInvokeToSkillAsync(activity, oauthCard.TokenExchangeResource.Id, oauthCard.ConnectionName, result.Token, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-#pragma warning disable CA1031 // Do not catch general exception types (ignoring, see comment below)
-                    catch
-#pragma warning restore CA1031 // Do not catch general exception types
-                    {
-                        // Failures in token exchange are not fatal. They simply mean that the user needs to be shown the OAuth card.
-                        return false;
-                    }
-                }
+                return false;
             }
 
-            return false;
+            var oauthCard = ((JObject)oauthCardAttachment.Content).ToObject<OAuthCard>();
+            if (string.IsNullOrWhiteSpace(oauthCard?.TokenExchangeResource?.Uri))
+            {
+                return false;
+            }
+
+            try
+            {
+                var settings = new OAuthPromptSettings() { ConnectionName = connectionName };
+                var result = await UserTokenAccess.ExchangeTokenAsync(turnContext, settings, new TokenExchangeRequest(oauthCard.TokenExchangeResource.Uri), cancellationToken).ConfigureAwait(false);
+
+                if (string.IsNullOrWhiteSpace(result?.Token))
+                {
+                    // If token above is null, then SSO has failed and hence we return false.
+                    return false;
+                }
+                
+                // If not, send an invoke to the skill with the token. 
+                return await SendTokenExchangeInvokeToSkillAsync(activity, oauthCard.TokenExchangeResource.Id, oauthCard.ConnectionName, result.Token, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Failures in token exchange are not fatal. They simply mean that the user needs to be shown the OAuth card.
+                return false;
+            }
         }
 
         private async Task<bool> SendTokenExchangeInvokeToSkillAsync(Activity incomingActivity, string id, string connectionName, string token, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #6841

## Description
This PR updates the **_InterceptOAuthCardsAsync_** method in _SkillDialog_ to support _CloudAdapter_ in combination with _expect replies_ delivery mode.

## Specific Changes
- In _InterceptOAuthCardsAsync_ added a call to _UserTokenAccess.ExchangeTokenAsync_ method, which handles both adapters.

## Testing
This image shows the token exchanged for SSO using _CloudAdapter_ and _expect replies_.
![image](https://github.com/user-attachments/assets/6231b1a6-f883-4eac-8bbd-842b75c6b639)
