### PR TITLE
[#6768] CosmosDBKeyEscape.TruncateKeyIfNeeded return different value after compiled

### DIFF
--- a/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
+++ b/tests/Microsoft.Bot.Builder.Azure.Tests/CosmosDBKeyEscapeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.Bot.Builder.Azure.Tests
@@ -40,7 +41,8 @@ namespace Microsoft.Bot.Builder.Azure.Tests
             Assert.True(sanitizedKey.Length <= CosmosDbKeyEscape.MaxKeyLength, "Key too long");
 
             // The resulting key should be:
-            var hash = tooLongKey.GetHashCode().ToString("x");
+            var getHashMethod = typeof(CosmosDbKeyEscape).GetMethod("GetDeterministicHashCode", BindingFlags.NonPublic | BindingFlags.Static);
+            var hash = ((int)getHashMethod.Invoke(null, new object[] { tooLongKey })).ToString("x");
             var correctKey = sanitizedKey.Substring(0, CosmosDbKeyEscape.MaxKeyLength - hash.Length) + hash;
 
             Assert.Equal(correctKey, sanitizedKey);


### PR DESCRIPTION
Fixes #6768

## Description
This PR implements a custom _GetHashCode_ method to return the same hash code even on different bots' runs. This code is used in _CosmosDBKeyEscape_ to truncate keys that are longer than 255 characters.

## Specific Changes
- Created the `GetDeterministicHashCode` method in the _CosmosDBKeyEscape_ class to replace the call to _String.GetHashCode_.
- Updated `Long_Key_Should_Be_Truncated` unit test to use the new method and verify its result.

## Testing
These images compare the hash codes returned by the GetHashCode and GetDeterministicHashCode methods in two different bot runs.
![image](https://github.com/user-attachments/assets/51b472e1-4fd2-4fd6-81a5-f8420bea0dcd)