### PR TITLE
feat: [#6693] Add dataset to SearchInvokeValue

### DIFF
--- a/libraries/Microsoft.Bot.Schema/SearchInvokeValue.cs
+++ b/libraries/Microsoft.Bot.Schema/SearchInvokeValue.cs
@@ -51,5 +51,14 @@ namespace Microsoft.Bot.Schema
         /// </value>
         [JsonProperty("context")]
         public object Context { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dataset to be queried to get the choices.
+        /// </summary>
+        /// <value>
+        /// The dataset of this search invoke action value.
+        /// </value>
+        [JsonProperty("dataset")]
+        public string Dataset { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #6693

## Description
This PR adds the 'dataset' property to the SearchInvokeValue class, so it can be used when the OnSearchInvokeAsync event is triggered.

## Specific Changes
  - Adds 'Dataset' property to the SearchInvokeValue class.

## Testing
The following image shows that the SearchInvokeValue having the dataset property set.
![image](https://github.com/user-attachments/assets/51fbb276-39a1-426d-8e77-f90cb17bbba7)

