### PR TITLE
Add obsolete tag to MsalServiceClientCredentialsFactory class

### DIFF
--- a/libraries/Microsoft.Bot.Connector/Authentication/MsalServiceClientCredentialsFactory.cs
+++ b/libraries/Microsoft.Bot.Connector/Authentication/MsalServiceClientCredentialsFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Bot.Connector.Authentication
     /// <summary>
     /// Credential factory that uses MSAL to acquire tokens.
     /// </summary>
+    [Obsolete("Use the ServiceClientCredentialsFactory implementation that corresponds to the authentication type (MSI, Certificate, Federated, etc.).", false)]
     public class MsalServiceClientCredentialsFactory : ServiceClientCredentialsFactory
     {
         private readonly IConfidentialClientApplication _clientApplication;


### PR DESCRIPTION
#minor

## Description
This PR adds the obsolete tag to the _**MsalServiceClientCredentialsFactory**_ class, so users opt to use one of the other factory classes depending on the type of authentication they use (_ConfigurationServiceClientCredentialFactory_, _CertificateServiceClientCredentialsFactory_, _FederatedServiceClientCredentialsFactory_, etc).

## Specific Changes
- Update _MsalServiceClientCredentialsFactory_ to add the Obsolete tag.

## Testing
This image shows the obsolete tag added to the class.
![image](https://github.com/user-attachments/assets/067fda49-7750-4a00-a973-2e24bbf7eb84)
