### PR TITLE
fix: [#6861]TeamsSSOTokenExchangeMiddleware.DeduplicatedTokenExchangeIdAsync fails on BlobStorage ETag validation

### DIFF
--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -290,6 +290,11 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                         $"An error occurred while trying to write an object. The underlying '{BlobErrorCode.InvalidBlockList}' error is commonly caused due to concurrently uploading an object larger than 128MB in size.",
                         ex);
                 }
+                catch (RequestFailedException ex)
+                when (ex.Status == 412)
+                {
+                    throw new InvalidOperationException($"Etag conflict: {ex.Message}");
+                }
             }
         }
 

--- a/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
+++ b/libraries/Microsoft.Bot.Builder.Azure.Blobs/BlobsStorage.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Bot.Builder.Azure.Blobs
                         ex);
                 }
                 catch (RequestFailedException ex)
-                when (ex.Status == 412)
+                when (ex.Status == (int)HttpStatusCode.PreconditionFailed)
                 {
                     throw new InvalidOperationException($"Etag conflict: {ex.Message}");
                 }


### PR DESCRIPTION
Fixes #6861

## Description
This PR adds the 412 error capture of the _BlobsStorage_ to be handled by _TeamsSSOTokenExchangeMiddleware_.

## Specific Changes
  - Added **_catch_** to capture 412 in _WriteAsync_ method of _BlobsStorage_.

## Testing
The following image shows the error being captured.
![image](https://github.com/user-attachments/assets/9e870161-e1a2-47ce-81d1-e0b215694adf)