### PR TITLE
Avoid allocations from EvaluationTarget.GetId

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/Expander.cs
@@ -89,12 +89,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
 
             var templateTarget = new EvaluationTarget(templateName, memory);
 
-            var currentEvaluateId = templateTarget.GetId();
-
-            if (_evaluationTargetStack.Any(e => e.GetId() == currentEvaluateId))
-            {
-                throw new InvalidOperationException($"{TemplateErrors.LoopDetected} {string.Join(" => ", _evaluationTargetStack.Reverse().Select(e => e.TemplateName))} => {templateName}");
-            }
+            EvaluationTarget.ThrowIfLoopDetected(_evaluationTargetStack, templateTarget.GetId(), templateName);
 
             // Using a stack to track the evaluation trace
             _evaluationTargetStack.Push(templateTarget);


### PR DESCRIPTION
GetId is used as part of a loop, and every call to it allocates a new string and possibly invokes Scope.Version(). We can avoid that string allocation by returning the two component pieces as a tuple, and by comparing the individual pieces, if the templates are different we can short-circuit and avoid the Version() invocation.