### PR TITLE
[#6889] CQA to support TokenCredential instead of key

### DIFF
--- a/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/CustomQuestionAnswering.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Bot.Builder.AI.QnA.Models;
 using Microsoft.Bot.Builder.AI.QnA.Utils;
 using Newtonsoft.Json;
 
@@ -48,9 +47,9 @@ namespace Microsoft.Bot.Builder.AI.QnA
                 throw new ArgumentException(nameof(endpoint.Host));
             }
 
-            if (string.IsNullOrEmpty(endpoint.EndpointKey))
+            if (string.IsNullOrEmpty(endpoint.EndpointKey) && string.IsNullOrEmpty(endpoint.ManagedIdentityClientId))
             {
-                throw new ArgumentException(nameof(endpoint.EndpointKey));
+                throw new ArgumentException("Either the EndpointKey or the ManagedIdentityCliendId must be provided");
             }
 
             if (_endpoint.Host.EndsWith("v2.0", StringComparison.Ordinal) || _endpoint.Host.EndsWith("v3.0", StringComparison.Ordinal))

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Dialogs/QnAMakerDialog.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
                 useTeamsAdaptiveCard,
                 httpClient)
         {
-            if (!string.IsNullOrEmpty(endpointKey))
+            if (!string.IsNullOrWhiteSpace(endpointKey))
             {
                 Console.WriteLine(
                     "Providing an endpointKey in the QnAMakerDialog constructor is deprecated, use WithEndpointKey() method instead and provide 'null' or 'empty' value in the constructor.");
@@ -195,8 +195,8 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             : this(
                 nameof(QnAMakerDialog),
                 knowledgeBaseId,
-                hostName,
                 endpointKey,
+                hostName,
                 noAnswer,
                 threshold,
                 activeLearningCardTitle,
@@ -475,7 +475,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// <param name="endpointKey">The QnA Maker endpoint key to use to query the knowledge base.</param>
         public void WithEndpointKey(string endpointKey)
         {
-            if (string.IsNullOrEmpty(endpointKey))
+            if (string.IsNullOrWhiteSpace(endpointKey))
             {
                 throw new ArgumentNullException(nameof(endpointKey));
             }
@@ -494,7 +494,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
         /// <param name="managedIdentityClientId">The QnA Maker managed identity client id to use to query the knowledge base.</param>
         public void WithManagedIdentityClientId(string managedIdentityClientId)
         {
-            if (string.IsNullOrEmpty(managedIdentityClientId))
+            if (string.IsNullOrWhiteSpace(managedIdentityClientId))
             {
                 throw new ArgumentNullException(nameof(managedIdentityClientId));
             }
@@ -625,7 +625,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Dialogs
             var endpointKey = EndpointKey?.GetValue(dc.State);
             var managedIdentityClientId = ManagedIdentityClientId?.GetValue(dc.State);
 
-            if (string.IsNullOrEmpty(endpointKey) && string.IsNullOrEmpty(managedIdentityClientId))
+            if (string.IsNullOrWhiteSpace(endpointKey) && string.IsNullOrWhiteSpace(managedIdentityClientId))
             {
                 throw new ArgumentException("An authorization method is required. Either EndpointKey or ManagedIdentityClientId must be set");    
             }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Microsoft.Bot.Builder.AI.QnA.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <!-- Force System.Text.Json to a safe version. -->
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(ReleasePackageVersion)' == '' " Version="$(LocalPackageVersion)" />
     <PackageReference Include="Microsoft.Bot.Configuration" Condition=" '$(ReleasePackageVersion)' != '' " Version="$(ReleasePackageVersion)" />

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerEndpoint.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/QnAMakerEndpoint.cs
@@ -67,5 +67,14 @@ namespace Microsoft.Bot.Builder.AI.QnA
         /// </value>
         [JsonProperty("host")]
         public string Host { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ClientId of the Managed Identity resource. Access control (IAM) role `Cognitive Services User` must be assigned in the Language resource to the Managed Identity resource.
+        /// </summary>
+        /// <value>
+        /// The ClientId of the Managed Identity resource.
+        /// </value>
+        [JsonProperty("managedIdentityClientId")]
+        public string ManagedIdentityClientId { get; set; }
     }
 }

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
@@ -79,9 +79,22 @@ namespace Microsoft.Bot.Builder.AI.QnA
             }
             else if (!string.IsNullOrWhiteSpace(endpoint.ManagedIdentityClientId))
             {
-                var client = new ManagedIdentityCredential(endpoint.ManagedIdentityClientId);
-                var accessToken = await client.GetTokenAsync(new Azure.Core.TokenRequestContext(["https://cognitiveservices.azure.com/.default"]));
-                request.Headers.Add("Authorization", $"Bearer {accessToken.Token}");
+                try
+                {
+                    var client = new ManagedIdentityCredential(endpoint.ManagedIdentityClientId);
+                    var accessToken = await client.GetTokenAsync(new Azure.Core.TokenRequestContext(["https://cognitiveservices.azure.com/.default"]));
+                    request.Headers.Add("Authorization", $"Bearer {accessToken.Token}");
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to acquire token using Managed Identity Client ID '{endpoint.ManagedIdentityClientId}'. " +
+                        $"Ensure the Managed Identity exists and has the 'Cognitive Services User' role assigned.", ex);
+                }
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(endpoint), "Either EndpointKey or ManagedIdentityClientId must be provided.");
             }
 
             request.Headers.UserAgent.Add(botBuilderInfo);

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
@@ -72,12 +72,12 @@ namespace Microsoft.Bot.Builder.AI.QnA
 
         private static async Task SetHeadersAsync(HttpRequestMessage request, QnAMakerEndpoint endpoint)
         {
-            if (!string.IsNullOrEmpty(endpoint.EndpointKey))
+            if (!string.IsNullOrWhiteSpace(endpoint.EndpointKey))
             {
                 request.Headers.Add("Authorization", $"EndpointKey {endpoint.EndpointKey}");
                 request.Headers.Add("Ocp-Apim-Subscription-Key", endpoint.EndpointKey);
             }
-            else if (!string.IsNullOrEmpty(endpoint.ManagedIdentityClientId))
+            else if (!string.IsNullOrWhiteSpace(endpoint.ManagedIdentityClientId))
             {
                 var client = new ManagedIdentityCredential(endpoint.ManagedIdentityClientId);
                 var accessToken = await client.GetTokenAsync(new Azure.Core.TokenRequestContext(["https://cognitiveservices.azure.com/.default"]));

--- a/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
+++ b/libraries/Microsoft.Bot.Builder.AI.QnA/Utils/HttpRequestUtils.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Identity;
 
 namespace Microsoft.Bot.Builder.AI.QnA
 {
@@ -60,7 +61,7 @@ namespace Microsoft.Bot.Builder.AI.QnA
             {
                 request.Content = new StringContent(payloadBody, Encoding.UTF8, "application/json");
 
-                SetHeaders(request, endpoint);
+                await SetHeadersAsync(request, endpoint);
 
                 var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
@@ -69,10 +70,20 @@ namespace Microsoft.Bot.Builder.AI.QnA
             }
         }
 
-        private static void SetHeaders(HttpRequestMessage request, QnAMakerEndpoint endpoint)
+        private static async Task SetHeadersAsync(HttpRequestMessage request, QnAMakerEndpoint endpoint)
         {
-            request.Headers.Add("Authorization", $"EndpointKey {endpoint.EndpointKey}");
-            request.Headers.Add("Ocp-Apim-Subscription-Key", endpoint.EndpointKey);
+            if (!string.IsNullOrEmpty(endpoint.EndpointKey))
+            {
+                request.Headers.Add("Authorization", $"EndpointKey {endpoint.EndpointKey}");
+                request.Headers.Add("Ocp-Apim-Subscription-Key", endpoint.EndpointKey);
+            }
+            else if (!string.IsNullOrEmpty(endpoint.ManagedIdentityClientId))
+            {
+                var client = new ManagedIdentityCredential(endpoint.ManagedIdentityClientId);
+                var accessToken = await client.GetTokenAsync(new Azure.Core.TokenRequestContext(["https://cognitiveservices.azure.com/.default"]));
+                request.Headers.Add("Authorization", $"Bearer {accessToken.Token}");
+            }
+
             request.Headers.UserAgent.Add(botBuilderInfo);
             request.Headers.UserAgent.Add(platformInfo);
         }

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/LanguageServiceTests.cs
@@ -2220,7 +2220,7 @@ namespace Microsoft.Bot.Builder.AI.QnA.Tests
             public LanguageServiceTestDialog(string knowledgeBaseId, string endpointKey, string hostName, HttpClient httpClient)
                 : base(nameof(LanguageServiceTestDialog))
             {
-                AddDialog(new QnAMakerDialog(knowledgeBaseId, endpointKey, hostName, httpClient: httpClient));
+                AddDialog(new QnAMakerDialog(knowledgeBaseId, endpointKey: endpointKey, hostName, httpClient: httpClient));
             }
 
             /// <summary>

--- a/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
+++ b/tests/Microsoft.Bot.Builder.AI.QnA.Tests/QnAMakerTests.cs
@@ -1986,7 +1986,7 @@ namespace Microsoft.Bot.Builder.AI.Tests
             public QnaMakerTestDialog(string knowledgeBaseId, string endpointKey, string hostName, HttpClient httpClient)
                 : base(nameof(QnaMakerTestDialog))
             {
-                AddDialog(new QnAMakerDialog(knowledgeBaseId, endpointKey, hostName, httpClient: httpClient));
+                AddDialog(new QnAMakerDialog(knowledgeBaseId, endpointKey: endpointKey, hostName, httpClient: httpClient));
             }
 
             /// <summary>


### PR DESCRIPTION
Fixes #6889

## Description
This PR adds the ability to use a Managed Identity ClientId to authenticate to the Language service.

## Specific Changes
  - Added the _Azure.Identity_ package as dependency in `Microsoft.Bot.Builder.AI.QnA`.
  - Added the **_ManagedIdentityClientId_** property to the `QnAMakerEndpoint` class.
  - Added an internal constructor in `QnAMakerDialog` to handle the Managed Identity Client Id.
  - Added _WithEndpointKey_ and _WithManagedIdentityClientId_ methods to the `QnAMakerDialog` class to configure which authentication the request will use.
- Added the ability to detect and get the MSI token in the `HttpRequestUtils` class.

## Testing
The following images show the [48.customQABot-all-features](https://github.com/microsoft/BotBuilder-Samples/tree/main/samples/csharp_dotnetcore/48.customQABot-all-features) sample working with both authentication methods, EndpointKey (Emulator) and ManagedIdentityClientId (WebChat)
![image](https://github.com/user-attachments/assets/f23776f5-6631-404b-bb5a-4b13dd1e270d)
