### PR TITLE
[#6820] Discrepancy between .NET and JavaScript results when using adaptive expression join() prebuilt function to join array elements

### DIFF
--- a/libraries/AdaptiveExpressions/BuiltinFunctions/Join.cs
+++ b/libraries/AdaptiveExpressions/BuiltinFunctions/Join.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Linq;
 using AdaptiveExpressions.Memory;
+using Newtonsoft.Json.Linq;
 
 namespace AdaptiveExpressions.BuiltinFunctions
 {
@@ -34,7 +35,11 @@ namespace AdaptiveExpressions.BuiltinFunctions
                 {
                     if (args.Count == 2)
                     {
-                        result = string.Join(args[1].ToString(), list.OfType<object>().Select(x => x.ToString()));
+                        result = string.Join(
+                            args[1].ToString(),
+                            list.OfType<object>()
+                                .SelectMany(x => x is IEnumerable arr && x is not string && x is not JToken ? arr.Cast<object>() : new[] { x })
+                                .Select(x => x?.ToString() ?? string.Empty));
                     }
                     else
                     {

--- a/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
+++ b/tests/AdaptiveExpressions.Tests/ExpressionParserTests.cs
@@ -996,6 +996,7 @@ namespace AdaptiveExpressions.Tests
             Test("join(createArray('a', 'b', 'c'), ',', ' and ')", "a,b and c"),
             Test("join(createArray('a', 'b'), ',', ' and ')", "a and b"),
             Test("join(createArray(\r\n'a',\r\n 'b'), ','\r\n,\r\n ' and ')", "a and b"),
+            Test("join(createArray(['a'], ['b'], ['c']), ',')", "a,b,c"),
             Test("join(foreach(dialog, item, item.key), ',')", "x,instance,options,title,subTitle"),
             Test("join(foreach(dialog, item => item.key), ',')", "x,instance,options,title,subTitle"),
             Test("foreach(dialog, item, item.value)[1].xxx", "instance"),


### PR DESCRIPTION
Fixes #6820

## Description
This PR fixes the **_join_** pre-built function in _AdaptiveExpressions_ to correctly return the values of an input with nested arrays.
Now, both JS and .NET implementations return the same result.

## Specific Changes
- Updated the _EvalJoin_ method in **_BuiltinFunctions/Join_** to handle nested arrays in the input.
- Added a test case to cover this scenario in **_ExpressionParserTests_**.

## Testing
These images show the new unit test passing.
![image](https://github.com/user-attachments/assets/f9abe5e4-a50a-4d0a-9de0-1df056c55ea9)
