### PR TITLE
Add CodeQL and archiving comments to ExtractZipFolder

### DIFF
--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
@@ -13,7 +13,8 @@ using Newtonsoft.Json;
 namespace Microsoft.Bot.Builder.Tests
 {
     /// <summary>
-    /// Helpers to get activities from trancript files    ///. </summary>
+    /// Helpers to get activities from trancript files.
+    /// </summary>
     public static class TranscriptUtilities
     {
         private const string BotBuilderTranscriptsLocationKey = "BOTBUILDER_TRANSCRIPTS_LOCATION";
@@ -164,11 +165,11 @@ namespace Microsoft.Bot.Builder.Tests
                     if (string.IsNullOrEmpty(entry.Name))
                     {
                         // No Name, it is a folder
-                        CreateDirectoryIfNotExists(Path.Combine(path, entryName));
+                        CreateDirectoryIfNotExists(Path.Combine(path, entryName)); // CodeQL [SM02729] Test code, run locally. Not user input. Entier framework targeting archiving on Dec 31, 2025
                     }
                     else
                     {
-                        entry.ExtractToFile(Path.Combine(path, entryName), overwrite: true);
+                        entry.ExtractToFile(Path.Combine(path, entryName), overwrite: true); // CodeQL [SM02729] Test code, run locally. Not user input. Entier framework targeting archiving on Dec 31, 2025
                     }
                 }
             }


### PR DESCRIPTION
#minor

This pull request makes minor updates to the `TranscriptUtilities` test helper, primarily adding clarifying comments regarding CodeQL findings and correcting a documentation comment.

- Documentation improvements:
  * Fixed the summary comment for the `TranscriptUtilities` class to properly close the XML tag and improve clarity.

- CodeQL and code safety clarifications:
  * Added comments to suppress CodeQL [SM02729] warnings in the `ExtractZipFolder` method, clarifying that the code is for test purposes, runs locally, does not process user input, and the framework is planned for deprecation.