### PR TITLE
Potential fix for code scanning alert no. 4: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/TranscriptUtilities.cs
@@ -161,14 +161,22 @@ namespace Microsoft.Bot.Builder.Tests
                 {
                     var entryName = entry.FullName.Remove(0, zipFolderEntry.FullName.Length);
 
+                    // Compute the full extraction path and resolve to prevent Zip Slip
+                    var destinationPath = Path.GetFullPath(Path.Combine(path, entryName));
+                    var fullExtractionRoot = Path.GetFullPath(path + Path.DirectorySeparatorChar);
+                    if (!destinationPath.StartsWith(fullExtractionRoot, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException($"Entry is outside the target dir: {destinationPath}");
+                    }
+
                     if (string.IsNullOrEmpty(entry.Name))
                     {
                         // No Name, it is a folder
-                        CreateDirectoryIfNotExists(Path.Combine(path, entryName));
+                        CreateDirectoryIfNotExists(destinationPath);
                     }
                     else
                     {
-                        entry.ExtractToFile(Path.Combine(path, entryName), overwrite: true);
+                        entry.ExtractToFile(destinationPath, overwrite: true);
                     }
                 }
             }


### PR DESCRIPTION
#minor

Potential fix for [https://github.com/microsoft/botbuilder-dotnet/security/code-scanning/4](https://github.com/microsoft/botbuilder-dotnet/security/code-scanning/4)

The fix is to ensure that any file path derived from the archive is not able to escape the intended extraction directory. The standard mitigation is to combine the extraction root (`path`) with the archive entry’s file name (as currently), then resolve this combined path to an absolute path (resolving traversals/links), and confirm it is still within the extraction root (also resolved to a canonical absolute path). If not, extraction should immediately abort with an exception. This must be done both for files and directory creation.

Specifically, in `ExtractZipFolder`:
- After calculating the destination path with `Path.Combine(path, entryName)`, use `Path.GetFullPath` on it.
- Also get the full path of the extraction root, with a path separator at the end.
- Before extracting (either directory creation or file extraction), check that the target path starts with the extraction root’s full path.
- Throw an exception if any entry does not meet this.

This change needs to be applied to both branches: directory creation (line 167) and file extraction (line 171).

No additional dependencies are needed, but care needs to be taken to only change the vulnerable region.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
