### PR TITLE
Remove concrete Conversations cast to enable DI of IConversations 

### DIFF
--- a/libraries/Microsoft.Bot.Builder/Skills/SkillHandlerImpl.cs
+++ b/libraries/Microsoft.Bot.Builder/Skills/SkillHandlerImpl.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Bot.Builder.Skills
             {
                 var client = turnContext.TurnState.Get<IConnectorClient>();
                 var conversationId = turnContext.Activity.Conversation.Id;
-                member = await ((Conversations)client.Conversations).GetConversationMemberAsync(userId, conversationId, cancellationToken).ConfigureAwait(false);
+                member = await client.Conversations.GetConversationMemberAsync(userId, conversationId, cancellationToken).ConfigureAwait(false);
             });
 
             await _adapter.ContinueConversationAsync(claimsIdentity, skillConversationReference.ConversationReference, skillConversationReference.OAuthScope, callback, cancellationToken).ConfigureAwait(false);

--- a/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
+++ b/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Bot.Builder.Teams
                 throw new InvalidOperationException("The GetMembers operation needs a valid user Id.");
             }
 
-            var teamMember = await ((Conversations)connectorClient.Conversations).GetConversationMemberAsync(userId, conversationId, cancellationToken).ConfigureAwait(false);
+            var teamMember = await connectorClient.Conversations.GetConversationMemberAsync(userId, conversationId, cancellationToken).ConfigureAwait(false);
             var teamsChannelAccount = JObject.FromObject(teamMember).ToObject<TeamsChannelAccount>();
             return teamsChannelAccount;
         }

--- a/libraries/Microsoft.Bot.Connector/ConversationsExtensions.cs
+++ b/libraries/Microsoft.Bot.Connector/ConversationsExtensions.cs
@@ -440,10 +440,40 @@ namespace Microsoft.Bot.Connector
         /// GetConversationMember.
         /// </summary>
         /// <remarks>
-        /// Enumerate the members of a conversation.
+        /// Retrieves a single member of a conversation by ID.
         ///
         /// This REST API takes a ConversationId and a UserId and returns a ChannelAccount
-        /// object for the members of the conversation.
+        /// object for the member of the conversation.
+        /// </remarks>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='userId'>
+        /// User ID.
+        /// </param>
+        /// <param name='conversationId'>
+        /// Conversation ID.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>The conversation member.</returns>
+        public static async Task<ChannelAccount> GetConversationMemberAsync(this IConversations operations, string userId, string conversationId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            using (var result = await operations.GetConversationMemberWithHttpMessagesAsync(userId, conversationId, null, cancellationToken).ConfigureAwait(false))
+            {
+                return result.Body;
+            }
+        }
+
+        /// <summary>
+        /// GetConversationMember.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a single member of a conversation by ID.
+        ///
+        /// This REST API takes a ConversationId and a UserId and returns a ChannelAccount
+        /// object for the member of the conversation.
         /// </remarks>
         /// <param name='operations'>
         /// The operations group for this extension method.

--- a/libraries/Microsoft.Bot.Connector/IConversations.cs
+++ b/libraries/Microsoft.Bot.Connector/IConversations.cs
@@ -330,6 +330,39 @@ namespace Microsoft.Bot.Connector
         Task<HttpOperationResponse<IList<ChannelAccount>>> GetConversationMembersWithHttpMessagesAsync(string conversationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// GetConversationMember.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves a single member of a conversation by ID.
+        ///
+        /// This REST API takes a ConversationId and a UserId and returns a ChannelAccount
+        /// object for the members of the conversation.
+        /// </remarks>
+        /// <param name='userId'>
+        /// User ID.
+        /// </param>
+        /// <param name='conversationId'>
+        /// Conversation ID.
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="ErrorResponseException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <returns>A task that represents the <see cref="HttpOperationResponse"/>.</returns>
+        Task<HttpOperationResponse<ChannelAccount>> GetConversationMemberWithHttpMessagesAsync(string userId, string conversationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// GetConversationPagedMembers.
         /// </summary>
         /// <remarks>

--- a/tests/Microsoft.Bot.Builder.Tests/MemoryConversations.cs
+++ b/tests/Microsoft.Bot.Builder.Tests/MemoryConversations.cs
@@ -38,6 +38,11 @@ namespace Microsoft.Bot.Builder.Tests
             throw new NotImplementedException();
         }
 
+        public Task<HttpOperationResponse<ChannelAccount>> GetConversationMemberWithHttpMessagesAsync(string userId, string conversationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<HttpOperationResponse<PagedMembersResult>> GetConversationPagedMembersWithHttpMessagesAsync(string conversationId, int? pageSize = null, string continuationToken = null, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
fixes https://github.com/microsoft/botbuilder-dotnet/issues/6905

This pull request introduces a new method for retrieving a single conversation member by user ID and conversation ID, and updates existing code to use this new method instead of casting to a concrete type. This improves code clarity and maintainability by leveraging an interface extension method and updating interface definitions accordingly.

**API and Interface Enhancements:**

* Added `GetConversationMemberWithHttpMessagesAsync` to the `IConversations` interface, enabling retrieval of a single conversation member by user ID and conversation ID.
* Implemented the corresponding method stub in `MemoryConversations` for test coverage.

**Extension Method Addition:**

* Introduced the `GetConversationMemberAsync` extension method for `IConversations`, which wraps the new interface method and returns a `ChannelAccount`.

**Refactoring to Use the New Method:**

* Updated `SkillHandlerImpl.cs` and `TeamsInfo.cs` to use the new `GetConversationMemberAsync` extension method, removing the need for casting to the concrete `Conversations` type. [[1]](diffhunk://#diff-db4813d8affc1fad8ee25339f45d443a147aec46a8996bb9a33217e80a706968L104-R104) [[2]](diffhunk://#diff-42550a224580972338c3698b0021fbc23cc89891a5aaefbefd1a839cc7a9d91eL504-R504)